### PR TITLE
Bump stylish-haskell and use new import grouping feature

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -7,6 +7,16 @@ steps:
   - imports:
       align: none
       post_qualify: true
+      group_imports: true
+      group_rules:
+        # Anything with 'Plutus' somewhere in the first component
+        # is one of our packages
+        - match: "^[^.]*Plutus[^.]*"
+          # Within that, group by the first component
+          sub_group: "^[^.]+"
+        # After that, group the rest on the first component of the name
+        - match: ".*"
+          sub_group: "^[^.]+"
   - language_pragmas:
       remove_redundant: false
 

--- a/cabal.project
+++ b/cabal.project
@@ -14,10 +14,10 @@ repository cardano-haskell-packages
 -- update either of these.
 
 -- repeating hackage index-state to work around haskell.nix parsing limitation
-index-state: 2022-11-15T00:00:00Z
+index-state: 2023-01-13T00:00:00Z
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2022-11-15T00:00:00Z
+  , hackage.haskell.org 2023-01-13T00:00:00Z
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2023-01-04T00:00:00Z
 

--- a/doc/notes/fomega/cek-cps-experiments/src/CekMachine.cps.hs
+++ b/doc/notes/fomega/cek-cps-experiments/src/CekMachine.cps.hs
@@ -27,15 +27,15 @@ import PlutusCore
 import PlutusCore.Constant
 import PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
 import PlutusCore.Evaluation.Result (EvaluationResult (..))
-import PlutusCore.View
-import PlutusPrelude
-
-import Data.Text qualified as T
-import Data.Text.IO qualified as T
 import PlutusCore.Pretty qualified as PLC
+import PlutusCore.View
+
+import PlutusPrelude
 
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
 
 termStr :: Plain Term -> String
 termStr = T.unpack . PLC.prettyPlcDefText

--- a/doc/notes/fomega/cek-cps-experiments/src/CekMachine.original.hs
+++ b/doc/notes/fomega/cek-cps-experiments/src/CekMachine.original.hs
@@ -21,6 +21,7 @@ import PlutusCore.Constant
 import PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
 import PlutusCore.Evaluation.Result (EvaluationResult (..))
 import PlutusCore.View
+
 import PlutusPrelude
 
 import Data.IntMap (IntMap)

--- a/doc/notes/fomega/cek-cps-experiments/src/CekMachine.recursive.hs
+++ b/doc/notes/fomega/cek-cps-experiments/src/CekMachine.recursive.hs
@@ -30,14 +30,14 @@ import PlutusCore
 import PlutusCore.Constant
 import PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
 import PlutusCore.Evaluation.Result (EvaluationResult (..))
-import PlutusCore.View
-import PlutusPrelude
-
-import Data.Text qualified as T
 import PlutusCore.Pretty qualified as PLC
+import PlutusCore.View
+
+import PlutusPrelude
 
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
+import Data.Text qualified as T
 
 termStr :: Plain Term -> String
 termStr = T.unpack . PLC.prettyPlcDefText

--- a/doc/notes/fomega/cek-cps-experiments/src/LMachine.hs
+++ b/doc/notes/fomega/cek-cps-experiments/src/LMachine.hs
@@ -44,9 +44,11 @@ import PlutusCore
 import PlutusCore.Constant
 import PlutusCore.Evaluation.MachineException
 import PlutusCore.View
+
 import PlutusPrelude
 
 import Control.Monad.Identity
+
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
 

--- a/doc/notes/fomega/cek-cps-experiments/src/Make.hs
+++ b/doc/notes/fomega/cek-cps-experiments/src/Make.hs
@@ -18,6 +18,7 @@ import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.StdLib.Data.Bool
 import PlutusCore.Type
+
 import PlutusPrelude
 
 import Data.Bits (bit)

--- a/doc/notes/fomega/scott-encoding-benchmarks/Benchmarks.hs
+++ b/doc/notes/fomega/scott-encoding-benchmarks/Benchmarks.hs
@@ -5,6 +5,7 @@ module Main where
 import Criterion.Main
 import Criterion.Main.Options
 import Criterion.Types
+
 import Test.QuickCheck
 
 --------------------

--- a/doc/notes/fomega/src/AlgTypes.hs
+++ b/doc/notes/fomega/src/AlgTypes.hs
@@ -6,6 +6,7 @@
 module AlgTypes where
 
 import Data.Set qualified as S
+
 import Language.LBNF
 
 -------------------------------------

--- a/doc/notes/fomega/src/Examples.hs
+++ b/doc/notes/fomega/src/Examples.hs
@@ -4,14 +4,19 @@
 module Examples where
 
 import AlgTypes
-import Large
-import Scott
-import Solver
 
 import Control.Applicative
 import Control.Monad
+
+import Large
+
+import Scott
+
+import Solver
+
 import System.IO
 import System.Random
+
 import Test.QuickCheck
 
 -- (use the runExample :: AlgSignature -> IO () from AlgTypes)

--- a/doc/notes/fomega/src/Scott.hs
+++ b/doc/notes/fomega/src/Scott.hs
@@ -1,7 +1,9 @@
 module Scott where
 
 import AlgTypes
+
 import Data.Set qualified as S
+
 import SystemF
 
 -- note that "#R" is not a valid bnfc Ident(ifier), and as such it won't

--- a/doc/notes/fomega/src/Solver.hs
+++ b/doc/notes/fomega/src/Solver.hs
@@ -2,6 +2,7 @@
 module Solver where
 
 import AlgTypes
+
 import Data.Set qualified as S
 
 -----------------------------------------------------

--- a/doc/notes/model/UTxO.hsproj/Examples/PubKey.hs
+++ b/doc/notes/model/UTxO.hsproj/Examples/PubKey.hs
@@ -14,11 +14,13 @@ import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 
-
 import Examples.Keys
 import Examples.PubKeyHashes
+
 import Ledger
+
 import UTxO
+
 import Witness
 
 

--- a/doc/notes/model/UTxO.hsproj/Examples/PubKeyHashes.hs
+++ b/doc/notes/model/UTxO.hsproj/Examples/PubKeyHashes.hs
@@ -15,8 +15,11 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 
 import Examples.Keys
+
 import Ledger
+
 import UTxO
+
 import Witness
 
 

--- a/doc/notes/model/UTxO.hsproj/Examples/Simple.hs
+++ b/doc/notes/model/UTxO.hsproj/Examples/Simple.hs
@@ -9,7 +9,9 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 
 import Ledger
+
 import UTxO
+
 import Witness
 
 

--- a/doc/notes/model/UTxO.hsproj/Ledger.hs
+++ b/doc/notes/model/UTxO.hsproj/Ledger.hs
@@ -11,12 +11,14 @@ module Ledger (
 ) where
 
 import "cryptonite" Crypto.Hash
+
 import Data.ByteArray qualified as BA
 import Data.ByteString.Char8 qualified as BS
 import Data.Set (Set)
 import Data.Set qualified as Set
 
 import Types
+
 import Witness
 
 

--- a/doc/notes/model/UTxO.hsproj/UTxO.hs
+++ b/doc/notes/model/UTxO.hsproj/UTxO.hs
@@ -24,6 +24,7 @@ module UTxO
 where
 
 import "cryptonite" Crypto.Hash
+
 import Data.List
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -32,7 +33,9 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 
 import Ledger
+
 import Types
+
 import Witness
 
 

--- a/doc/notes/model/UTxO.hsproj/Witness.hs
+++ b/doc/notes/model/UTxO.hsproj/Witness.hs
@@ -36,8 +36,10 @@ module Witness (
 
 import "cryptonite" Crypto.Hash
 import "cryptonite" Crypto.PubKey.ECC.ECDSA
+
 import Data.ByteArray qualified as BA
 import Data.ByteString.Char8 qualified as BS
+
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 

--- a/doc/read-the-docs-site/tutorials/AuctionValidator.hs
+++ b/doc/read-the-docs-site/tutorials/AuctionValidator.hs
@@ -6,11 +6,13 @@
 module AuctionValidator where
 
 import PlutusCore.Default qualified as PLC
+
 import PlutusLedgerApi.V1 (POSIXTime, PubKeyHash, Value, adaSymbol, adaToken, singleton)
 import PlutusLedgerApi.V1.Address (pubKeyHashAddress)
 import PlutusLedgerApi.V1.Interval (contains)
 import PlutusLedgerApi.V2 (Datum (..), OutputDatum (..), ScriptContext (..), TxInfo (..), TxOut (..), from, to)
 import PlutusLedgerApi.V2.Contexts (getContinuingOutputs)
+
 import PlutusTx
 import PlutusTx.Bool
 import PlutusTx.Builtins
@@ -18,6 +20,7 @@ import PlutusTx.Lift
 import PlutusTx.Maybe
 import PlutusTx.Prelude qualified as PlutusTx
 import PlutusTx.Show qualified as PlutusTx
+
 import Prelude qualified as Haskell
 
 -- BLOCK1

--- a/doc/read-the-docs-site/tutorials/BasicPlutusTx.hs
+++ b/doc/read-the-docs-site/tutorials/BasicPlutusTx.hs
@@ -7,13 +7,10 @@
 module BasicPlutusTx where
 
 import PlutusCore.Default qualified as PLC
--- Main Plutus Tx module.
+
 import PlutusTx
--- Additional support for lifting.
-import PlutusTx.Lift
--- Builtin functions.
 import PlutusTx.Builtins
--- The Plutus Tx Prelude, discussed further below.
+import PlutusTx.Lift
 import PlutusTx.Prelude
 
 -- Setup for doctest examples.

--- a/doc/read-the-docs-site/tutorials/BasicPolicies.hs
+++ b/doc/read-the-docs-site/tutorials/BasicPolicies.hs
@@ -6,15 +6,16 @@
 module BasicPolicies where
 
 import PlutusCore.Default qualified as PLC
-import PlutusTx
-import PlutusTx.Lift
-import PlutusTx.Prelude
 
 import PlutusLedgerApi.V1.Contexts
 import PlutusLedgerApi.V1.Crypto
 import PlutusLedgerApi.V1.Scripts
 import PlutusLedgerApi.V1.Value
+
+import PlutusTx
 import PlutusTx.AssocMap qualified as Map
+import PlutusTx.Lift
+import PlutusTx.Prelude
 
 tname :: TokenName
 tname = error ()

--- a/doc/read-the-docs-site/tutorials/BasicValidators.hs
+++ b/doc/read-the-docs-site/tutorials/BasicValidators.hs
@@ -9,9 +9,6 @@
 module BasicValidators where
 
 import PlutusCore.Default qualified as PLC
-import PlutusTx
-import PlutusTx.Lift
-import PlutusTx.Prelude
 
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1.Contexts
@@ -19,10 +16,15 @@ import PlutusLedgerApi.V1.Crypto
 import PlutusLedgerApi.V1.Scripts
 import PlutusLedgerApi.V1.Value
 
+import PlutusTx
+import PlutusTx.Lift
+import PlutusTx.Prelude
+
+import Codec.Serialise
+
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 
-import Codec.Serialise
 import Flat qualified
 
 import Prelude (IO, print, show)

--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1672878275,
-        "narHash": "sha256-rxvW6ZEylpZolEsJbdQ1tCxBLlG52mEJwL734u4zJCs=",
+        "lastModified": 1673569630,
+        "narHash": "sha256-xuE7H4IiadgrhMin16Jy7F+J+g9Rg3eahP5LxosbXqA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d07ba13b6bf6197ec96c7e912cb1184eaf005928",
+        "rev": "34444b8bc36e0e1ab433754a5828291879623578",
         "type": "github"
       },
       "original": {

--- a/nix/cells/plutus/library/haskell-language-server-project.nix
+++ b/nix/cells/plutus/library/haskell-language-server-project.nix
@@ -13,7 +13,7 @@ cell.library.haskell-nix.cabalProject' {
   # b) Pull out the tools themselves from the HLS project so we can use
   #    them elsewhere
   cabalProjectLocal = ''
-    constraints: stylish-haskell==0.14.2.0, hlint==3.4.1
+    constraints: stylish-haskell==0.14.3.0, hlint==3.4.1
   '';
 
   src = inputs.haskell-language-server;

--- a/plutus-benchmark/cek-calibration/Main.hs
+++ b/plutus-benchmark/cek-calibration/Main.hs
@@ -15,21 +15,24 @@ get an idea of the average cost of the basic CEK operations.
 module Main (main) where
 
 
-import Prelude qualified as Haskell
-
 import PlutusCore
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Pretty qualified as PP
+
 import PlutusTx qualified as Tx
 import PlutusTx.Prelude as Tx
+
 import UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
 import Control.Exception
 import Control.Lens
 import Control.Monad.Except
+
 import Criterion.Main
 import Criterion.Types qualified as C
+
+import Prelude qualified as Haskell
 
 type PlainTerm = UPLC.Term Name DefaultUni DefaultFun ()
 

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -19,18 +19,20 @@ module PlutusBenchmark.Common
      )
 where
 
-import Paths_plutus_benchmark as Export
-
-import PlutusTx qualified as Tx
-
 import PlutusCore qualified as PLC
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
+
+import PlutusTx qualified as Tx
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
 
 import Criterion.Main
 import Criterion.Types (Config (..))
+
+import Paths_plutus_benchmark as Export
+
 import System.FilePath
 
 {- | The Criterion configuration returned by `getConfig` will cause an HTML report

--- a/plutus-benchmark/ed25519-throughput/Main.hs
+++ b/plutus-benchmark/ed25519-throughput/Main.hs
@@ -20,12 +20,13 @@ import PlutusCore (DefaultFun, DefaultUni)
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (exBudgetCPU, exBudgetMemory))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
-import PlutusTx qualified as Tx
-import UntypedPlutusCore qualified as UPLC
-import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 
+import PlutusTx qualified as Tx
 import PlutusTx.IsData (toData, unstableMakeIsData)
 import PlutusTx.Prelude as Tx hiding (sort, (*))
+
+import UntypedPlutusCore qualified as UPLC
+import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 
 import Cardano.Crypto.DSIGN.Class (ContextDSIGN, DSIGNAlgorithm, Signable, deriveVerKeyDSIGN, genKeyDSIGN,
                                    rawSerialiseSigDSIGN, rawSerialiseVerKeyDSIGN, signDSIGN)
@@ -35,13 +36,17 @@ import Cardano.Crypto.Seed (mkSeedFromBytes)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Hash qualified as Hash
+
 import Flat qualified
+
 import Hedgehog.Internal.Gen qualified as G
 import Hedgehog.Internal.Range qualified as R
-import System.IO.Unsafe (unsafePerformIO)
-import Text.Printf (printf)
 
 import Prelude (Double, IO, Integral, String, fromIntegral, (*), (/))
+
+import System.IO.Unsafe (unsafePerformIO)
+
+import Text.Printf (printf)
 
 -- Protocol parameters (November 2022)
 

--- a/plutus-benchmark/lists/bench/Bench.hs
+++ b/plutus-benchmark/lists/bench/Bench.hs
@@ -3,14 +3,12 @@
 
 module Main (main) where
 
-import Criterion.Main
-
 import PlutusBenchmark.Common (benchTermCek, getConfig)
-
 import PlutusBenchmark.Lists.Sort qualified as Sort
-
 import PlutusBenchmark.Lists.Sum.Compiled qualified as Sum.Compiled
 import PlutusBenchmark.Lists.Sum.HandWritten qualified as Sum.HandWritten
+
+import Criterion.Main
 
 benchmarks :: [Benchmark]
 benchmarks =

--- a/plutus-benchmark/lists/exe/Main.hs
+++ b/plutus-benchmark/lists/exe/Main.hs
@@ -6,9 +6,6 @@
 
 module Main where
 
-import Data.HashMap.Monoidal qualified as H
-import Text.Printf (printf)
-
 import PlutusBenchmark.Common (Term)
 import PlutusBenchmark.Lists.Sort
 
@@ -16,7 +13,12 @@ import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory
+
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
+
+import Data.HashMap.Monoidal qualified as H
+
+import Text.Printf (printf)
 
 getBudgetUsage :: Term -> Maybe Integer
 getBudgetUsage term =

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/HandWritten.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/HandWritten.hs
@@ -5,14 +5,18 @@ module PlutusBenchmark.Lists.Sum.HandWritten where
 
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
-import Control.Monad.Except
-import Data.Either
 import PlutusCore.Compiler.Erase (eraseTerm)
 import PlutusCore.StdLib.Data.List qualified as BuiltinList
 import PlutusCore.StdLib.Data.ScottList qualified as ScottList
+
 import PlutusTx qualified as Tx
 import PlutusTx.Builtins.Internal qualified as BI
+
 import UntypedPlutusCore qualified as UPLC
+
+import Control.Monad.Except
+
+import Data.Either
 
 
 ---------------- Hand-written folds, using stuff from PlutusCore.StdLib.Data  ----------------

--- a/plutus-benchmark/lists/test/Sort/Spec.hs
+++ b/plutus-benchmark/lists/test/Sort/Spec.hs
@@ -1,12 +1,11 @@
 -- editorconfig-checker-disable-file
 module Sort.Spec (tests) where
 
+import PlutusBenchmark.Common (Term, cekResultMatchesHaskellValue)
+import PlutusBenchmark.Lists.Sort qualified as Sort
+
 import Test.Tasty
 import Test.Tasty.QuickCheck
-
-import PlutusBenchmark.Common (Term, cekResultMatchesHaskellValue)
-
-import PlutusBenchmark.Lists.Sort qualified as Sort
 
 isSorted :: Ord a => [a] -> Bool
 isSorted []       = True

--- a/plutus-benchmark/lists/test/Spec.hs
+++ b/plutus-benchmark/lists/test/Spec.hs
@@ -4,10 +4,11 @@
 
 module Main (main) where
 
-import Test.Tasty
-
 import Sort.Spec qualified as Sort
+
 import Sum.Spec qualified as Sum
+
+import Test.Tasty
 
 allTests :: TestTree
 allTests =

--- a/plutus-benchmark/lists/test/Sum/Spec.hs
+++ b/plutus-benchmark/lists/test/Sum/Spec.hs
@@ -1,13 +1,12 @@
 -- editorconfig-checker-disable-file
 module Sum.Spec (tests) where
 
-import Test.Tasty
-import Test.Tasty.QuickCheck
-
 import PlutusBenchmark.Common (Term, cekResultMatchesHaskellValue)
-
 import PlutusBenchmark.Lists.Sum.Compiled qualified as Compiled
 import PlutusBenchmark.Lists.Sum.HandWritten qualified as HandWritten
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
 
 -- | Check that the various summation functions all give the same result as 'sum'
 

--- a/plutus-benchmark/nofib/bench/BenchHaskell.hs
+++ b/plutus-benchmark/nofib/bench/BenchHaskell.hs
@@ -3,16 +3,15 @@
 
 module Main (main) where
 
-import Shared (mkBenchMarks)
-
-import Criterion.Main
-
 import PlutusBenchmark.Common (getConfig)
-
 import PlutusBenchmark.NoFib.Clausify qualified as Clausify
 import PlutusBenchmark.NoFib.Knights qualified as Knights
 import PlutusBenchmark.NoFib.Prime qualified as Prime
 import PlutusBenchmark.NoFib.Queens qualified as Queens
+
+import Criterion.Main
+
+import Shared (mkBenchMarks)
 
 benchClausify :: Clausify.StaticFormula -> Benchmarkable
 benchClausify f = nf Clausify.runClausify f

--- a/plutus-benchmark/nofib/bench/BenchPlc.hs
+++ b/plutus-benchmark/nofib/bench/BenchPlc.hs
@@ -2,16 +2,15 @@
 {- | Plutus benchmarks based on some nofib examples. -}
 module Main where
 
-import Shared (mkBenchMarks)
-
-import Criterion.Main
-
 import PlutusBenchmark.Common (benchTermCek, getConfig)
-
 import PlutusBenchmark.NoFib.Clausify qualified as Clausify
 import PlutusBenchmark.NoFib.Knights qualified as Knights
 import PlutusBenchmark.NoFib.Prime qualified as Prime
 import PlutusBenchmark.NoFib.Queens qualified as Queens
+
+import Criterion.Main
+
+import Shared (mkBenchMarks)
 
 benchClausify :: Clausify.StaticFormula -> Benchmarkable
 benchClausify f = benchTermCek $ Clausify.mkClausifyTerm f

--- a/plutus-benchmark/nofib/bench/Shared.hs
+++ b/plutus-benchmark/nofib/bench/Shared.hs
@@ -2,11 +2,11 @@
 module Shared (mkBenchMarks, BenchmarkRunners)
 where
 
-import Criterion.Main
-
 import PlutusBenchmark.NoFib.Clausify qualified as Clausify
 import PlutusBenchmark.NoFib.Prime qualified as Prime
 import PlutusBenchmark.NoFib.Queens qualified as Queens
+
+import Criterion.Main
 
 {- | Package together functions to create benchmarks for each program given suitable inputs. -}
 type BenchmarkRunners =

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -4,23 +4,7 @@
 
 module Main where
 
-import Prelude ((<>))
-import Prelude qualified as Hs
-
-import Control.Lens hiding (argument)
-import Control.Monad ()
-import Control.Monad.Trans.Except (runExceptT)
-import Data.ByteString qualified as BS
-import Data.Char (isSpace)
-import Flat qualified
-import Options.Applicative as Opt hiding (action)
-import System.Exit (exitFailure)
-import System.IO
-import Text.PrettyPrint.ANSI.Leijen (Doc, indent, line, string, text, vsep)
-import Text.Printf (printf)
-
 import PlutusBenchmark.Common (toAnonDeBruijnTerm)
-
 import PlutusBenchmark.NoFib.Clausify qualified as Clausify
 import PlutusBenchmark.NoFib.Knights qualified as Knights
 import PlutusBenchmark.NoFib.LastPiece qualified as LastPiece
@@ -33,11 +17,33 @@ import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import PlutusCore.Pretty (prettyPlcClassicDebug)
+
 import PlutusTx (getPlcNoAnn)
 import PlutusTx.Code (CompiledCode, sizePlc)
 import PlutusTx.Prelude hiding (fmap, mappend, (<$), (<$>), (<*>), (<>))
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
+
+import Control.Lens hiding (argument)
+import Control.Monad ()
+import Control.Monad.Trans.Except (runExceptT)
+
+import Data.ByteString qualified as BS
+import Data.Char (isSpace)
+
+import Flat qualified
+
+import Options.Applicative as Opt hiding (action)
+
+import Prelude ((<>))
+import Prelude qualified as Hs
+
+import System.Exit (exitFailure)
+import System.IO
+
+import Text.PrettyPrint.ANSI.Leijen (Doc, indent, line, string, text, vsep)
+import Text.Printf (printf)
 
 failWithMsg :: Hs.String -> IO a
 failWithMsg s = hPutStrLn stderr s >> exitFailure

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
@@ -14,6 +14,7 @@ import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
 import PlutusTx qualified as Tx
 import PlutusTx.Prelude as Plutus
+
 import Prelude qualified as Haskell
 
 type Var = Integer

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights.hs
@@ -9,15 +9,17 @@
 module PlutusBenchmark.NoFib.Knights where
 
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
-
-import Data.Char
 import PlutusBenchmark.NoFib.Knights.ChessSetList
 import PlutusBenchmark.NoFib.Knights.KnightHeuristic
 import PlutusBenchmark.NoFib.Knights.Queue
 
 import PlutusCore.Pretty qualified as PLC
+
 import PlutusTx qualified as Tx
 import PlutusTx.Prelude as Tx
+
+import Data.Char
+
 import Prelude qualified as Haskell
 
 {-# INLINABLE zipConst #-}

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/ChessSetList.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/ChessSetList.hs
@@ -20,13 +20,14 @@ module PlutusBenchmark.NoFib.Knights.ChessSetList
       isSquareFree
     ) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics
-
 import PlutusBenchmark.NoFib.Knights.Sort
 import PlutusBenchmark.NoFib.Knights.Utils
 
 import PlutusTx.Prelude as Tx
+
+import Control.DeepSeq (NFData)
+
+import GHC.Generics
 
 import Prelude qualified as Haskell
 

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
@@ -21,12 +21,14 @@ module PlutusBenchmark.NoFib.LastPiece where
 
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
-import Data.Char (isSpace)
-
 import PlutusCore.Pretty qualified as PLC
+
 import PlutusTx as PlutusTx
 import PlutusTx.Builtins as Tx
 import PlutusTx.Prelude as PLC hiding (Semigroup (..), check, foldMap)
+
+import Data.Char (isSpace)
+
 import Prelude qualified as Haskell
 
 -------------------------------------

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
@@ -19,18 +19,21 @@
 
 module PlutusBenchmark.NoFib.Prime where
 
-import Control.DeepSeq (NFData)
-import Data.Char (isSpace)
-import GHC.Generics
-
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
-import Prelude qualified as Haskell
-
 import PlutusCore.Pretty qualified as PLC
+
 import PlutusTx qualified as Tx
 import PlutusTx.Builtins (divideInteger, modInteger)
 import PlutusTx.Prelude as Tx hiding (even)
+
+import Control.DeepSeq (NFData)
+
+import Data.Char (isSpace)
+
+import GHC.Generics
+
+import Prelude qualified as Haskell
 
 ---------------- Extras ----------------
 

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
@@ -22,18 +22,23 @@ module PlutusBenchmark.NoFib.Queens where
 	See Proceedings of WAAAPL '99
 -}
 
-import Control.DeepSeq (NFData)
-import Control.Monad (forM_)
-import Data.Char (isSpace)
-import GHC.Generics
-import Prelude qualified as Haskell
-import System.Environment
-
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
 import PlutusCore.Pretty qualified as PLC
+
 import PlutusTx qualified as Tx
 import PlutusTx.Prelude as TxPrelude hiding (abs, sortBy)
+
+import Control.DeepSeq (NFData)
+import Control.Monad (forM_)
+
+import Data.Char (isSpace)
+
+import GHC.Generics
+
+import Prelude qualified as Haskell
+
+import System.Environment
 
 -----------------------------
 -- The main program

--- a/plutus-benchmark/nofib/test/Spec.hs
+++ b/plutus-benchmark/nofib/test/Spec.hs
@@ -8,13 +8,7 @@ run to completion. -}
 
 module Main where
 
-import Test.Tasty
-import Test.Tasty.Extras (TestNested, runTestNestedIn)
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck
-
 import PlutusBenchmark.Common (Term, cekResultMatchesHaskellValue)
-
 import PlutusBenchmark.NoFib.Clausify qualified as Clausify
 import PlutusBenchmark.NoFib.Knights qualified as Knights
 import PlutusBenchmark.NoFib.Prime (Result (Composite, Prime))
@@ -22,8 +16,14 @@ import PlutusBenchmark.NoFib.Prime qualified as Prime
 import PlutusBenchmark.NoFib.Queens qualified as Queens
 
 import PlutusCore.Default
+
 import PlutusTx qualified as Tx
 import PlutusTx.Test qualified as Tx
+
+import Test.Tasty
+import Test.Tasty.Extras (TestNested, runTestNestedIn)
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
 
 runTestNested :: TestNested -> TestTree
 runTestNested = runTestNestedIn ["nofib", "test"]

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/ScriptContexts.hs
@@ -8,6 +8,7 @@ module PlutusBenchmark.ScriptContexts where
 import PlutusLedgerApi.V1
 import PlutusLedgerApi.V1.Address
 import PlutusLedgerApi.V1.Value
+
 import PlutusTx qualified as PlutusTx
 import PlutusTx.Builtins qualified as PlutusTx
 import PlutusTx.Prelude qualified as PlutusTx

--- a/plutus-benchmark/script-contexts/test/Spec.hs
+++ b/plutus-benchmark/script-contexts/test/Spec.hs
@@ -1,15 +1,15 @@
 module Main (main) where
 
-import Test.Tasty
-import Test.Tasty.Extras (TestNested, runTestNestedIn)
-import Test.Tasty.HUnit
-
 import PlutusBenchmark.Common (compiledCodeToTerm, runTermCek)
-
 import PlutusBenchmark.ScriptContexts
 
 import PlutusCore.Evaluation.Result
+
 import PlutusTx.Test qualified as Tx
+
+import Test.Tasty
+import Test.Tasty.Extras (TestNested, runTestNestedIn)
+import Test.Tasty.HUnit
 
 runTestNested :: TestNested -> TestTree
 runTestNested = runTestNestedIn ["script-contexts", "test"]

--- a/plutus-benchmark/validation/BenchCek.hs
+++ b/plutus-benchmark/validation/BenchCek.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Common
-import Control.DeepSeq (force)
-import Criterion
 import PlutusBenchmark.Common
+
 import UntypedPlutusCore as UPLC
+
+import Common
+
+import Control.DeepSeq (force)
+
+import Criterion
 
 {-|
  Benchmarks only for the CEK execution time of the data/*.flat validation scripts

--- a/plutus-benchmark/validation/BenchDec.hs
+++ b/plutus-benchmark/validation/BenchDec.hs
@@ -2,11 +2,15 @@
 module Main where
 
 import PlutusLedgerApi.V1
+
 import UntypedPlutusCore qualified as UPLC
 
 import Common
+
 import Control.Exception
+
 import Criterion
+
 import Data.ByteString as BS
 
 {-|

--- a/plutus-benchmark/validation/BenchFull.hs
+++ b/plutus-benchmark/validation/BenchFull.hs
@@ -2,12 +2,16 @@
 module Main where
 
 import PlutusCore.Evaluation.Machine.ExBudget
+
 import PlutusLedgerApi.Test.EvaluationContext (evalCtxForTesting)
 import PlutusLedgerApi.V1
+
 import UntypedPlutusCore qualified as UPLC
 
 import Common
+
 import Criterion
+
 import Data.ByteString as BS
 import Data.Either
 

--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -16,17 +16,21 @@ import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Data qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.Exception
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
 
 import Criterion.Main
 import Criterion.Main.Options (Mode, parseWith)
 import Criterion.Types (Config (..))
-import Options.Applicative
 
 import Data.ByteString qualified as BS
 import Data.List (isPrefixOf)
+
 import Flat
+
+import Options.Applicative
+
 import System.Directory (listDirectory)
 import System.FilePath
 

--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -2,14 +2,18 @@
 
 module Main (main) where
 
-import Control.Monad.Trans.Except
-import MAlonzo.Code.Main (runUAgda)
 import PlutusConformance.Common
+
 import PlutusCore (Error (..))
 import PlutusCore.Default
 import PlutusCore.Quote
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.DeBruijn
+
+import Control.Monad.Trans.Except
+
+import MAlonzo.Code.Main (runUAgda)
 
 -- | Our `evaluator` for the Agda UPLC tests is the CEK machine.
 agdaEvalUplcProg :: UplcProg -> Maybe UplcProg

--- a/plutus-conformance/executables/test-utils/Spec.hs
+++ b/plutus-conformance/executables/test-utils/Spec.hs
@@ -9,13 +9,17 @@ module Main (
     main,
 ) where
 
-import Data.Foldable (for_)
-import Data.Text.IO qualified as T
-import Options.Applicative
-import Options.Applicative.Help.Pretty (Doc, string)
 import PlutusConformance.Common
+
 import PlutusCore.Error (ParserErrorBundle (ParseErrorB))
 import PlutusCore.Pretty (Pretty (pretty), Render (render))
+
+import Data.Foldable (for_)
+import Data.Text.IO qualified as T
+
+import Options.Applicative
+import Options.Applicative.Help.Pretty (Doc, string)
+
 import Test.Tasty.Golden (findByExtension)
 
 -- |  The arguments to the executable.

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -5,29 +5,38 @@
 {- | Plutus conformance test suite library. -}
 module PlutusConformance.Common where
 
-import Control.Lens (traverseOf)
-import Control.Monad.Trans.Except
-import Data.Text qualified as T
-import Data.Text.IO qualified as T
-import MAlonzo.Code.Main (runUAgda)
 import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Error (Error (..), ParserErrorBundle)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekParameters)
 import PlutusCore.Name (Name)
 import PlutusCore.Quote (Quote, runQuote, runQuoteT)
+
 import PlutusPrelude (display, void)
+
+import UntypedPlutusCore qualified as UPLC
+import UntypedPlutusCore.DeBruijn
+import UntypedPlutusCore.Evaluation.Machine.Cek (evaluateCekNoEmit)
+import UntypedPlutusCore.Parser qualified as UPLC
+
+import Control.Lens (traverseOf)
+import Control.Monad.Trans.Except
+
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+
+import MAlonzo.Code.Main (runUAgda)
+
 import System.Directory
 import System.FilePath (takeBaseName, (</>))
+
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.ExpectedFailure (expectFail)
 import Test.Tasty.Golden (findByExtension)
 import Test.Tasty.Golden.Advanced (goldenTest)
 import Test.Tasty.Providers (TestTree)
+
 import Text.Megaparsec (SourcePos)
-import UntypedPlutusCore qualified as UPLC
-import UntypedPlutusCore.DeBruijn
-import UntypedPlutusCore.Evaluation.Machine.Cek (evaluateCekNoEmit)
-import UntypedPlutusCore.Parser qualified as UPLC
+
 import Witherable (Witherable (wither))
 
 -- Common functions for all tests

--- a/plutus-core/common/Annotation.hs
+++ b/plutus-core/common/Annotation.hs
@@ -21,9 +21,13 @@ import Data.MonoTraversable
 import Data.Semigroup (Any (..))
 import Data.Set (Set)
 import Data.Set qualified as Set
+
 import Flat (Flat (..))
+
 import GHC.Generics
+
 import Prettyprinter
+
 import Text.Megaparsec.Pos as Megaparsec
 
 newtype InlineHints name a = InlineHints { shouldInline :: a -> name -> Bool }

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Bool.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Bool.hs
@@ -1,11 +1,13 @@
 module Benchmarks.Bool (makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 
+import Common
+
 import Criterion.Main
+
+import Generators
+
 import System.Random (StdGen)
 
 -- We only have ifThenElse at the moment, which should be constant cost.

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
@@ -1,16 +1,19 @@
 -- editorconfig-checker-disable-file
 module Benchmarks.ByteStrings (makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 
+import Common
+
 import Criterion.Main
+
 import Data.ByteString qualified as BS
-import System.Random (StdGen, randomR)
+
+import Generators
 
 import Hedgehog qualified as H
+
+import System.Random (StdGen, randomR)
 
 ---------------- ByteString builtins ----------------
 

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/CryptoAndHashes.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/CryptoAndHashes.hs
@@ -5,8 +5,6 @@
 
 module Benchmarks.CryptoAndHashes (makeBenchmarks) where
 
-import Common
-import Generators
 import PlutusCore
 
 import Cardano.Crypto.DSIGN.Class (ContextDSIGN, DSIGNAlgorithm, Signable, deriveVerKeyDSIGN, genKeyDSIGN,
@@ -16,9 +14,16 @@ import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
 import Cardano.Crypto.Seed (mkSeedFromBytes)
 
+import Common
+
 import Criterion.Main (Benchmark, bgroup)
+
 import Data.ByteString (ByteString)
+
+import Generators
+
 import Hedgehog qualified as H (Seed)
+
 import System.Random (StdGen)
 
 numSamples :: Int

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Data.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Data.hs
@@ -2,13 +2,15 @@
 
 module Benchmarks.Data (makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 import PlutusCore.Data
 
+import Common
+
 import Criterion.Main
+
+import Generators
+
 import System.Random (StdGen)
 
 {- | Benchmarks for builtins operating on Data.  Recall that Data is defined by

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Integers.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Integers.hs
@@ -1,12 +1,14 @@
 -- editorconfig-checker-disable-file
 module Benchmarks.Integers (makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 
+import Common
+
 import Criterion.Main
+
+import Generators
+
 import System.Random (StdGen)
 
 ---------------- Integer builtins ----------------

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Lists.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Lists.hs
@@ -1,14 +1,18 @@
 -- editorconfig-checker-disable-file
 module Benchmarks.Lists (makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 
+import Common
+
 import Criterion.Main
+
 import Data.ByteString (ByteString)
+
+import Generators
+
 import Hedgehog qualified as H
+
 import System.Random (StdGen)
 
 

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Misc.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Misc.hs
@@ -1,11 +1,13 @@
 module Benchmarks.Misc (makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 
+import Common
+
 import Criterion.Main
+
+import Generators
+
 import System.Random (StdGen)
 
 

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -14,9 +14,6 @@
 
 module Benchmarks.Nops (makeBenchmarks) where
 
-import Common
-import Generators (randBool, randNwords)
-
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Evaluation.Machine.BuiltinCostModel hiding (BuiltinCostModel)
@@ -24,13 +21,20 @@ import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.ExMemory (ExMemoryUsage)
 import PlutusCore.Evaluation.Machine.MachineParameters (CostModel (..), MachineParameters, mkMachineParameters)
 import PlutusCore.Pretty
+
 import PlutusPrelude
+
 import UntypedPlutusCore.Evaluation.Machine.Cek
+
+import Common
 
 import Criterion.Main (Benchmark, bgroup)
 
 import Data.Char (toLower)
 import Data.Ix (Ix)
+
+import Generators (randBool, randNwords)
+
 import System.Random (StdGen)
 
 {- | A benchmark that just loads the unit constant, which is about the minimal

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Pairs.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Pairs.hs
@@ -1,11 +1,13 @@
 module Benchmarks.Pairs (makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 
+import Common
+
 import Criterion.Main
+
+import Generators
+
 import System.Random (StdGen)
 
 

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
@@ -3,13 +3,16 @@
 
 module Benchmarks.Strings (makeSizedTextStrings, makeBenchmarks) where
 
-import Common
-import Generators
-
 import PlutusCore
 
+import Common
+
 import Criterion.Main
+
 import Data.Text qualified as T
+
+import Generators
+
 import System.Random (StdGen)
 
 

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Tracing.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Tracing.hs
@@ -3,9 +3,11 @@ module Benchmarks.Tracing (makeBenchmarks) where
 import PlutusCore
 
 import Common
-import Generators
 
 import Criterion.Main
+
+import Generators
+
 import System.Random (StdGen)
 
 

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Unit.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Unit.hs
@@ -6,10 +6,13 @@ import PlutusCore
 import PlutusCore.Evaluation.Machine.ExMemory
 
 import Common
-import Generators
 
 import Control.DeepSeq (NFData)
+
 import Criterion.Main
+
+import Generators
+
 import System.Random (StdGen)
 
 

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -17,11 +17,14 @@ import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.MkPlc
 import PlutusCore.Pretty (Pretty)
+
 import UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
 import Control.DeepSeq (NFData, force)
+
 import Criterion.Main
+
 import Data.ByteString qualified as BS
 import Data.Typeable (Typeable)
 

--- a/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
+++ b/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
@@ -5,6 +5,7 @@ module CriterionExtensions (criterionMainWith, BenchmarkingPhase(..)) where
 
 import Control.Monad (unless)
 import Control.Monad.Trans (liftIO)
+
 import Criterion.Internal (runAndAnalyse, runFixedIters)
 import Criterion.IO.Printf (printError, writeCsv)
 import Criterion.Main (makeMatcher)
@@ -15,7 +16,9 @@ import Criterion.Types
 
 import Data.List (sort)
 import Data.Time.Clock (getCurrentTime)
+
 import Options.Applicative (execParser)
+
 import System.Directory (doesFileExist, renameFile)
 import System.Environment (getProgName)
 import System.Exit (exitFailure)

--- a/plutus-core/cost-model/budgeting-bench/Generators.hs
+++ b/plutus-core/cost-model/budgeting-bench/Generators.hs
@@ -7,6 +7,7 @@ import PlutusCore.Data
 import PlutusCore.Evaluation.Machine.ExMemory (ExMemoryUsage (..))
 
 import Control.Monad
+
 import Data.Bits
 import Data.ByteString (ByteString)
 import Data.Int (Int64)
@@ -18,8 +19,10 @@ import Hedgehog qualified as H
 import Hedgehog.Internal.Gen qualified as G
 import Hedgehog.Internal.Range qualified as R
 import Hedgehog.Internal.Tree qualified as T
+
 import System.IO.Unsafe (unsafePerformIO)
 import System.Random (StdGen, randomR)
+
 import Test.QuickCheck
 import Test.QuickCheck.Instances.ByteString ()
 

--- a/plutus-core/cost-model/budgeting-bench/Main.hs
+++ b/plutus-core/cost-model/budgeting-bench/Main.hs
@@ -4,8 +4,6 @@
 -- See CostModelGeneration.md
 module Main (main) where
 
-import CriterionExtensions (BenchmarkingPhase (Continue, Start), criterionMainWith)
-
 import Benchmarks.Bool qualified
 import Benchmarks.ByteStrings qualified
 import Benchmarks.CryptoAndHashes qualified
@@ -21,6 +19,9 @@ import Benchmarks.Unit qualified
 
 import Criterion.Main
 import Criterion.Types as C
+
+import CriterionExtensions (BenchmarkingPhase (Continue, Start), criterionMainWith)
+
 import System.Random (getStdGen)
 
 ---------------- Miscellaneous ----------------

--- a/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
+++ b/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
@@ -12,9 +12,11 @@ import PlutusCore.Evaluation.Machine.BuiltinCostModel
 import PlutusCore.Evaluation.Machine.ExMemory
 
 import Barbies (bmap, bsequence)
+
 import Control.Applicative (Const (Const, getConst))
 import Control.Exception (TypeError (TypeError))
 import Control.Monad.Catch (throwM)
+
 import Data.ByteString.Hash qualified as PlutusHash
 import Data.ByteString.Lazy qualified as BSL (fromStrict)
 import Data.Coerce (coerce)
@@ -24,9 +26,11 @@ import Data.Functor.Compose (Compose (Compose))
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T (encodeUtf8)
 import Data.Vector (Vector, find)
+
 import GHC.Generics (Generic)
 
 import H.Prelude (MonadR, Region)
+
 import Language.R (SomeSEXP, defaultConfig, fromSomeSEXP, runRegion, withEmbeddedR)
 import Language.R.QQ (r)
 

--- a/plutus-core/cost-model/create-cost-model/Main.hs
+++ b/plutus-core/cost-model/create-cost-model/Main.hs
@@ -5,7 +5,9 @@ import CreateBuiltinCostModel (createBuiltinCostModel)
 
 import Data.Aeson.Encode.Pretty
 import Data.ByteString.Lazy qualified as BSL (ByteString, putStr, writeFile)
+
 import Options.Applicative
+
 import System.Directory
 import System.Exit
 import System.IO (hPutStrLn, stderr)

--- a/plutus-core/cost-model/print-cost-model/Main.hs
+++ b/plutus-core/cost-model/print-cost-model/Main.hs
@@ -7,16 +7,18 @@
    builtins and print it in readable form. -}
 module Main where
 
-import Paths_plutus_core
-
 import Data.Aeson
 import Data.Aeson.Key as Key (toString)
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Lazy as BSL (getContents, readFile)
 import Data.List (intercalate)
 import Data.Text (Text)
+
+import Paths_plutus_core
+
 import System.Environment (getArgs, getProgName)
 import System.Exit
+
 import Text.Printf (printf)
 
 data ModelComponent = Cpu | Memory

--- a/plutus-core/cost-model/test/TH.hs
+++ b/plutus-core/cost-model/test/TH.hs
@@ -9,6 +9,7 @@ module TH (genTest)
 where
 
 import Data.Char (toUpper)
+
 import Language.Haskell.TH
 
 toUpper1 :: String -> String

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -17,24 +17,28 @@ import PlutusCore.Evaluation.Machine.BuiltinCostModel
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
 import PlutusCore.Evaluation.Machine.ExMemory
 
-import CreateBuiltinCostModel
-import TH
-
 import Control.Applicative (Const, getConst)
 import Control.Monad.Morph (MFunctor, hoist, lift)
+
+import CreateBuiltinCostModel
+
 import Data.Coerce (coerce)
 import Data.String (fromString)
-import Unsafe.Coerce (unsafeCoerce)
 
 import H.Prelude as H (MonadR, io)
-import Language.R as R (R, SomeSEXP, defaultConfig, fromSomeSEXP, runRegion, unsafeRunRegion, withEmbeddedR)
-import Language.R.QQ (r)
 
 import Hedgehog (Gen, Group (..), Property, PropertyName, PropertyT, TestLimit, checkSequential, diff, forAll, property,
                  withTests)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Main qualified as HH (defaultMain)
 import Hedgehog.Range qualified as Range
+
+import Language.R as R (R, SomeSEXP, defaultConfig, fromSomeSEXP, runRegion, unsafeRunRegion, withEmbeddedR)
+import Language.R.QQ (r)
+
+import TH
+
+import Unsafe.Coerce (unsafeCoerce)
 
 {- | This module is supposed to test that the R cost models for built-in functions
    defined in models.R (using the CSV output from 'cost-model-budgeting-bench'))

--- a/plutus-core/executables/debugger/Draw.hs
+++ b/plutus-core/executables/debugger/Draw.hs
@@ -4,8 +4,6 @@
 -- | Renders the debugger in the terminal.
 module Draw where
 
-import Types
-
 import Brick.AttrMap qualified as B
 import Brick.Focus qualified as B
 import Brick.Types qualified as B
@@ -13,11 +11,15 @@ import Brick.Widgets.Border qualified as BB
 import Brick.Widgets.Center qualified as BC
 import Brick.Widgets.Core qualified as B
 import Brick.Widgets.Edit qualified as BE
+
 import Data.Bifunctor
 import Data.Maybe
 import Data.Text (Text)
 import Data.Text qualified as Text
+
 import Lens.Micro
+
+import Types
 
 drawDebugger ::
     DebuggerState ->

--- a/plutus-core/executables/debugger/Event.hs
+++ b/plutus-core/executables/debugger/Event.hs
@@ -7,25 +7,34 @@
 -- | Handler of debugger events.
 module Event where
 
-import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty qualified as PLC
-import Types
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
+
+import Annotation
 
 import Brick.Focus qualified as B
 import Brick.Main qualified as B
 import Brick.Types qualified as B
 import Brick.Widgets.Edit qualified as BE
+
 import Control.Concurrent.MVar
 import Control.Monad.State
+
 import Data.Text qualified as Text
+
 import Graphics.Vty qualified as Vty
+
 import Lens.Micro
+
 import Prettyprinter
+
 import Text.Megaparsec
+
+import Types
 
 handleDebuggerEvent :: MVar (D.Cmd Breakpoints)
                     -> B.BrickEvent ResourceName CustomBrickEvent

--- a/plutus-core/executables/debugger/Main.hs
+++ b/plutus-core/executables/debugger/Main.hs
@@ -20,14 +20,11 @@ import PlutusCore.Error
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.Pretty qualified as PLC
+
 import UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
 import UntypedPlutusCore.Parser qualified as UPLC
-
-import Draw
-import Event
-import Types
 
 import Brick.AttrMap qualified as B
 import Brick.BChan qualified as B
@@ -35,17 +32,30 @@ import Brick.Focus qualified as B
 import Brick.Main qualified as B
 import Brick.Util qualified as B
 import Brick.Widgets.Edit qualified as BE
+
 import Control.Concurrent
 import Control.Monad.Except
 import Control.Monad.Extra
 import Control.Monad.ST (RealWorld)
+
 import Data.ByteString.Lazy qualified as Lazy
 import Data.Text.IO qualified as Text
+
+import Draw
+
+import Event
+
 import Flat
+
 import Graphics.Vty qualified as Vty
+
 import Lens.Micro
+
 import Options.Applicative qualified as OA
+
 import System.Directory.Extra
+
+import Types
 
 debuggerAttrMap :: B.AttrMap
 debuggerAttrMap =

--- a/plutus-core/executables/debugger/Types.hs
+++ b/plutus-core/executables/debugger/Types.hs
@@ -6,16 +6,19 @@
 -- | Debugger TUI Types.
 module Types where
 
-import Annotation
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal (CekState)
 
+import Annotation
+
 import Brick.Focus qualified as B
 import Brick.Types qualified as B
 import Brick.Widgets.Edit qualified as BE
+
 import Data.MonoTraversable
 import Data.Text (Text)
+
 import Lens.Micro.TH
 
 type Breakpoints = [Breakpoint]

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -4,27 +4,34 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Main where
 
+import PlutusCore qualified as PLC
+import PlutusCore.Error (ParserErrorBundle (..))
+import PlutusCore.Executable.Common hiding (runPrint)
+import PlutusCore.Executable.Parsers
+import PlutusCore.Quote (runQuoteT)
+
+import PlutusIR as PIR
+import PlutusIR.Analysis.RetainedSize qualified as PIR
+import PlutusIR.Compiler qualified as PIR
+import PlutusIR.Core.Plated
+
+import PlutusPrelude
+
 import Control.Lens hiding (argument, set', (<.>))
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Reader
+
 import Data.ByteString.Lazy.Char8 qualified as BSL
 import Data.Coerce
 import Data.Csv qualified as Csv
 import Data.IntMap qualified as IM
 import Data.List (sortOn)
 import Data.Text qualified as T
+
 import GHC.Generics
+
 import Options.Applicative
-import PlutusCore qualified as PLC
-import PlutusCore.Error (ParserErrorBundle (..))
-import PlutusCore.Executable.Common hiding (runPrint)
-import PlutusCore.Executable.Parsers
-import PlutusCore.Quote (runQuoteT)
-import PlutusIR as PIR
-import PlutusIR.Analysis.RetainedSize qualified as PIR
-import PlutusIR.Compiler qualified as PIR
-import PlutusIR.Core.Plated
-import PlutusPrelude
+
 import Text.Megaparsec (errorBundlePretty)
 
 type PLCTerm  = PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun (PIR.Provenance ())

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -13,12 +13,14 @@ import PlutusCore.Executable.Common
 import PlutusCore.Executable.Parsers
 import PlutusCore.Pretty qualified as PP
 
+import Control.DeepSeq (rnf)
+import Control.Lens ((&), (^.))
+
 import Data.Functor (void)
 import Data.Text.IO qualified as T
 
-import Control.DeepSeq (rnf)
-import Control.Lens ((&), (^.))
 import Options.Applicative
+
 import System.Exit (exitSuccess)
 
 plcHelpText :: String

--- a/plutus-core/executables/src/PlutusCore/Executable/Common.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Common.hs
@@ -10,8 +10,6 @@
 
 module PlutusCore.Executable.Common where
 
-import PlutusPrelude
-
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Check.Uniques as PLC (checkProgram)
@@ -32,17 +30,20 @@ import PlutusCore.StdLib.Data.ChurchNat qualified as StdLib
 import PlutusCore.StdLib.Data.Integer qualified as StdLib
 import PlutusCore.StdLib.Data.Unit qualified as StdLib
 
+import PlutusIR.Core.Type qualified as PIR
+import PlutusIR.Parser qualified as PIR (parse, program)
+
+import PlutusPrelude
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Check.Uniques qualified as UPLC (checkProgram)
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 import UntypedPlutusCore.Parser qualified as UPLC (parse, program)
 
-import PlutusIR.Core.Type qualified as PIR
-import PlutusIR.Parser qualified as PIR (parse, program)
-
 import Control.DeepSeq (rnf)
 import Control.Lens hiding (ix, op)
 import Control.Monad.Except
+
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BSL
 import Data.Foldable (traverse_)
@@ -54,13 +55,17 @@ import Data.Maybe (fromJust)
 import Data.Proxy (Proxy (..))
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
+
 import Flat (Flat, flat, unflat)
+
 import GHC.TypeLits (symbolVal)
+
 import Prettyprinter ((<+>))
 
 import System.CPUTime (getCPUTime)
 import System.Exit (exitFailure, exitSuccess)
 import System.Mem (performGC)
+
 import Text.Megaparsec (errorBundlePretty)
 import Text.Printf (printf)
 

--- a/plutus-core/executables/traceToStacks/Main.hs
+++ b/plutus-core/executables/traceToStacks/Main.hs
@@ -21,8 +21,10 @@ control this with the '--column' argument.
 module Main where
 
 import Common
+
 import Data.ByteString.Lazy qualified as BSL
 import Data.List (intercalate)
+
 import Options.Applicative
 
 column :: Parser Int

--- a/plutus-core/executables/traceToStacks/TestGetStacks.hs
+++ b/plutus-core/executables/traceToStacks/TestGetStacks.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Common
+
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -10,7 +10,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Main (main) where
 
-import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..), ExRestrictingBudget (..))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
@@ -19,28 +18,33 @@ import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.Executable.Common
 import PlutusCore.Executable.Parsers
 
-import Data.Foldable
-import Data.List (nub)
-import Data.List.Split (splitOn)
-import Data.Text qualified as T
 import PlutusPrelude
 
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.DeBruijn
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal qualified as D
+
+import Annotation
 
 import Control.DeepSeq (rnf)
 import Control.Monad.Except
+import Control.Monad.ST (RealWorld)
+
+import Data.Foldable
+import Data.List (nub)
+import Data.List.Split (splitOn)
+import Data.Maybe
+import Data.Text qualified as T
+
 import Options.Applicative
+
+import System.Console.Haskeline qualified as Repl
 import System.Exit (exitFailure)
 import System.IO (hPrint, stderr)
-import Text.Read (readMaybe)
 
-import Control.Monad.ST (RealWorld)
-import Data.Maybe
-import System.Console.Haskeline qualified as Repl
-import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
-import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal qualified as D
+import Text.Read (readMaybe)
 
 uplcHelpText :: String
 uplcHelpText = helpText "Untyped Plutus Core"

--- a/plutus-core/index-envs/bench/Main.hs
+++ b/plutus-core/index-envs/bench/Main.hs
@@ -6,8 +6,6 @@
 module Main where
 
 import Criterion.Main
-import Data.Semigroup
-import System.Random
 
 import Data.Maybe (fromJust)
 import Data.Proxy
@@ -16,8 +14,11 @@ import Data.RandomAccessList.Class
 import Data.RandomAccessList.RelativizedMap qualified as RM
 import Data.RandomAccessList.SkewBinary qualified as B
 import Data.RandomAccessList.SkewBinarySlab qualified as BS
+import Data.Semigroup
 import Data.Vector.NonEmpty qualified as NEV
 import Data.Word
+
+import System.Random
 
 ralWorkloads :: forall e . (RandomAccessList e, Element e ~ ()) => Proxy e -> [Benchmark]
 ralWorkloads _ =

--- a/plutus-core/index-envs/src/Data/RandomAccessList/Class.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/Class.hs
@@ -14,6 +14,7 @@ import Data.Maybe (fromJust, fromMaybe)
 import Data.RAList qualified as RAL
 import Data.Vector.NonEmpty qualified as NEV
 import Data.Word
+
 import GHC.Exts
 
 -- | Typeclass for various types implementing the "signature" of a random-access list.

--- a/plutus-core/index-envs/src/Data/RandomAccessList/RelativizedMap.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/RelativizedMap.hs
@@ -3,11 +3,10 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Data.RandomAccessList.RelativizedMap (RelativizedMap (..))where
 
+import Data.IntMap.Strict qualified as IM
+import Data.RandomAccessList.Class qualified as RAL
 import Data.Word
 
-import Data.RandomAccessList.Class qualified as RAL
-
-import Data.IntMap.Strict qualified as IM
 import GHC.Exts (IsList)
 
 -- | A sequence implemented by a map from "levels" to values and a counter giving the "current" level.

--- a/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinary.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinary.hs
@@ -15,10 +15,10 @@ module Data.RandomAccessList.SkewBinary
     ) where
 
 import Data.Bits (unsafeShiftR)
-import Data.Word
-import GHC.Exts
-
 import Data.RandomAccessList.Class qualified as RAL
+import Data.Word
+
+import GHC.Exts
 
 -- | A complete binary tree.
 -- Note: the size of the tree is not stored/cached,

--- a/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinarySlab.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinarySlab.hs
@@ -15,11 +15,11 @@ module Data.RandomAccessList.SkewBinarySlab
     ) where
 
 import Data.Bits (unsafeShiftR)
+import Data.RandomAccessList.Class qualified as RAL
 import Data.Vector.NonEmpty qualified as NEV
 import Data.Word
-import GHC.Exts
 
-import Data.RandomAccessList.Class qualified as RAL
+import GHC.Exts
 
 {- Note [Skew binary slab lists]
 This module implements a very similar structure to the one in 'SkewBinary', but

--- a/plutus-core/index-envs/test/RAList/Spec.hs
+++ b/plutus-core/index-envs/test/RAList/Spec.hs
@@ -10,6 +10,7 @@
 module RAList.Spec (tests) where
 
 import Control.Exception
+
 import Data.List qualified as List
 import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (fromJust, isNothing)
@@ -19,7 +20,9 @@ import Data.RandomAccessList.RelativizedMap qualified as RM
 import Data.RandomAccessList.SkewBinary qualified as B
 import Data.RandomAccessList.SkewBinarySlab qualified as BS
 import Data.Vector.NonEmpty qualified as NEV
+
 import GHC.Exts
+
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Instances ()
 import Test.Tasty

--- a/plutus-core/index-envs/test/Spec.hs
+++ b/plutus-core/index-envs/test/Spec.hs
@@ -3,6 +3,7 @@ module Main
     ) where
 
 import RAList.Spec qualified as RAList
+
 import Test.Tasty
 
 main :: IO ()

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -22,10 +22,10 @@ import PlutusCore.Builtin
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Pretty
-
 import PlutusCore.StdLib.Data.ScottList qualified as Plc
 
 import Control.Exception
+
 import Data.Default.Class
 import Data.Either
 import Data.Hashable (Hashable)
@@ -33,8 +33,10 @@ import Data.Kind qualified as GHC (Type)
 import Data.Proxy
 import Data.Tuple
 import Data.Void
+
 import GHC.Generics
 import GHC.Ix
+
 import Prettyprinter
 
 instance (Bounded a, Bounded b) => Bounded (Either a b) where

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
@@ -8,19 +8,17 @@ module PlutusCore.Examples.Data.Data
 import PlutusCore.Core
 import PlutusCore.Data
 import PlutusCore.Default
+import PlutusCore.Examples.Builtins
+import PlutusCore.Examples.Data.List
+import PlutusCore.Examples.Data.Pair
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Data
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.Integer
 import PlutusCore.StdLib.Data.List
 import PlutusCore.StdLib.Data.Pair
-
-import PlutusCore.Examples.Builtins
-import PlutusCore.Examples.Data.List
-import PlutusCore.Examples.Data.Pair
 
 import Data.ByteString (ByteString)
 

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
@@ -12,7 +12,6 @@ import PlutusCore.Core
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.Unit
 import PlutusCore.StdLib.Type

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/List.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/List.hs
@@ -6,14 +6,12 @@ module PlutusCore.Examples.Data.List
 
 import PlutusCore.Core
 import PlutusCore.Default
+import PlutusCore.Examples.Builtins
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.List
-
-import PlutusCore.Examples.Builtins
 
 -- | Monomorphic @map@ over built-in lists.
 --

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Pair.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Pair.hs
@@ -6,13 +6,11 @@ module PlutusCore.Examples.Data.Pair
 
 import PlutusCore.Core
 import PlutusCore.Default
+import PlutusCore.Examples.Builtins
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Pair
-
-import PlutusCore.Examples.Builtins
 
 -- | Apply a monomorphic function to both components of a pair.
 --

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
@@ -17,7 +17,6 @@ import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Normalize
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Type
 
 import Universe

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
@@ -15,7 +15,6 @@ import PlutusCore.Default.Builtins
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Integer
 import PlutusCore.StdLib.Data.Unit
 

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Everything.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Everything.hs
@@ -11,15 +11,8 @@ module PlutusCore.Examples.Everything
     , builtins
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core
 import PlutusCore.Default
-import PlutusCore.FsTree
-import PlutusCore.MkPlc
-
-import PlutusCore.StdLib.Type
-
 import PlutusCore.Examples.Builtins
 import PlutusCore.Examples.Data.Data
 import PlutusCore.Examples.Data.InterList
@@ -28,6 +21,11 @@ import PlutusCore.Examples.Data.Pair
 import PlutusCore.Examples.Data.Shad
 import PlutusCore.Examples.Data.TreeForest
 import PlutusCore.Examples.Data.Vec
+import PlutusCore.FsTree
+import PlutusCore.MkPlc
+import PlutusCore.StdLib.Type
+
+import PlutusPrelude
 
 -- | All examples exported as a single value.
 examples :: PlcFolderContents DefaultUni (Either DefaultFun ExtensionFun)

--- a/plutus-core/plutus-core/satint-test/TestSatInt.hs
+++ b/plutus-core/plutus-core/satint-test/TestSatInt.hs
@@ -7,9 +7,11 @@
 module Main where
 
 import Control.Exception as E
+
 import Data.List
 import Data.Maybe
 import Data.SatInt
+
 import Test.Framework as TF
 import Test.Framework.Providers.HUnit
 import Test.Framework.Providers.QuickCheck2

--- a/plutus-core/plutus-core/src/Crypto.hs
+++ b/plutus-core/plutus-core/src/Crypto.hs
@@ -10,17 +10,20 @@ module Crypto (
   verifySchnorrSecp256k1Signature,
   ) where
 
+import PlutusCore.Builtin.Emitter (Emitter, emit)
+import PlutusCore.Evaluation.Result (EvaluationResult (EvaluationFailure))
+
 import Cardano.Crypto.DSIGN.Class qualified as DSIGN
 import Cardano.Crypto.DSIGN.EcdsaSecp256k1 (EcdsaSecp256k1DSIGN, toMessageHash)
 import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
+
 import Crypto.ECC.Ed25519Donna (publicKey, signature, verify)
 import Crypto.Error (CryptoFailable (..))
+
 import Data.ByteString qualified as BS
 import Data.Kind (Type)
 import Data.Text (Text, pack)
-import PlutusCore.Builtin.Emitter (Emitter, emit)
-import PlutusCore.Evaluation.Result (EvaluationResult (EvaluationFailure))
 
 -- | Ed25519 signature verification
 -- This will fail if the key or the signature are not of the expected length.

--- a/plutus-core/plutus-core/src/Data/Aeson/Flatten.hs
+++ b/plutus-core/plutus-core/src/Data/Aeson/Flatten.hs
@@ -10,9 +10,7 @@ module Data.Aeson.Flatten
     ) where
 
 import Data.Aeson
-#if MIN_VERSION_aeson(2,0,0)
 import Data.Aeson.KeyMap
-#endif
 import Data.HashMap.Strict qualified as HM
 import Data.Text qualified as Text
 

--- a/plutus-core/plutus-core/src/Data/Aeson/THReader.hs
+++ b/plutus-core/plutus-core/src/Data/Aeson/THReader.hs
@@ -2,8 +2,10 @@
 module Data.Aeson.THReader where
 
 import Data.Aeson
+
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Syntax.Compat
+
 import TH.RelativePaths
 
 readJSONFromFile :: (FromJSON a, Lift a) => String -> SpliceQ a

--- a/plutus-core/plutus-core/src/Data/ByteString/Hash.hs
+++ b/plutus-core/plutus-core/src/Data/ByteString/Hash.hs
@@ -10,6 +10,7 @@ import Cardano.Crypto.Hash.Blake2b
 import Cardano.Crypto.Hash.Class
 import Cardano.Crypto.Hash.SHA256
 import Cardano.Crypto.Hash.SHA3_256
+
 import Data.ByteString qualified as BS
 import Data.Proxy
 

--- a/plutus-core/plutus-core/src/Data/Functor/Foldable/Monadic.hs
+++ b/plutus-core/plutus-core/src/Data/Functor/Foldable/Monadic.hs
@@ -1,7 +1,8 @@
 module Data.Functor.Foldable.Monadic (cataM) where
 
-import Data.Functor.Foldable
 import PlutusPrelude
+
+import Data.Functor.Foldable
 
 cataM :: (Recursive t, Traversable (Base t), Monad m) => (Base t a -> m a) -> t -> m a
 cataM f = c where c = f <=< (traverse c . project)

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -18,20 +18,22 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 module Data.SatInt (SatInt) where
 
 import Codec.Serialise (Serialise)
+
 import Control.DeepSeq (NFData)
+
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Bits
 import Data.Csv
 import Data.Primitive (Prim)
+
 import GHC.Base
 import GHC.Generics
-#if MIN_VERSION_base(4,16,0)
 import GHC.Integer (smallInteger)
-#else
 import GHC.Num (smallInteger)
-#endif
 import GHC.Real
+
 import Language.Haskell.TH.Syntax (Lift)
+
 import NoThunks.Class
 
 newtype SatInt = SI { unSatInt :: Int }

--- a/plutus-core/plutus-core/src/GHC/Natural/Extras.hs
+++ b/plutus-core/plutus-core/src/GHC/Natural/Extras.hs
@@ -5,6 +5,7 @@ module GHC.Natural.Extras (naturalToWord64Maybe, Natural (..)) where
 
 import Data.IntCast (intCastEq)
 import Data.Word (Word64)
+
 import GHC.Natural
 
 -- Note this will only work on 64bit platforms, but that's all we build on

--- a/plutus-core/plutus-core/src/PlutusCore/Analysis/Definitions.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Analysis/Definitions.hs
@@ -15,14 +15,13 @@ import PlutusCore.Core
 import PlutusCore.Error
 import PlutusCore.Name
 
-import Data.Functor.Foldable
-
 import Control.Lens hiding (use, uses)
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Writer
 
 import Data.Foldable
+import Data.Functor.Foldable
 import Data.Set qualified as Set
 
 {- Note [Unique usage errors]

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Elaborate.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Elaborate.hs
@@ -24,6 +24,7 @@ import PlutusCore.Core.Type
 import Data.Kind qualified as GHC
 import Data.Type.Bool
 import Data.Type.Equality
+
 import GHC.TypeLits
 
 -- The 'TryUnify' gadget explained in detail in https://github.com/effectfully/sketches/tree/master/poly-type-of-saga/part1-try-unify

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Emitter.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Emitter.hs
@@ -5,6 +5,7 @@ module PlutusCore.Builtin.Emitter
     ) where
 
 import Control.Monad.Trans.Writer.Strict (Writer, runWriter, tell)
+
 import Data.DList as DList
 import Data.Text (Text)
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownKind.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownKind.hs
@@ -11,7 +11,9 @@ import PlutusCore.Core
 
 import Data.Kind as GHC
 import Data.Proxy
+
 import GHC.Types
+
 import Universe
 
 infixr 5 `SingKindArrow`

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -31,8 +31,6 @@ module PlutusCore.Builtin.KnownType
     , readKnownSelf
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Builtin.Emitter
 import PlutusCore.Builtin.HasConstant
 import PlutusCore.Builtin.Polymorphism
@@ -40,13 +38,18 @@ import PlutusCore.Core
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Result
 
+import PlutusPrelude
+
 import Control.Monad.Except
+
 import Data.DList (DList)
 import Data.Either.Extras
 import Data.String
 import Data.Text (Text)
+
 import GHC.Exts (inline, oneShot)
 import GHC.TypeLits
+
 import Universe
 
 -- | A constraint for \"@a@ is a 'ReadKnownIn' and 'MakeKnownIn' by means of being included

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownTypeAst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownTypeAst.hs
@@ -36,7 +36,9 @@ import Data.Proxy
 import Data.Some.GADT qualified as GADT
 import Data.Text qualified as Text
 import Data.Type.Bool
+
 import GHC.TypeLits
+
 import Universe
 
 {- Note [Rep vs Type context]

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -17,8 +17,6 @@
 
 module PlutusCore.Builtin.Meaning where
 
-import PlutusPrelude
-
 import PlutusCore.Builtin.Elaborate
 import PlutusCore.Builtin.HasConstant
 import PlutusCore.Builtin.KnownKind
@@ -31,11 +29,15 @@ import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Name
 
+import PlutusPrelude
+
 import Control.DeepSeq
+
 import Data.Array
 import Data.Kind qualified as GHC
 import Data.Proxy
 import Data.Some.GADT
+
 import GHC.Exts (inline, lazy, oneShot)
 import GHC.TypeLits
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
@@ -16,15 +16,17 @@ module PlutusCore.Builtin.Polymorphism
     , TyForallRep
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Builtin.HasConstant
 import PlutusCore.Core
 import PlutusCore.Evaluation.Machine.ExMemory
 
+import PlutusPrelude
+
 import Data.Kind qualified as GHC (Type)
+
 import GHC.Ix
 import GHC.TypeLits
+
 import Universe
 
 {- Note [Motivation for polymorphic built-in functions]

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
@@ -4,12 +4,13 @@
 
 module PlutusCore.Builtin.Runtime where
 
-import PlutusPrelude
-
 import PlutusCore.Builtin.KnownType
 import PlutusCore.Evaluation.Machine.ExBudget
 
+import PlutusPrelude
+
 import Control.DeepSeq
+
 import NoThunks.Class
 
 -- | A 'BuiltinRuntime' represents a possibly partial builtin application.

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/TypeScheme.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/TypeScheme.hs
@@ -27,7 +27,9 @@ import PlutusCore.Name
 import Data.Kind qualified as GHC (Type)
 import Data.Proxy
 import Data.Text qualified as Text
+
 import GHC.TypeLits
+
 import Type.Reflection
 
 infixr 9 `TypeSchemeArrow`

--- a/plutus-core/plutus-core/src/PlutusCore/Check/Normal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Check/Normal.hs
@@ -10,10 +10,10 @@ module PlutusCore.Check.Normal
     , NormCheckError (..)
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core
 import PlutusCore.Error
+
+import PlutusPrelude
 
 import Control.Monad.Except
 

--- a/plutus-core/plutus-core/src/PlutusCore/Check/Scoping.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Check/Scoping.hs
@@ -9,6 +9,7 @@ import PlutusCore.Name
 import PlutusCore.Quote
 
 import Control.Monad.Except
+
 import Data.Coerce
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty

--- a/plutus-core/plutus-core/src/PlutusCore/Compiler.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Compiler.hs
@@ -13,6 +13,7 @@ import PlutusCore.Core
 import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.Rename
+
 import UntypedPlutusCore.Core qualified as UPLC
 import UntypedPlutusCore.Simplify qualified as UPLC
 

--- a/plutus-core/plutus-core/src/PlutusCore/Compiler/Erase.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Compiler/Erase.hs
@@ -1,6 +1,7 @@
 module PlutusCore.Compiler.Erase (eraseTerm, eraseProgram) where
 
 import PlutusCore.Core
+
 import UntypedPlutusCore.Core qualified as UPLC
 
 -- | Erase a Typed Plutus Core term to its untyped counterpart.

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
@@ -12,13 +12,13 @@
 
 module PlutusCore.Core.Instance.Eq () where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Type
 import PlutusCore.DeBruijn
 import PlutusCore.Eq
 import PlutusCore.Name
 import PlutusCore.Rename.Monad
+
+import PlutusPrelude
 
 import Universe
 

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Classic.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Classic.hs
@@ -12,15 +12,16 @@
 
 module PlutusCore.Core.Instance.Pretty.Classic () where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Instance.Pretty.Common ()
 import PlutusCore.Core.Type
 import PlutusCore.Pretty.Classic
 import PlutusCore.Pretty.PrettyConst
 
+import PlutusPrelude
+
 import Prettyprinter
 import Prettyprinter.Custom
+
 import Universe
 
 instance Pretty ann => PrettyBy (PrettyConfigClassic configName) (Kind ann) where

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Common.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Common.hs
@@ -4,9 +4,9 @@
 
 module PlutusCore.Core.Instance.Pretty.Common () where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Type
+
+import PlutusPrelude
 
 instance Pretty (Version ann) where
     pretty (Version _ i j k) = pretty i <> "." <> pretty j <> "." <> pretty k

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Default.hs
@@ -9,13 +9,13 @@
 
 module PlutusCore.Core.Instance.Pretty.Default () where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Instance.Pretty.Classic ()
 import PlutusCore.Core.Type
 import PlutusCore.Name
 import PlutusCore.Pretty.Classic
 import PlutusCore.Pretty.PrettyConst
+
+import PlutusPrelude
 
 import Universe
 

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Plc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Plc.hs
@@ -6,12 +6,12 @@
 
 module PlutusCore.Core.Instance.Pretty.Plc () where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Instance.Pretty.Classic ()
 import PlutusCore.Core.Instance.Pretty.Readable ()
 import PlutusCore.Core.Type
 import PlutusCore.Pretty.Plc
+
+import PlutusPrelude
 
 deriving via PrettyAny (Kind ann)
     instance DefaultPrettyPlcStrategy (Kind ann) =>

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Readable.hs
@@ -12,15 +12,17 @@
 
 module PlutusCore.Core.Instance.Pretty.Readable (typeBinderDocM) where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Instance.Pretty.Common ()
 import PlutusCore.Core.Type
 import PlutusCore.Pretty.PrettyConst
 import PlutusCore.Pretty.Readable
 
+import PlutusPrelude
+
 import Control.Monad.Reader
+
 import Prettyprinter
+
 import Universe
 
 -- | Pretty-print a binding at the type level.

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Recursive.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Recursive.hs
@@ -12,6 +12,7 @@ module PlutusCore.Core.Instance.Recursive
     ) where
 
 import PlutusCore.Core.Type
+
 import PlutusPrelude
 
 import Data.Functor.Foldable.TH

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
@@ -25,10 +25,10 @@ module PlutusCore.Core.Plated
     , termUniquesDeep
     ) where
 
-import PlutusPrelude ((<^>))
-
 import PlutusCore.Core.Type
 import PlutusCore.Name
+
+import PlutusPrelude ((<^>))
 
 import Control.Lens
 

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
@@ -53,16 +53,20 @@ module PlutusCore.Core.Type
     )
 where
 
-import PlutusPrelude
-
 import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Name
 
+import PlutusPrelude
+
 import Control.Lens
+
 import Data.Hashable
 import Data.Kind qualified as GHC
+
 import Instances.TH.Lift ()
+
 import Language.Haskell.TH.Lift
+
 import Universe
 
 data Kind ann

--- a/plutus-core/plutus-core/src/PlutusCore/Data.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Data.hs
@@ -16,8 +16,10 @@ import Codec.CBOR.Encoding qualified as CBOR
 import Codec.CBOR.Magic qualified as CBOR
 import Codec.Serialise (Serialise (decode, encode))
 import Codec.Serialise.Decoding (decodeSequenceLenIndef, decodeSequenceLenN)
+
 import Control.DeepSeq (NFData)
 import Control.Monad.Except
+
 import Data.Bits (shiftR)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base64 qualified as Base64
@@ -25,9 +27,13 @@ import Data.ByteString.Lazy qualified as BSL
 import Data.Data qualified
 import Data.Text.Encoding qualified as Text
 import Data.Word (Word64, Word8)
+
 import GHC.Generics
+
 import NoThunks.Class
+
 import Prelude
+
 import Prettyprinter
 
 -- Attempting to make this strict made code slower by 2%,

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
@@ -32,9 +32,8 @@ module PlutusCore.DeBruijn
     , fromFake, toFake
     ) where
 
-import PlutusCore.DeBruijn.Internal
-
 import PlutusCore.Core.Type
+import PlutusCore.DeBruijn.Internal
 import PlutusCore.Name
 import PlutusCore.Quote
 

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -47,6 +47,7 @@ import PlutusCore.Name
 import PlutusCore.Pretty
 import PlutusCore.Quote
 
+import Control.DeepSeq (NFData)
 import Control.Exception
 import Control.Lens hiding (Index, Level, index, ix)
 import Control.Monad.Error.Lens
@@ -55,14 +56,14 @@ import Control.Monad.Reader
 import Control.Monad.State
 
 import Data.Bimap qualified as BM
+import Data.Coerce
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Word
-import Prettyprinter
 
-import Control.DeepSeq (NFData)
-import Data.Coerce
 import GHC.Generics
+
+import Prettyprinter
 
 -- | A relative index used for de Bruijn identifiers.
 newtype Index = Index Word64

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -14,8 +14,6 @@
 
 module PlutusCore.Default.Builtins where
 
-import PlutusPrelude
-
 import PlutusCore.Builtin
 import PlutusCore.Data
 import PlutusCore.Default.Universe
@@ -25,9 +23,13 @@ import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Evaluation.Result
 import PlutusCore.Pretty
 
+import PlutusPrelude
+
 import Codec.Serialise (serialise)
+
 import Crypto (verifyEcdsaSecp256k1Signature, verifyEd25519Signature_V1, verifyEd25519Signature_V2,
                verifySchnorrSecp256k1Signature)
+
 import Data.ByteString qualified as BS
 import Data.ByteString.Hash qualified as Hash
 import Data.ByteString.Lazy qualified as BSL
@@ -35,9 +37,11 @@ import Data.Char
 import Data.Ix
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8', encodeUtf8)
+
 import Flat hiding (from, to)
 import Flat.Decoder
 import Flat.Encoder as Flat
+
 import Prettyprinter (viaShow)
 
 -- See Note [Pattern matching on built-in types].

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -42,6 +42,7 @@ import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Result
 
 import Control.Applicative
+
 import Data.Bits (toIntegralSized)
 import Data.ByteString qualified as BS
 import Data.Int
@@ -49,10 +50,13 @@ import Data.IntCast (intCastEq)
 import Data.Proxy
 import Data.Text qualified as Text
 import Data.Word
+
 import GHC.Exts (inline, oneShot)
+
 import Text.Pretty
 import Text.PrettyBy
 import Text.PrettyBy.Fixity
+
 import Universe as Export
 
 {- Note [PLC types and universes]

--- a/plutus-core/plutus-core/src/PlutusCore/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Eq.hs
@@ -19,10 +19,10 @@ module PlutusCore.Eq
     , eqM
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Name
 import PlutusCore.Rename.Monad
+
+import PlutusPrelude
 
 import Control.Lens
 

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -29,19 +29,23 @@ module PlutusCore.Error
     , ShowErrorComponent (..)
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core
 import PlutusCore.DeBruijn.Internal
 import PlutusCore.Name
 import PlutusCore.Pretty
 
+import PlutusPrelude
+
 import Control.Lens hiding (use)
 import Control.Monad.Error.Lens
 import Control.Monad.Except
+
 import Data.Text qualified as T
+
 import Prettyprinter (hardline, hsep, indent, squotes, (<+>))
+
 import Text.Megaparsec as M
+
 import Universe
 
 -- | Lifts an 'Either' into an error context where we can embed the 'Left' value into the error.

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
@@ -39,17 +39,20 @@ module PlutusCore.Evaluation.Machine.BuiltinCostModel
     )
 where
 
-import PlutusPrelude hiding (toList)
-
 import PlutusCore.Evaluation.Machine.CostingFun.Core
 import PlutusCore.Evaluation.Machine.CostingFun.JSON ()
 import PlutusCore.Evaluation.Machine.ExBudget
 
+import PlutusPrelude hiding (toList)
+
 import Barbies
+
 import Data.Aeson
 import Data.Kind qualified as Kind
 import Data.Monoid
+
 import Deriving.Aeson
+
 import Language.Haskell.TH.Syntax hiding (Name, newName)
 
 type BuiltinCostModel = BuiltinCostModelBase CostingFun

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -26,8 +26,6 @@ module PlutusCore.Evaluation.Machine.Ck
     , readKnownCk
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Evaluation.Machine.Exception
@@ -37,13 +35,17 @@ import PlutusCore.Name
 import PlutusCore.Pretty (PrettyConfigPlc, PrettyConst)
 import PlutusCore.Subst
 
+import PlutusPrelude
+
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.ST
+
 import Data.DList (DList)
 import Data.DList qualified as DList
 import Data.STRef
 import Data.Text (Text)
+
 import Universe
 
 infix 4 |>, <|

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -16,16 +16,19 @@ where
 
 import PlutusCore.Evaluation.Machine.BuiltinCostModel ()
 import PlutusCore.Evaluation.Machine.MachineParameters (CostModel (..))
+
 import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts (CekMachineCosts, cekMachineCostsPrefix)
 
 import Control.Exception
 import Control.Monad.Except
+
 import Data.Aeson
 import Data.Aeson.Flatten
 import Data.HashMap.Strict qualified as HM
 import Data.Map qualified as Map
 import Data.Map.Merge.Lazy qualified as Map
 import Data.Text qualified as Text
+
 import Prettyprinter
 
 {- Note [Cost model parameters]

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -37,10 +37,14 @@ import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExMemory
 
 import Control.DeepSeq
+
 import Data.Default.Class
 import Data.Hashable
+
 import Deriving.Aeson
+
 import GHC.Exts
+
 import Language.Haskell.TH.Syntax hiding (Name, newName)
 
 -- | A class used for convenience in this module, don't export it.

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/JSON.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/JSON.hs
@@ -12,10 +12,11 @@
 -- a lot of time optimizing loads of Core whose performance doesn't matter.
 module PlutusCore.Evaluation.Machine.CostingFun.JSON () where
 
-import Data.Aeson
-import Deriving.Aeson
-
 import PlutusCore.Evaluation.Machine.CostingFun.Core
+
+import Data.Aeson
+
+import Deriving.Aeson
 
 type ModelJSON prefix = CustomJSON '[FieldLabelModifier (StripPrefix prefix, CamelToSnake)]
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -146,14 +146,20 @@ module PlutusCore.Evaluation.Machine.ExBudget
 where
 
 import PlutusCore.Evaluation.Machine.ExMemory
+
 import PlutusPrelude hiding (toList)
 
 import Codec.Serialise (Serialise (..))
+
 import Data.Char (toLower)
 import Data.Semigroup
+
 import Deriving.Aeson
+
 import Language.Haskell.TH.Lift (Lift)
+
 import NoThunks.Class
+
 import Prettyprinter
 
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -17,20 +17,20 @@ module PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 where
 
 import PlutusCore.Builtin
-
 import PlutusCore.DataFilePaths qualified as DFP
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.BuiltinCostModel
 import PlutusCore.Evaluation.Machine.CostModelInterface
 import PlutusCore.Evaluation.Machine.MachineParameters
 
+import PlutusPrelude
+
 import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
 import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
 import Data.Aeson.THReader
--- Not using 'noinline' from "GHC.Exts", because our CI was unable to find it there, somehow.
+
 import GHC.Magic (noinline)
-import PlutusPrelude
 
 -- | The default cost model for built-in functions.
 defaultBuiltinCostModel :: BuiltinCostModel

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -19,21 +19,28 @@ module PlutusCore.Evaluation.Machine.ExMemory
 
 import PlutusCore.Data
 import PlutusCore.Pretty
+
 import PlutusPrelude
 
 import Codec.Serialise (Serialise)
+
 import Control.Monad.RWS.Strict
+
 import Data.Aeson
 import Data.ByteString qualified as BS
 import Data.Proxy
 import Data.SatInt
 import Data.Text qualified as T
+
 import GHC.Exts (Int (I#))
 import GHC.Integer
 import GHC.Integer.Logarithms
 import GHC.Prim
+
 import Language.Haskell.TH.Syntax (Lift)
+
 import NoThunks.Class
+
 import Universe
 
 {-

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
@@ -32,18 +32,20 @@ module PlutusCore.Evaluation.Machine.Exception
     , unsafeExtractEvaluationResult
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Instance.Pretty.Common ()
 import PlutusCore.Evaluation.Result
 import PlutusCore.Pretty
 
+import PlutusPrelude
+
 import Control.Lens
 import Control.Monad.Error.Lens (throwing, throwing_)
 import Control.Monad.Except
+
 import Data.Either.Extras
 import Data.String (IsString)
 import Data.Text (Text)
+
 import Prettyprinter
 
 -- | When unlifting of a PLC term into a Haskell value fails, this error is thrown.

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -12,8 +12,10 @@ import PlutusCore.Builtin
 
 import Control.DeepSeq
 import Control.Lens
+
 import GHC.Exts (inline)
 import GHC.Generics
+
 import NoThunks.Class
 
 {-| We need to account for the costs of evaluator steps and also built-in function

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
@@ -9,9 +9,11 @@ import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.CostModelInterface
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.MachineParameters
+
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
 import Control.Monad.Except
+
 import GHC.Exts (inline)
 
 type DefaultMachineParameters =

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
@@ -16,9 +16,9 @@ module PlutusCore.Evaluation.Result
     , isEvaluationFailure
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Pretty
+
+import PlutusPrelude
 
 import Control.Lens
 import Control.Monad.Except

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -25,14 +25,18 @@ import PlutusCore.DeBruijn
 import PlutusCore.Name
 
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
+
 import Data.Coerce
 import Data.Functor
 import Data.Proxy
 import Data.Word (Word8)
+
 import Flat
 import Flat.Decoder
 import Flat.Encoder
+
 import GHC.Natural.Extras
+
 import Universe
 
 {- Note [Stable encoding of PLC]

--- a/plutus-core/plutus-core/src/PlutusCore/Mark.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Mark.hs
@@ -5,10 +5,11 @@ module PlutusCore.Mark
     , markNonFreshProgram
     ) where
 
-import Data.Set.Lens (setOf)
 import PlutusCore.Core
 import PlutusCore.Name
 import PlutusCore.Quote
+
+import Data.Set.Lens (setOf)
 
 -- | Marks all the 'Unique's in a type as used, so they will not be generated in future. Useful if you
 -- have a type which was not generated in 'Quote'.

--- a/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
@@ -46,10 +46,11 @@ module PlutusCore.MkPlc
     , mkIterKindArrow
     ) where
 
-import PlutusPrelude
-import Prelude hiding (error)
-
 import PlutusCore.Core
+
+import PlutusPrelude
+
+import Prelude hiding (error)
 
 import Universe
 

--- a/plutus-core/plutus-core/src/PlutusCore/Name.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Name.hs
@@ -35,16 +35,19 @@ module PlutusCore.Name
     , isEmpty
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Pretty.ConfigName
 
+import PlutusPrelude
+
 import Control.Lens
+
 import Data.Hashable
 import Data.IntMap.Strict qualified as IM
 import Data.Text (Text)
 import Data.Text qualified as T
+
 import Instances.TH.Lift ()
+
 import Language.Haskell.TH.Syntax (Lift)
 
 -- | A 'Name' represents variables/names in Plutus Core.

--- a/plutus-core/plutus-core/src/PlutusCore/Normalize/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Normalize/Internal.hs
@@ -20,11 +20,13 @@ import PlutusCore.MkPlc (mkTyBuiltinOf)
 import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.Rename
+
 import PlutusPrelude
 
 import Control.Lens
 import Control.Monad.Reader
 import Control.Monad.State
+
 import Universe
 
 {- Note [Global uniqueness]

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -13,8 +13,6 @@ module PlutusCore.Parser
     , ParserError(..)
     ) where
 
-import Control.Monad.Except (MonadError)
-import Data.Text (Text)
 import PlutusCore.Core (Program (..), Term (..), Type)
 import PlutusCore.Default
 import PlutusCore.Error (AsParserErrorBundle, ParserError (..))
@@ -24,6 +22,11 @@ import PlutusCore.Parser.Builtin as Export
 import PlutusCore.Parser.ParserCommon as Export
 import PlutusCore.Parser.Type as Export
 import PlutusCore.Quote (MonadQuote)
+
+import Control.Monad.Except (MonadError)
+
+import Data.Text (Text)
+
 import Text.Megaparsec (MonadParsec (notFollowedBy), SourcePos, anySingle, choice, getSourcePos, many, some, try)
 
 -- | A parsable PLC term.

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -4,19 +4,21 @@
 
 module PlutusCore.Parser.Builtin where
 
-import PlutusPrelude (Word8, reoption)
-
 import PlutusCore.Default
 import PlutusCore.Error (ParserError (UnknownBuiltinFunction))
 import PlutusCore.Parser.ParserCommon
 import PlutusCore.Parser.Type (defaultUni)
 import PlutusCore.Pretty (display)
 
+import PlutusPrelude (Word8, reoption)
+
 import Control.Monad.Combinators
+
 import Data.ByteString (ByteString, pack)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Text.Internal.Read (hexDigitToInt)
+
 import Text.Megaparsec (customFailure, getSourcePos, takeWhileP)
 import Text.Megaparsec.Char (char, hexDigitChar)
 import Text.Megaparsec.Char.Lexer qualified as Lex

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
@@ -6,20 +6,23 @@
 
 module PlutusCore.Parser.ParserCommon where
 
-import Data.Char (isAlphaNum)
-import Data.Map qualified as M
-import Data.Text qualified as T
-import PlutusPrelude
-import Text.Megaparsec hiding (ParseError, State, parse, some)
-import Text.Megaparsec.Char (char, letterChar, space1)
-import Text.Megaparsec.Char.Lexer qualified as Lex hiding (hexadecimal)
-
-import Control.Monad.Except
-import Control.Monad.State (MonadState (get, put), StateT, evalStateT)
 import PlutusCore.Core.Type
 import PlutusCore.Error
 import PlutusCore.Name
 import PlutusCore.Quote
+
+import PlutusPrelude
+
+import Control.Monad.Except
+import Control.Monad.State (MonadState (get, put), StateT, evalStateT)
+
+import Data.Char (isAlphaNum)
+import Data.Map qualified as M
+import Data.Text qualified as T
+
+import Text.Megaparsec hiding (ParseError, State, parse, some)
+import Text.Megaparsec.Char (char, letterChar, space1)
+import Text.Megaparsec.Char.Lexer qualified as Lex hiding (hexadecimal)
 
 {- Note [Whitespace invariant]
 Every top-level 'Parser' must consume all whitespace after the thing that it parses, hence make

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
@@ -5,8 +5,6 @@
 
 module PlutusCore.Parser.Type where
 
-import PlutusPrelude
-
 import PlutusCore.Core.Type
 import PlutusCore.Data
 import PlutusCore.Default
@@ -14,9 +12,13 @@ import PlutusCore.MkPlc (mkIterTyApp)
 import PlutusCore.Name
 import PlutusCore.Parser.ParserCommon
 
+import PlutusPrelude
+
 import Control.Monad
+
 import Data.ByteString (ByteString)
 import Data.Text (Text)
+
 import Text.Megaparsec hiding (ParseError, State, many, parse, some)
 
 -- | A PLC @Type@ to be parsed. ATM the parser only works

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Classic.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Classic.hs
@@ -15,9 +15,9 @@ module PlutusCore.Pretty.Classic
     , prettyClassicDebug
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Pretty.ConfigName
+
+import PlutusPrelude
 
 import Prettyprinter.Internal (Doc (Empty))
 

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Default.hs
@@ -6,9 +6,9 @@ module PlutusCore.Pretty.Default
     , displayPlcCondensedErrorClassic
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Pretty.Plc
+
+import PlutusPrelude
 
 -- | Pretty-print a value in the default mode using the classic view.
 prettyPlcDef :: PrettyPlc a => a -> Doc ann

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Extra.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Extra.hs
@@ -12,6 +12,7 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
+
 import Text.PrettyBy.Internal
 
 instance PrettyDefaultBy config [(k, v)] => DefaultPrettyBy config (Map k v) where

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Plc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Plc.hs
@@ -30,11 +30,11 @@ module PlutusCore.Pretty.Plc
     , prettyPlcCondensedErrorBy
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Pretty.Classic
 import PlutusCore.Pretty.ConfigName
 import PlutusCore.Pretty.Readable
+
+import PlutusPrelude
 
 -- | Whether to pretty-print PLC errors in full or with some information omitted.
 data CondensedErrors

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
@@ -16,6 +16,7 @@ module PlutusCore.Pretty.PrettyConst where
 import PlutusCore.Data
 
 import Codec.Serialise (serialise)
+
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Coerce
@@ -23,11 +24,15 @@ import Data.Foldable (fold)
 import Data.Proxy
 import Data.Text qualified as T
 import Data.Word (Word8)
+
 import Numeric (showHex)
+
 import Prettyprinter
 import Prettyprinter.Internal (Doc (Text))
+
 import Text.PrettyBy
 import Text.PrettyBy.Internal (DefaultPrettyBy (..))
+
 import Universe
 
 {- Note [Prettyprinting built-in constants]

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Readable.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Readable.hs
@@ -12,11 +12,12 @@ module PlutusCore.Pretty.Readable
     , module PlutusCore.Pretty.Readable
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Pretty.ConfigName
 
+import PlutusPrelude
+
 import Control.Lens
+
 import Text.Pretty
 import Text.PrettyBy.Fixity as Export
 

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Utils.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Utils.hs
@@ -8,7 +8,9 @@ import PlutusPrelude
 
 import Data.ByteString qualified as BS
 import Data.Text qualified as T
+
 import Numeric (showHex)
+
 import Prettyprinter.Internal
 
 asBytes :: Word8 -> Doc ann

--- a/plutus-core/plutus-core/src/PlutusCore/Quote.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Quote.hs
@@ -24,9 +24,9 @@ module PlutusCore.Quote
     , markNonFreshMax
     ) where
 
-import PlutusPrelude (fromMaybe)
-
 import PlutusCore.Name (Name (Name), TyName (TyName), Unique (..))
+
+import PlutusPrelude (fromMaybe)
 
 import Control.Monad.Except
 import Control.Monad.Morph as MM
@@ -34,10 +34,12 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Maybe
 import Control.Monad.Writer
+
 import Data.Functor.Identity
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
+
 import Hedgehog (GenT, PropertyT)
 
 -- | The state contains the "next" 'Unique' that should be used for a name

--- a/plutus-core/plutus-core/src/PlutusCore/Rename.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Rename.hs
@@ -15,13 +15,13 @@ module PlutusCore.Rename
     , liftDupable
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core
 import PlutusCore.Mark
 import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.Rename.Internal
+
+import PlutusPrelude
 
 {- Note [Marking]
 We use functions from the @markNonFresh*@ family in order to ensure that bound variables never get

--- a/plutus-core/plutus-core/src/PlutusCore/Rename/Monad.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Rename/Monad.hs
@@ -21,10 +21,10 @@ module PlutusCore.Rename.Monad
     , withRenamedName
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Name
 import PlutusCore.Quote
+
+import PlutusPrelude
 
 import Control.Lens
 import Control.Monad.Reader

--- a/plutus-core/plutus-core/src/PlutusCore/Size.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Size.hs
@@ -11,13 +11,15 @@ module PlutusCore.Size
     , serialisedSize
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core
 
+import PlutusPrelude
+
 import Control.Lens
+
 import Data.ByteString qualified as BS
 import Data.Monoid
+
 import Flat hiding (to)
 
 newtype Size = Size

--- a/plutus-core/plutus-core/src/PlutusCore/Subst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Subst.hs
@@ -24,12 +24,13 @@ module PlutusCore.Subst
     , tvTy
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core
+
+import PlutusPrelude
 
 import Control.Lens
 import Control.Lens.Unsound qualified as Unsound
+
 import Data.Set as Set
 
 purely :: ((a -> Identity b) -> c -> Identity d) -> (a -> b) -> c -> d

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
@@ -26,8 +26,6 @@ module PlutusCore.TypeCheck
     , checkTypeOfProgram
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
@@ -36,6 +34,8 @@ import PlutusCore.Normalize
 import PlutusCore.Quote
 import PlutusCore.Rename
 import PlutusCore.TypeCheck.Internal
+
+import PlutusPrelude
 
 -- | The constraint for built-in types/functions are kind/type-checkable.
 --

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
@@ -27,15 +27,16 @@ import PlutusCore.Normalize.Internal (MonadNormalizeType)
 import PlutusCore.Normalize.Internal qualified as Norm
 import PlutusCore.Quote
 import PlutusCore.Rename
+
 import PlutusPrelude
 
 import Control.Lens
 import Control.Monad.Error.Lens
 import Control.Monad.Except
--- Using @transformers@ rather than @mtl@, because the former doesn't impose the 'Monad' constraint
--- on 'local'.
 import Control.Monad.Trans.Reader
+
 import Data.Array
+
 import Universe
 
 {- Note [Global uniqueness]

--- a/plutus-core/plutus-core/src/Universe/Core.hs
+++ b/plutus-core/plutus-core/src/Universe/Core.hs
@@ -54,6 +54,7 @@ import Control.Applicative
 import Control.DeepSeq
 import Control.Monad
 import Control.Monad.Trans.State.Strict
+
 import Data.GADT.Compare
 import Data.GADT.Compare.TH
 import Data.GADT.DeepSeq
@@ -62,7 +63,9 @@ import Data.Kind
 import Data.Proxy
 import Data.Some.Newtype
 import Data.Type.Equality
+
 import Text.Show.Deriving
+
 import Type.Reflection
 
 {- Note [Universes]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
@@ -16,7 +16,6 @@ import PlutusCore.Default.Builtins
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Unit
 
 import Universe

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
@@ -10,19 +10,19 @@ module PlutusCore.StdLib.Data.Data
     , caseData
     ) where
 
-import Prelude hiding (uncurry)
-
 import PlutusCore.Core
 import PlutusCore.Data
 import PlutusCore.Default
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
-import Data.ByteString (ByteString)
 import PlutusCore.StdLib.Data.Integer
 import PlutusCore.StdLib.Data.Pair
 import PlutusCore.StdLib.Data.Unit
+
+import Data.ByteString (ByteString)
+
+import Prelude hiding (uncurry)
 
 -- | @Data@ as a built-in PLC type.
 dataTy :: uni `Contains` Data => Type TyName uni ()

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Function.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Function.hs
@@ -20,19 +20,19 @@ module PlutusCore.StdLib.Data.Function
     , getSingleFixOf
     ) where
 
-import PlutusPrelude
-import Prelude hiding (const)
-
 import PlutusCore.Core
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Meta.Data.Tuple
 import PlutusCore.StdLib.Type
 
+import PlutusPrelude
+
 import Control.Lens.Indexed (ifor)
 import Control.Monad
+
+import Prelude hiding (const)
 
 -- | 'id' as a PLC term.
 --

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/List.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/List.hs
@@ -14,16 +14,15 @@ module PlutusCore.StdLib.Data.List
     , product
     ) where
 
-import Prelude hiding (enumFromTo, map, product, reverse, sum)
-
 import PlutusCore.Core
 import PlutusCore.Default
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.Unit
+
+import Prelude hiding (enumFromTo, map, product, reverse, sum)
 
 -- | @[]@ as a built-in PLC type.
 list :: uni `Contains` [] => Type TyName uni ()

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
@@ -14,16 +14,15 @@ module PlutusCore.StdLib.Data.Nat
     , natToInteger
     ) where
 
-import Prelude hiding (succ)
-
 import PlutusCore.Core
 import PlutusCore.Default.Builtins
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Type
+
+import Prelude hiding (succ)
 
 import Universe
 

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
@@ -11,13 +11,13 @@ module PlutusCore.StdLib.Data.Pair
     , uncurry
     ) where
 
-import Prelude hiding (fst, snd, uncurry)
-
 import PlutusCore.Core
 import PlutusCore.Default
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
+
+import Prelude hiding (fst, snd, uncurry)
 
 -- | @(,)@ as a built-in PLC type.
 pair :: uni `Contains` (,) => Type TyName uni ()

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
@@ -19,19 +19,18 @@ module PlutusCore.StdLib.Data.ScottList
     , product
     ) where
 
-import Prelude hiding (enumFromTo, map, product, reverse, sum)
-
 import PlutusCore.Core
 import PlutusCore.Default.Builtins
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Bool
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.Integer
 import PlutusCore.StdLib.Data.Unit
 import PlutusCore.StdLib.Type
+
+import Prelude hiding (enumFromTo, map, product, reverse, sum)
 
 import Universe
 

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Sum.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Sum.hs
@@ -8,12 +8,12 @@ module PlutusCore.StdLib.Data.Sum
     , right
     ) where
 
-import Prelude hiding (sum)
-
 import PlutusCore.Core
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
+
+import Prelude hiding (sum)
 
 -- | 'Either' as a PLC type.
 --

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Everything.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Everything.hs
@@ -12,7 +12,6 @@ module PlutusCore.StdLib.Everything
 
 import PlutusCore.Default
 import PlutusCore.FsTree
-
 import PlutusCore.StdLib.Data.Bool
 import PlutusCore.StdLib.Data.ChurchNat
 import PlutusCore.StdLib.Data.Data

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta.hs
@@ -11,7 +11,6 @@ module PlutusCore.StdLib.Meta
 import PlutusCore.Core
 import PlutusCore.MkPlc
 import PlutusCore.Name
-
 import PlutusCore.StdLib.Data.Nat as Plc
 import PlutusCore.StdLib.Data.ScottList
 import PlutusCore.StdLib.Data.Sum

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -17,14 +17,15 @@ module PlutusCore.StdLib.Meta.Data.Tuple
     , getSpineToTuple
     ) where
 
-import PlutusPrelude (showText)
-
 import PlutusCore.Core
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
 
+import PlutusPrelude (showText)
+
 import Control.Lens.Indexed (ifor, itraverse)
+
 import Data.Traversable
 
 -- | A Plutus Core (Scott-encoded) tuple.

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
@@ -10,13 +10,13 @@ module PlutusCore.StdLib.Type
     , makeRecursiveType
     ) where
 
-import PlutusPrelude
-
 import PlutusCore.Core
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Pretty
 import PlutusCore.Quote
+
+import PlutusPrelude
 
 {- Note [Arity of patterns functors]
 The arity of a pattern functor is the number of arguments the pattern functor receives in addition

--- a/plutus-core/plutus-core/test/CBOR/DataStability.hs
+++ b/plutus-core/plutus-core/test/CBOR/DataStability.hs
@@ -33,14 +33,16 @@ where
 import PlutusCore.Data
 
 import Codec.Serialise (deserialise)
+
 import Data.ByteString.Lazy qualified as BSL (fromStrict, length)
 import Data.Maybe (fromJust)
 import Data.Text (Text)
-import Text.Hex (decodeHex)
-import Text.Printf (printf)
 
 import Test.Tasty
 import Test.Tasty.HUnit
+
+import Text.Hex (decodeHex)
+import Text.Printf (printf)
 
 tests :: TestTree
 tests = testGroup "CBOR"

--- a/plutus-core/plutus-core/test/Check/Spec.hs
+++ b/plutus-core/plutus-core/test/Check/Spec.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE TypeApplications  #-}
 module Check.Spec (tests) where
 
-import PlutusPrelude
-
 import PlutusCore
 import PlutusCore.Check.Normal qualified as Normal
 import PlutusCore.Check.Uniques qualified as Uniques
@@ -14,9 +12,14 @@ import PlutusCore.Generators.Hedgehog
 import PlutusCore.Generators.Hedgehog.AST
 import PlutusCore.MkPlc
 
+import PlutusPrelude
+
 import Control.Monad.Except
+
 import Data.Either
+
 import Hedgehog hiding (Var)
+
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -19,13 +19,19 @@ import Data.Either.Extras
 import Data.Map qualified as Map
 import Data.Maybe
 import Data.Text qualified as Text
+
 import Instances.TH.Lift ()
+
 import Language.Haskell.TH.Syntax qualified as TH
+
 import Prettyprinter
+
 import System.FilePath
+
+import TH.RelativePaths
+
 import Test.Tasty
 import Test.Tasty.HUnit
-import TH.RelativePaths
 
 {- Note [Testing the expected ledger cost model parameters]
 The ledger is going to call us with a particular 'CostModelParams'. This will be originally derived from the model

--- a/plutus-core/plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Machines.hs
@@ -6,7 +6,6 @@ module Evaluation.Machines
     )
 where
 
-import GHC.Exts (fromString)
 import PlutusCore
 import PlutusCore.Evaluation.Machine.Ck
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
@@ -14,6 +13,8 @@ import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Generators.Hedgehog.Interesting
 import PlutusCore.Generators.Hedgehog.Test
 import PlutusCore.Pretty
+
+import GHC.Exts (fromString)
 
 import Test.Tasty
 import Test.Tasty.Hedgehog

--- a/plutus-core/plutus-core/test/Evaluation/Spec.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Spec.hs
@@ -18,18 +18,25 @@ import PlutusCore.Builtin as PLC
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Generators.Hedgehog (GenArbitraryTerm (..), GenTypedTerm (..), forAllNoShow)
 import PlutusCore.Pretty
+
 import PlutusPrelude
 
 import Control.Exception
 import Control.Monad.Except
+
 import Data.Ix
 import Data.Kind qualified as GHC
+
 import Evaluation.Machines (test_machines)
+
 import GHC.Exts (fromString)
+
 import Hedgehog hiding (Opaque, Var, eval)
 import Hedgehog.Gen qualified as Gen
+
 import Test.Tasty
 import Test.Tasty.Hedgehog
+
 import Type.Reflection
 
 type Term uni fun = PLC.Term TyName Name uni fun ()

--- a/plutus-core/plutus-core/test/Names/Spec.hs
+++ b/plutus-core/plutus-core/test/Names/Spec.hs
@@ -7,21 +7,21 @@
 
 module Names.Spec where
 
-import PlutusCore.Test
-
 import PlutusCore
 import PlutusCore.DeBruijn
-import PlutusCore.Mark
-import PlutusCore.Pretty
-import PlutusCore.Rename.Internal
-
 import PlutusCore.Generators.Hedgehog
 import PlutusCore.Generators.Hedgehog.AST as AST
 import PlutusCore.Generators.Hedgehog.Interesting
+import PlutusCore.Mark
+import PlutusCore.Pretty
+import PlutusCore.Rename.Internal
+import PlutusCore.Test
 
 import GHC.Exts (fromString)
+
 import Hedgehog hiding (Var)
 import Hedgehog.Gen qualified as Gen
+
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit

--- a/plutus-core/plutus-core/test/Normalization/Check.hs
+++ b/plutus-core/plutus-core/test/Normalization/Check.hs
@@ -4,6 +4,7 @@ module Normalization.Check ( test_normalizationCheck ) where
 
 import PlutusCore
 import PlutusCore.Check.Normal
+
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/plutus-core/plutus-core/test/Normalization/Type.hs
+++ b/plutus-core/plutus-core/test/Normalization/Type.hs
@@ -14,6 +14,7 @@ import Control.Monad.Morph (hoist)
 
 import Hedgehog
 import Hedgehog.Internal.Property (forAllT)
+
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit

--- a/plutus-core/plutus-core/test/Pretty/Readable.hs
+++ b/plutus-core/plutus-core/test/Pretty/Readable.hs
@@ -1,17 +1,15 @@
 module Pretty.Readable (test_Pretty) where
 
 import PlutusCore.Default
+import PlutusCore.Examples.Everything (examples)
 import PlutusCore.FsTree
 import PlutusCore.Pretty
-
-import PlutusCore.Examples.Everything (examples)
 import PlutusCore.StdLib.Everything (stdLib)
 
 import Data.Default.Class
 
-import Test.Tasty.Extras
-
 import Test.Tasty
+import Test.Tasty.Extras
 
 prettyConfigReadable :: PrettyConfigPlc
 prettyConfigReadable

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -10,18 +10,6 @@ module Main
     ( main
     ) where
 
-import PlutusPrelude
-
-import CBOR.DataStability qualified
-import Check.Spec qualified as Check
-import CostModelInterface.Spec
-import Evaluation.Spec (test_evaluation)
-import Names.Spec
-import Normalization.Check
-import Normalization.Type
-import Pretty.Readable
-import TypeSynthesis.Spec (test_typecheck)
-
 import PlutusCore
 import PlutusCore.Check.Uniques qualified as Uniques
 import PlutusCore.DeBruijn
@@ -32,7 +20,16 @@ import PlutusCore.Generators.NEAT.Spec qualified as NEAT
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
 
+import PlutusPrelude
+
+import CBOR.DataStability qualified
+
+import Check.Spec qualified as Check
+
 import Control.Monad.Except
+
+import CostModelInterface.Spec
+
 import Data.ByteString.Lazy qualified as BSL
 import Data.Either (isLeft)
 import Data.Foldable (for_)
@@ -41,16 +38,31 @@ import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text.IO (readFile)
 import Data.Word (Word64)
+
+import Evaluation.Spec (test_evaluation)
+
 import Flat (flat, unflat)
+
 import Hedgehog hiding (Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+
+import Names.Spec
+
+import Normalization.Check
+import Normalization.Type
+
 import Prelude hiding (readFile)
+
+import Pretty.Readable
+
 import Test.Tasty
 import Test.Tasty.Golden
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit
 import Test.Tasty.Options
+
+import TypeSynthesis.Spec (test_typecheck)
 
 main :: IO ()
 main = do

--- a/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
@@ -9,21 +9,22 @@ module TypeSynthesis.Spec
     ( test_typecheck
     ) where
 
-import PlutusPrelude
-
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Error
+import PlutusCore.Examples.Builtins
+import PlutusCore.Examples.Everything (builtins, examples)
 import PlutusCore.FsTree
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
-
-import PlutusCore.Examples.Builtins
-import PlutusCore.Examples.Everything (builtins, examples)
 import PlutusCore.StdLib.Everything (stdLib)
 
+import PlutusPrelude
+
 import Control.Monad.Except
+
 import System.FilePath ((</>))
+
 import Test.Tasty
 import Test.Tasty.Extras
 import Test.Tasty.HUnit

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
@@ -16,17 +16,16 @@ import PlutusIR
 import PlutusIR.Analysis.Usages qualified as Usages
 import PlutusIR.Purity
 
+import Algebra.Graph.Class qualified as G
+
 import Control.Lens hiding (Strict)
 import Control.Monad.Reader
 import Control.Monad.State
 
-import Algebra.Graph.Class qualified as G
+import Data.Foldable
+import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-
-import Data.List.NonEmpty qualified as NE
-
-import Data.Foldable
 
 type StrictnessMap = Map.Map PLC.Unique Strictness
 type DepState = StrictnessMap

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/RetainedSize.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/RetainedSize.hs
@@ -9,19 +9,21 @@ module PlutusIR.Analysis.RetainedSize
     , annotateWithRetainedSize
     ) where
 
-import PlutusPrelude
+import PlutusCore qualified as PLC
+import PlutusCore.Builtin as PLC
+import PlutusCore.Name
 
 import PlutusIR.Analysis.Dependencies
 import PlutusIR.Analysis.Size
 import PlutusIR.Core
 
-import PlutusCore qualified as PLC
-import PlutusCore.Builtin as PLC
-import PlutusCore.Name
+import PlutusPrelude
 
 import Algebra.Graph qualified as C
 import Algebra.Graph.ToGraph
+
 import Control.Lens
+
 import Data.Graph.Dom (domTree)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Size.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Size.hs
@@ -7,11 +7,11 @@ module PlutusIR.Analysis.Size
     , varDeclSize
     ) where
 
-import PlutusPrelude
+import PlutusCore.Size (Size (..), kindSize, tyVarDeclSize, typeSize, varDeclSize)
 
 import PlutusIR.Core
 
-import PlutusCore.Size (Size (..), kindSize, tyVarDeclSize, typeSize, varDeclSize)
+import PlutusPrelude
 
 import Control.Lens
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Usages.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Usages.hs
@@ -3,13 +3,13 @@
 -- | Functions for computing variable usage inside terms and types.
 module PlutusIR.Analysis.Usages (termUsages, typeUsages, Usages, getUsageCount, allUsed) where
 
-import PlutusPrelude ((<^>))
+import PlutusCore qualified as PLC
+import PlutusCore.Name qualified as PLC
 
 import PlutusIR
 import PlutusIR.Subst
 
-import PlutusCore qualified as PLC
-import PlutusCore.Name qualified as PLC
+import PlutusPrelude ((<^>))
 
 import Control.Lens
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -35,8 +35,10 @@ module PlutusIR.Compiler (
     AllowEscape(..),
     toDefaultCompilationCtx) where
 
-import PlutusIR
+import PlutusCore qualified as PLC
+import PlutusCore.Builtin qualified as PLC
 
+import PlutusIR
 import PlutusIR.Compiler.Let qualified as Let
 import PlutusIR.Compiler.Lower
 import PlutusIR.Compiler.Provenance
@@ -54,15 +56,14 @@ import PlutusIR.Transform.ThunkRecursions qualified as ThunkRec
 import PlutusIR.Transform.Unwrap qualified as Unwrap
 import PlutusIR.TypeCheck.Internal
 
-import PlutusCore qualified as PLC
-import PlutusCore.Builtin qualified as PLC
+import PlutusPrelude
 
 import Control.Lens
 import Control.Monad
 import Control.Monad.Extra (orM, whenM)
 import Control.Monad.Reader
+
 import Debug.Trace (traceM)
-import PlutusPrelude
 
 -- Simplifier passes
 data Pass uni fun =

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
@@ -18,7 +18,9 @@ module PlutusIR.Compiler.Datatype
     , resultTypeName
     ) where
 
-import PlutusPrelude (showText)
+import PlutusCore.MkPlc qualified as PLC
+import PlutusCore.Quote
+import PlutusCore.StdLib.Type qualified as Types
 
 import PlutusIR
 import PlutusIR.Compiler.Names
@@ -28,16 +30,13 @@ import PlutusIR.Error
 import PlutusIR.MkPir qualified as PIR
 import PlutusIR.Transform.Substitute
 
-import PlutusCore.MkPlc qualified as PLC
-import PlutusCore.Quote
-import PlutusCore.StdLib.Type qualified as Types
+import PlutusPrelude (showText)
 
 import Control.Monad.Error.Lens
 
+import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Data.Traversable
-
-import Data.List.NonEmpty qualified as NE
 
 {- NOTE [Normalization of data-constructors' types]
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Definitions.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Definitions.hs
@@ -31,11 +31,16 @@ module PlutusIR.Compiler.Definitions (DefT
                                               , lookupConstructors
                                               , lookupDestructor) where
 
+import PlutusCore.MkPlc qualified as PLC
+import PlutusCore.Quote
+
 import PlutusIR as PIR
 import PlutusIR.MkPir hiding (error)
 
-import PlutusCore.MkPlc qualified as PLC
-import PlutusCore.Quote
+import Algebra.Graph.AdjacencyMap qualified as AM
+import Algebra.Graph.AdjacencyMap.Algorithm qualified as AM
+import Algebra.Graph.NonEmpty.AdjacencyMap qualified as NAM
+import Algebra.Graph.ToGraph qualified as Graph
 
 import Control.Lens
 import Control.Monad.Except
@@ -43,11 +48,6 @@ import Control.Monad.Morph qualified as MM
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
-
-import Algebra.Graph.AdjacencyMap qualified as AM
-import Algebra.Graph.AdjacencyMap.Algorithm qualified as AM
-import Algebra.Graph.NonEmpty.AdjacencyMap qualified as NAM
-import Algebra.Graph.ToGraph qualified as Graph
 
 import Data.Bifunctor (first, second)
 import Data.Foldable

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Error.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Error.hs
@@ -17,6 +17,7 @@ import Control.Lens
 
 import Data.Text qualified as T
 import Data.Typeable
+
 import Prettyprinter ((<+>))
 import Prettyprinter qualified as PP
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
@@ -14,11 +14,10 @@ import PlutusIR.Compiler.Types
 import PlutusIR.Error
 import PlutusIR.MkPir qualified as PIR
 
+import Control.Lens hiding (Strict)
 import Control.Monad
 import Control.Monad.Error.Lens
 import Control.Monad.Trans
-
-import Control.Lens hiding (Strict)
 
 import Data.List.NonEmpty hiding (partition, reverse)
 import Data.List.NonEmpty qualified as NE

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Lower.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Lower.hs
@@ -4,11 +4,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module PlutusIR.Compiler.Lower where
 
+import PlutusCore qualified as PLC
+
 import PlutusIR
 import PlutusIR.Compiler.Types
 import PlutusIR.Error
-
-import PlutusCore qualified as PLC
 
 import Control.Monad.Error.Lens
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Provenance.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Provenance.hs
@@ -5,11 +5,12 @@
 -- | Module handling provenances of terms.
 module PlutusIR.Compiler.Provenance where
 
-import PlutusIR
-
 import PlutusCore.Pretty qualified as PLC
 
+import PlutusIR
+
 import Data.Set qualified as S
+
 import Prettyprinter ((<+>))
 import Prettyprinter qualified as PP
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Recursion.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Recursion.hs
@@ -5,6 +5,12 @@
 -- | Functions for compiling PIR recursive let-bound functions into PLC.
 module PlutusIR.Compiler.Recursion where
 
+import PlutusCore qualified as PLC
+import PlutusCore.MkPlc qualified as PLC
+import PlutusCore.Quote
+import PlutusCore.StdLib.Data.Function qualified as Function
+import PlutusCore.StdLib.Meta.Data.Tuple qualified as Tuple
+
 import PlutusIR
 import PlutusIR.Compiler.Definitions
 import PlutusIR.Compiler.Provenance
@@ -18,12 +24,6 @@ import Control.Monad.Trans
 
 import Data.List.NonEmpty hiding (length)
 import Data.Set qualified as Set
-
-import PlutusCore qualified as PLC
-import PlutusCore.MkPlc qualified as PLC
-import PlutusCore.Quote
-import PlutusCore.StdLib.Data.Function qualified as Function
-import PlutusCore.StdLib.Meta.Data.Tuple qualified as Tuple
 
 {- Note [Recursive lets]
 We need to define these with a fixpoint. We can derive a fixpoint operator for values

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
@@ -8,16 +8,6 @@
 {-# LANGUAGE TypeOperators         #-}
 module PlutusIR.Compiler.Types where
 
-import PlutusIR qualified as PIR
-import PlutusIR.Compiler.Provenance
-import PlutusIR.Error
-
-import Control.Monad.Except
-import Control.Monad.Reader
-
-import Control.Lens
-
-import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.MkPlc qualified as PLC
@@ -25,7 +15,18 @@ import PlutusCore.Pretty qualified as PLC
 import PlutusCore.Quote
 import PlutusCore.StdLib.Type qualified as Types
 import PlutusCore.TypeCheck.Internal qualified as PLC
+
+import PlutusIR qualified as PIR
+import PlutusIR.Compiler.Provenance
+import PlutusIR.Error
+
 import PlutusPrelude
+
+import Annotation
+
+import Control.Lens
+import Control.Monad.Except
+import Control.Monad.Reader
 
 import Data.Text qualified as T
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Flat.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Flat.hs
@@ -3,10 +3,10 @@
 {-# OPTIONS_GHC -Wno-orphans       #-}
 module PlutusIR.Core.Instance.Flat () where
 
-import PlutusIR.Core.Type
-
 import PlutusCore qualified as PLC
 import PlutusCore.Flat ()
+
+import PlutusIR.Core.Type
 
 import Flat (Flat)
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty.hs
@@ -6,13 +6,13 @@
 {-# OPTIONS_GHC -Wno-orphans       #-}
 module PlutusIR.Core.Instance.Pretty () where
 
-import PlutusPrelude
-
 import PlutusCore qualified as PLC
 import PlutusCore.Flat ()
 import PlutusCore.Pretty qualified as PLC
 
 import PlutusIR.Core.Type
+
+import PlutusPrelude
 
 import Prettyprinter
 import Prettyprinter.Custom

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
@@ -19,8 +19,11 @@ import PlutusCore.Default.Universe
 import PlutusCore.Pretty.ConfigName
 import PlutusCore.Pretty.PrettyConst
 import PlutusCore.Pretty.Readable
+
 import PlutusIR.Core.Type
+
 import PlutusPrelude
+
 import Prettyprinter
 import Prettyprinter.Custom
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Scoping.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Scoping.hs
@@ -7,11 +7,11 @@
 {-# OPTIONS_GHC -Wno-orphans       #-}
 module PlutusIR.Core.Instance.Scoping where
 
-import PlutusIR.Core.Type
-
 import PlutusCore.Check.Scoping
 import PlutusCore.MkPlc
 import PlutusCore.Quote
+
+import PlutusIR.Core.Type
 
 import Data.Foldable
 import Data.List.NonEmpty (NonEmpty (..), (<|))

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Plated.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Plated.hs
@@ -37,6 +37,7 @@ import PlutusCore.Name qualified as PLC
 import PlutusIR.Core.Type
 
 import Control.Lens hiding (Strict, (<.>))
+
 import Data.Functor.Apply
 import Data.Functor.Bind.Class
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -26,9 +26,6 @@ module PlutusIR.Core.Type (
     progTerm,
     ) where
 
-import PlutusPrelude
-
-import Control.Lens.TH
 import PlutusCore (Kind, Name, TyName, Type (..))
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin (HasConstant (..), throwNotAConstant)
@@ -37,6 +34,10 @@ import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Flat ()
 import PlutusCore.MkPlc (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
 import PlutusCore.Name qualified as PLC
+
+import PlutusPrelude
+
+import Control.Lens.TH
 
 import Data.Text qualified as T
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Error.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Error.hs
@@ -20,11 +20,15 @@ module PlutusIR.Error
 
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty qualified as PLC
+
 import PlutusIR qualified as PIR
+
 import PlutusPrelude
 
 import Control.Lens
+
 import Data.Text qualified as T
+
 import Prettyprinter as PP
 
 data TypeErrorExt uni ann =

--- a/plutus-core/plutus-ir/src/PlutusIR/Mark.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Mark.hs
@@ -7,11 +7,11 @@ module PlutusIR.Mark
 
 import PlutusCore.Core qualified as PLC
 import PlutusCore.Name qualified as PLC
-
 import PlutusCore.Quote
 
-import Data.Set.Lens (setOf)
 import PlutusIR.Core
+
+import Data.Set.Lens (setOf)
 
 -- | Marks all the 'Unique's in a term as used, so they will not be generated in future. Useful if you
 -- have a term which was not generated in 'Quote'.

--- a/plutus-core/plutus-ir/src/PlutusIR/MkPir.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/MkPir.hs
@@ -7,9 +7,9 @@ module PlutusIR.MkPir ( module MkPlc
                                , mkLet
                                ) where
 
-import PlutusIR
-
 import PlutusCore.MkPlc as MkPlc
+
+import PlutusIR
 
 import Data.List.NonEmpty qualified as NE
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Normalize.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Normalize.hs
@@ -13,11 +13,13 @@ import PlutusCore.Normalize as Export (normalizeType)
 import PlutusCore.Normalize.Internal hiding (normalizeTypesInM)
 import PlutusCore.Quote
 import PlutusCore.Rename (rename)
+
 import PlutusIR
 import PlutusIR.Transform.Rename ()
 
 import Control.Lens
 import Control.Monad ((>=>))
+
 import Universe (HasUniApply)
 
 -- | Normalize every 'Type' in a 'Term'.

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -14,18 +14,23 @@ module PlutusIR.Parser
     , topSourcePos
     ) where
 
+import PlutusCore (MonadQuote)
 import PlutusCore.Default qualified as PLC (DefaultFun, DefaultUni)
+import PlutusCore.Error (AsParserErrorBundle)
 import PlutusCore.Parser hiding (parseProgram, program)
+
 import PlutusIR as PIR
 import PlutusIR.MkPir qualified as PIR
+
 import PlutusPrelude
-import Prelude hiding (fail)
 
 import Control.Monad.Combinators.NonEmpty qualified as NE
 import Control.Monad.Except (MonadError)
+
 import Data.Text (Text)
-import PlutusCore (MonadQuote)
-import PlutusCore.Error (AsParserErrorBundle)
+
+import Prelude hiding (fail)
+
 import Text.Megaparsec hiding (ParseError, State, many, parse, some)
 
 -- | A parsable PIR pTerm.

--- a/plutus-core/plutus-ir/src/PlutusIR/Purity.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Purity.hs
@@ -5,10 +5,11 @@
 
 module PlutusIR.Purity (isPure, firstEffectfulTerm) where
 
+import PlutusCore.Builtin
+
 import PlutusIR
 
 import Data.List.NonEmpty qualified as NE
-import PlutusCore.Builtin
 
 -- | An argument taken by a builtin: could be a term of a type.
 data Arg tyname name uni fun a = TypeArg (Type tyname uni a) | TermArg (Term tyname name uni fun a)

--- a/plutus-core/plutus-ir/src/PlutusIR/Subst.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Subst.hs
@@ -13,6 +13,7 @@ module PlutusIR.Subst
     , tvTy
     ) where
 
+import PlutusCore.Core.Plated (typeTyVars)
 import PlutusCore.Core.Type qualified as PLC
 import PlutusCore.Subst (ftvTy, ftvTyCtx, tvTy)
 
@@ -20,10 +21,10 @@ import PlutusIR.Core
 
 import Control.Lens
 import Control.Lens.Unsound qualified as Unsound
+
 import Data.Set as S hiding (foldr)
 import Data.Set.Lens (setOf)
 import Data.Traversable (mapAccumL)
-import PlutusCore.Core.Plated (typeTyVars)
 
 -- | Get all the free term variables in a PIR term.
 fvTerm :: Ord name => Traversal' (Term tyname name uni fun ann) name

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
@@ -10,6 +10,7 @@ module PlutusIR.Transform.Beta (
 import PlutusIR
 
 import Control.Lens (over)
+
 import Data.List.NonEmpty qualified as NE
 
 {- Note [Multi-beta]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
@@ -6,26 +6,27 @@
 -- | Optimization passes for removing dead code, mainly dead let bindings.
 module PlutusIR.Transform.DeadCode (removeDeadBindings) where
 
+import PlutusCore qualified as PLC
+import PlutusCore.Builtin qualified as PLC
+import PlutusCore.Name qualified as PLC
+import PlutusCore.Quote (MonadQuote, freshTyName, liftQuote)
+import PlutusCore.StdLib.Data.ScottUnit qualified as Unit
+
 import PlutusIR
 import PlutusIR.Analysis.Dependencies qualified as Deps
 import PlutusIR.MkPir
 import PlutusIR.Transform.Rename ()
 
-import PlutusCore qualified as PLC
-import PlutusCore.Builtin qualified as PLC
-import PlutusCore.Name qualified as PLC
+import Algebra.Graph qualified as G
+import Algebra.Graph.ToGraph qualified as T
 
 import Control.Lens
 import Control.Monad.Reader
 
 import Data.Coerce
+import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 
-import Algebra.Graph qualified as G
-import Algebra.Graph.ToGraph qualified as T
-import Data.List.NonEmpty qualified as NE
-import PlutusCore.Quote (MonadQuote, freshTyName, liftQuote)
-import PlutusCore.StdLib.Data.ScottUnit qualified as Unit
 import Witherable (Witherable (wither))
 
 -- | Remove all the dead let bindings in a term.

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
@@ -12,15 +12,6 @@ should be KEPT IN SYNC, so if you make changes here please either make them in t
 one too or add to the comment that summarises the differences.
 -}
 module PlutusIR.Transform.Inline.UnconditionalInline (inline, InlineHints (..)) where
-import PlutusIR
-import PlutusIR.Analysis.Dependencies qualified as Deps
-import PlutusIR.Analysis.Usages qualified as Usages
-import PlutusIR.MkPir (mkLet)
-import PlutusIR.Transform.Inline.Utils
-import PlutusIR.Transform.Rename ()
-import PlutusPrelude
-
-import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Name
@@ -28,12 +19,25 @@ import PlutusCore.Quote
 import PlutusCore.Rename (dupable, liftDupable)
 import PlutusCore.Subst (typeSubstTyNamesM)
 
+import PlutusIR
+import PlutusIR.Analysis.Dependencies qualified as Deps
+import PlutusIR.Analysis.Usages qualified as Usages
+import PlutusIR.MkPir (mkLet)
+import PlutusIR.Transform.Inline.Utils
+import PlutusIR.Transform.Rename ()
+
+import PlutusPrelude
+
+import Algebra.Graph qualified as G
+
+import Annotation
+
 import Control.Lens hiding (Strict)
 import Control.Monad.Reader
 import Control.Monad.State
 
-import Algebra.Graph qualified as G
 import Data.Map qualified as Map
+
 import Witherable (Witherable (wither))
 
 {- Note [Inlining approach and 'Secrets of the GHC Inliner']

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
@@ -9,18 +9,20 @@
 
 module PlutusIR.Transform.Inline.Utils where
 
+import PlutusCore.Builtin qualified as PLC
+import PlutusCore.Name
+import PlutusCore.Quote
+import PlutusCore.Rename
+
 import PlutusIR
 import PlutusIR.Analysis.Dependencies qualified as Deps
 import PlutusIR.Analysis.Usages qualified as Usages
 import PlutusIR.Purity (firstEffectfulTerm, isPure)
 import PlutusIR.Transform.Rename ()
+
 import PlutusPrelude
 
 import Annotation
-import PlutusCore.Builtin qualified as PLC
-import PlutusCore.Name
-import PlutusCore.Quote
-import PlutusCore.Rename
 
 import Control.Lens hiding (Strict)
 import Control.Monad.Reader

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloat.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloat.hs
@@ -10,6 +10,7 @@ module PlutusIR.Transform.LetFloat (floatTerm) where
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Name qualified as PLC
+
 import PlutusIR
 import PlutusIR.Purity
 import PlutusIR.Subst
@@ -19,6 +20,7 @@ import Control.Lens hiding (Strict)
 import Control.Monad.Extra
 import Control.Monad.Reader
 import Control.Monad.Writer
+
 import Data.Coerce
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
@@ -27,6 +29,7 @@ import Data.Semigroup.Foldable
 import Data.Semigroup.Generic
 import Data.Set qualified as S
 import Data.Set.Lens (setOf)
+
 import GHC.Generics
 
 {- Note [Let Floating pass]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/NonStrict.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/NonStrict.hs
@@ -5,12 +5,12 @@
 -- | Compile non-strict bindings into strict bindings.
 module PlutusIR.Transform.NonStrict (compileNonStrictBindings) where
 
+import PlutusCore.Quote
+import PlutusCore.StdLib.Data.ScottUnit qualified as Unit
+
 import PlutusIR
 import PlutusIR.Transform.Rename ()
 import PlutusIR.Transform.Substitute
-
-import PlutusCore.Quote
-import PlutusCore.StdLib.Data.ScottUnit qualified as Unit
 
 import Control.Lens hiding (Strict)
 import Control.Monad.State

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
@@ -6,14 +6,20 @@ module PlutusIR.Transform.RecSplit
     (recSplit) where
 
 import PlutusCore.Name qualified as PLC
+
 import PlutusIR
+import PlutusIR.MkPir (mkLet)
 import PlutusIR.Subst
+
+import PlutusPrelude ((<^>))
 
 import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.AdjacencyMap.Algorithm qualified as AM hiding (isAcyclic)
 import Algebra.Graph.NonEmpty.AdjacencyMap qualified as AMN
 import Algebra.Graph.ToGraph (isAcyclic)
+
 import Control.Lens
+
 import Data.Either
 import Data.Foldable (foldl')
 import Data.List (nub)
@@ -22,8 +28,6 @@ import Data.Map qualified as M
 import Data.Semigroup.Foldable
 import Data.Set qualified as S
 import Data.Set.Lens (setOf)
-import PlutusIR.MkPir (mkLet)
-import PlutusPrelude ((<^>))
 
 {- Note [LetRec splitting pass]
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Rename.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Rename.hs
@@ -18,14 +18,14 @@ module PlutusIR.Transform.Rename
     , renameProgramM
     ) where
 
-import PlutusPrelude
+import PlutusCore qualified as PLC
+import PlutusCore.Name qualified as PLC
+import PlutusCore.Rename.Internal qualified as PLC
 
 import PlutusIR
 import PlutusIR.Mark
 
-import PlutusCore qualified as PLC
-import PlutusCore.Name qualified as PLC
-import PlutusCore.Rename.Internal qualified as PLC
+import PlutusPrelude
 
 import Control.Monad.Reader
 import Control.Monad.Trans.Cont (ContT (..))

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Substitute.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Substitute.hs
@@ -12,9 +12,9 @@ module PlutusIR.Transform.Substitute (
     , bindingSubstTyNames
     ) where
 
-import PlutusIR
-
 import PlutusCore.Subst (substTyVar, typeSubstTyNames)
+
+import PlutusIR
 
 import Control.Lens
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/ThunkRecursions.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/ThunkRecursions.hs
@@ -5,13 +5,16 @@
 -- compilable to PLC. See Note [Thunking recursions] for details.
 module PlutusIR.Transform.ThunkRecursions (thunkRecursions) where
 
-import Control.Lens (transformOf)
-import Data.List.NonEmpty (partition)
-import Data.Maybe (mapMaybe)
 import PlutusCore.Builtin
+
 import PlutusIR
 import PlutusIR.MkPir (mkLet, mkVar)
 import PlutusIR.Purity (isPure)
+
+import Control.Lens (transformOf)
+
+import Data.List.NonEmpty (partition)
+import Data.Maybe (mapMaybe)
 
 {- Note [Thunking recursions]
 Our fixpoint combinators in Plutus Core know how to handle mutually recursive values

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck.hs
@@ -18,6 +18,7 @@ module PlutusIR.TypeCheck
 
 import PlutusCore.Rename
 import PlutusCore.TypeCheck qualified as PLC
+
 import PlutusIR
 import PlutusIR.Error
 import PlutusIR.Transform.Rename ()

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
@@ -23,7 +23,9 @@ module PlutusIR.TypeCheck.Internal
     ) where
 
 
-import PlutusPrelude
+import PlutusCore (toPatFuncKind, tyVarDeclName, typeAnn)
+import PlutusCore.Error as PLC
+import PlutusCore.TypeCheck.Internal hiding (checkTypeM, inferTypeM, runTypeCheckM)
 
 import PlutusIR
 import PlutusIR.Compiler.Datatype
@@ -33,17 +35,14 @@ import PlutusIR.Error
 import PlutusIR.MkPir qualified as PIR
 import PlutusIR.Transform.Rename ()
 
-import PlutusCore (toPatFuncKind, tyVarDeclName, typeAnn)
-import PlutusCore.Error as PLC
--- we mirror inferTypeM, checkTypeM of plc-tc and extend it for plutus-ir terms
-import PlutusCore.TypeCheck.Internal hiding (checkTypeM, inferTypeM, runTypeCheckM)
+import PlutusPrelude
 
 import Control.Monad.Error.Lens
 import Control.Monad.Except
--- Using @transformers@ rather than @mtl@, because the former doesn't impose the 'Monad' constraint
--- on 'local'.
 import Control.Monad.Trans.Reader
+
 import Data.Foldable
+
 import Universe
 
 {- Note [PLC Typechecker code reuse]

--- a/plutus-core/plutus-ir/test/GeneratorSpec/Builtin.hs
+++ b/plutus-core/plutus-ir/test/GeneratorSpec/Builtin.hs
@@ -5,6 +5,7 @@ import PlutusCore.Data
 import PlutusCore.Generators.QuickCheck
 
 import Codec.Serialise
+
 import Test.QuickCheck
 
 -- | This mainly tests that the `Data` generator isn't non-terminating or too slow.

--- a/plutus-core/plutus-ir/test/GeneratorSpec/Substitution.hs
+++ b/plutus-core/plutus-ir/test/GeneratorSpec/Substitution.hs
@@ -2,13 +2,14 @@
 module GeneratorSpec.Substitution where
 
 import PlutusCore.Generators.QuickCheck
-
 import PlutusCore.Name
 import PlutusCore.Quote (runQuote)
 import PlutusCore.Rename
+
 import PlutusIR.Subst
 
 import Control.Monad
+
 import Data.Either
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set

--- a/plutus-core/plutus-ir/test/GeneratorSpec/Terms.hs
+++ b/plutus-core/plutus-ir/test/GeneratorSpec/Terms.hs
@@ -7,17 +7,18 @@
 
 module GeneratorSpec.Terms where
 
-import PlutusCore.Generators.QuickCheck
-import PlutusIR.Generators.QuickCheck
-
 import PlutusCore.Default
+import PlutusCore.Generators.QuickCheck
 import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.Rename
+
 import PlutusIR
 import PlutusIR.Core.Instance.Pretty.Readable
+import PlutusIR.Generators.QuickCheck
 
 import Control.Monad.Reader
+
 import Data.Bifunctor
 import Data.Char
 import Data.Either
@@ -26,6 +27,7 @@ import Data.Hashable
 import Data.HashMap.Strict qualified as HashMap
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict qualified as Map
+
 import Test.QuickCheck
 
 -- | 'rename' a 'Term' and 'show' it afterwards.

--- a/plutus-core/plutus-ir/test/GeneratorSpec/Types.hs
+++ b/plutus-core/plutus-ir/test/GeneratorSpec/Types.hs
@@ -7,6 +7,7 @@ import PlutusCore.Generators.QuickCheck
 import Data.Bifunctor
 import Data.Either
 import Data.Map.Strict qualified as Map
+
 import Test.QuickCheck
 
 -- | Check that the types we generate are kind-correct.

--- a/plutus-core/plutus-ir/test/NamesSpec.hs
+++ b/plutus-core/plutus-ir/test/NamesSpec.hs
@@ -3,12 +3,12 @@ module NamesSpec
     ) where
 
 
+import PlutusCore.Rename
+import PlutusCore.Test
+
 import PlutusIR.Generators.AST
 import PlutusIR.Mark
 import PlutusIR.Transform.Rename
-
-import PlutusCore.Rename
-import PlutusCore.Test
 
 import Test.Tasty
 

--- a/plutus-core/plutus-ir/test/ParserSpec.hs
+++ b/plutus-core/plutus-ir/test/ParserSpec.hs
@@ -4,23 +4,23 @@
 
 module ParserSpec (parsing) where
 
-import PlutusPrelude
-
-import Data.Char
-import Data.Text qualified as T
-
+import PlutusCore (runQuoteT)
 import PlutusCore.Default qualified as PLC
+import PlutusCore.Error (ParserErrorBundle)
 
 import PlutusIR
 import PlutusIR.Generators.AST
 import PlutusIR.Parser
 
+import PlutusPrelude
+
+import Data.Char
+import Data.Text qualified as T
+
 import Hedgehog hiding (Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 
-import PlutusCore (runQuoteT)
-import PlutusCore.Error (ParserErrorBundle)
 import Test.Tasty
 import Test.Tasty.Extras
 import Test.Tasty.Hedgehog

--- a/plutus-core/plutus-ir/test/Spec.hs
+++ b/plutus-core/plutus-ir/test/Spec.hs
@@ -7,25 +7,29 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Main (main) where
 
-import PlutusPrelude
-
-import GeneratorSpec
-import NamesSpec
-import ParserSpec
-import TransformSpec
-import TypeSpec
+import PlutusCore qualified as PLC
 
 import PlutusIR
 import PlutusIR.Core.Instance.Pretty.Readable
 import PlutusIR.Parser (pTerm)
 import PlutusIR.Test
 
-import PlutusCore qualified as PLC
+import PlutusPrelude
+
+import Flat (flat, unflat)
+
+import GeneratorSpec
+
+import NamesSpec
+
+import ParserSpec
 
 import Test.Tasty
 import Test.Tasty.Extras
 
-import Flat (flat, unflat)
+import TransformSpec
+
+import TypeSpec
 
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["plutus-ir/test"] tests

--- a/plutus-core/plutus-ir/test/TransformSpec.hs
+++ b/plutus-core/plutus-ir/test/TransformSpec.hs
@@ -5,14 +5,10 @@
 
 module TransformSpec (transform) where
 
-import Test.Tasty.Extras
-
-import PlutusCore.Quote
-
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty qualified as PLC
+import PlutusCore.Quote
 import PlutusCore.Test
-import PlutusPrelude
 
 import PlutusIR.Analysis.RetainedSize qualified as RetainedSize
 import PlutusIR.Error as PIR
@@ -29,6 +25,10 @@ import PlutusIR.Transform.Rename ()
 import PlutusIR.Transform.ThunkRecursions qualified as ThunkRec
 import PlutusIR.Transform.Unwrap qualified as Unwrap
 import PlutusIR.TypeCheck as TC
+
+import PlutusPrelude
+
+import Test.Tasty.Extras
 
 import Text.Megaparsec.Pos
 

--- a/plutus-core/plutus-ir/test/TypeSpec.hs
+++ b/plutus-core/plutus-ir/test/TypeSpec.hs
@@ -1,10 +1,10 @@
 module TypeSpec where
 
-import Test.Tasty.Extras
-
 import PlutusIR.Parser
 import PlutusIR.Test
 import PlutusIR.Transform.Rename ()
+
+import Test.Tasty.Extras
 
 types :: TestNested
 types = testNested "types"

--- a/plutus-core/prelude/PlutusPrelude.hs
+++ b/plutus-core/prelude/PlutusPrelude.hs
@@ -95,6 +95,7 @@ import Control.DeepSeq (NFData)
 import Control.Exception (Exception, throw)
 import Control.Lens
 import Control.Monad.Reader
+
 import Data.Array
 import Data.Bifunctor (first, second)
 import Data.Coerce (Coercible, coerce)
@@ -111,10 +112,14 @@ import Data.Text qualified as T
 import Data.Traversable (for)
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
+
 import Debug.Trace
+
 import GHC.Generics
 import GHC.Natural (Natural)
+
 import Prettyprinter
+
 import Text.PrettyBy.Default
 import Text.PrettyBy.Internal
 

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/AST.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/AST.hs
@@ -18,17 +18,19 @@ module PlutusCore.Generators.Hedgehog.AST
     , mangleNames
     ) where
 
-import PlutusPrelude
-
 import PlutusCore
 import PlutusCore.Subst
+
+import PlutusPrelude
 
 import Control.Lens (coerced)
 import Control.Monad.Morph (hoist)
 import Control.Monad.Reader
+
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.Lens (setOf)
+
 import Hedgehog hiding (Size, Var)
 import Hedgehog.Internal.Gen qualified as Gen
 import Hedgehog.Range qualified as Range

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Builtin.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Builtin.hs
@@ -30,9 +30,11 @@ import Data.Kind qualified as GHC
 import Data.Text (Text)
 import Data.Type.Equality
 import Data.Word (Word8)
+
 import Hedgehog hiding (Opaque, Var, eval)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+
 import Type.Reflection
 
 -- | This class exists so we can provide an ad-hoc typed term generator

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Denotation.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Denotation.hs
@@ -21,11 +21,13 @@ import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
 import PlutusCore.Name
+
 import PlutusPrelude
 
 import Data.Dependent.Map (DMap)
 import Data.Dependent.Map qualified as DMap
 import Data.Functor.Compose
+
 import Type.Reflection
 
 type KnownType val a = (KnownTypeAst (UniOf val) a, MakeKnown val a)

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Entity.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Entity.hs
@@ -24,27 +24,30 @@ module PlutusCore.Generators.Hedgehog.Entity
     , withAnyTermLoose
     ) where
 
-import PlutusPrelude
-
-import PlutusCore.Generators.Hedgehog.Denotation
-import PlutusCore.Generators.Hedgehog.TypedBuiltinGen
-import PlutusCore.Generators.Hedgehog.Utils
-
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
+import PlutusCore.Generators.Hedgehog.Denotation
+import PlutusCore.Generators.Hedgehog.TypedBuiltinGen
+import PlutusCore.Generators.Hedgehog.Utils
 import PlutusCore.Name
 import PlutusCore.Pretty (PrettyConst, prettyConst)
 import PlutusCore.Quote
 
+import PlutusPrelude
+
 import Control.Monad.Morph qualified as Morph
 import Control.Monad.Reader
+
 import Data.ByteString qualified as BS
 import Data.Kind as GHC
 import Data.Proxy
+
 import Hedgehog hiding (Size, Var)
 import Hedgehog.Gen qualified as Gen
+
 import Prettyprinter
+
 import Type.Reflection
 
 type Plain f (uni :: GHC.Type -> GHC.Type) (fun :: GHC.Type) = f TyName Name uni fun ()

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Interesting.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Interesting.hs
@@ -21,18 +21,16 @@ module PlutusCore.Generators.Hedgehog.Interesting
     , fromInterestingTermGens
     ) where
 
-import PlutusCore.Generators.Hedgehog.Denotation
-import PlutusCore.Generators.Hedgehog.Entity
-import PlutusCore.Generators.Hedgehog.TypedBuiltinGen
-
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
 import PlutusCore.Evaluation.Result
+import PlutusCore.Generators.Hedgehog.Denotation
+import PlutusCore.Generators.Hedgehog.Entity
+import PlutusCore.Generators.Hedgehog.TypedBuiltinGen
 import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
-
 import PlutusCore.StdLib.Data.Bool
 import PlutusCore.StdLib.Data.Function as Function
 import PlutusCore.StdLib.Data.Nat
@@ -42,9 +40,11 @@ import PlutusCore.StdLib.Meta
 import PlutusCore.StdLib.Type
 
 import Data.List (genericIndex)
+
 import Hedgehog hiding (Size, Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+
 import Type.Reflection
 
 -- | The type of terms-and-their-values generators.

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Test.hs
@@ -16,25 +16,27 @@ module PlutusCore.Generators.Hedgehog.Test
     , propEvaluate
     ) where
 
-import PlutusPrelude (ShowPretty (..))
-
-import PlutusCore.Generators.Hedgehog.Interesting
-import PlutusCore.Generators.Hedgehog.TypeEvalCheck
-import PlutusCore.Generators.Hedgehog.Utils
-
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Result
+import PlutusCore.Generators.Hedgehog.Interesting
+import PlutusCore.Generators.Hedgehog.TypeEvalCheck
+import PlutusCore.Generators.Hedgehog.Utils
 import PlutusCore.Name
 import PlutusCore.Pretty
 
+import PlutusPrelude (ShowPretty (..))
+
 import Control.Monad.Except
+
 import Data.Functor ((<&>))
 import Data.Text.IO qualified as Text
+
 import Hedgehog hiding (Size, Var, eval)
 import Hedgehog.Gen qualified as Gen
+
 import System.FilePath ((</>))
 
 -- | Generate a term using a given generator and check that it's well-typed and evaluates correctly.

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypeEvalCheck.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypeEvalCheck.hs
@@ -19,23 +19,24 @@ module PlutusCore.Generators.Hedgehog.TypeEvalCheck
     , unsafeTypeEvalCheck
     ) where
 
-import PlutusPrelude
-
-import PlutusCore.Generators.Hedgehog.TypedBuiltinGen
-import PlutusCore.Generators.Hedgehog.Utils
-
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Evaluation.Machine.Ck
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.Exception
+import PlutusCore.Generators.Hedgehog.TypedBuiltinGen
+import PlutusCore.Generators.Hedgehog.Utils
 import PlutusCore.Normalize
 import PlutusCore.Pretty
 
+import PlutusPrelude
+
 import Control.Lens.TH
 import Control.Monad.Except
+
 import Data.Proxy
 import Data.String
+
 import Prettyprinter
 
 {- Note [Type-eval checking]

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypedBuiltinGen.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypedBuiltinGen.hs
@@ -19,18 +19,21 @@ module PlutusCore.Generators.Hedgehog.TypedBuiltinGen
     , genTypedBuiltinDef
     ) where
 
-import PlutusPrelude
-
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Pretty
 
+import PlutusPrelude
+
 import Data.ByteString qualified as BS
 import Data.Functor.Identity
+
 import Hedgehog hiding (Size, Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+
 import Prettyprinter
+
 import Type.Reflection
 
 -- | Generate a UTF-8 lazy 'ByteString' containg lower-case letters.

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Utils.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Utils.hs
@@ -21,7 +21,9 @@ import PlutusCore.Pretty
 
 import Control.Monad.Morph
 import Control.Monad.Reader
+
 import Data.Functor.Identity
+
 import Hedgehog hiding (Size, Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Internal.Property (forAllWithT)

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Common.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Common.hs
@@ -19,11 +19,13 @@ module PlutusCore.Generators.NEAT.Common where
 
 
 
-import Control.Enumerable
-import Data.Stream qualified as Stream
-import Data.Text qualified as Text
 import PlutusCore.Name (Name, TyName (..))
 import PlutusCore.Quote (MonadQuote (..), freshName)
+
+import Control.Enumerable
+
+import Data.Stream qualified as Stream
+import Data.Text qualified as Text
 
 data Z deriving stock (Eq, Ord, Show)
 

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
@@ -42,13 +42,16 @@ import UntypedPlutusCore.Evaluation.Machine.Cek qualified as U
 
 import Control.Monad.Except
 import Control.Search (Enumerable (..), Options (..), search')
+
 import Data.Maybe
 import Data.Stream qualified as Stream
 import Data.Tagged
 import Data.Text qualified as Text
+
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.Options
+
 import Text.Printf
 
 -- * Property-based tests

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
@@ -36,8 +36,15 @@ module PlutusCore.Generators.NEAT.Term
   , Neutral (..)
   ) where
 
+import PlutusCore
+import PlutusCore.Data
+import PlutusCore.Default
+import PlutusCore.Generators.NEAT.Common
+import PlutusCore.Generators.NEAT.Type
+
 import Control.Enumerable
 import Control.Monad.Except
+
 import Data.Bifunctor.TH
 import Data.ByteString (ByteString, pack)
 import Data.Coolean (Cool, false, toCool, true, (&&&))
@@ -45,13 +52,8 @@ import Data.Map qualified as Map
 import Data.Stream qualified as Stream
 import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8)
-import PlutusCore
-import PlutusCore.Data
-import PlutusCore.Default
-import PlutusCore.Generators.NEAT.Common
-import Text.Printf
 
-import PlutusCore.Generators.NEAT.Type
+import Text.Printf
 
 {-
 

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Type.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Type.hs
@@ -28,10 +28,11 @@ module PlutusCore.Generators.NEAT.Type where
 
 
 
-import Control.Enumerable
-import Control.Monad.Except
 import PlutusCore
 import PlutusCore.Generators.NEAT.Common
+
+import Control.Enumerable
+import Control.Monad.Except
 
 newtype Neutral a = Neutral
   { unNeutral :: a

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Builtin.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Builtin.hs
@@ -23,8 +23,10 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Word
+
 import Test.QuickCheck
 import Test.QuickCheck.Instances.ByteString ()
+
 import Universe
 
 instance Arbitrary Data where

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Common.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Common.hs
@@ -12,17 +12,21 @@ import PlutusCore.Default
 import PlutusCore.Name
 import PlutusCore.TypeCheck (defKindCheckConfig)
 import PlutusCore.TypeCheck.Internal (inferKindM, runTypeCheckM, withTyVar)
+
 import PlutusIR
 import PlutusIR.Error
 
 import Data.Bifunctor
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+
 import GHC.Stack
+
 import Test.QuickCheck.Gen (Gen)
 import Test.QuickCheck.Gen qualified as Gen
 import Test.QuickCheck.Modifiers (NonNegative (..))
 import Test.QuickCheck.Property
+
 import Text.Pretty
 import Text.PrettyBy
 import Text.PrettyBy.Internal

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/GenTm.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/GenTm.hs
@@ -12,17 +12,18 @@ module PlutusCore.Generators.QuickCheck.GenTm
   , Gen
   ) where
 
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.Utils
-
-import PlutusCore.Default
 import PlutusCore.Name
+
 import PlutusIR
 import PlutusIR.Compiler
 import PlutusIR.Subst
 
 import Control.Monad.Except
 import Control.Monad.Reader
+
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe
@@ -30,6 +31,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.Lens (setOf)
 import Data.String
+
 import Test.QuickCheck (Arbitrary (..), Gen)
 import Test.QuickCheck qualified as QC
 import Test.QuickCheck.GenT as Export hiding (var)

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/GenerateKinds.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/GenerateKinds.hs
@@ -4,9 +4,8 @@
 
 module PlutusCore.Generators.QuickCheck.GenerateKinds where
 
-import PlutusCore.Generators.QuickCheck.GenTm
-
 import PlutusCore
+import PlutusCore.Generators.QuickCheck.GenTm
 
 {- Note [Shriking order on kinds]
 A kind @k1 = foldr (->) * ks1@ is less than or equal to a kind @k2 = foldr (->) * ks2@ when @ks1@

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/GenerateTypes.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/GenerateTypes.hs
@@ -3,25 +3,27 @@
 
 module PlutusCore.Generators.QuickCheck.GenerateTypes where
 
+import PlutusCore.Builtin
+import PlutusCore.Core
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Builtin
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.GenerateKinds ()
 import PlutusCore.Generators.QuickCheck.GenTm
-
-import PlutusCore.Builtin
-import PlutusCore.Core
-import PlutusCore.Default
 import PlutusCore.Name
 import PlutusCore.Normalize
 import PlutusCore.Quote (runQuote)
+
 import PlutusIR
 import PlutusIR.Core.Instance.Pretty.Readable
 
 import Control.Monad.Reader
+
 import Data.Foldable
 import Data.Map.Strict qualified as Map
 import Data.Maybe
 import Data.String
+
 import Test.QuickCheck (shuffle)
 
 {- Note [Debugging generators that don't generate well-typed/kinded terms/types]

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/ShrinkTypes.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/ShrinkTypes.hs
@@ -7,14 +7,13 @@
 -- this module or reverse-engineer the shrinker and fix the problem.
 module PlutusCore.Generators.QuickCheck.ShrinkTypes where
 
+import PlutusCore.Builtin
+import PlutusCore.Core
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Builtin
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.GenerateKinds
 import PlutusCore.Generators.QuickCheck.GenTm
-
-import PlutusCore.Builtin
-import PlutusCore.Core
-import PlutusCore.Default
 import PlutusCore.MkPlc (mkTyBuiltin)
 import PlutusCore.Name
 import PlutusCore.Pretty
@@ -22,6 +21,7 @@ import PlutusCore.Subst
 
 import Data.Map.Strict qualified as Map
 import Data.Set.Lens (setOf)
+
 import GHC.Stack
 
 {- Note [Avoiding Shrinking Loops]

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Substitutions.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Substitutions.hs
@@ -2,17 +2,18 @@
 
 module PlutusCore.Generators.QuickCheck.Substitutions where
 
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.GenerateTypes
 import PlutusCore.Generators.QuickCheck.ShrinkTypes
 import PlutusCore.Generators.QuickCheck.Utils
-
-import PlutusCore.Default
 import PlutusCore.Name
+
 import PlutusIR
 import PlutusIR.Subst
 
 import Control.Monad.Except
+
 import Data.Map.Strict (Map)
 import Data.Map.Strict.Internal qualified as Map
 import Data.Maybe
@@ -21,7 +22,9 @@ import Data.MultiSet.Lens
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.Lens
+
 import GHC.Stack
+
 import Test.QuickCheck hiding (reason)
 
 type TypeSub = Map TyName (Type TyName DefaultUni ())

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Unification.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Unification.hs
@@ -2,19 +2,20 @@
 
 module PlutusCore.Generators.QuickCheck.Unification where
 
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.GenerateTypes
 import PlutusCore.Generators.QuickCheck.Substitutions
 import PlutusCore.Generators.QuickCheck.Utils
-
-import PlutusCore.Default
 import PlutusCore.Name
 import PlutusCore.Pretty
+
 import PlutusIR
 
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State.Strict
+
 import Data.Map.Strict.Internal qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Utils.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Utils.hs
@@ -7,6 +7,7 @@ import PlutusCore.Default
 import PlutusCore.MkPlc hiding (error)
 import PlutusCore.Name
 import PlutusCore.Pretty
+
 import PlutusIR
 import PlutusIR.Compiler.Datatype
 import PlutusIR.Core.Instance.Pretty.Readable
@@ -18,7 +19,9 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.Lens (setOf)
 import Data.String
+
 import Prettyprinter
+
 import Test.QuickCheck
 
 -- | Show a `Doc` when a property fails.

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -40,20 +40,17 @@ module PlutusCore.Test
     , module TastyExtras
     ) where
 
-import Test.Tasty.Extras as TastyExtras
-
-import PlutusPrelude
-
-import PlutusCore.Generators.Hedgehog.AST
-import PlutusCore.Generators.Hedgehog.Utils
-
 import PlutusCore qualified as TPLC
 import PlutusCore.Check.Scoping
 import PlutusCore.DeBruijn
 import PlutusCore.Evaluation.Machine.Ck qualified as TPLC
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as TPLC
+import PlutusCore.Generators.Hedgehog.AST
+import PlutusCore.Generators.Hedgehog.Utils
 import PlutusCore.Pretty
 import PlutusCore.Rename.Monad qualified as TPLC
+
+import PlutusPrelude
 
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
@@ -63,20 +60,25 @@ import Control.Lens
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
+
 import Data.Either.Extras
 import Data.Text (Text)
-import Hedgehog
-import Prettyprinter qualified as PP
-import System.IO.Unsafe
-import Test.Tasty
-import Test.Tasty.Hedgehog
-import Test.Tasty.HUnit
 
+import Hedgehog
 import Hedgehog.Internal.Config
 import Hedgehog.Internal.Property
 import Hedgehog.Internal.Region
 import Hedgehog.Internal.Report
 import Hedgehog.Internal.Runner
+
+import Prettyprinter qualified as PP
+
+import System.IO.Unsafe
+
+import Test.Tasty
+import Test.Tasty.Extras as TastyExtras
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
 
 -- | Map the 'TestLimit' of a 'Property' with a given function.
 mapTestLimit :: (TestLimit -> TestLimit) -> Property -> Property

--- a/plutus-core/testlib/PlutusIR/Generators/AST.hs
+++ b/plutus-core/testlib/PlutusIR/Generators/AST.hs
@@ -14,12 +14,12 @@ module PlutusIR.Generators.AST
     , genRecursivity
     ) where
 
-import PlutusIR
-
 import PlutusCore.Default qualified as PLC
 import PlutusCore.Generators.Hedgehog.AST as Export (AstGen, genBuiltin, genConstant, genKind, genVersion, runAstGen,
                                                      simpleRecursive)
 import PlutusCore.Generators.Hedgehog.AST qualified as PLC
+
+import PlutusIR
 
 import Hedgehog hiding (Rec, Var)
 import Hedgehog.Gen qualified as Gen

--- a/plutus-core/testlib/PlutusIR/Generators/QuickCheck/Common.hs
+++ b/plutus-core/testlib/PlutusIR/Generators/QuickCheck/Common.hs
@@ -3,14 +3,14 @@
 
 module PlutusIR.Generators.QuickCheck.Common where
 
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.Substitutions
 import PlutusCore.Generators.QuickCheck.Unification
-
-import PlutusCore.Default
 import PlutusCore.Name
 import PlutusCore.Quote (runQuoteT)
 import PlutusCore.Rename
+
 import PlutusIR
 import PlutusIR.Compiler
 import PlutusIR.Error
@@ -18,10 +18,12 @@ import PlutusIR.Subst
 import PlutusIR.TypeCheck
 
 import Control.Monad.Except
+
 import Data.Bifunctor
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set.Lens (setOf)
+
 import Text.PrettyBy
 
 -- | Compute the datatype declarations that escape from a term.

--- a/plutus-core/testlib/PlutusIR/Generators/QuickCheck/GenerateTerms.hs
+++ b/plutus-core/testlib/PlutusIR/Generators/QuickCheck/GenerateTerms.hs
@@ -16,8 +16,9 @@
 
 module PlutusIR.Generators.QuickCheck.GenerateTerms where
 
-import PlutusIR.Generators.QuickCheck.Common
-
+import PlutusCore.Builtin
+import PlutusCore.Core (argsFunKind)
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Builtin
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.GenerateTypes
@@ -26,21 +27,20 @@ import PlutusCore.Generators.QuickCheck.ShrinkTypes
 import PlutusCore.Generators.QuickCheck.Substitutions
 import PlutusCore.Generators.QuickCheck.Unification
 import PlutusCore.Generators.QuickCheck.Utils
-
-import PlutusCore.Builtin
-import PlutusCore.Core (argsFunKind)
-import PlutusCore.Default
 import PlutusCore.MkPlc (mkConstantOf)
 import PlutusCore.Name
 import PlutusCore.Subst (typeSubstClosedType)
+
 import PlutusIR
 import PlutusIR.Compiler
 import PlutusIR.Core.Instance.Pretty.Readable
+import PlutusIR.Generators.QuickCheck.Common
 import PlutusIR.Subst
 
 import Control.Lens ((<&>))
 import Control.Monad.Except
 import Control.Monad.Reader
+
 import Data.Bifunctor
 import Data.Default.Class
 import Data.Either
@@ -52,8 +52,11 @@ import Data.Proxy
 import Data.Set qualified as Set
 import Data.Set.Lens (setOf)
 import Data.String
+
 import GHC.Stack
+
 import Prettyprinter
+
 import Text.PrettyBy
 
 -- | This type keeps track of what kind of argument, term argument (`InstArg`) or

--- a/plutus-core/testlib/PlutusIR/Generators/QuickCheck/ShrinkTerms.hs
+++ b/plutus-core/testlib/PlutusIR/Generators/QuickCheck/ShrinkTerms.hs
@@ -9,22 +9,21 @@
 
 module PlutusIR.Generators.QuickCheck.ShrinkTerms where
 
-import PlutusIR.Generators.QuickCheck.Common
-
+import PlutusCore.Builtin
+import PlutusCore.Data
+import PlutusCore.Default
 import PlutusCore.Generators.QuickCheck.Builtin
 import PlutusCore.Generators.QuickCheck.Common
 import PlutusCore.Generators.QuickCheck.ShrinkTypes
 import PlutusCore.Generators.QuickCheck.Substitutions
 import PlutusCore.Generators.QuickCheck.Utils
-
-import PlutusCore.Builtin
-import PlutusCore.Data
-import PlutusCore.Default
 import PlutusCore.MkPlc (mkConstant, mkConstantOf, mkTyBuiltin)
 import PlutusCore.Name
 import PlutusCore.Pretty
 import PlutusCore.Subst (typeSubstClosedType)
+
 import PlutusIR
+import PlutusIR.Generators.QuickCheck.Common
 import PlutusIR.Subst
 
 import Data.Bifunctor
@@ -35,7 +34,9 @@ import Data.Map.Strict qualified as Map
 import Data.Proxy
 import Data.Set qualified as Set
 import Data.Set.Lens (setOf)
+
 import GHC.Stack
+
 import Test.QuickCheck (shrinkList)
 
 addTmBind :: Binding TyName Name DefaultUni DefaultFun ()

--- a/plutus-core/testlib/PlutusIR/Test.hs
+++ b/plutus-core/testlib/PlutusIR/Test.hs
@@ -9,8 +9,21 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module PlutusIR.Test where
 
+import PlutusCore qualified as PLC
+import PlutusCore.Compiler qualified as PLC
+import PlutusCore.Error (ParserErrorBundle)
+import PlutusCore.Name
+import PlutusCore.Pretty
+import PlutusCore.Pretty qualified as PLC
+import PlutusCore.Quote (runQuoteT)
+import PlutusCore.Test
+
+import PlutusIR as PIR
+import PlutusIR.Compiler as PIR
+import PlutusIR.Parser (Parser, parse)
+import PlutusIR.TypeCheck
+
 import PlutusPrelude
-import Test.Tasty.Extras
 
 import Control.Exception
 import Control.Lens hiding (op, transform)
@@ -18,26 +31,15 @@ import Control.Monad.Except
 import Control.Monad.Morph
 import Control.Monad.Reader as Reader
 
-import PlutusCore qualified as PLC
-import PlutusCore.Compiler qualified as PLC
-import PlutusCore.Name
-import PlutusCore.Pretty
-import PlutusCore.Pretty qualified as PLC
-import PlutusCore.Quote (runQuoteT)
-import PlutusCore.Test
-import PlutusIR as PIR
-import PlutusIR.Compiler as PIR
-import PlutusIR.Parser (Parser, parse)
-import PlutusIR.TypeCheck
-import System.FilePath (joinPath, (</>))
-
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 
-import PlutusCore.Error (ParserErrorBundle)
-
 import Prettyprinter
 import Prettyprinter.Render.Text
+
+import System.FilePath (joinPath, (</>))
+
+import Test.Tasty.Extras
 
 instance ( PLC.Pretty (PLC.SomeTypeIn uni), PLC.GEq uni, PLC.Typecheckable uni fun
          , PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, Pretty fun, Pretty a

--- a/plutus-core/testlib/Test/Tasty/Extras.hs
+++ b/plutus-core/testlib/Test/Tasty/Extras.hs
@@ -16,10 +16,13 @@ module Test.Tasty.Extras
 import PlutusPrelude
 
 import Control.Monad.Reader
+
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
+
 import System.FilePath ((</>))
+
 import Test.Tasty
 import Test.Tasty.Golden
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore.hs
@@ -9,6 +9,10 @@ module UntypedPlutusCore (
     , mkDefaultProg
     ) where
 
+import PlutusCore.Core qualified as PLC
+import PlutusCore.Default qualified as PLC
+import PlutusCore.Name as Export
+
 import UntypedPlutusCore.Check.Scope as Export
 import UntypedPlutusCore.Core as Export
 import UntypedPlutusCore.DeBruijn as Export
@@ -16,10 +20,6 @@ import UntypedPlutusCore.Parser as Parser (parseScoped)
 import UntypedPlutusCore.Simplify as Export
 import UntypedPlutusCore.Size as Export
 import UntypedPlutusCore.Subst as Export
-
-import PlutusCore.Core qualified as PLC
-import PlutusCore.Default qualified as PLC
-import PlutusCore.Name as Export
 
 -- | Take one UPLC program and apply it to another.
 applyProgram ::

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Definitions.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Definitions.hs
@@ -7,16 +7,16 @@ module UntypedPlutusCore.Analysis.Definitions
     , runTermDefs
     ) where
 
-import UntypedPlutusCore.Core
-
 import PlutusCore.Analysis.Definitions (ScopeType (TermScope), UniqueInfos, addDef, addUsage)
 import PlutusCore.Error
 import PlutusCore.Name
 
-import Data.Functor.Foldable
+import UntypedPlutusCore.Core
 
 import Control.Monad.State
 import Control.Monad.Writer
+
+import Data.Functor.Foldable
 
 termDefs
     :: (Ord ann,

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Usages.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Usages.hs
@@ -3,11 +3,11 @@
 -- | Functions for computing variable usage inside terms.
 module UntypedPlutusCore.Analysis.Usages (termUsages, Usages, getUsageCount, allUsed) where
 
-import UntypedPlutusCore.Core.Type
-import UntypedPlutusCore.Subst
-
 import PlutusCore qualified as PLC
 import PlutusCore.Name qualified as PLC
+
+import UntypedPlutusCore.Core.Type
+import UntypedPlutusCore.Subst
 
 import Control.Lens
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Scope.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Scope.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module UntypedPlutusCore.Check.Scope (checkScope) where
 
-import Control.Lens hiding (index)
 import UntypedPlutusCore.Core.Type as UPLC
 import UntypedPlutusCore.DeBruijn as UPLC
 
+import Control.Lens hiding (index)
 import Control.Monad.Error.Lens
 import Control.Monad.Except
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Uniques.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Uniques.hs
@@ -5,11 +5,11 @@ module UntypedPlutusCore.Check.Uniques
     , AsUniqueError (..)
     ) where
 
-import UntypedPlutusCore.Analysis.Definitions
-import UntypedPlutusCore.Core
-
 import PlutusCore.Error
 import PlutusCore.Name
+
+import UntypedPlutusCore.Analysis.Definitions
+import UntypedPlutusCore.Core
 
 import Control.Monad.Error.Lens
 import Control.Monad.Except

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
@@ -7,14 +7,14 @@
 
 module UntypedPlutusCore.Core.Instance.Eq () where
 
-import PlutusPrelude
-
-import UntypedPlutusCore.Core.Type
-
 import PlutusCore.DeBruijn
 import PlutusCore.Eq
 import PlutusCore.Name
 import PlutusCore.Rename.Monad
+
+import PlutusPrelude
+
+import UntypedPlutusCore.Core.Type
 
 import Universe
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Flat.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Flat.hs
@@ -10,14 +10,16 @@
 
 module UntypedPlutusCore.Core.Instance.Flat where
 
-import UntypedPlutusCore.Core.Type
-
 import PlutusCore.Flat
 
+import UntypedPlutusCore.Core.Type
+
 import Data.Word (Word8)
+
 import Flat
 import Flat.Decoder
 import Flat.Encoder
+
 import Universe
 
 {-

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Classic.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Classic.hs
@@ -10,16 +10,17 @@
 
 module UntypedPlutusCore.Core.Instance.Pretty.Classic () where
 
-import PlutusPrelude
-
-import UntypedPlutusCore.Core.Type
-
 import PlutusCore.Core.Instance.Pretty.Common ()
 import PlutusCore.Pretty.Classic
 import PlutusCore.Pretty.PrettyConst
 
+import PlutusPrelude
+
+import UntypedPlutusCore.Core.Type
+
 import Prettyprinter
 import Prettyprinter.Custom
+
 import Universe
 
 instance

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Default.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Default.hs
@@ -9,10 +9,10 @@
 
 module UntypedPlutusCore.Core.Instance.Pretty.Default () where
 
-import PlutusPrelude
-
 import PlutusCore.Pretty.Classic
 import PlutusCore.Pretty.PrettyConst
+
+import PlutusPrelude
 
 import UntypedPlutusCore.Core.Instance.Pretty.Classic ()
 import UntypedPlutusCore.Core.Type

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Plc.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Plc.hs
@@ -6,13 +6,13 @@
 
 module UntypedPlutusCore.Core.Instance.Pretty.Plc () where
 
+import PlutusCore.Pretty.Plc
+
 import PlutusPrelude
 
 import UntypedPlutusCore.Core.Instance.Pretty.Classic ()
 import UntypedPlutusCore.Core.Instance.Pretty.Readable ()
 import UntypedPlutusCore.Core.Type
-
-import PlutusCore.Pretty.Plc
 
 deriving via PrettyAny (Term name uni fun ann)
     instance DefaultPrettyPlcStrategy (Term name uni fun ann) =>

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Readable.hs
@@ -10,15 +10,16 @@
 
 module UntypedPlutusCore.Core.Instance.Pretty.Readable () where
 
-import PlutusPrelude
-
-import UntypedPlutusCore.Core.Type
-
 import PlutusCore.Core.Instance.Pretty.Common ()
 import PlutusCore.Pretty.PrettyConst
 import PlutusCore.Pretty.Readable
 
+import PlutusPrelude
+
+import UntypedPlutusCore.Core.Type
+
 import Prettyprinter
+
 import Universe
 
 instance

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Plated.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Plated.hs
@@ -12,6 +12,7 @@ module UntypedPlutusCore.Core.Plated
 
 import PlutusCore.Core (HasUniques)
 import PlutusCore.Name
+
 import UntypedPlutusCore.Core.Type
 
 import Control.Lens

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -25,13 +25,15 @@ module UntypedPlutusCore.Core.Type
     , uvarDeclAnn
     ) where
 
-import Control.Lens
-import PlutusPrelude
-
 import PlutusCore.Builtin qualified as TPLC
 import PlutusCore.Core qualified as TPLC
 import PlutusCore.MkPlc
 import PlutusCore.Name qualified as TPLC
+
+import PlutusPrelude
+
+import Control.Lens
+
 import Universe
 
 {- Note [Term constructor ordering and numbers]

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
@@ -24,9 +24,9 @@ module UntypedPlutusCore.DeBruijn
     ) where
 
 import PlutusCore.DeBruijn.Internal
-
 import PlutusCore.Name
 import PlutusCore.Quote
+
 import UntypedPlutusCore.Core
 
 import Control.Lens hiding (Index, Level, index)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -53,6 +53,13 @@ module UntypedPlutusCore.Evaluation.Machine.Cek
     )
 where
 
+import PlutusCore.Builtin
+import PlutusCore.Evaluation.Machine.Exception
+import PlutusCore.Evaluation.Machine.MachineParameters
+import PlutusCore.Name
+import PlutusCore.Pretty
+import PlutusCore.Quote
+
 import PlutusPrelude
 
 import UntypedPlutusCore.Core
@@ -62,17 +69,12 @@ import UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
 import UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
 import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
-import PlutusCore.Builtin
-import PlutusCore.Evaluation.Machine.Exception
-import PlutusCore.Evaluation.Machine.MachineParameters
-import PlutusCore.Name
-import PlutusCore.Pretty
-import PlutusCore.Quote
-
 import Control.Monad.Except
 import Control.Monad.State
+
 import Data.Bifunctor
 import Data.Text (Text)
+
 import Universe
 
 {- Note [CEK runners naming convention]

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
@@ -14,9 +14,13 @@ where
 import PlutusCore.Evaluation.Machine.ExBudget
 
 import Control.DeepSeq
+
 import Data.Text qualified as Text
+
 import Deriving.Aeson
+
 import Language.Haskell.TH.Syntax (Lift)
+
 import NoThunks.Class
 
 -- | The prefix of the field names in the CekMachineCosts type, used for

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Driver.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Driver.hs
@@ -25,6 +25,7 @@ import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
 import Control.Lens hiding (Context)
 import Control.Monad.Reader
 import Control.Monad.Trans.Free as F
+
 import Data.Function
 
 {- Note [Stepping the driver]

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Internal.hs
@@ -42,30 +42,24 @@ import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.Evaluation.Result
+
 import PlutusPrelude
+
 import UntypedPlutusCore.Core
 import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts (CekMachineCosts (..))
+import UntypedPlutusCore.Evaluation.Machine.Cek.Internal hiding (Context (..), runCekDeBruijn)
 
 import Control.Lens hiding (Context, ix)
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.ST
+
 import Data.RandomAccessList.Class qualified as Env
 import Data.Semigroup (stimes)
 import Data.Text (Text)
 import Data.Word64Array.Word8 hiding (Index)
+
 import GHC.IO (ioToST)
-
-{- Note [Debuggable vs Original versions of CEK]
-
-The debuggable version of CEK was created from copying over the original CEK/Internal.hs module
-and modifying the `computeCek`, `returnCek` functions.
-These functions were modified so as to execute a single step (Compute or Return resp.) and immediately
-return with the CEK's machine new state (`CekState`), whereas previously these two functions would iteratively run to completion.
-
-The interface otherwise remains the same. Moreover, the `Original.runCekDeBruijn` and `Debug.runCekDeBruijn` must behave equivalently.
--}
-import UntypedPlutusCore.Evaluation.Machine.Cek.Internal hiding (Context (..), runCekDeBruijn)
 
 data CekState uni fun ann =
     -- loaded a term but not fired the cek yet

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/EmitterMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/EmitterMode.hs
@@ -4,9 +4,13 @@
 
 module UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode (noEmitter, logEmitter, logWithTimeEmitter, logWithBudgetEmitter) where
 
+import PlutusCore.Evaluation.Machine.ExBudget
+import PlutusCore.Evaluation.Machine.ExMemory
+
 import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
 import Control.Monad.ST.Unsafe (unsafeIOToST)
+
 import Data.ByteString.Builder qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Csv qualified as CSV
@@ -19,8 +23,6 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import PlutusCore.Evaluation.Machine.ExBudget
-import PlutusCore.Evaluation.Machine.ExMemory
 
 -- | No emitter.
 noEmitter :: EmitterMode uni fun

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -22,16 +22,17 @@ module UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
     )
 where
 
-import PlutusPrelude
-
-import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
-
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 
+import PlutusPrelude
+
+import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+
 import Control.Lens (ifoldMap)
 import Control.Monad.Except
+
 import Data.Hashable (Hashable)
 import Data.HashMap.Monoidal as HashMap
 import Data.List (intersperse)
@@ -40,7 +41,9 @@ import Data.Primitive.PrimArray
 import Data.SatInt
 import Data.Semigroup.Generic
 import Data.STRef
+
 import Prettyprinter
+
 import Text.PrettyBy (IgnorePrettyConfig (..))
 
 -- | Construct an 'ExBudgetMode' out of a function returning a value of the budgeting state type.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -54,13 +54,6 @@ module UntypedPlutusCore.Evaluation.Machine.Cek.Internal
     )
 where
 
-import PlutusPrelude
-
-import UntypedPlutusCore.Core
-
-
-import Data.RandomAccessList.Class qualified as Env
-import Data.RandomAccessList.SkewBinary qualified as Env
 import PlutusCore.Builtin
 import PlutusCore.DeBruijn
 import PlutusCore.Evaluation.Machine.ExBudget
@@ -70,6 +63,9 @@ import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.Evaluation.Result
 import PlutusCore.Pretty
 
+import PlutusPrelude
+
+import UntypedPlutusCore.Core
 import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts (CekMachineCosts (..))
 
 import Control.Lens.Review
@@ -77,14 +73,19 @@ import Control.Monad.Catch
 import Control.Monad.Except
 import Control.Monad.ST
 import Control.Monad.ST.Unsafe
+
 import Data.DList (DList)
 import Data.Hashable (Hashable)
 import Data.Kind qualified as GHC
+import Data.RandomAccessList.Class qualified as Env
+import Data.RandomAccessList.SkewBinary qualified as Env
 import Data.Semigroup (stimes)
 import Data.Text (Text)
 import Data.Word
 import Data.Word64Array.Word8 hiding (Index)
+
 import Prettyprinter
+
 import Universe
 
 {- Note [Compilation peculiarities]

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Mark.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Mark.hs
@@ -4,11 +4,13 @@ module UntypedPlutusCore.Mark
     , markNonFreshProgram
     ) where
 
-import Data.Set.Lens (setOf)
 import PlutusCore.Core (HasUniques)
 import PlutusCore.Name
 import PlutusCore.Quote
+
 import UntypedPlutusCore.Core
+
+import Data.Set.Lens (setOf)
 
 -- | Marks all the 'Unique's in a term as used, so they will not be generated in future. Useful if you
 -- have a term which was not generated in 'Quote'.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/MkUPlc.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/MkUPlc.hs
@@ -1,9 +1,11 @@
 -- editorconfig-checker-disable-file
 module UntypedPlutusCore.MkUPlc (UVarDecl (..), uvarDeclName, uvarDeclAnn, mkVar, mkIterApp, mkIterLamAbs, Def(..), UTermDef) where
 
-import Data.List
 import PlutusCore.MkPlc (Def (..))
+
 import UntypedPlutusCore.Core.Type
+
+import Data.List
 
 -- | A term definition as a variable.
 type UTermDef name uni fun ann = Def (UVarDecl name ann) (Term name uni fun ann)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -12,21 +12,24 @@ module UntypedPlutusCore.Parser
     , SourcePos
     ) where
 
-import Prelude hiding (fail)
-
-import Control.Monad.Except (MonadError, (<=<))
-
 import PlutusCore qualified as PLC
+import PlutusCore.Error (AsParserErrorBundle)
+import PlutusCore.MkPlc (mkIterApp)
+import PlutusCore.Parser hiding (parseProgram, parseTerm, program)
+
 import PlutusPrelude (through)
-import Text.Megaparsec hiding (ParseError, State, parse)
+
 import UntypedPlutusCore.Check.Uniques (checkProgram)
 import UntypedPlutusCore.Core.Type qualified as UPLC
 import UntypedPlutusCore.Rename (Rename (rename))
 
+import Control.Monad.Except (MonadError, (<=<))
+
 import Data.Text (Text)
-import PlutusCore.Error (AsParserErrorBundle)
-import PlutusCore.MkPlc (mkIterApp)
-import PlutusCore.Parser hiding (parseProgram, parseTerm, program)
+
+import Prelude hiding (fail)
+
+import Text.Megaparsec hiding (ParseError, State, parse)
 
 -- Parsers for UPLC terms
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Rename.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Rename.hs
@@ -8,15 +8,15 @@ module UntypedPlutusCore.Rename
     ( Rename (..)
     ) where
 
+import PlutusCore.Core (HasUniques)
+import PlutusCore.Name
+import PlutusCore.Rename (Rename (..))
+
 import PlutusPrelude
 
 import UntypedPlutusCore.Core
 import UntypedPlutusCore.Mark
 import UntypedPlutusCore.Rename.Internal
-
-import PlutusCore.Core (HasUniques)
-import PlutusCore.Name
-import PlutusCore.Rename (Rename (..))
 
 instance HasUniques (Term name uni fun ann) => Rename (Term name uni fun ann) where
     -- See Note [Marking].

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Rename/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Rename/Internal.hs
@@ -7,12 +7,12 @@ module UntypedPlutusCore.Rename.Internal
     , renameProgramM
     ) where
 
-import UntypedPlutusCore.Core
-
 import PlutusCore.Core (HasUniques)
 import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.Rename.Monad as Export
+
+import UntypedPlutusCore.Core
 
 
 -- | Rename a 'Term' in the 'RenameM' monad.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
@@ -2,17 +2,18 @@
 {-# LANGUAGE TemplateHaskell #-}
 module UntypedPlutusCore.Simplify ( simplifyTerm, simplifyProgram, SimplifyOpts (..), soMaxSimplifierIterations, soInlineHints, defaultSimplifyOpts, InlineHints (..) ) where
 
-import UntypedPlutusCore.Core.Type
-import UntypedPlutusCore.Transform.ForceDelay
-import UntypedPlutusCore.Transform.Inline
-
-import Control.Monad
-import Data.List
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Name
 import PlutusCore.Quote
 
+import UntypedPlutusCore.Core.Type
+import UntypedPlutusCore.Transform.ForceDelay
+import UntypedPlutusCore.Transform.Inline
+
 import Control.Lens.TH
+import Control.Monad
+
+import Data.List
 
 data SimplifyOpts name a = SimplifyOpts { _soMaxSimplifierIterations  :: Int, _soInlineHints :: InlineHints name a }
   deriving stock (Show)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Size.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Size.hs
@@ -9,6 +9,7 @@ module UntypedPlutusCore.Size
 import UntypedPlutusCore.Core
 
 import Data.ByteString qualified as BS
+
 import Flat
 
 -- | Count the number of AST nodes in a term.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -22,8 +22,14 @@ See Note [The problem of inlining destructors].
 -}
 module UntypedPlutusCore.Transform.Inline (inline, InlineHints (..)) where
 
+import PlutusCore qualified as PLC
+import PlutusCore.Builtin qualified as PLC
+import PlutusCore.Name
+import PlutusCore.Quote
 import PlutusCore.Rename (Dupable, dupable, liftDupable)
+
 import PlutusPrelude
+
 import UntypedPlutusCore.Analysis.Usages qualified as Usages
 import UntypedPlutusCore.Core.Plated
 import UntypedPlutusCore.Core.Type
@@ -31,16 +37,13 @@ import UntypedPlutusCore.MkUPlc
 import UntypedPlutusCore.Rename ()
 
 import Annotation
-import PlutusCore qualified as PLC
-import PlutusCore.Builtin qualified as PLC
-import PlutusCore.Name
-import PlutusCore.Quote
 
 import Control.Lens hiding (Strict)
 import Control.Monad.Reader
 import Control.Monad.State
 
 import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
+
 import Witherable (wither)
 
 {- Note [Differences from PIR inliner]

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/Common.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/Common.hs
@@ -3,9 +3,11 @@
 {-# LANGUAGE TypeFamilies     #-}
 module DeBruijn.Common where
 
-import Data.Semigroup
 import PlutusCore.MkPlc
+
 import UntypedPlutusCore as UPLC
+
+import Data.Semigroup
 
 timesT :: Index -> (a -> a)  -> a -> a
 timesT n = appEndo . stimes n . Endo

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/Scope.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/Scope.hs
@@ -1,14 +1,18 @@
 {-# LANGUAGE TypeApplications #-}
 module DeBruijn.Scope (test_scope) where
 
+import PlutusCore.Default
+import PlutusCore.MkPlc
+
 import UntypedPlutusCore as UPLC
 
 import Control.Monad.Except
+
 import Data.Bifunctor
 import Data.Either
+
 import DeBruijn.Common
-import PlutusCore.Default
-import PlutusCore.MkPlc
+
 import Test.Tasty.Extras
 import Test.Tasty.HUnit
 

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/Spec.hs
@@ -3,6 +3,7 @@ module DeBruijn.Spec (test_debruijn) where
 
 import DeBruijn.Scope (test_scope)
 import DeBruijn.UnDeBruijnify (test_undebruijnify)
+
 import Test.Tasty
 import Test.Tasty.Extras
 

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/UnDeBruijnify.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/UnDeBruijnify.hs
@@ -2,16 +2,20 @@
 {-# LANGUAGE TypeApplications #-}
 module DeBruijn.UnDeBruijnify (test_undebruijnify) where
 
-import Control.Monad.Except
-import Control.Monad.State
-import DeBruijn.Common
 import PlutusCore.Default
 import PlutusCore.Error
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
 import PlutusCore.Quote
-import Test.Tasty.Extras
+
 import UntypedPlutusCore as UPLC
+
+import Control.Monad.Except
+import Control.Monad.State
+
+import DeBruijn.Common
+
+import Test.Tasty.Extras
 
 -- Note: The point of these tests is that
 -- binders with wrong indices will be undebruinified successfully, whereas

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
@@ -26,6 +26,7 @@ import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
 import Control.Monad.Except
+
 import Data.Text (Text)
 
 -- | Type check and evaluate a term.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -20,12 +20,10 @@ import PlutusCore.Data
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.MachineParameters
-import PlutusCore.Generators.Hedgehog.Interesting
-import PlutusCore.MkPlc hiding (error)
-import PlutusPrelude
-
 import PlutusCore.Examples.Builtins
 import PlutusCore.Examples.Data.Data
+import PlutusCore.Generators.Hedgehog.Interesting
+import PlutusCore.MkPlc hiding (error)
 import PlutusCore.StdLib.Data.Bool
 import PlutusCore.StdLib.Data.Data
 import PlutusCore.StdLib.Data.Function qualified as Plc
@@ -36,17 +34,22 @@ import PlutusCore.StdLib.Data.ScottList qualified as Scott
 import PlutusCore.StdLib.Data.ScottUnit qualified as Scott
 import PlutusCore.StdLib.Data.Unit
 
+import PlutusPrelude
+
+import Control.Exception
+
+import Data.ByteString (ByteString)
+import Data.Proxy
+import Data.Text (Text)
+
 import Evaluation.Builtins.Common
 import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519_V1Prop, ed25519_V2Prop,
                                                   schnorrSecp256k1Prop)
 
-import Control.Exception
-import Data.ByteString (ByteString)
-import Data.Proxy
-import Data.Text (Text)
 import Hedgehog hiding (Opaque, Size, Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
@@ -14,20 +14,22 @@ import PlutusCore.Evaluation.Result
 import PlutusCore.MkPlc hiding (error)
 import PlutusCore.Pretty
 import PlutusCore.StdLib.Data.Unit
+
 import PlutusPrelude
 
 import UntypedPlutusCore as UPLC (Name, Term, TyName)
+
+import Data.Text (Text)
 
 import Evaluation.Builtins.Common
 
 import Hedgehog hiding (Size, Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit
-
-import Data.Text (Text)
 
 -- | Convert a Haskell value to a PLC term and then convert back to a Haskell value
 -- of a different type.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
@@ -15,6 +15,14 @@ module Evaluation.Builtins.SignatureVerification (
   ) where
 
 
+import PlutusCore (DefaultFun (VerifyEcdsaSecp256k1Signature, VerifyEd25519Signature, VerifySchnorrSecp256k1Signature),
+                   EvaluationResult (EvaluationFailure, EvaluationSuccess))
+import PlutusCore.Default as Plutus (BuiltinVersion (..))
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+import PlutusCore.MkPlc (builtin, mkConstant, mkIterApp)
+
+import PlutusPrelude
+
 import Cardano.Crypto.DSIGN.Class (ContextDSIGN, DSIGNAlgorithm, SignKeyDSIGN, Signable, deriveVerKeyDSIGN, genKeyDSIGN,
                                    rawDeserialiseSigDSIGN, rawDeserialiseVerKeyDSIGN, rawSerialiseSigDSIGN,
                                    rawSerialiseVerKeyDSIGN, signDSIGN)
@@ -23,23 +31,21 @@ import Cardano.Crypto.DSIGN.EcdsaSecp256k1 (EcdsaSecp256k1DSIGN, MessageHash, Si
 import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
 import Cardano.Crypto.Seed (mkSeedFromBytes)
+
 import Control.Lens.Extras (is)
 import Control.Lens.Fold (preview)
 import Control.Lens.Prism (Prism', prism')
 import Control.Lens.Review (review)
+
 import Data.ByteString (ByteString)
 import Data.Kind (Type)
+
 import Evaluation.Builtins.Common (typecheckEvaluateCek)
+
 import Hedgehog (Gen, PropertyT, annotateShow, cover, failure, forAllWith, (===))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import PlutusCore (DefaultFun (VerifyEcdsaSecp256k1Signature, VerifyEd25519Signature, VerifySchnorrSecp256k1Signature),
-                   EvaluationResult (EvaluationFailure, EvaluationSuccess))
-import PlutusCore.Default as Plutus (BuiltinVersion (..))
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 
-import PlutusCore.MkPlc (builtin, mkConstant, mkIterApp)
-import PlutusPrelude
 import Text.Show.Pretty (ppShow)
 
 ecdsaSecp256k1Prop :: PropertyT IO ()

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Debug.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Debug.hs
@@ -14,15 +14,19 @@ module Evaluation.Debug
 
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.MachineParameters
+
 import UntypedPlutusCore
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
 
 import Control.Monad.RWS
 import Control.Monad.ST (RealWorld)
+
 import Data.ByteString.Lazy.Char8 qualified as BS
 import Data.Void
+
 import Prettyprinter
+
 import Test.Tasty
 import Test.Tasty.Golden
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
@@ -6,17 +6,19 @@ module Evaluation.FreeVars
     ( test_freevars
     ) where
 
-import Test.Tasty
-import Test.Tasty.HUnit
-
-import Data.Either
-import Data.RandomAccessList.Class qualified as Env
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.MkPlc
+
 import UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
 import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+
+import Data.Either
+import Data.RandomAccessList.Class qualified as Env
+
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- TODO: share examples with plutus-ledger-api:Spec.Eval
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
@@ -8,8 +8,13 @@ module Evaluation.Golden
     , namesAndTests
     ) where
 
-import Prelude hiding (even)
-
+import PlutusCore
+import PlutusCore.Compiler.Erase
+import PlutusCore.Evaluation.Machine.Ck
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+import PlutusCore.Generators.Hedgehog.Interesting
+import PlutusCore.MkPlc
+import PlutusCore.Pretty
 import PlutusCore.StdLib.Data.Bool
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.Nat
@@ -18,19 +23,15 @@ import PlutusCore.StdLib.Meta
 import PlutusCore.StdLib.Meta.Data.Tuple
 import PlutusCore.StdLib.Type
 
-import PlutusCore
-import PlutusCore.Compiler.Erase
-import PlutusCore.Evaluation.Machine.Ck
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
-import PlutusCore.Generators.Hedgehog.Interesting
-import PlutusCore.MkPlc
-import PlutusCore.Pretty
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
 import Data.Bifunctor
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
+
+import Prelude hiding (even)
+
 import Test.Tasty
 import Test.Tasty.Golden
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -9,9 +9,6 @@ module Evaluation.Machines
     , test_tallying
     ) where
 
-import UntypedPlutusCore
-import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
-
 import PlutusCore qualified as Plc
 import PlutusCore.Builtin
 import PlutusCore.Compiler.Erase
@@ -19,22 +16,28 @@ import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plc
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Machine.MachineParameters
+import PlutusCore.Examples.Builtins
 import PlutusCore.FsTree
 import PlutusCore.Generators.Hedgehog.Interesting
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
-import PlutusPrelude
-
-import PlutusCore.Examples.Builtins
 import PlutusCore.StdLib.Data.Nat qualified as Plc
 import PlutusCore.StdLib.Meta
 import PlutusCore.StdLib.Meta.Data.Function (etaExpand)
 
+import PlutusPrelude
+
+import UntypedPlutusCore
+import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
+
 import GHC.Exts (fromString)
 import GHC.Ix
+
 import Hedgehog hiding (Size, Var, eval)
+
 import Prettyprinter
 import Prettyprinter.Render.Text
+
 import Test.Tasty
 import Test.Tasty.Extras
 import Test.Tasty.Hedgehog

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Regressions.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Regressions.hs
@@ -6,17 +6,23 @@ module Evaluation.Regressions (
   schnorrVerifyRegressions
   ) where
 
-import Data.Bits (zeroBits)
-import Data.ByteString (ByteString)
-import Data.List.Split (chunksOf)
-import Evaluation.Builtins.Common (typecheckEvaluateCek)
-import GHC.Exts (fromListN)
 import PlutusCore (DefaultFun (VerifySchnorrSecp256k1Signature), EvaluationResult (EvaluationFailure))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultBuiltinCostModel)
 import PlutusCore.MkPlc (builtin, mkConstant, mkIterApp)
+
 import PlutusPrelude
+
+import Data.Bits (zeroBits)
+import Data.ByteString (ByteString)
+import Data.List.Split (chunksOf)
+
+import Evaluation.Builtins.Common (typecheckEvaluateCek)
+
+import GHC.Exts (fromListN)
+
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
+
 import Text.Read (readMaybe)
 
 schnorrVerifyRegressions :: TestTree

--- a/plutus-core/untyped-plutus-core/test/Generators.hs
+++ b/plutus-core/untyped-plutus-core/test/Generators.hs
@@ -6,8 +6,6 @@
 -- | UPLC property tests (pretty-printing\/parsing and binary encoding\/decoding).
 module Generators where
 
-import PlutusPrelude (display, fold, on, void)
-
 import PlutusCore (Name, _nameText)
 import PlutusCore.Compiler.Erase (eraseProgram)
 import PlutusCore.Default (Closed, DefaultFun, DefaultUni, Everywhere, GEq)
@@ -18,6 +16,9 @@ import PlutusCore.Generators.Hedgehog.AST qualified as AST
 import PlutusCore.Parser (defaultUni, parseGen)
 import PlutusCore.Pretty (displayPlcDef)
 import PlutusCore.Quote (QuoteT, runQuoteT)
+
+import PlutusPrelude (display, fold, on, void)
+
 import UntypedPlutusCore.Core.Type (Program (Program),
                                     Term (Apply, Builtin, Constant, Delay, Error, Force, LamAbs, Var))
 import UntypedPlutusCore.Parser (SourcePos, parseProgram, parseTerm)
@@ -25,12 +26,13 @@ import UntypedPlutusCore.Parser (SourcePos, parseProgram, parseTerm)
 import Data.Text (Text)
 import Data.Text qualified as T
 
+import Flat qualified
+
 import Hedgehog (property, tripping)
+
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.HUnit (testCase, (@?=))
-
-import Flat qualified
 
 -- | A 'Program' which we compare using textual equality of names rather than alpha-equivalence.
 newtype TextualProgram a = TextualProgram

--- a/plutus-core/untyped-plutus-core/test/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Spec.hs
@@ -3,19 +3,22 @@
 {-# LANGUAGE TypeApplications  #-}
 module Main where
 
-import GHC.IO.Encoding (setLocaleEncoding, utf8)
-
 import DeBruijn.Spec (test_debruijn)
+
 import Evaluation.Builtins (test_builtins)
 import Evaluation.Debug (test_debug)
 import Evaluation.FreeVars (test_freevars)
 import Evaluation.Golden (test_golden)
 import Evaluation.Machines
 import Evaluation.Regressions (schnorrVerifyRegressions)
+
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
+
 import Generators (test_parsing)
-import Transform.Simplify (test_simplify)
 
 import Test.Tasty
+
+import Transform.Simplify (test_simplify)
 
 main :: IO ()
 main = do

--- a/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
@@ -7,11 +7,14 @@ import PlutusCore qualified as PLC
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
 import PlutusCore.Quote
+
 import UntypedPlutusCore
 
 import Control.Lens ((&), (.~))
+
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text.Encoding (encodeUtf8)
+
 import Test.Tasty
 import Test.Tasty.Golden
 

--- a/plutus-ledger-api/src/Codec/CBOR/Extras.hs
+++ b/plutus-ledger-api/src/Codec/CBOR/Extras.hs
@@ -2,7 +2,9 @@ module Codec.CBOR.Extras where
 
 import Codec.CBOR.Decoding as CBOR
 import Codec.Serialise (Serialise, decode, encode)
+
 import Data.Either.Extras
+
 import Flat qualified
 import Flat.Decoder qualified as Flat
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common.hs
@@ -56,6 +56,7 @@ module PlutusLedgerApi.Common
 import PlutusCore.Data as PlutusCore (Data (..))
 import PlutusCore.Evaluation.Machine.CostModelInterface (CostModelParams)
 import PlutusCore.Evaluation.Machine.ExBudget as PlutusCore (ExBudget (..))
+
 import PlutusLedgerApi.Common.Eval
 import PlutusLedgerApi.Common.ParamName
 import PlutusLedgerApi.Common.SerialisedScript

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
@@ -18,7 +18,6 @@ module PlutusLedgerApi.Common.Eval
     , assertWellFormedCostModelParams
     ) where
 
-import Control.Lens
 import PlutusCore
 import PlutusCore as ScriptPlutus (Version, defaultVersion)
 import PlutusCore.Data as Plutus
@@ -29,18 +28,24 @@ import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus
 import PlutusCore.Evaluation.Machine.MachineParameters.Default
 import PlutusCore.MkPlc qualified as UPLC
 import PlutusCore.Pretty
+
 import PlutusLedgerApi.Common.SerialisedScript
 import PlutusLedgerApi.Common.Versions
+
 import PlutusPrelude
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
 
-
+import Control.Lens
 import Control.Monad.Except
 import Control.Monad.Writer
+
 import Data.Text as Text
 import Data.Tuple
+
 import NoThunks.Class
+
 import Prettyprinter
 
 -- | Errors that can be thrown when evaluating a Plutus script.

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/ParamName.hs
@@ -16,11 +16,13 @@ import PlutusCore.Evaluation.Machine.CostModelInterface
 
 import Control.Monad.Except
 import Control.Monad.Writer.Strict
+
 import Data.Bifunctor
 import Data.Char (toLower)
 import Data.List.Extra
 import Data.Map as Map
 import Data.Text qualified as Text
+
 import GHC.Generics
 
 {-| A parameter name for different plutus versions.

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
@@ -13,7 +13,9 @@ module PlutusLedgerApi.Common.ProtocolVersions
     ) where
 
 import Codec.Serialise (Serialise)
+
 import GHC.Generics (Generic)
+
 import Prettyprinter
 
 -- | This represents the Cardano protocol version, with its major and minor components.

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/SerialisedScript.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/SerialisedScript.hs
@@ -15,23 +15,29 @@ module PlutusLedgerApi.Common.SerialisedScript
     ) where
 
 import PlutusCore
+
 import PlutusLedgerApi.Common.Versions
+
 import PlutusTx.Code
+
 import UntypedPlutusCore qualified as UPLC
 
 import Codec.CBOR.Decoding qualified as CBOR
 import Codec.CBOR.Extras
 import Codec.CBOR.Read qualified as CBOR
 import Codec.Serialise
+
 import Control.Arrow ((>>>))
 import Control.Exception
 import Control.Lens
 import Control.Monad.Error.Lens
 import Control.Monad.Except
+
 import Data.ByteString.Lazy as BSL (ByteString, fromStrict, toStrict)
 import Data.ByteString.Short
 import Data.Coerce
 import Data.Set as Set
+
 import Prettyprinter
 
 -- | An error that occurred during script deserialization.

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
@@ -14,11 +14,14 @@ module PlutusLedgerApi.Common.Versions
     ) where
 
 import PlutusCore
+
 import PlutusLedgerApi.Common.ProtocolVersions
+
 import PlutusPrelude
 
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+
 import Prettyprinter
 
 {- Note [New builtins and protocol versions]

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
@@ -97,11 +97,10 @@ module PlutusLedgerApi.V1 (
     , ScriptDecodeError (..)
     ) where
 
-import Control.Monad.Except (MonadError)
-import Data.SatInt
 import PlutusCore.Data qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
+
 import PlutusLedgerApi.Common as Common hiding (assertScriptWellFormed, evaluateScriptCounting,
                                          evaluateScriptRestricting)
 import PlutusLedgerApi.Common qualified as Common (assertScriptWellFormed, evaluateScriptCounting,
@@ -118,9 +117,14 @@ import PlutusLedgerApi.V1.ParamName
 import PlutusLedgerApi.V1.Scripts as Scripts
 import PlutusLedgerApi.V1.Time
 import PlutusLedgerApi.V1.Value
+
 import PlutusTx (FromData (..), ToData (..), UnsafeFromData (..), fromData, toData)
 import PlutusTx.Builtins.Internal (BuiltinData (..), builtinDataToData, dataToBuiltinData)
 import PlutusTx.Prelude (BuiltinByteString, fromBuiltin, toBuiltin)
+
+import Control.Monad.Except (MonadError)
+
+import Data.SatInt
 
 -- | An alias to the language version this module exposes at runtime.
 --  MAYBE: Use CPP '__FILE__' + some TH to automate this.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Address.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Address.hs
@@ -16,16 +16,19 @@ module PlutusLedgerApi.V1.Address
     , stakingCredential
     ) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
-import PlutusTx qualified
-import PlutusTx.Bool qualified as PlutusTx
-import PlutusTx.Eq qualified as PlutusTx
-import Prettyprinter
-
 import PlutusLedgerApi.V1.Credential (Credential (..), StakingCredential)
 import PlutusLedgerApi.V1.Crypto
 import PlutusLedgerApi.V1.Scripts
+
+import PlutusTx qualified
+import PlutusTx.Bool qualified as PlutusTx
+import PlutusTx.Eq qualified as PlutusTx
+
+import Control.DeepSeq (NFData)
+
+import GHC.Generics (Generic)
+
+import Prettyprinter
 
 -- | An address may contain two credentials, the payment credential and optionally a 'StakingCredential'.
 data Address = Address

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Bytes.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Bytes.hs
@@ -14,8 +14,12 @@ module PlutusLedgerApi.V1.Bytes
     , encodeByteString
     ) where
 
+import PlutusTx
+import PlutusTx.Prelude qualified as P
+
 import Control.DeepSeq (NFData)
 import Control.Exception
+
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Internal (c2w, w2c)
@@ -24,9 +28,9 @@ import Data.String (IsString (..))
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TE
 import Data.Word (Word8)
+
 import GHC.Generics (Generic)
-import PlutusTx
-import PlutusTx.Prelude qualified as P
+
 import Prettyprinter.Extras (Pretty, PrettyShow (..))
 
 {- | An error that is encountered when converting a `ByteString` to a `LedgerBytes`. -}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
@@ -36,12 +36,6 @@ module PlutusLedgerApi.V1.Contexts
     , ownCurrencySymbol
     ) where
 
-import GHC.Generics (Generic)
-import PlutusTx
-import PlutusTx.Prelude
-import Prettyprinter
-import Prettyprinter.Extras
-
 import PlutusLedgerApi.V1.Address (Address (..))
 import PlutusLedgerApi.V1.Credential (Credential (..), StakingCredential)
 import PlutusLedgerApi.V1.Crypto (PubKeyHash (..))
@@ -50,7 +44,16 @@ import PlutusLedgerApi.V1.Scripts
 import PlutusLedgerApi.V1.Time (POSIXTimeRange)
 import PlutusLedgerApi.V1.Tx (TxId (..), TxOut (..), TxOutRef (..))
 import PlutusLedgerApi.V1.Value (CurrencySymbol (..), Value)
+
+import PlutusTx
+import PlutusTx.Prelude
+
+import GHC.Generics (Generic)
+
 import Prelude qualified as Haskell
+
+import Prettyprinter
+import Prettyprinter.Extras
 
 {- Note [Script types in pending transactions]
 To validate a transaction, we have to evaluate the validation script of each of

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Credential.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Credential.hs
@@ -13,13 +13,17 @@ module PlutusLedgerApi.V1.Credential
     , Credential(..)
     ) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
 import PlutusLedgerApi.V1.Crypto (PubKeyHash)
 import PlutusLedgerApi.V1.Scripts (ScriptHash)
+
 import PlutusTx qualified
 import PlutusTx.Bool qualified as PlutusTx
 import PlutusTx.Eq qualified as PlutusTx
+
+import Control.DeepSeq (NFData)
+
+import GHC.Generics (Generic)
+
 import Prettyprinter (Pretty (..), (<+>))
 
 -- | Staking credential used to assign rewards.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Crypto.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Crypto.hs
@@ -8,14 +8,19 @@ module PlutusLedgerApi.V1.Crypto
     ( PubKeyHash(..)
     ) where
 
-import Control.DeepSeq (NFData)
-import Data.String
-import GHC.Generics (Generic)
 import PlutusLedgerApi.V1.Bytes (LedgerBytes (..))
+
 import PlutusTx qualified
 import PlutusTx.Lift (makeLift)
 import PlutusTx.Prelude qualified as PlutusTx
 import PlutusTx.Show qualified as PlutusTx
+
+import Control.DeepSeq (NFData)
+
+import Data.String
+
+import GHC.Generics (Generic)
+
 import Prettyprinter
 
 {- | The hash of a public key. This is frequently used to identify the public key,

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/DCert.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/DCert.hs
@@ -11,12 +11,16 @@ module PlutusLedgerApi.V1.DCert
     ( DCert(..)
     ) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
 import PlutusLedgerApi.V1.Credential (StakingCredential)
 import PlutusLedgerApi.V1.Crypto (PubKeyHash)
+
 import PlutusTx qualified
 import PlutusTx.Prelude qualified as P
+
+import Control.DeepSeq (NFData)
+
+import GHC.Generics (Generic)
+
 import Prettyprinter.Extras
 
 -- | A representation of the ledger DCert. Some information is digested, and

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
@@ -8,10 +8,10 @@ module PlutusLedgerApi.V1.EvaluationContext
     , CostModelApplyError (..)
     ) where
 
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
+
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1.ParamName as V1
-
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
 
 import Control.Monad
 import Control.Monad.Except

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
@@ -35,14 +35,17 @@ module PlutusLedgerApi.V1.Interval
     , strictUpperBound
     ) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
-import Prelude qualified as Haskell
-import Prettyprinter (Pretty (pretty), comma, (<+>))
-
 import PlutusTx qualified
 import PlutusTx.Lift (makeLift)
 import PlutusTx.Prelude
+
+import Control.DeepSeq (NFData)
+
+import GHC.Generics (Generic)
+
+import Prelude qualified as Haskell
+
+import Prettyprinter (Pretty (pretty), comma, (<+>))
 
 {- | An interval of @a@s.
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/ParamName.hs
@@ -4,9 +4,11 @@ module PlutusLedgerApi.V1.ParamName
     , tagWithParamNames
     ) where
 
-import Data.Ix
-import GHC.Generics
 import PlutusLedgerApi.Common.ParamName
+
+import Data.Ix
+
+import GHC.Generics
 
 {-| The enumeration of all possible cost model parameter names for this language version.
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Scripts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Scripts.hs
@@ -21,18 +21,24 @@ module PlutusLedgerApi.V1.Scripts
     , ScriptHash(..)
     ) where
 
-import Prelude qualified as Haskell
-
-import Codec.Serialise (Serialise (..))
-import Control.DeepSeq (NFData)
-import Data.String
-import Data.Text (Text)
-import GHC.Generics (Generic)
 import PlutusLedgerApi.V1.Bytes (LedgerBytes (..))
+
 import PlutusTx (FromData (..), ToData (..), UnsafeFromData (..), makeLift)
 import PlutusTx.Builtins as Builtins
 import PlutusTx.Builtins.Internal as BI
 import PlutusTx.Prelude
+
+import Codec.Serialise (Serialise (..))
+
+import Control.DeepSeq (NFData)
+
+import Data.String
+import Data.Text (Text)
+
+import GHC.Generics (Generic)
+
+import Prelude qualified as Haskell
+
 import Prettyprinter
 
 {- Note [Serialise instances for Datum and Redeemer]

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Time.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Time.hs
@@ -17,13 +17,18 @@ module PlutusLedgerApi.V1.Time
     , fromMilliSeconds
     ) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
 import PlutusLedgerApi.V1.Interval
+
 import PlutusTx qualified
 import PlutusTx.Lift (makeLift)
 import PlutusTx.Prelude
+
+import Control.DeepSeq (NFData)
+
+import GHC.Generics (Generic)
+
 import Prelude qualified as Haskell
+
 import Prettyprinter (Pretty (pretty), (<+>))
 
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs
@@ -29,13 +29,11 @@ module PlutusLedgerApi.V1.Tx
     ,pubKeyHashTxOut
     ) where
 
-import Control.DeepSeq (NFData)
-import Control.Lens
-import Data.Map (Map)
-import Data.Maybe (isJust)
-import Data.String (IsString)
-import GHC.Generics (Generic)
-import Prettyprinter
+import PlutusLedgerApi.V1.Address
+import PlutusLedgerApi.V1.Bytes
+import PlutusLedgerApi.V1.Crypto
+import PlutusLedgerApi.V1.Scripts
+import PlutusLedgerApi.V1.Value
 
 import PlutusTx qualified
 import PlutusTx.Bool qualified as PlutusTx
@@ -43,11 +41,16 @@ import PlutusTx.Builtins qualified as PlutusTx
 import PlutusTx.Eq qualified as PlutusTx
 import PlutusTx.Ord qualified as PlutusTx
 
-import PlutusLedgerApi.V1.Address
-import PlutusLedgerApi.V1.Bytes
-import PlutusLedgerApi.V1.Crypto
-import PlutusLedgerApi.V1.Scripts
-import PlutusLedgerApi.V1.Value
+import Control.DeepSeq (NFData)
+import Control.Lens
+
+import Data.Map (Map)
+import Data.Maybe (isJust)
+import Data.String (IsString)
+
+import GHC.Generics (Generic)
+
+import Prettyprinter
 {- | A transaction ID, i.e. the hash of a transaction. Hashed with BLAKE2b-256. 32 byte.
 
 This is a simple type without any validation, __use with caution__.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -47,23 +47,28 @@ module PlutusLedgerApi.V1.Value(
     , flattenValue
     ) where
 
-import Prelude qualified as Haskell
-
-import Control.DeepSeq (NFData)
-import Data.ByteString qualified as BS
-import Data.Data (Data)
-import Data.String (IsString (fromString))
-import Data.Text (Text)
-import Data.Text qualified as Text
-import Data.Text.Encoding qualified as E
-import GHC.Generics (Generic)
 import PlutusLedgerApi.V1.Bytes (LedgerBytes (LedgerBytes), encodeByteString)
+
 import PlutusTx qualified
 import PlutusTx.AssocMap qualified as Map
 import PlutusTx.Lift (makeLift)
 import PlutusTx.Ord qualified as Ord
 import PlutusTx.Prelude as PlutusTx hiding (sort)
 import PlutusTx.These (These (..))
+
+import Control.DeepSeq (NFData)
+
+import Data.ByteString qualified as BS
+import Data.Data (Data)
+import Data.String (IsString (fromString))
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as E
+
+import GHC.Generics (Generic)
+
+import Prelude qualified as Haskell
+
 import Prettyprinter (Pretty, (<>))
 import Prettyprinter.Extras (PrettyShow (PrettyShow))
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
@@ -101,7 +101,7 @@ module PlutusLedgerApi.V2 (
     , ScriptDecodeError (..)
     ) where
 
-import Control.Monad.Except (MonadError)
+import PlutusCore.Data qualified as PLC
 
 import PlutusLedgerApi.Common as Common hiding (assertScriptWellFormed, evaluateScriptCounting,
                                          evaluateScriptRestricting)
@@ -115,8 +115,9 @@ import PlutusLedgerApi.V2.EvaluationContext
 import PlutusLedgerApi.V2.ParamName
 import PlutusLedgerApi.V2.Tx (OutputDatum (..))
 
-import PlutusCore.Data qualified as PLC
 import PlutusTx.AssocMap (Map, fromList)
+
+import Control.Monad.Except (MonadError)
 
 -- | An alias to the language version this module exposes at runtime.
 --  MAYBE: Use CPP '__FILE__' + some TH to automate this.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
@@ -37,12 +37,6 @@ module PlutusLedgerApi.V2.Contexts
     , ownCurrencySymbol
     ) where
 
-import GHC.Generics (Generic)
-import PlutusTx
-import PlutusTx.AssocMap hiding (filter, mapMaybe)
-import PlutusTx.Prelude hiding (toList)
-import Prettyprinter (Pretty (..), nest, vsep, (<+>))
-
 import PlutusLedgerApi.V1.Address (Address (..))
 import PlutusLedgerApi.V1.Contexts (ScriptPurpose (..))
 import PlutusLedgerApi.V1.Credential (Credential (..), StakingCredential)
@@ -53,7 +47,15 @@ import PlutusLedgerApi.V1.Time (POSIXTimeRange)
 import PlutusLedgerApi.V1.Value (CurrencySymbol, Value)
 import PlutusLedgerApi.V2.Tx (TxId (..), TxOut (..), TxOutRef (..))
 
+import PlutusTx
+import PlutusTx.AssocMap hiding (filter, mapMaybe)
+import PlutusTx.Prelude hiding (toList)
+
+import GHC.Generics (Generic)
+
 import Prelude qualified as Haskell
+
+import Prettyprinter (Pretty (..), nest, vsep, (<+>))
 
 -- | An input of a pending transaction.
 data TxInInfo = TxInInfo

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
@@ -9,10 +9,10 @@ module PlutusLedgerApi.V2.EvaluationContext
     , CostModelApplyError (..)
     ) where
 
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
+
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V2.ParamName as V2
-
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
 
 import Control.Monad
 import Control.Monad.Except

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/ParamName.hs
@@ -4,9 +4,11 @@ module PlutusLedgerApi.V2.ParamName
     , tagWithParamNames
     ) where
 
-import Data.Ix
-import GHC.Generics
 import PlutusLedgerApi.Common.ParamName
+
+import Data.Ix
+
+import GHC.Generics
 
 {-| The enumeration of all possible cost model parameter names for this language version.
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
@@ -31,22 +31,25 @@ module PlutusLedgerApi.V2.Tx
     , pubKeyHashTxOut
     ) where
 
-import Control.DeepSeq (NFData)
-import Control.Lens
-import Data.Maybe (isJust)
-import GHC.Generics (Generic)
-import Prettyprinter
-
-import PlutusTx qualified
-import PlutusTx.Bool qualified as PlutusTx
-import PlutusTx.Eq qualified as PlutusTx
-
 import PlutusLedgerApi.V1.Address
 import PlutusLedgerApi.V1.Crypto
 import PlutusLedgerApi.V1.Scripts
 import PlutusLedgerApi.V1.Tx hiding (TxOut (..), isPayToScriptOut, isPubKeyOut, outAddress, outValue, pubKeyHashTxOut,
                               txOutDatum, txOutPubKey)
 import PlutusLedgerApi.V1.Value
+
+import PlutusTx qualified
+import PlutusTx.Bool qualified as PlutusTx
+import PlutusTx.Eq qualified as PlutusTx
+
+import Control.DeepSeq (NFData)
+import Control.Lens
+
+import Data.Maybe (isJust)
+
+import GHC.Generics (Generic)
+
+import Prettyprinter
 
 -- | The datum attached to an output: either nothing; a datum hash; or the datum itself (an "inline datum").
 data OutputDatum = NoOutputDatum | OutputDatumHash DatumHash | OutputDatum Datum

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -102,7 +102,7 @@ module PlutusLedgerApi.V3 (
     , ScriptDecodeError (..)
     ) where
 
-import Control.Monad.Except (MonadError)
+import PlutusCore.Data qualified as PLC
 
 import PlutusLedgerApi.Common as Common hiding (assertScriptWellFormed, evaluateScriptCounting,
                                          evaluateScriptRestricting)
@@ -116,8 +116,9 @@ import PlutusLedgerApi.V2.Tx (OutputDatum (..))
 import PlutusLedgerApi.V3.EvaluationContext
 import PlutusLedgerApi.V3.ParamName
 
-import PlutusCore.Data qualified as PLC
 import PlutusTx.AssocMap (Map, fromList)
+
+import Control.Monad.Except (MonadError)
 
 -- | An alias to the language version this module exposes at runtime.
 --  MAYBE: Use CPP '__FILE__' + some TH to automate this.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
@@ -9,10 +9,10 @@ module PlutusLedgerApi.V3.EvaluationContext
     , CostModelApplyError (..)
     ) where
 
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV2))
+
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V3.ParamName as V3
-
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV2))
 
 import Control.Monad
 import Control.Monad.Except

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
@@ -4,9 +4,11 @@ module PlutusLedgerApi.V3.ParamName
     , tagWithParamNames
     ) where
 
-import Data.Ix
-import GHC.Generics
 import PlutusLedgerApi.Common.ParamName
+
+import Data.Ix
+
+import GHC.Generics
 
 {-| The enumeration of all possible cost model parameter names for this language version.
 

--- a/plutus-ledger-api/src/Prettyprinter/Extras.hs
+++ b/plutus-ledger-api/src/Prettyprinter/Extras.hs
@@ -11,7 +11,9 @@ import Data.Foldable (Foldable (toList))
 import Data.Proxy (Proxy (..))
 import Data.String (IsString (..))
 import Data.Tagged
+
 import GHC.TypeLits (KnownSymbol, symbolVal)
+
 import Prettyprinter
 
 -- | Newtype wrapper for deriving 'Pretty' via a 'Show' instance

--- a/plutus-ledger-api/test-onchain-evaluation/Main.hs
+++ b/plutus-ledger-api/test-onchain-evaluation/Main.hs
@@ -7,22 +7,26 @@
 module Main (main) where
 
 import PlutusCore.Pretty
+
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.Test.EvaluationEvent
 import PlutusLedgerApi.V1 qualified as V1
 import PlutusLedgerApi.V2 qualified as V2
 
 import Codec.Serialise qualified as CBOR
+
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception (evaluate)
 import Control.Monad.Extra (whenJust)
+import Control.Monad.Writer.Strict
+
 import Data.List.NonEmpty (nonEmpty, toList)
 import Data.Maybe (catMaybes)
 
-import Control.Monad.Writer.Strict
 import System.Directory.Extra (listFiles)
 import System.Environment (getEnv)
 import System.FilePath (isExtensionOf, takeBaseName)
+
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -5,6 +5,12 @@ import PlutusLedgerApi.Common.Versions
 import PlutusLedgerApi.Test.EvaluationContext (evalCtxForTesting)
 import PlutusLedgerApi.Test.Examples
 import PlutusLedgerApi.V1
+
+import Control.Monad (void)
+
+import Data.Either
+import Data.Word (Word8)
+
 import Spec.CostModelParams qualified
 import Spec.Eval qualified
 import Spec.Interval qualified
@@ -14,10 +20,6 @@ import Spec.Versions qualified
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
-
-import Control.Monad (void)
-import Data.Either
-import Data.Word (Word8)
 
 main :: IO ()
 main = defaultMain tests

--- a/plutus-ledger-api/test/Spec/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/CostModelParams.hs
@@ -3,26 +3,29 @@
 {-# LANGUAGE TypeApplications #-}
 module Spec.CostModelParams where
 
-import PlutusLedgerApi.Common
-import PlutusLedgerApi.V1 as V1
-import PlutusLedgerApi.V2 as V2
-import PlutusLedgerApi.V3 as V3
-
 import PlutusCore.Evaluation.Machine.BuiltinCostModel as Plutus
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults as Plutus
 import PlutusCore.Evaluation.Machine.MachineParameters as Plutus
 
+import PlutusLedgerApi.Common
+import PlutusLedgerApi.V1 as V1
+import PlutusLedgerApi.V2 as V2
+import PlutusLedgerApi.V3 as V3
+
 import Barbies
+
 import Control.Lens
 import Control.Monad.Except
 import Control.Monad.Writer.Strict
+
 import Data.Either
 import Data.List.Extra
 import Data.Map as Map
 import Data.Maybe
 import Data.Set as Set
 import Data.Text qualified as Text
+
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/plutus-ledger-api/test/Spec/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Eval.hs
@@ -6,12 +6,15 @@ module Spec.Eval (tests) where
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.MkPlc
+
 import PlutusLedgerApi.Common.Versions
 import PlutusLedgerApi.Test.EvaluationContext (evalCtxForTesting)
 import PlutusLedgerApi.V1 as Api
+
 import UntypedPlutusCore as UPLC
 
 import Data.Either
+
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/plutus-ledger-api/test/Spec/Interval.hs
+++ b/plutus-ledger-api/test/Spec/Interval.hs
@@ -5,12 +5,15 @@
 
 module Spec.Interval where
 
+import PlutusLedgerApi.V1.Interval qualified as Interval
+
 import Data.List (sort)
+
 import Hedgehog (Property, forAll, property)
 import Hedgehog qualified
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import PlutusLedgerApi.V1.Interval qualified as Interval
+
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.HUnit (assertBool, testCase)

--- a/plutus-ledger-api/test/Spec/NoThunks.hs
+++ b/plutus-ledger-api/test/Spec/NoThunks.hs
@@ -3,21 +3,23 @@
 
 module Spec.NoThunks (tests) where
 
-import NoThunks.Class
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults as Plutu
+import PlutusCore.Pretty
 
 import PlutusLedgerApi.V1 as V1
 import PlutusLedgerApi.V2 as V2
 import PlutusLedgerApi.V3 as V3
 
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults as Plutu
-import PlutusCore.Pretty
-
 import Control.Monad.Except
 import Control.Monad.Extra (whenJust)
 import Control.Monad.Writer.Strict
+
 import Data.List.Extra (enumerate)
 import Data.Map qualified as Map
 import Data.Maybe (fromJust)
+
+import NoThunks.Class
+
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/plutus-ledger-api/test/Spec/Versions.hs
+++ b/plutus-ledger-api/test/Spec/Versions.hs
@@ -7,20 +7,25 @@ module Spec.Versions (tests) where
 import PlutusCore as PLC
 import PlutusCore.Data as PLC
 import PlutusCore.MkPlc as PLC
+
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.Common.Versions
 import PlutusLedgerApi.V1 qualified as V1
 import PlutusLedgerApi.V2 qualified as V2
 import PlutusLedgerApi.V3 qualified as V3
+
 import PlutusPrelude
+
 import UntypedPlutusCore as UPLC
 
 import Control.Monad.Except
+
 import Data.ByteString.Short as BSS
 import Data.Either
 import Data.Foldable (for_)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationContext.hs
@@ -6,7 +6,9 @@ module PlutusLedgerApi.Test.EvaluationContext
 
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus
+
 import PlutusLedgerApi.Common
+
 import PlutusPrelude
 
 import Data.Either.Extras

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
@@ -18,17 +18,22 @@ module PlutusLedgerApi.Test.EvaluationEvent (
 
 import PlutusCore.Data qualified as PLC
 import PlutusCore.Pretty
+
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1 qualified as V1
 import PlutusLedgerApi.V2 qualified as V2
 
 import Codec.Serialise (Serialise (..))
+
 import Data.ByteString.Base64 qualified as Base64
 import Data.ByteString.Short qualified as BS
 import Data.List.NonEmpty (NonEmpty, toList)
 import Data.Text.Encoding qualified as Text
+
 import GHC.Generics (Generic)
+
 import Prettyprinter
+
 import PyF (fmt)
 
 

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Examples.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Examples.hs
@@ -5,10 +5,13 @@ module PlutusLedgerApi.Test.Examples (alwaysSucceedingNAryFunction, alwaysFailin
 
 import PlutusCore qualified as PLC
 import PlutusCore.MkPlc qualified as PLC
+
 import PlutusLedgerApi.V1
+
 import UntypedPlutusCore qualified as UPLC
 
 import Numeric.Natural
+
 import Universe (Some (Some))
 
 {- Note [Manually constructing scripts]

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
@@ -6,6 +6,7 @@ module PlutusLedgerApi.Test.Scripts
     ) where
 
 import PlutusLedgerApi.V1.Scripts
+
 import PlutusTx
 
 -- | @()@ as a datum.

--- a/plutus-metatheory/Setup.hs
+++ b/plutus-metatheory/Setup.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+
 import Distribution.Simple qualified as D
 import Distribution.Simple.PreProcess qualified as D
 import Distribution.Simple.Program qualified as D
@@ -10,7 +12,6 @@ import Distribution.Types.ComponentLocalBuildInfo qualified as D
 import Distribution.Types.LocalBuildInfo qualified as D
 import Distribution.Verbosity qualified as D
 
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import System.IO.Unsafe (unsafePerformIO)
 
 {-

--- a/plutus-metatheory/src/Opts.hs
+++ b/plutus-metatheory/src/Opts.hs
@@ -3,13 +3,14 @@
 -- editorconfig-checker-disable-file
 module Opts where
 
+import PlutusCore.Executable.Common
+import PlutusCore.Executable.Parsers
+
 import Data.Semigroup ((<>))
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Options.Applicative
 
-import PlutusCore.Executable.Common
-import PlutusCore.Executable.Parsers
+import Options.Applicative
 
 -- The different evaluation modes of plc-agda
 data EvalMode = U | TL | TCK | TCEK deriving stock (Show, Read)

--- a/plutus-metatheory/src/Raw.hs
+++ b/plutus-metatheory/src/Raw.hs
@@ -7,17 +7,17 @@
 {-# LANGUAGE TypeApplications      #-}
 module Raw where
 
-import Data.ByteString as BS
-import Data.Text qualified as T
 import PlutusCore
 import PlutusCore.Data
 import PlutusCore.DeBruijn
 import PlutusCore.Default
+import PlutusCore.Error (ParserErrorBundle)
 import PlutusCore.Parser
 import PlutusCore.Pretty
 
+import Data.ByteString as BS
 import Data.Either
-import PlutusCore.Error (ParserErrorBundle)
+import Data.Text qualified as T
 
 data RType = RTyVar Integer
            | RTyFun RType RType

--- a/plutus-metatheory/src/Untyped.hs
+++ b/plutus-metatheory/src/Untyped.hs
@@ -4,10 +4,12 @@ module Untyped where
 
 import PlutusCore.Data
 import PlutusCore.Default
+
 import UntypedPlutusCore
 
 import Data.ByteString as BS
 import Data.Text as T
+
 import Universe
 
 

--- a/plutus-metatheory/test/TestDetailed.hs
+++ b/plutus-metatheory/test/TestDetailed.hs
@@ -2,20 +2,22 @@
 {-# LANGUAGE LambdaCase #-}
 module TestDetailed where
 import Control.Exception
+
 import Data.Text qualified as T
-import GHC.IO.Handle
-import System.Directory
-import System.Environment
-import System.Exit
-import System.IO
-import System.Process
 
 import Distribution.TestSuite
+
+import GHC.IO.Handle
 
 import MAlonzo.Code.Main qualified as M
 import MAlonzo.Code.Raw qualified as R
 
+import System.Directory
+import System.Environment
+import System.Exit
+import System.IO
 import System.IO.Extra
+import System.Process
 
 -- this function is based on this stackoverflow answer:
 -- https://stackoverflow.com/a/9664017

--- a/plutus-metatheory/test/TestNEAT.hs
+++ b/plutus-metatheory/test/TestNEAT.hs
@@ -1,29 +1,34 @@
 -- editorconfig-checker-disable-file
 module Main where
 
-import Control.Monad.Except
-import Data.Coolean
-import Data.Either
-import Data.List
 import PlutusCore
 import PlutusCore.Compiler.Erase
+import PlutusCore.DeBruijn
 import PlutusCore.Evaluation.Machine.Ck
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Generators.NEAT.Spec
 import PlutusCore.Generators.NEAT.Term
 import PlutusCore.Normalize
 import PlutusCore.Pretty
-import Test.Tasty
-import Test.Tasty.HUnit
+
 import UntypedPlutusCore qualified as U
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as U
 
-import MAlonzo.Code.Main (checkKindAgda, checkTypeAgda, inferKindAgda, inferTypeAgda, normalizeTypeAgda,
-                          normalizeTypeTermAgda, runTCEKAgda, runTCKAgda, runTLAgda, runUAgda)
-import PlutusCore.DeBruijn
-import Raw hiding (TypeError, tynames)
+import Control.Monad.Except
+
+import Data.Coolean
+import Data.Either
+import Data.List
 
 import Debug.Trace
+
+import MAlonzo.Code.Main (checkKindAgda, checkTypeAgda, inferKindAgda, inferTypeAgda, normalizeTypeAgda,
+                          normalizeTypeTermAgda, runTCEKAgda, runTCKAgda, runTLAgda, runUAgda)
+
+import Raw hiding (TypeError, tynames)
+
+import Test.Tasty
+import Test.Tasty.HUnit
 
 main :: IO ()
 main = defaultMain allTests

--- a/plutus-metatheory/test/TestSimple.hs
+++ b/plutus-metatheory/test/TestSimple.hs
@@ -4,12 +4,13 @@
 module Main where
 
 import Control.Exception
+
+import MAlonzo.Code.Main qualified as M
+
 import System.Environment
 import System.Exit
 import System.IO.Extra
 import System.Process
-
-import MAlonzo.Code.Main qualified as M
 
 -- |List of tests that are expected to succeed
 succeedingEvalTests = ["succInteger"

--- a/plutus-tx-plugin/app/GeneratePluginOptionsDoc.hs
+++ b/plutus-tx-plugin/app/GeneratePluginOptionsDoc.hs
@@ -8,12 +8,16 @@ module Main (main) where
 import PlutusTx.Options qualified as O
 
 import Control.Lens
+
 import Data.Map qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
+
 import Options.Applicative qualified as OA
+
 import Prettyprinter
+
 import PyF (fmt)
 
 

--- a/plutus-tx-plugin/src/PlutusTx/Annotation.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Annotation.hs
@@ -6,7 +6,9 @@ module PlutusTx.Annotation where
 import PlutusTx.Code
 
 import Data.Set qualified as Set
+
 import GHC.Generics
+
 import Prettyprinter
 
 -- | An annotation type used during the compilation.

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
@@ -6,17 +6,17 @@
 -- | Convenient functions for compiling binders.
 module PlutusTx.Compiler.Binders where
 
+import PlutusIR qualified as PIR
+
 import PlutusTx.Compiler.Names
 import PlutusTx.Compiler.Types
 import PlutusTx.PIRTypes
 
-import GHC.Plugins qualified as GHC
-
-import PlutusIR qualified as PIR
-
 import Control.Monad.Reader
 
 import Data.Traversable
+
+import GHC.Plugins qualified as GHC
 
 -- Binder helpers
 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -18,14 +18,10 @@ module PlutusTx.Compiler.Builtins (
     , lookupBuiltinType
     , errorFunc) where
 
-import PlutusTx.Builtins.Class qualified as Builtins
-import PlutusTx.Builtins.Internal qualified as Builtins
-
-import PlutusTx.Compiler.Error
-import PlutusTx.Compiler.Names
-import PlutusTx.Compiler.Types
-import PlutusTx.Compiler.Utils
-import PlutusTx.PIRTypes
+import PlutusCore qualified as PLC
+import PlutusCore.Builtin qualified as PLC
+import PlutusCore.Data qualified as PLC
+import PlutusCore.Quote
 
 import PlutusIR qualified as PIR
 import PlutusIR.Compiler.Definitions qualified as PIR
@@ -33,15 +29,13 @@ import PlutusIR.Compiler.Names
 import PlutusIR.MkPir qualified as PIR
 import PlutusIR.Purity qualified as PIR
 
-import PlutusCore qualified as PLC
-import PlutusCore.Builtin qualified as PLC
-import PlutusCore.Data qualified as PLC
-import PlutusCore.Quote
-
-import GHC.Plugins qualified as GHC
-import GHC.Types.TyThing qualified as GHC
-
-import Language.Haskell.TH.Syntax qualified as TH
+import PlutusTx.Builtins.Class qualified as Builtins
+import PlutusTx.Builtins.Internal qualified as Builtins
+import PlutusTx.Compiler.Error
+import PlutusTx.Compiler.Names
+import PlutusTx.Compiler.Types
+import PlutusTx.Compiler.Utils
+import PlutusTx.PIRTypes
 
 import Control.Monad.Reader (ask, asks)
 
@@ -49,6 +43,11 @@ import Data.ByteString qualified as BS
 import Data.Functor
 import Data.Proxy
 import Data.Text (Text)
+
+import GHC.Plugins qualified as GHC
+import GHC.Types.TyThing qualified as GHC
+
+import Language.Haskell.TH.Syntax qualified as TH
 
 {- Note [Mapping builtins]
 We want the user to be able to call the Plutus builtins as normal Haskell functions.

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
@@ -17,17 +17,19 @@ module PlutusTx.Compiler.Error (
     , throwPlain
     , pruneContext) where
 
-import PlutusIR.Compiler qualified as PIR
-
-import Language.Haskell.TH qualified as TH
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty qualified as PLC
+
 import PlutusIR qualified as PIR
+import PlutusIR.Compiler qualified as PIR
 
 import Control.Lens
 import Control.Monad.Except
 
 import Data.Text qualified as T
+
+import Language.Haskell.TH qualified as TH
+
 import Prettyprinter qualified as PP
 
 -- | An error with some (nested) context. The integer argument to 'WithContextC' represents

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
@@ -6,13 +6,13 @@
 -- | Functions for compiling GHC kinds into PlutusCore kinds.
 module PlutusTx.Compiler.Kind (compileKind) where
 
+import PlutusCore qualified as PLC
+
 import PlutusTx.Compiler.Error
 import PlutusTx.Compiler.Types
 import PlutusTx.Compiler.Utils
 
 import GHC.Plugins qualified as GHC
-
-import PlutusCore qualified as PLC
 
 compileKind :: Compiling uni fun m ann => GHC.Kind -> m (PLC.Kind ())
 compileKind k = withContextM 2 (sdToTxt $ "Compiling kind:" GHC.<+> GHC.ppr k) $ case k of

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
@@ -6,12 +6,12 @@
 -- | Simulating laziness.
 module PlutusTx.Compiler.Laziness where
 
-import PlutusTx.Compiler.Types
-import PlutusTx.PIRTypes
+import PlutusCore.Quote
 
 import PlutusIR qualified as PIR
 
-import PlutusCore.Quote
+import PlutusTx.Compiler.Types
+import PlutusTx.PIRTypes
 
 {- Note [Object- vs meta-language combinators]
 Many of the things we define as *meta*-langugage combinators (i.e. operations on terms) could be defined

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
@@ -7,18 +7,16 @@
 module PlutusTx.Compiler.Names where
 
 
-import PlutusTx.Compiler.Kind
-import {-# SOURCE #-} PlutusTx.Compiler.Type
-import PlutusTx.Compiler.Types
-import PlutusTx.PLCTypes
-
-import GHC.Plugins qualified as GHC
-
 import PlutusCore qualified as PLC
 import PlutusCore.MkPlc qualified as PLC
 import PlutusCore.Quote
 
 import PlutusIR.Compiler.Names
+
+import PlutusTx.Compiler.Kind
+import {-# SOURCE #-} PlutusTx.Compiler.Type
+import PlutusTx.Compiler.Types
+import PlutusTx.PLCTypes
 
 import Data.Char
 import Data.Functor
@@ -26,6 +24,8 @@ import Data.List
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 import Data.Text qualified as T
+
+import GHC.Plugins qualified as GHC
 
 lookupName :: Scope uni -> GHC.Name -> Maybe (PLCVar uni)
 lookupName (Scope ns _) n = Map.lookup n ns

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
@@ -17,6 +17,12 @@ module PlutusTx.Compiler.Type (
     getMatch,
     getMatchInstantiated) where
 
+import PlutusCore.Name qualified as PLC
+
+import PlutusIR qualified as PIR
+import PlutusIR.Compiler.Definitions qualified as PIR
+import PlutusIR.MkPir qualified as PIR
+
 import PlutusTx.Compiler.Binders
 import PlutusTx.Compiler.Error
 import PlutusTx.Compiler.Kind
@@ -25,17 +31,6 @@ import PlutusTx.Compiler.Types
 import PlutusTx.Compiler.Utils
 import PlutusTx.PIRTypes
 
-import GHC.Builtin.Types.Prim qualified as GHC
-import GHC.Core.FamInstEnv qualified as GHC
-import GHC.Core.Multiplicity qualified as GHC
-import GHC.Plugins qualified as GHC
-
-import PlutusIR qualified as PIR
-import PlutusIR.Compiler.Definitions qualified as PIR
-import PlutusIR.MkPir qualified as PIR
-
-import PlutusCore.Name qualified as PLC
-
 import Control.Monad.Extra
 import Control.Monad.Reader
 
@@ -43,6 +38,11 @@ import Data.List (sortBy)
 import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 import Data.Traversable
+
+import GHC.Builtin.Types.Prim qualified as GHC
+import GHC.Core.FamInstEnv qualified as GHC
+import GHC.Core.Multiplicity qualified as GHC
+import GHC.Plugins qualified as GHC
 
 -- Types
 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -12,20 +12,17 @@ module PlutusTx.Compiler.Types (
     module Annotation
     ) where
 
-import PlutusTx.Compiler.Error
-import PlutusTx.Coverage
-import PlutusTx.PLCTypes
-
-import PlutusIR.Compiler.Definitions
-
-import Annotation
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Default qualified as PLC
 import PlutusCore.Quote
 
-import GHC qualified
-import GHC.Core.FamInstEnv qualified as GHC
-import GHC.Plugins qualified as GHC
+import PlutusIR.Compiler.Definitions
+
+import PlutusTx.Compiler.Error
+import PlutusTx.Coverage
+import PlutusTx.PLCTypes
+
+import Annotation
 
 import Control.Monad.Except
 import Control.Monad.Reader
@@ -36,7 +33,12 @@ import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 
+import GHC qualified
+import GHC.Core.FamInstEnv qualified as GHC
+import GHC.Plugins qualified as GHC
+
 import Language.Haskell.TH.Syntax qualified as TH
+
 import Prettyprinter
 
 type NameInfo = Map.Map TH.Name GHC.TyThing

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Utils.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Utils.hs
@@ -8,17 +8,17 @@ module PlutusTx.Compiler.Utils where
 import PlutusTx.Compiler.Error
 import PlutusTx.Compiler.Types
 
+import Control.Monad.Except
+import Control.Monad.Reader
+
+import Data.Map qualified as Map
+import Data.Text qualified as T
+
 import GHC.Core qualified as GHC
 import GHC.Plugins qualified as GHC
 import GHC.Types.TyThing qualified as GHC
 
-import Control.Monad.Except
-import Control.Monad.Reader
-
 import Language.Haskell.TH.Syntax qualified as TH
-
-import Data.Map qualified as Map
-import Data.Text qualified as T
 
 -- | Get the 'GHC.TyThing' for a given 'TH.Name' which was stored in the builtin name info,
 -- failing if it is missing.

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -11,10 +11,14 @@
 module PlutusTx.Options where
 
 import PlutusIR.Compiler qualified as PIR
+
 import PlutusTx.Compiler.Types
+
+import UntypedPlutusCore qualified as UPLC
 
 import Control.Exception
 import Control.Lens
+
 import Data.Bifunctor (first)
 import Data.Either.Validation
 import Data.Foldable (foldl', toList)
@@ -26,13 +30,16 @@ import Data.Proxy
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Type.Equality
+
 import GHC.Plugins qualified as GHC
+
 import Prettyprinter
+
 import PyF (fmt)
 
 import Text.Read (readMaybe)
+
 import Type.Reflection
-import UntypedPlutusCore qualified as UPLC
 
 data PluginOptions = PluginOptions
     { _posDoTypecheck                    :: Bool

--- a/plutus-tx-plugin/src/PlutusTx/PIRTypes.hs
+++ b/plutus-tx-plugin/src/PlutusTx/PIRTypes.hs
@@ -1,7 +1,8 @@
 module PlutusTx.PIRTypes where
 
-import Annotation
 import PlutusIR qualified as PIR
+
+import Annotation
 
 type PIRKind = PIR.Kind Ann
 type PIRType uni = PIR.Type PIR.TyName uni Ann

--- a/plutus-tx-plugin/src/PlutusTx/PLCTypes.hs
+++ b/plutus-tx-plugin/src/PlutusTx/PLCTypes.hs
@@ -1,9 +1,11 @@
 module PlutusTx.PLCTypes where
 
-import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.MkPlc qualified as PLC
+
 import UntypedPlutusCore qualified as UPLC
+
+import Annotation
 
 type PLCKind = PLC.Kind Ann
 type PLCType uni = PLC.Type PLC.TyName uni Ann

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -13,8 +13,6 @@
 
 module Budget.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusTx.Builtins qualified as PlutusTx
 import PlutusTx.Code
 import PlutusTx.IsData qualified as PlutusTx
@@ -22,6 +20,8 @@ import PlutusTx.Prelude qualified as PlutusTx
 import PlutusTx.Show qualified as PlutusTx
 import PlutusTx.Test (goldenBudget, goldenPir)
 import PlutusTx.TH (compile)
+
+import Test.Tasty.Extras
 
 tests :: TestNested
 tests = testNested "Budget" [

--- a/plutus-tx-plugin/test/IsData/Spec.hs
+++ b/plutus-tx-plugin/test/IsData/Spec.hs
@@ -15,11 +15,10 @@
 
 module IsData.Spec where
 
-import Test.Tasty.Extras
-
-import Plugin.Data.Spec
-
+import PlutusCore qualified as PLC
+import PlutusCore.MkPlc qualified as PLC
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.IsData qualified as IsData
@@ -27,11 +26,13 @@ import PlutusTx.Plugin
 import PlutusTx.Prelude qualified as P
 import PlutusTx.Test
 
-import PlutusCore qualified as PLC
-import PlutusCore.MkPlc qualified as PLC
 import UntypedPlutusCore qualified as UPLC
 
 import Data.Proxy
+
+import Plugin.Data.Spec
+
+import Test.Tasty.Extras
 
 IsData.unstableMakeIsData ''MyMonoData
 IsData.unstableMakeIsData ''MyMonoRecord

--- a/plutus-tx-plugin/test/Lib.hs
+++ b/plutus-tx-plugin/test/Lib.hs
@@ -11,24 +11,26 @@
 {-# OPTIONS_GHC -Wno-orphans  #-}
 module Lib where
 
-import Control.Exception
-import Control.Lens
-import Control.Monad.Except
-import Data.Either.Extras
-import Data.Text (Text)
-import Flat (Flat)
-import Test.Tasty.Extras
-
+import PlutusCore qualified as PLC
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
+import PlutusCore.Pretty
 import PlutusCore.Test
 
 import PlutusTx.Code
 
-import PlutusCore qualified as PLC
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
-import PlutusCore.Pretty
-
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
+
+import Control.Exception
+import Control.Lens
+import Control.Monad.Except
+
+import Data.Either.Extras
+import Data.Text (Text)
+
+import Flat (Flat)
+
+import Test.Tasty.Extras
 
 instance (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun) =>
             ToUPlc (CompiledCodeIn uni fun a) uni fun where

--- a/plutus-tx-plugin/test/Lift/Spec.hs
+++ b/plutus-tx-plugin/test/Lift/Spec.hs
@@ -8,16 +8,17 @@
 {-# OPTIONS_GHC   -Wno-orphans #-}
 module Lift.Spec where
 
-import Test.Tasty.Extras
-
-import Plugin.Data.Spec
-import Plugin.Primitives.Spec
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Lift qualified as Lift
 import PlutusTx.Test ()
+
+import Plugin.Data.Spec
+import Plugin.Primitives.Spec
+
+import Test.Tasty.Extras
 
 Lift.makeLift ''MyMonoData
 Lift.makeLift ''MyMonoRecord

--- a/plutus-tx-plugin/test/Optimization/Spec.hs
+++ b/plutus-tx-plugin/test/Optimization/Spec.hs
@@ -11,13 +11,14 @@
 
 module Optimization.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as PlutusTx
 import PlutusTx.Code
 import PlutusTx.Test ()
 import PlutusTx.TH (compile)
+
+import Test.Tasty.Extras
 
 -- These are tests that run with the simplifier on, and run all the way to UPLC.
 -- This can be interesting to make sure that important optimizations fire, including

--- a/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
@@ -12,9 +12,8 @@
 
 module Plugin.Basic.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Plugin
@@ -22,6 +21,8 @@ import PlutusTx.Prelude as P
 import PlutusTx.Test
 
 import Data.Proxy
+
+import Test.Tasty.Extras
 
 
 basic :: TestNested

--- a/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
@@ -8,18 +8,19 @@
 
 module Plugin.Coverage.Spec (coverage) where
 
-import Control.Lens
-
-
-import Data.Map qualified as Map
-import Data.Proxy
-import Data.Set (Set)
-import Data.Set qualified as Set
 import PlutusTx.Code
 import PlutusTx.Coverage
 import PlutusTx.Plugin
 import PlutusTx.Prelude qualified as P
 import PlutusTx.Test
+
+import Control.Lens
+
+import Data.Map qualified as Map
+import Data.Proxy
+import Data.Set (Set)
+import Data.Set qualified as Set
+
 import Prelude as Haskell
 
 import Test.Tasty

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -16,9 +16,8 @@
 
 module Plugin.Data.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Plugin
@@ -26,6 +25,8 @@ import PlutusTx.Prelude qualified as P
 import PlutusTx.Test
 
 import Data.Proxy
+
+import Test.Tasty.Extras
 
 datat :: TestNested
 datat = testNested "Data" [

--- a/plutus-tx-plugin/test/Plugin/Debug/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Debug/Spec.hs
@@ -11,15 +11,16 @@
 
 module Plugin.Debug.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusCore.Pretty
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Plugin
 import PlutusTx.Test
 
 import Data.Proxy
+
+import Test.Tasty.Extras
 
 debug :: TestNested
 debug =

--- a/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
@@ -14,9 +14,8 @@
 
 module Plugin.Errors.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Plugin
@@ -25,9 +24,9 @@ import PlutusTx.Test ()
 import Data.Proxy
 import Data.String
 
--- Normally GHC will irritatingly case integers for us in some circumstances, but we want to do it
--- explicitly here, so we need to see the constructors.
 import GHC.Num.Integer
+
+import Test.Tasty.Extras
 
 -- this module does lots of weird stuff deliberately
 {- HLINT ignore -}

--- a/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
@@ -15,18 +15,19 @@
 
 module Plugin.Functions.Spec where
 
-import Test.Tasty.Extras
-
-import Plugin.Data.Spec
-import Plugin.Lib
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Plugin
 import PlutusTx.Test
 
 import Data.Proxy
+
+import Plugin.Data.Spec
+import Plugin.Lib
+
+import Test.Tasty.Extras
 
 functions :: TestNested
 functions = testNested "Functions" [

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -11,17 +11,18 @@
 
 module Plugin.Laziness.Spec where
 
-import Test.Tasty.Extras
-
-import Plugin.Lib
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Plugin
 import PlutusTx.Test
 
 import Data.Proxy
+
+import Plugin.Lib
+
+import Test.Tasty.Extras
 
 laziness :: TestNested
 laziness = testNested "Laziness" [

--- a/plutus-tx-plugin/test/Plugin/Lib.hs
+++ b/plutus-tx-plugin/test/Plugin/Lib.hs
@@ -8,9 +8,8 @@
 {-# LANGUAGE UndecidableInstances  #-}
 module Plugin.Lib where
 
-import PlutusTx.Prelude
-
 import PlutusTx.Builtins qualified as Builtins
+import PlutusTx.Prelude
 
 -- This is here for the Plugin spec, but we're testing using things from a different module
 andExternal :: Bool -> Bool -> Bool

--- a/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
@@ -10,16 +10,17 @@
 
 module Plugin.NoTrace.Spec where
 
-import Test.Tasty.Extras
-
-import Data.Proxy
-import Prelude qualified as H
-
 import PlutusTx
 import PlutusTx.Builtins qualified as B
 import PlutusTx.Plugin
 import PlutusTx.Prelude qualified as P
 import PlutusTx.Test
+
+import Data.Proxy
+
+import Prelude qualified as H
+
+import Test.Tasty.Extras
 
 noTrace :: TestNested
 noTrace = testNested "NoTrace"

--- a/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
@@ -11,9 +11,8 @@
 
 module Plugin.Primitives.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusCore.Test
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Lift
@@ -22,6 +21,8 @@ import PlutusTx.Prelude qualified as P
 import PlutusTx.Test
 
 import Data.Proxy
+
+import Test.Tasty.Extras
 
 primitives :: TestNested
 primitives = testNested "Primitives" [

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -15,9 +15,8 @@
 
 module Plugin.Profiling.Spec where
 
-import Test.Tasty.Extras
-
 import PlutusCore.Test (ToUPlc (toUPlc), goldenUEvalProfile)
+
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code (CompiledCode)
 import PlutusTx.Plugin (plc)
@@ -25,7 +24,10 @@ import PlutusTx.Test (goldenPir)
 
 import Data.Functor.Identity
 import Data.Proxy (Proxy (Proxy))
+
 import Prelude
+
+import Test.Tasty.Extras
 
 profiling :: TestNested
 profiling = testNested "Profiling" [

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -1,7 +1,5 @@
 module Plugin.Spec where
 
-import Test.Tasty.Extras
-
 import Plugin.Basic.Spec
 import Plugin.Coverage.Spec
 import Plugin.Data.Spec
@@ -14,6 +12,8 @@ import Plugin.Primitives.Spec
 import Plugin.Profiling.Spec
 import Plugin.Strict.Spec
 import Plugin.Typeclasses.Spec
+
+import Test.Tasty.Extras
 
 tests :: TestNested
 tests = testNested "Plugin" [

--- a/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
@@ -9,8 +9,6 @@
 
 module Plugin.Strict.Spec (strict) where
 
-import Test.Tasty.Extras
-
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Builtins.Internal qualified as BI
 import PlutusTx.Code
@@ -19,6 +17,8 @@ import PlutusTx.Prelude qualified as P
 import PlutusTx.Test
 
 import Data.Proxy
+
+import Test.Tasty.Extras
 
 strict :: TestNested
 strict = testNested "Strict" [

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
@@ -12,18 +12,17 @@
 
 module Plugin.Typeclasses.Spec where
 
-import Test.Tasty.Extras
-
-import Plugin.Typeclasses.Lib
-
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
 import PlutusTx.Plugin
 import PlutusTx.Prelude qualified as P
 import PlutusTx.Test
 
-
 import Data.Proxy
+
+import Plugin.Typeclasses.Lib
+
+import Test.Tasty.Extras
 
 typeclasses :: TestNested
 typeclasses = testNested "Typeclasses" [

--- a/plutus-tx-plugin/test/Spec.hs
+++ b/plutus-tx-plugin/test/Spec.hs
@@ -1,11 +1,17 @@
 module Main (main) where
 
 import Budget.Spec qualified as Budget
+
 import IsData.Spec qualified as IsData
+
 import Lift.Spec qualified as Lift
+
 import Optimization.Spec qualified as Optimization
+
 import Plugin.Spec qualified as Plugin
+
 import StdLib.Spec qualified as Lib
+
 import TH.Spec qualified as TH
 
 import Test.Tasty

--- a/plutus-tx-plugin/test/StdLib/Spec.hs
+++ b/plutus-tx-plugin/test/StdLib/Spec.hs
@@ -10,36 +10,39 @@
 
 module StdLib.Spec where
 
+import PlutusCore.Data qualified as PLC
+import PlutusCore.Test (TestNested, goldenUEval, testNested)
+
+import PlutusPrelude (reoption)
+
+import PlutusTx.Builtins.Internal (BuiltinData (BuiltinData))
+import PlutusTx.Code (CompiledCode, getPlcNoAnn)
+import PlutusTx.Eq qualified as PlutusTx
+import PlutusTx.Lift qualified as Lift
+import PlutusTx.Ord qualified as PlutusTx
+import PlutusTx.Plugin (plc)
+import PlutusTx.Prelude qualified as PlutusTx
+import PlutusTx.Ratio qualified as Ratio
+import PlutusTx.Test (goldenPir)
+
 import Control.DeepSeq (NFData, force)
 import Control.Exception (SomeException, evaluate, try)
 import Control.Monad.IO.Class (MonadIO (liftIO))
+
+import Data.Proxy (Proxy (Proxy))
 import Data.Ratio ((%))
+import Data.Ratio qualified as GHCRatio
+
 import GHC.Exts (fromString)
 import GHC.Real (reduce)
+
 import Hedgehog (MonadGen, Property)
 import Hedgehog qualified
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import PlutusCore.Test (TestNested, goldenUEval, testNested)
-import PlutusTx.Test (goldenPir)
+
 import Test.Tasty (TestName)
 import Test.Tasty.Hedgehog (testPropertyNamed)
-
-import PlutusTx.Eq qualified as PlutusTx
-import PlutusTx.Ord qualified as PlutusTx
-import PlutusTx.Prelude qualified as PlutusTx
-import PlutusTx.Ratio qualified as Ratio
-
-import PlutusTx.Builtins.Internal (BuiltinData (BuiltinData))
-import PlutusTx.Code (CompiledCode, getPlcNoAnn)
-import PlutusTx.Lift qualified as Lift
-import PlutusTx.Plugin (plc)
-
-import PlutusCore.Data qualified as PLC
-
-import Data.Proxy (Proxy (Proxy))
-import Data.Ratio qualified as GHCRatio
-import PlutusPrelude (reoption)
 
 roundPlc :: CompiledCode (Ratio.Rational -> Integer)
 roundPlc = plc (Proxy @"roundPlc") Ratio.round

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -17,10 +17,6 @@
 
 module TH.Spec (tests) where
 
-import Test.Tasty.Extras
-
-import Lib
-
 import PlutusCore.Pretty
 
 import PlutusTx
@@ -28,9 +24,13 @@ import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Prelude
 import PlutusTx.Show (show)
 
+import Lib
+
 import Prelude qualified as Haskell
 
 import TH.TestTH
+
+import Test.Tasty.Extras
 
 data SomeType = One Integer | Two | Three ()
 

--- a/plutus-tx-plugin/test/TH/TestTH.hs
+++ b/plutus-tx-plugin/test/TH/TestTH.hs
@@ -5,9 +5,10 @@
 {-# LANGUAGE TemplateHaskell     #-}
 module TH.TestTH where
 
-import Language.Haskell.TH
 import PlutusTx.Builtins
 import PlutusTx.Prelude
+
+import Language.Haskell.TH
 
 {- HLINT ignore -}
 

--- a/plutus-tx-plugin/test/size/Main.hs
+++ b/plutus-tx-plugin/test/size/Main.hs
@@ -10,7 +10,9 @@ import PlutusTx.Prelude qualified as Plutus
 import PlutusTx.Ratio qualified as PlutusRatio
 import PlutusTx.Test
 import PlutusTx.TH (compile)
+
 import Prelude
+
 import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()

--- a/plutus-tx/src/PlutusTx.hs
+++ b/plutus-tx/src/PlutusTx.hs
@@ -26,6 +26,7 @@ module PlutusTx (
     liftCode) where
 
 import PlutusCore.Data (Data (..))
+
 import PlutusTx.Builtins (BuiltinData, builtinDataToData, dataToBuiltinData)
 import PlutusTx.Code (CompiledCode, CompiledCodeIn, applyCode, getPir, getPirNoAnn, getPlc, getPlcNoAnn)
 import PlutusTx.IsData (FromData (..), ToData (..), UnsafeFromData (..), fromData, makeIsDataIndexed, toData,

--- a/plutus-tx/src/PlutusTx/Applicative.hs
+++ b/plutus-tx/src/PlutusTx/Applicative.hs
@@ -1,14 +1,16 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Applicative where
 
-import Control.Applicative (Const (..))
-import Data.Functor.Identity (Identity (..))
 import PlutusTx.Base
 import PlutusTx.Bool (Bool)
 import PlutusTx.Either (Either (..))
 import PlutusTx.Functor
 import PlutusTx.Maybe (Maybe (..))
 import PlutusTx.Monoid (Monoid (..), mappend)
+
+import Control.Applicative (Const (..))
+
+import Data.Functor.Identity (Identity (..))
 
 {- HLINT ignore -}
 

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -39,9 +39,6 @@ module PlutusTx.AssocMap (
     , mapThese
     ) where
 
-import Control.DeepSeq (NFData)
-import Data.Data
-import GHC.Generics (Generic)
 import PlutusTx.Builtins qualified as P
 import PlutusTx.Builtins.Internal qualified as BI
 import PlutusTx.IsData
@@ -49,7 +46,15 @@ import PlutusTx.Lift (makeLift)
 import PlutusTx.Prelude hiding (filter, mapMaybe, null, toList)
 import PlutusTx.Prelude qualified as P
 import PlutusTx.These
+
+import Control.DeepSeq (NFData)
+
+import Data.Data
+
+import GHC.Generics (Generic)
+
 import Prelude qualified as Haskell
+
 import Prettyprinter (Pretty (..))
 
 {- HLINT ignore "Use newtype instead of data" -}

--- a/plutus-tx/src/PlutusTx/Builtins/Class.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Class.hs
@@ -12,16 +12,17 @@
 
 module PlutusTx.Builtins.Class where
 
-import Data.ByteString (ByteString)
+import PlutusTx.Base (const, id, ($))
+import PlutusTx.Bool (Bool (..))
 import PlutusTx.Builtins.Internal
+import PlutusTx.Integer (Integer)
 
+import Data.ByteString (ByteString)
 import Data.String (IsString (..))
 import Data.Text (Text, pack)
 
 import GHC.Magic qualified as Magic
-import PlutusTx.Base (const, id, ($))
-import PlutusTx.Bool (Bool (..))
-import PlutusTx.Integer (Integer)
+
 import Prelude qualified as Haskell (String)
 
 {- Note [Fundeps versus type families in To/FromBuiltin]

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -14,10 +14,20 @@
 -- Most users should not use this module directly, but rather use 'PlutusTx.Builtins'.
 module PlutusTx.Builtins.Internal where
 
+import PlutusCore.Builtin.Emitter (Emitter (Emitter))
+import PlutusCore.Data qualified as PLC
+import PlutusCore.Evaluation.Result (EvaluationResult (EvaluationFailure, EvaluationSuccess))
+import PlutusCore.Pretty (Pretty (..))
+
+import PlutusTx.Utils (mustBeReplaced)
+
 import Codec.Serialise
+
 import Control.DeepSeq (NFData (..))
 import Control.Monad.Trans.Writer.Strict (runWriter)
+
 import Crypto qualified
+
 import Data.ByteArray qualified as BA
 import Data.ByteString qualified as BS
 import Data.ByteString.Hash qualified as Hash
@@ -29,18 +39,10 @@ import Data.Hashable (Hashable (..))
 import Data.Kind (Type)
 import Data.Text as Text (Text, empty)
 import Data.Text.Encoding as Text (decodeUtf8, encodeUtf8)
-import PlutusCore.Builtin.Emitter (Emitter (Emitter))
-import PlutusCore.Data qualified as PLC
-import PlutusCore.Evaluation.Result (EvaluationResult (EvaluationFailure, EvaluationSuccess))
-import PlutusCore.Pretty (Pretty (..))
-import PlutusTx.Utils (mustBeReplaced)
-import Prettyprinter (viaShow)
 
-{-
-We do not use qualified import because the whole module contains off-chain code
-which is replaced later with on-chain implementations by the plutus-tx-plugin.
--}
 import Prelude as Haskell
+
+import Prettyprinter (viaShow)
 
 {- Note [Builtin name definitions]
 The builtins here have definitions so they can be used in off-chain code too.

--- a/plutus-tx/src/PlutusTx/Code.hs
+++ b/plutus-tx/src/PlutusTx/Code.hs
@@ -13,19 +13,25 @@
 module PlutusTx.Code where
 
 import PlutusCore qualified as PLC
+
 import PlutusIR qualified as PIR
+
 import PlutusTx.Coverage
 import PlutusTx.Lift.Instances ()
+
 import UntypedPlutusCore qualified as UPLC
 
 import Annotation
+
 import Control.Exception
+
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Functor (void)
+
 import Flat (Flat (..), unflat)
 import Flat.Decoder (DecodeException)
--- We do not use qualified import because the whole module contains off-chain code
+
 import Prelude as Haskell
 
 -- The final type parameter is inferred to be phantom, but we give it a nominal

--- a/plutus-tx/src/PlutusTx/Coverage.hs
+++ b/plutus-tx/src/PlutusTx/Coverage.hs
@@ -30,13 +30,14 @@ module PlutusTx.Coverage ( CoverageAnnotation(..)
                          , coverageDataFromLogMsg
                          ) where
 
-import Control.Lens
+import PlutusCore.Flat
 
 import Codec.Serialise
 
-import PlutusCore.Flat
-
 import Control.DeepSeq
+import Control.Lens
+import Control.Monad.Writer
+
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import Data.Foldable
 import Data.Map (Map)
@@ -44,15 +45,14 @@ import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String
-import Text.Read
 
-import Control.Monad.Writer
-
-import Prettyprinter
+import Flat hiding (to)
 
 import Prelude
 
-import Flat hiding (to)
+import Prettyprinter
+
+import Text.Read
 
 {- Note [Coverage annotations]
    During compilation we can insert coverage annotations in `trace` calls in

--- a/plutus-tx/src/PlutusTx/Either.hs
+++ b/plutus-tx/src/PlutusTx/Either.hs
@@ -6,6 +6,7 @@ We export off-chain Haskell's Either type as on-chain Plutus's Either type since
 -}
 
 import PlutusTx.Bool (Bool (..))
+
 import Prelude (Either (..))
 
 

--- a/plutus-tx/src/PlutusTx/Eq.hs
+++ b/plutus-tx/src/PlutusTx/Eq.hs
@@ -4,6 +4,7 @@ module PlutusTx.Eq (Eq(..), (/=)) where
 import PlutusTx.Bool
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Either (Either (..))
+
 import Prelude (Maybe (..))
 
 {- HLINT ignore -}

--- a/plutus-tx/src/PlutusTx/ErrorCodes.hs
+++ b/plutus-tx/src/PlutusTx/ErrorCodes.hs
@@ -2,9 +2,11 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.ErrorCodes where
 
+import PlutusTx.Builtins as Builtins
+
 import Data.Map (Map)
 import Data.Map qualified as Map
-import PlutusTx.Builtins as Builtins
+
 import Prelude (String)
 
 {-

--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -36,12 +36,6 @@ module PlutusTx.Foldable (
   product
   ) where
 
-import Control.Applicative (Alternative (..), Const (..))
-import Data.Coerce (Coercible, coerce)
-import Data.Functor.Identity (Identity (..))
-import Data.Monoid (First (..))
-import Data.Semigroup (Dual (..), Endo (..), Product (..), Sum (..))
-import GHC.Exts (build)
 import PlutusTx.Applicative (Applicative (pure), (*>))
 import PlutusTx.Base
 import PlutusTx.Bool (Bool (..), not)
@@ -52,6 +46,15 @@ import PlutusTx.Maybe (Maybe (..))
 import PlutusTx.Monoid (Monoid (..))
 import PlutusTx.Numeric (AdditiveMonoid, AdditiveSemigroup ((+)), MultiplicativeMonoid)
 import PlutusTx.Semigroup ((<>))
+
+import Control.Applicative (Alternative (..), Const (..))
+
+import Data.Coerce (Coercible, coerce)
+import Data.Functor.Identity (Identity (..))
+import Data.Monoid (First (..))
+import Data.Semigroup (Dual (..), Endo (..), Product (..), Sum (..))
+
+import GHC.Exts (build)
 
 import Prelude qualified as Haskell (Monad, return, (>>), (>>=))
 

--- a/plutus-tx/src/PlutusTx/Functor.hs
+++ b/plutus-tx/src/PlutusTx/Functor.hs
@@ -1,11 +1,13 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Functor (Functor(..), (<$>), (<$)) where
 
-import Control.Applicative (Const (..))
-import Data.Functor.Identity (Identity (..))
-
 import PlutusTx.Base
 import PlutusTx.Either (Either (..))
+
+import Control.Applicative (Const (..))
+
+import Data.Functor.Identity (Identity (..))
+
 import Prelude (Maybe (..))
 
 {- HLINT ignore -}

--- a/plutus-tx/src/PlutusTx/IsData/Class.hs
+++ b/plutus-tx/src/PlutusTx/IsData/Class.hs
@@ -9,23 +9,23 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.IsData.Class where
 
-import Prelude qualified as Haskell (Int, error)
-
 import PlutusCore.Data qualified as PLC
+
+import PlutusTx.Applicative
 import PlutusTx.Base
 import PlutusTx.Builtins as Builtins
 import PlutusTx.Builtins.Internal (BuiltinData (..))
 import PlutusTx.Builtins.Internal qualified as BI
-import PlutusTx.Maybe (Maybe (..))
-
-import PlutusTx.Applicative
 import PlutusTx.ErrorCodes
+import PlutusTx.Maybe (Maybe (..))
 import PlutusTx.Trace
 
 import Data.Kind
 import Data.Void
 
 import GHC.TypeLits (ErrorMessage (..), TypeError)
+
+import Prelude qualified as Haskell (Int, error)
 
 
 {- HLINT ignore -}

--- a/plutus-tx/src/PlutusTx/IsData/TH.hs
+++ b/plutus-tx/src/PlutusTx/IsData/TH.hs
@@ -4,21 +4,19 @@
 {-# LANGUAGE TemplateHaskell #-}
 module PlutusTx.IsData.TH (unstableMakeIsData, makeIsDataIndexed) where
 
+import PlutusTx.Applicative qualified as PlutusTx
+import PlutusTx.Builtins as Builtins
+import PlutusTx.Builtins.Internal qualified as BI
+import PlutusTx.ErrorCodes
+import PlutusTx.IsData.Class
+import PlutusTx.Trace (traceError)
+
 import Data.Foldable
 import Data.Traversable
 
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Datatype qualified as TH
-import PlutusTx.ErrorCodes
 
-import PlutusTx.Applicative qualified as PlutusTx
-
-import PlutusTx.Builtins as Builtins
-import PlutusTx.Builtins.Internal qualified as BI
-import PlutusTx.IsData.Class
-import PlutusTx.Trace (traceError)
-
--- We do not use qualified import because the whole module contains off-chain code
 import Prelude as Haskell
 
 toDataClause :: (TH.ConstructorInfo, Int) -> TH.Q TH.Clause

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -18,12 +18,12 @@ module PlutusTx.Lift (
     makeLift,
     LiftError(..)) where
 
-import PlutusTx.Code
-import PlutusTx.Lift.Class qualified as Lift
-import PlutusTx.Lift.Instances ()
-import PlutusTx.Lift.TH (LiftError (..), makeLift, makeTypeable)
+import PlutusCore qualified as PLC
+import PlutusCore.Compiler qualified as PLC
+import PlutusCore.Pretty (PrettyConst)
+import PlutusCore.Quote
+import PlutusCore.StdLib.Data.Function qualified as PLC
 
-import Data.Bifunctor
 import PlutusIR
 import PlutusIR qualified as PIR
 import PlutusIR.Compiler
@@ -31,11 +31,10 @@ import PlutusIR.Compiler.Definitions
 import PlutusIR.Error qualified as PIR
 import PlutusIR.MkPir qualified as PIR
 
-import PlutusCore qualified as PLC
-import PlutusCore.Compiler qualified as PLC
-import PlutusCore.Pretty (PrettyConst)
-import PlutusCore.Quote
-import PlutusCore.StdLib.Data.Function qualified as PLC
+import PlutusTx.Code
+import PlutusTx.Lift.Class qualified as Lift
+import PlutusTx.Lift.Instances ()
+import PlutusTx.Lift.TH (LiftError (..), makeLift, makeTypeable)
 
 import UntypedPlutusCore qualified as UPLC
 
@@ -44,12 +43,13 @@ import Control.Lens hiding (lifted)
 import Control.Monad.Except hiding (lift)
 import Control.Monad.Reader hiding (lift)
 
+import Data.Bifunctor
 import Data.Proxy
 import Data.Typeable qualified as GHC
-import Prettyprinter
 
--- We do not use qualified import because the whole module contains off-chain code
 import Prelude as Haskell
+
+import Prettyprinter
 
 type PrettyPrintable uni fun = (Pretty (PLC.SomeTypeIn uni), PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, Pretty fun)
 

--- a/plutus-tx/src/PlutusTx/Lift/Class.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Class.hs
@@ -19,26 +19,27 @@ module PlutusTx.Lift.Class
     , RTCompile
     ) where
 
-import PlutusIR
-import PlutusIR.Compiler.Definitions
-
 import PlutusCore qualified as PLC
 import PlutusCore.Data
 import PlutusCore.Quote
+
+import PlutusIR
+import PlutusIR.Compiler.Definitions
 import PlutusIR.MkPir
+
 import PlutusTx.Builtins
 import PlutusTx.Builtins.Class (FromBuiltin)
 import PlutusTx.Builtins.Internal (BuiltinList)
-
-import Language.Haskell.TH qualified as TH hiding (newName)
 
 import Data.ByteString qualified as BS
 import Data.Kind qualified as GHC
 import Data.Proxy
 import Data.Text qualified as T
+
 import GHC.TypeLits (ErrorMessage (..), TypeError)
 
--- We do not use qualified import because the whole module contains off-chain code
+import Language.Haskell.TH qualified as TH hiding (newName)
+
 import Prelude as Haskell
 
 {- Note [Compiling at TH time and runtime]

--- a/plutus-tx/src/PlutusTx/Lift/Instances.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Instances.hs
@@ -15,6 +15,7 @@
 module PlutusTx.Lift.Instances () where
 
 import PlutusCore.Data
+
 import PlutusTx.Bool (Bool (..))
 import PlutusTx.Either (Either (..))
 import PlutusTx.Lift.TH

--- a/plutus-tx/src/PlutusTx/Lift/TH.hs
+++ b/plutus-tx/src/PlutusTx/Lift/TH.hs
@@ -21,41 +21,40 @@ module PlutusTx.Lift.TH (
     , LiftError (..)
     ) where
 
-import PlutusTx.Lift.Class
-import PlutusTx.Lift.THUtils
+import PlutusCore.Default qualified as PLC
+import PlutusCore.MkPlc qualified as PLC
 
 import PlutusIR
 import PlutusIR.Compiler.Definitions
 import PlutusIR.Compiler.Names
 import PlutusIR.MkPir
 
-import PlutusCore.Default qualified as PLC
-import PlutusCore.MkPlc qualified as PLC
+import PlutusTx.Lift.Class
+import PlutusTx.Lift.THUtils
 
+import Control.Exception qualified as Prelude (Exception, throw)
 import Control.Monad.Except hiding (lift)
 import Control.Monad.Reader hiding (lift)
 import Control.Monad.State hiding (lift)
 import Control.Monad.Trans qualified as Trans
+
+import Data.Foldable
+import Data.List (sortBy)
+import Data.Map qualified as Map
+import Data.Maybe
+import Data.Proxy
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Traversable
 
 import Language.Haskell.TH qualified as TH hiding (newName)
 import Language.Haskell.TH.Datatype qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH hiding (newName)
 import Language.Haskell.TH.Syntax.Compat qualified as TH
 
-import Data.Map qualified as Map
-import Data.Set qualified as Set
-
-import Control.Exception qualified as Prelude (Exception, throw)
-import Data.Foldable
-import Data.List (sortBy)
-import Data.Maybe
-import Data.Proxy
-import Data.Text qualified as T
-import Data.Traversable
-import Prettyprinter qualified as PP
-
--- We do not use qualified import because the whole module contains off-chain code
 import Prelude as Haskell
+
+import Prettyprinter qualified as PP
 
 type RTCompileScope uni fun = ReaderT (LocalVars uni) (RTCompile uni fun)
 type THCompile = StateT Deps (ReaderT THLocalVars (ExceptT LiftError TH.Q))

--- a/plutus-tx/src/PlutusTx/Lift/THUtils.hs
+++ b/plutus-tx/src/PlutusTx/Lift/THUtils.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE TemplateHaskell #-}
 module PlutusTx.Lift.THUtils where
 
+import PlutusCore.Quote
+
 import PlutusIR
 import PlutusIR.Compiler.Names
-
-import PlutusCore.Quote
 
 import Control.Monad
 
@@ -16,7 +16,6 @@ import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Datatype qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH
 
--- We do not use qualified import because the whole module contains off-chain code
 import Prelude as Haskell
 
 -- | Very nearly the same as 'TH.showName', but doesn't print uniques, since we don't need to

--- a/plutus-tx/src/PlutusTx/List.hs
+++ b/plutus-tx/src/PlutusTx/List.hs
@@ -34,6 +34,7 @@ import PlutusTx.Eq (Eq, (/=), (==))
 import PlutusTx.ErrorCodes
 import PlutusTx.Ord (Ord, Ordering (..), compare, (<), (<=))
 import PlutusTx.Trace (traceError)
+
 import Prelude (Maybe (..))
 
 {- HLINT ignore -}

--- a/plutus-tx/src/PlutusTx/Maybe.hs
+++ b/plutus-tx/src/PlutusTx/Maybe.hs
@@ -8,6 +8,7 @@ We export off-chain Haskell's Maybe type as on-chain Plutus's Maybe type since t
 import PlutusTx.Base (id)
 import PlutusTx.Bool
 import PlutusTx.List (foldr)
+
 import Prelude (Maybe (..))
 
 {- HLINT ignore -}

--- a/plutus-tx/src/PlutusTx/Monoid.hs
+++ b/plutus-tx/src/PlutusTx/Monoid.hs
@@ -3,13 +3,14 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Monoid (Monoid (..), mappend, mconcat, Group (..), gsub) where
 
-import Data.Monoid (First (..))
-import Data.Semigroup (Dual (..), Endo (..))
 import PlutusTx.Base (id)
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.List
 import PlutusTx.Maybe
 import PlutusTx.Semigroup
+
+import Data.Monoid (First (..))
+import Data.Semigroup (Dual (..), Endo (..))
 
 {- HLINT ignore -}
 

--- a/plutus-tx/src/PlutusTx/Numeric.hs
+++ b/plutus-tx/src/PlutusTx/Numeric.hs
@@ -23,13 +23,14 @@ module PlutusTx.Numeric (
   abs,
   ) where
 
-import Data.Semigroup (Product (Product), Sum (Sum))
 import PlutusTx.Bool (Bool (False, True), (&&), (||))
 import PlutusTx.Builtins (Integer, addInteger, divideInteger, modInteger, multiplyInteger, quotientInteger,
                           remainderInteger, subtractInteger)
 import PlutusTx.Monoid (Group, Monoid (mempty), gsub)
 import PlutusTx.Ord (Ord ((<)))
 import PlutusTx.Semigroup (Semigroup ((<>)))
+
+import Data.Semigroup (Product (Product), Sum (Sum))
 
 infixl 7 *
 infixl 6 +, -

--- a/plutus-tx/src/PlutusTx/Ord.hs
+++ b/plutus-tx/src/PlutusTx/Ord.hs
@@ -11,6 +11,7 @@ import PlutusTx.Bool (Bool (..))
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Either (Either (..))
 import PlutusTx.Eq
+
 import Prelude (Maybe (..), Ordering (..))
 
 {- HLINT ignore -}

--- a/plutus-tx/src/PlutusTx/Plugin/Utils.hs
+++ b/plutus-tx/src/PlutusTx/Plugin/Utils.hs
@@ -6,10 +6,12 @@
 {-# OPTIONS_GHC -Wno-unused-foralls #-}
 module PlutusTx.Plugin.Utils where
 
-import Data.Proxy
-import GHC.TypeLits
 import PlutusTx.Code
 import PlutusTx.Utils
+
+import Data.Proxy
+
+import GHC.TypeLits
 
 {- Note [plc and Proxy]
 It would be nice to use TypeApplications instead of passing a Proxy to plc.

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -82,8 +82,8 @@ module PlutusTx.Prelude (
     toBuiltin
     ) where
 
-import Data.String (IsString (..))
 import PlutusCore.Data (Data (..))
+
 import PlutusTx.Applicative as Applicative
 import PlutusTx.Base as Base
 import PlutusTx.Bool as Bool
@@ -110,6 +110,8 @@ import PlutusTx.Ratio as Ratio
 import PlutusTx.Semigroup as Semigroup
 import PlutusTx.Trace as Trace
 import PlutusTx.Traversable as Traversable
+
+import Data.String (IsString (..))
 
 import Prelude qualified as Haskell (return, (=<<), (>>), (>>=))
 

--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -36,6 +36,7 @@ module PlutusTx.Ratio(
 import PlutusTx.Applicative qualified as P
 import PlutusTx.Base qualified as P
 import PlutusTx.Bool qualified as P
+import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Eq qualified as P
 import PlutusTx.ErrorCodes qualified as P
 import PlutusTx.Integer (Integer)
@@ -46,11 +47,12 @@ import PlutusTx.Numeric qualified as P
 import PlutusTx.Ord qualified as P
 import PlutusTx.Trace qualified as P
 
-import PlutusTx.Builtins qualified as Builtins
-
 import Control.Monad (guard)
+
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), object, withObject, (.:))
+
 import GHC.Real qualified as Ratio
+
 import Prelude (Ord (..), Show, (*))
 import Prelude qualified as Haskell
 

--- a/plutus-tx/src/PlutusTx/Semigroup.hs
+++ b/plutus-tx/src/PlutusTx/Semigroup.hs
@@ -1,13 +1,15 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Semigroup (Semigroup (..), Max (..), Min (..)) where
 
-import Data.Monoid (First (..))
-import Data.Semigroup (Dual (..), Endo (..))
 import PlutusTx.Base
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Functor
 import PlutusTx.List ((++))
 import PlutusTx.Ord (Ord (..), Ordering (..))
+
+import Data.Monoid (First (..))
+import Data.Semigroup (Dual (..), Endo (..))
+
 import Prelude (Maybe (..))
 
 {- HLINT ignore -}

--- a/plutus-tx/src/PlutusTx/Show/TH.hs
+++ b/plutus-tx/src/PlutusTx/Show/TH.hs
@@ -14,8 +14,10 @@ import Data.Deriving.Internal (isInfixDataCon, isNonUnitTuple, isSym, varTToName
 import Data.List.Extra (dropEnd, foldl', intersperse)
 import Data.Maybe
 import Data.Traversable (for)
+
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Datatype qualified as TH
+
 import Prelude (pure, (+), (<$>), (<>))
 import Prelude qualified as Haskell
 

--- a/plutus-tx/src/PlutusTx/Sqrt.hs
+++ b/plutus-tx/src/PlutusTx/Sqrt.hs
@@ -18,6 +18,7 @@ import PlutusTx.IsData (makeIsDataIndexed)
 import PlutusTx.Lift (makeLift)
 import PlutusTx.Prelude (Integer, divide, negate, otherwise, ($), (*), (+), (<), (<=), (==))
 import PlutusTx.Ratio (Rational, denominator, numerator, unsafeRatio)
+
 import Prelude qualified as Haskell
 
 -- | Integer square-root representation, discarding imaginary integers.

--- a/plutus-tx/src/PlutusTx/TH.hs
+++ b/plutus-tx/src/PlutusTx/TH.hs
@@ -6,16 +6,18 @@ module PlutusTx.TH (
     compileUntyped,
     loadFromFile) where
 
-import Data.Proxy
-import Language.Haskell.TH qualified as TH
-import Language.Haskell.TH.Syntax qualified as TH
-import Language.Haskell.TH.Syntax.Compat qualified as TH
 import PlutusTx.Code
 import PlutusTx.Plugin.Utils
 
--- We do not use qualified import because the whole module contains off-chain code
 import Control.Monad.IO.Class
+
 import Data.ByteString qualified as BS
+import Data.Proxy
+
+import Language.Haskell.TH qualified as TH
+import Language.Haskell.TH.Syntax qualified as TH
+import Language.Haskell.TH.Syntax.Compat qualified as TH
+
 import Prelude
 
 -- | Compile a quoted Haskell expression into a corresponding Plutus Core program.

--- a/plutus-tx/src/PlutusTx/Traversable.hs
+++ b/plutus-tx/src/PlutusTx/Traversable.hs
@@ -3,9 +3,6 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Traversable (Traversable(..), sequenceA, mapM, sequence, for, fmapDefault, foldMapDefault) where
 
-import Control.Applicative (Const (..))
-import Data.Coerce (coerce)
-import Data.Functor.Identity (Identity (..))
 import PlutusTx.Applicative (Applicative (..), liftA2)
 import PlutusTx.Base
 import PlutusTx.Either (Either (..))
@@ -13,6 +10,11 @@ import PlutusTx.Foldable (Foldable)
 import PlutusTx.Functor (Functor, (<$>))
 import PlutusTx.Maybe (Maybe (..))
 import PlutusTx.Monoid (Monoid)
+
+import Control.Applicative (Const (..))
+
+import Data.Coerce (coerce)
+import Data.Functor.Identity (Identity (..))
 
 -- | Plutus Tx version of 'Data.Traversable.Traversable'.
 class (Functor t, Foldable t) => Traversable t where

--- a/plutus-tx/test/Rational/Laws.hs
+++ b/plutus-tx/test/Rational/Laws.hs
@@ -9,6 +9,7 @@ import Rational.Laws.Ord (ordLaws)
 import Rational.Laws.Other (otherLaws)
 import Rational.Laws.Ring (ringLaws)
 import Rational.Laws.Serialization (serializationLaws)
+
 import Test.Tasty (TestTree, testGroup)
 
 lawsTests :: TestTree

--- a/plutus-tx/test/Rational/Laws/Additive.hs
+++ b/plutus-tx/test/Rational/Laws/Additive.hs
@@ -2,10 +2,14 @@
 
 module Rational.Laws.Additive (additiveLaws) where
 
-import Hedgehog (Property, property)
 import PlutusTx.Prelude qualified as Plutus
+
+import Hedgehog (Property, property)
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genRational, normalAndEquivalentTo)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Construction.hs
+++ b/plutus-tx/test/Rational/Laws/Construction.hs
@@ -4,12 +4,16 @@
 
 module Rational.Laws.Construction (constructionLaws) where
 
-import Hedgehog (Gen, Property, cover, property, (===))
-import Hedgehog.Gen qualified as Gen
 import PlutusTx.Prelude qualified as Plutus
 import PlutusTx.Ratio qualified as Ratio
+
+import Hedgehog (Gen, Property, cover, property, (===))
+import Hedgehog.Gen qualified as Gen
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genInteger, genIntegerPos, normalAndEquivalentToMaybe, testCoverProperty)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Eq.hs
+++ b/plutus-tx/test/Rational/Laws/Eq.hs
@@ -3,11 +3,15 @@
 
 module Rational.Laws.Eq (eqLaws) where
 
+import PlutusTx.Prelude qualified as Plutus
+
 import Hedgehog (Property, PropertyT, property, success, (===))
 import Hedgehog.Function (fnWith, forAllFn)
-import PlutusTx.Prelude qualified as Plutus
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genInteger, genRational, testEntangled, testEntangled3, varyRational)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Helpers.hs
+++ b/plutus-tx/test/Rational/Laws/Helpers.hs
@@ -17,19 +17,25 @@ module Rational.Laws.Helpers (
   normalAndEquivalentToMaybe,
   ) where
 
+import PlutusTx.Prelude qualified as Plutus
+import PlutusTx.Ratio qualified as Ratio
+
 import Data.Functor.Contravariant (contramap)
 import Data.Kind (Type)
 import Data.Maybe (isJust, isNothing)
+
 import GHC.Exts (fromString)
+
 import Hedgehog (Gen, MonadTest, Property, PropertyT, assert, cover, failure, forAllWith, property, success, (===))
 import Hedgehog.Function (Arg (build), CoGen, vary, via)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import PlutusTx.Prelude qualified as Plutus
-import PlutusTx.Ratio qualified as Ratio
+
 import Prelude
+
 import Test.Tasty (TestTree, localOption)
 import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit), testPropertyNamed)
+
 import Text.Show.Pretty (ppShow)
 
 -- This is a hack to avoid coverage issues.

--- a/plutus-tx/test/Rational/Laws/Module.hs
+++ b/plutus-tx/test/Rational/Laws/Module.hs
@@ -2,10 +2,14 @@
 
 module Rational.Laws.Module (moduleLaws) where
 
-import Hedgehog (Property, property)
 import PlutusTx.Prelude qualified as Plutus
+
+import Hedgehog (Property, property)
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genInteger, genRational, normalAndEquivalentTo)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Multiplicative.hs
+++ b/plutus-tx/test/Rational/Laws/Multiplicative.hs
@@ -2,10 +2,14 @@
 
 module Rational.Laws.Multiplicative (multiplicativeLaws) where
 
-import Hedgehog (Property, property)
 import PlutusTx.Prelude qualified as Plutus
+
+import Hedgehog (Property, property)
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genRational, normalAndEquivalentTo)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Ord.hs
+++ b/plutus-tx/test/Rational/Laws/Ord.hs
@@ -3,10 +3,14 @@
 
 module Rational.Laws.Ord (ordLaws) where
 
-import Hedgehog (Property, PropertyT, property, success, (/==), (===))
 import PlutusTx.Prelude qualified as Plutus
+
+import Hedgehog (Property, PropertyT, property, success, (/==), (===))
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genRational, normalAndEquivalentTo, testEntangled, testEntangled3)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Other.hs
+++ b/plutus-tx/test/Rational/Laws/Other.hs
@@ -4,13 +4,17 @@
 
 module Rational.Laws.Other (otherLaws) where
 
+import PlutusTx.Prelude qualified as Plutus
+import PlutusTx.Ratio qualified as Ratio
+
 import Hedgehog (Gen, Property, assert, cover, property, (/==), (===))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import PlutusTx.Prelude qualified as Plutus
-import PlutusTx.Ratio qualified as Ratio
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genInteger, genIntegerPos, genRational, testCoverProperty)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Ring.hs
+++ b/plutus-tx/test/Rational/Laws/Ring.hs
@@ -3,10 +3,14 @@
 
 module Rational.Laws.Ring (ringLaws) where
 
-import Hedgehog (Property, property, (===))
 import PlutusTx.Prelude qualified as Plutus
+
+import Hedgehog (Property, property, (===))
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genRational)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Rational/Laws/Serialization.hs
+++ b/plutus-tx/test/Rational/Laws/Serialization.hs
@@ -3,11 +3,16 @@
 
 module Rational.Laws.Serialization (serializationLaws) where
 
-import Data.Aeson (decode, encode)
-import Hedgehog (Property, property, tripping, (===))
 import PlutusTx.IsData.Class (fromBuiltinData, toBuiltinData, unsafeFromBuiltinData)
+
+import Data.Aeson (decode, encode)
+
+import Hedgehog (Property, property, tripping, (===))
+
 import Prelude
+
 import Rational.Laws.Helpers (forAllWithPP, genRational)
+
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/plutus-tx/test/Show/Spec.hs
+++ b/plutus-tx/test/Show/Spec.hs
@@ -11,14 +11,19 @@ import PlutusTx.Builtins.Internal qualified as BI
 import PlutusTx.Show
 
 import Control.Monad.Trans.Reader as Reader
+
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Char8 qualified as Char8
 import Data.Text qualified as Text
+
 import Hedgehog
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+
 import Prelude hiding (Show (..))
+
 import System.FilePath
+
 import Test.Tasty
 import Test.Tasty.Extras
 import Test.Tasty.Hedgehog

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -4,26 +4,35 @@
 {-# LANGUAGE TypeApplications  #-}
 module Main(main) where
 
-import Codec.CBOR.FlatTerm qualified as FlatTerm
-import Codec.Serialise (deserialiseOrFail, serialise)
-import Codec.Serialise qualified as Serialise
-import Control.Exception (ErrorCall, catch)
-import Data.ByteString qualified as BS
-import Data.Either (isLeft)
-import Data.Word (Word64)
-import Hedgehog (MonadGen, Property, PropertyT, annotateShow, assert, forAll, property, tripping)
-import Hedgehog.Gen qualified as Gen
-import Hedgehog.Range qualified as Range
 import PlutusCore.Data (Data (B, Constr, I, List, Map))
+
 import PlutusTx.Enum (Enum (..))
 import PlutusTx.List (nub, nubBy, partition, sort, sortBy)
 import PlutusTx.Numeric (negate)
 import PlutusTx.Prelude (dropByteString, one, takeByteString)
 import PlutusTx.Ratio (Rational, denominator, numerator, recip, unsafeRatio)
 import PlutusTx.Sqrt (Sqrt (Approximately, Exactly, Imaginary), isqrt, rsqrt)
+
+import Codec.CBOR.FlatTerm qualified as FlatTerm
+import Codec.Serialise (deserialiseOrFail, serialise)
+import Codec.Serialise qualified as Serialise
+
+import Control.Exception (ErrorCall, catch)
+
+import Data.ByteString qualified as BS
+import Data.Either (isLeft)
+import Data.Word (Word64)
+
+import Hedgehog (MonadGen, Property, PropertyT, annotateShow, assert, forAll, property, tripping)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+
 import Prelude hiding (Enum (..), Rational, negate, recip)
+
 import Rational.Laws (lawsTests)
+
 import Show.Spec qualified
+
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.Extras (runTestNestedIn)
 import Test.Tasty.Hedgehog (testPropertyNamed)

--- a/plutus-tx/testlib/PlutusTx/Test.hs
+++ b/plutus-tx/testlib/PlutusTx/Test.hs
@@ -25,32 +25,40 @@ module PlutusTx.Test (
     goldenBudget
     ) where
 
-import Prelude
-
-import Control.Exception
-import Control.Lens
-import Control.Monad.Except
-import Control.Monad.Reader qualified as Reader
-import Data.Either.Extras
-import Data.Kind (Type)
-import Data.Tagged (Tagged (Tagged))
-import Data.Text (Text)
-import Flat (Flat)
-import Prettyprinter
-import System.FilePath ((</>))
-import Test.Tasty (TestName, TestTree)
-import Test.Tasty.Extras
-import Test.Tasty.Providers (IsTest (run, testOptions), singleTest, testFailed, testPassed)
-import Type.Reflection (Typeable)
-
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Pretty
 import PlutusCore.Test
+
 import PlutusTx.Code (CompiledCode, CompiledCodeIn, getPir, getPirNoAnn, getPlcNoAnn, sizePlc)
+
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
+
+import Control.Exception
+import Control.Lens
+import Control.Monad.Except
+import Control.Monad.Reader qualified as Reader
+
+import Data.Either.Extras
+import Data.Kind (Type)
+import Data.Tagged (Tagged (Tagged))
+import Data.Text (Text)
+
+import Flat (Flat)
+
+import Prelude
+
+import Prettyprinter
+
+import System.FilePath ((</>))
+
+import Test.Tasty (TestName, TestTree)
+import Test.Tasty.Extras
+import Test.Tasty.Providers (IsTest (run, testOptions), singleTest, testFailed, testPassed)
+
+import Type.Reflection (Typeable)
 
 
 -- Size testing for Tasty

--- a/prettyprinter-configurable/Setup.hs
+++ b/prettyprinter-configurable/Setup.hs
@@ -12,7 +12,6 @@ module Main where
 
 #if MIN_VERSION_cabal_doctest(1,0,0)
 import Distribution.Extra.Doctest (defaultMainWithDoctests)
-#else
 import Distribution.Simple
 #endif
 

--- a/prettyprinter-configurable/doctest/Main.hs
+++ b/prettyprinter-configurable/doctest/Main.hs
@@ -1,7 +1,9 @@
 module Main where
 
 import Build_doctests (flags, module_sources, pkgs)
+
 import System.Environment (unsetEnv)
+
 import Test.DocTest (doctest)
 
 main :: IO ()

--- a/prettyprinter-configurable/src/Text/PrettyBy/Default.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Default.hs
@@ -10,13 +10,14 @@ module Text.PrettyBy.Default
     , displayBy
     ) where
 
-import Text.Pretty
-import Text.PrettyBy.Internal
-
 import Data.Text qualified as Strict
 import Data.Text.Lazy qualified as Lazy
+
 import Prettyprinter.Render.String (renderString)
 import Prettyprinter.Render.Text (renderLazy, renderStrict)
+
+import Text.Pretty
+import Text.PrettyBy.Internal
 
 -- | A default layout for default rendering.
 layoutDef :: Doc ann -> SimpleDocStream ann

--- a/prettyprinter-configurable/src/Text/PrettyBy/Fixity.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Fixity.hs
@@ -17,15 +17,17 @@ module Text.PrettyBy.Fixity
     , module Text.PrettyBy.Fixity
     ) where
 
+import Control.Monad.Reader
+
+import Data.String
+
+import Lens.Micro
+
 import Text.Fixity as Export
 import Text.Pretty
 import Text.PrettyBy.Internal
 import Text.PrettyBy.Internal.Utils
 import Text.PrettyBy.Monad as Export
-
-import Control.Monad.Reader
-import Data.String
-import Lens.Micro
 
 -- | A constraint for \"'RenderContext' is a part of @config@\".
 class HasRenderContext config where

--- a/prettyprinter-configurable/src/Text/PrettyBy/Internal.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Internal.hs
@@ -51,8 +51,6 @@ module Text.PrettyBy.Internal
     , PrettyAny (..)
     ) where
 
-import Text.Pretty
-
 import Data.Bifunctor
 import Data.Coerce
 import Data.Functor.Const
@@ -65,8 +63,11 @@ import Data.Text qualified as Strict
 import Data.Text.Lazy qualified as Lazy
 import Data.Void
 import Data.Word
+
 import GHC.Natural
 import GHC.TypeLits
+
+import Text.Pretty
 
 -- ##########################
 -- ## The 'PrettyBy' class ##

--- a/prettyprinter-configurable/src/Text/PrettyBy/Internal/Utils.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Internal/Utils.hs
@@ -6,7 +6,9 @@ module Text.PrettyBy.Internal.Utils
     ) where
 
 import Control.Monad.Reader
+
 import Data.Functor.Const
+
 import Lens.Micro
 import Lens.Micro.Internal ((#.))
 

--- a/prettyprinter-configurable/src/Text/PrettyBy/Monad.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Monad.hs
@@ -14,13 +14,14 @@ module Text.PrettyBy.Monad
     , displayM
     ) where
 
+import Control.Monad.Reader
+
+import Lens.Micro
+
 import Text.Pretty
 import Text.PrettyBy.Default
 import Text.PrettyBy.Internal
 import Text.PrettyBy.Internal.Utils
-
-import Control.Monad.Reader
-import Lens.Micro
 
 -- | A constraint for \"@config@ is a part of @env@\".
 class HasPrettyConfig env config | env -> config where

--- a/prettyprinter-configurable/test/Default.hs
+++ b/prettyprinter-configurable/test/Default.hs
@@ -16,16 +16,17 @@ module Default
     ( test_default
     ) where
 
-import Text.Pretty
-import Text.PrettyBy
-import Text.PrettyBy.Fixity
-
 import Data.Proxy
 import Data.Text qualified as Text
 import Data.Text.Arbitrary
+
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck
+
+import Text.Pretty
+import Text.PrettyBy
+import Text.PrettyBy.Fixity
 
 newtype OnlyType = OnlyType RenderContext
 

--- a/prettyprinter-configurable/test/Expr.hs
+++ b/prettyprinter-configurable/test/Expr.hs
@@ -10,22 +10,24 @@ module Expr
     ( test_expr
     ) where
 
-import Text.Pretty
-import Text.PrettyBy
-import Text.PrettyBy.Fixity
-
 import Control.Monad.Combinators.Expr
+
 import Data.Bifunctor
 import Data.Char
 import Data.Functor.Identity
 import Data.String
 import Data.Text (Text)
 import Data.Void
+
 import Test.Tasty
 import Test.Tasty.HUnit
+
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as Lexer
+import Text.Pretty
+import Text.PrettyBy
+import Text.PrettyBy.Fixity
 
 data Expr
     = Var Text                   -- ^ A variable.

--- a/prettyprinter-configurable/test/Main.hs
+++ b/prettyprinter-configurable/test/Main.hs
@@ -1,11 +1,14 @@
 module Main where
 
 import Default
+
 import Expr
+
 import NonDefault
-import Universal
 
 import Test.Tasty
+
+import Universal
 
 main :: IO ()
 main = defaultMain $ testGroup "all"

--- a/prettyprinter-configurable/test/NonDefault.hs
+++ b/prettyprinter-configurable/test/NonDefault.hs
@@ -10,14 +10,16 @@ module NonDefault
     ( test_nonDefault
     ) where
 
-import Text.Pretty
-import Text.PrettyBy.Internal
-
 import Data.Char (intToDigit)
 import Data.Text (Text)
+
 import Numeric (showIntAtBase)
+
 import Test.Tasty
 import Test.Tasty.HUnit
+
+import Text.Pretty
+import Text.PrettyBy.Internal
 
 -- | A pretty-printing config.
 data CustomDefaults = CustomDefaults

--- a/prettyprinter-configurable/test/Universal.hs
+++ b/prettyprinter-configurable/test/Universal.hs
@@ -16,11 +16,11 @@ module Universal
     ( test_universal
     ) where
 
-import Text.Pretty
-import Text.PrettyBy
-
 import Test.Tasty
 import Test.Tasty.HUnit
+
+import Text.Pretty
+import Text.PrettyBy
 
 data ViaPretty
     = ViaPretty

--- a/stubs/plutus-ghc-stub/src/GhcPlugins.hs
+++ b/stubs/plutus-ghc-stub/src/GhcPlugins.hs
@@ -4,4 +4,5 @@ module GhcPlugins(
     ) where
 
 import Plugins
+
 import StubTypes

--- a/stubs/plutus-ghc-stub/src/Plugins.hs
+++ b/stubs/plutus-ghc-stub/src/Plugins.hs
@@ -10,9 +10,12 @@ module Plugins (
 
 
 import Control.Monad
+
 import Data.List
 import Data.Semigroup qualified
+
 import StubTypes
+
 import TcRnTypes qualified
 
 plugins :: DynFlags -> [LoadedPlugin]

--- a/stubs/plutus-ghc-stub/src/StubTypes.hs
+++ b/stubs/plutus-ghc-stub/src/StubTypes.hs
@@ -9,10 +9,12 @@ module StubTypes where
 import Control.Exception qualified as Exception
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO (..))
+
 import Data.ByteString
 import Data.Data (Data)
 import Data.Functor.Identity
 import Data.String (IsString (..))
+
 import Language.Haskell.TH qualified as TH
 
 data DynFlags    = DynFlags_

--- a/word-array/bench/Main.hs
+++ b/word-array/bench/Main.hs
@@ -10,15 +10,16 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-import Test.Tasty.Bench (bench, bgroup, defaultMain, env, nf, nfIO)
-
 import Control.Monad.Primitive
+
 import Data.Foldable (for_)
 import Data.Functor.Const
 import Data.Monoid
 import Data.Primitive
 import Data.Word
 import Data.Word64Array.Word8
+
+import Test.Tasty.Bench (bench, bgroup, defaultMain, env, nf, nfIO)
 
 main :: IO ()
 main = do

--- a/word-array/src/Data/Word64Array/Word8.hs
+++ b/word-array/src/Data/Word64Array/Word8.hs
@@ -22,12 +22,15 @@ module Data.Word64Array.Word8
   ) where
 
 import Control.DeepSeq
+
 import Data.Bits
 import Data.Functor
 import Data.Maybe (fromMaybe)
 import Data.MonoTraversable
 import Data.Word
+
 import Numeric (showHex)
+
 import Text.Show (showListWith)
 
 {- Note [Representation of WordArray]

--- a/word-array/test/Spec.hs
+++ b/word-array/test/Spec.hs
@@ -5,6 +5,7 @@ import Data.MonoTraversable
 import Data.Vector
 import Data.Word
 import Data.Word64Array.Word8 as WordArray
+
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck


### PR DESCRIPTION
- Bump stylish-haskell to 0.14.4
- Add grouping to stylish-haskell config
- Apply changes

EDIT: hmm, my PR body got lost. This bumps our `stylish-haskell` version so we can group imports in the way we've often discussed doing, but automatically. The rule mechanism is fairly flexible, so we can do various things quite easily. I think what I've put here is decent, namely:
- Group everything with "Plutus" in the first component
- Within that, group on the first component
- Everything else goes together

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
