### PR TITLE
(Backport 1.5) Forget about the existence of version 1.1.0

### DIFF
--- a/doc/read-the-docs-site/plutus-doc.cabal
+++ b/doc/read-the-docs-site/plutus-doc.cabal
@@ -72,9 +72,9 @@ executable doc-doctests
     , containers
     , flat               <0.5
     , lens
-    , plutus-core        ^>=1.5
-    , plutus-ledger-api  ^>=1.5
-    , plutus-tx          ^>=1.5
+    , plutus-core         ^>=1.5
+    , plutus-ledger-api   ^>=1.5
+    , plutus-tx           ^>=1.5
     , prettyprinter
     , random
     , serialise

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -62,8 +62,8 @@ library plutus-benchmark-common
     , base         >=4.9 && <5
     , criterion
     , filepath
-    , plutus-core  ^>=1.5
-    , plutus-tx    ^>=1.5
+    , plutus-core   ^>=1.5
+    , plutus-tx     ^>=1.5
 
 ---------------- nofib ----------------
 
@@ -93,9 +93,9 @@ library nofib-internal
     , base                     >=4.9 && <5
     , deepseq
     , plutus-benchmark-common
-    , plutus-core              ^>=1.5
-    , plutus-tx                ^>=1.5
-    , plutus-tx-plugin         ^>=1.5
+    , plutus-core               ^>=1.5
+    , plutus-tx                 ^>=1.5
+    , plutus-tx-plugin           ^>=1.5
 
 executable nofib-exe
   import:         lang
@@ -114,8 +114,8 @@ executable nofib-exe
     , nofib-internal
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.5
-    , plutus-tx                ^>=1.5
+    , plutus-core               ^>=1.5
+    , plutus-tx                 ^>=1.5
     , transformers
 
 benchmark nofib
@@ -163,8 +163,8 @@ test-suite plutus-benchmark-nofib-tests
     , base                                            >=4.9 && <5
     , nofib-internal
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.5
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib}   ^>=1.5
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}         ^>=1.5
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -196,9 +196,9 @@ library lists-internal
     , base                     >=4.9 && <5
     , mtl
     , plutus-benchmark-common
-    , plutus-core              ^>=1.5
-    , plutus-tx                ^>=1.5
-    , plutus-tx-plugin         ^>=1.5
+    , plutus-core               ^>=1.5
+    , plutus-tx                 ^>=1.5
+    , plutus-tx-plugin           ^>=1.5
 
 executable list-sort-exe
   import:         lang
@@ -213,7 +213,7 @@ executable list-sort-exe
     , lists-internal
     , monoidal-containers
     , plutus-benchmark-common
-    , plutus-core              ^>=1.5
+    , plutus-core               ^>=1.5
 
 benchmark lists
   import:         lang
@@ -247,8 +247,8 @@ test-suite plutus-benchmark-lists-tests
     , base                             >=4.9 && <5
     , lists-internal
     , plutus-benchmark-common
-    , plutus-core:plutus-core-testlib  ^>=1.5
-    , plutus-tx:plutus-tx-testlib      ^>=1.5
+    , plutus-core:plutus-core-testlib   ^>=1.5
+    , plutus-tx:plutus-tx-testlib       ^>=1.5
     , tasty
     , tasty-quickcheck
 
@@ -270,8 +270,8 @@ benchmark validation
     , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.5
-    , plutus-ledger-api        ^>=1.5
+    , plutus-core               ^>=1.5
+    , plutus-ledger-api         ^>=1.5
 
 ---------------- validation-decode ----------------
 
@@ -291,8 +291,8 @@ benchmark validation-decode
     , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.5
-    , plutus-ledger-api        ^>=1.5
+    , plutus-core               ^>=1.5
+    , plutus-ledger-api         ^>=1.5
 
 ---------------- validation-full ----------------
 
@@ -312,8 +312,8 @@ benchmark validation-full
     , flat                                                              <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core                                                       ^>=1.5
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.5
+    , plutus-core                                                        ^>=1.5
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}   ^>=1.5
 
 ---------------- Cek cost model calibration ----------------
 
@@ -335,9 +335,9 @@ benchmark cek-calibration
     , criterion         >=1.5.9.0
     , lens
     , mtl
-    , plutus-core       ^>=1.5
-    , plutus-tx         ^>=1.5
-    , plutus-tx-plugin  ^>=1.5
+    , plutus-core        ^>=1.5
+    , plutus-tx          ^>=1.5
+    , plutus-tx-plugin    ^>=1.5
 
 ---------------- Signature verification throughput ----------------
 
@@ -359,9 +359,9 @@ executable ed25519-throughput
     , cardano-crypto-class
     , flat                  <0.5
     , hedgehog
-    , plutus-core           ^>=1.5
-    , plutus-tx             ^>=1.5
-    , plutus-tx-plugin      ^>=1.5
+    , plutus-core            ^>=1.5
+    , plutus-tx              ^>=1.5
+    , plutus-tx-plugin        ^>=1.5
 
 ---------------- script contexts ----------------
 
@@ -378,9 +378,9 @@ library script-contexts-internal
   exposed-modules: PlutusBenchmark.ScriptContexts
   build-depends:
     , base               >=4.9 && <5
-    , plutus-ledger-api  ^>=1.5
-    , plutus-tx          ^>=1.5
-    , plutus-tx-plugin   ^>=1.5
+    , plutus-ledger-api   ^>=1.5
+    , plutus-tx           ^>=1.5
+    , plutus-tx-plugin     ^>=1.5
 
 test-suite plutus-benchmark-script-contexts-tests
   import:         lang
@@ -395,8 +395,8 @@ test-suite plutus-benchmark-script-contexts-tests
   build-depends:
     , base                                            >=4.9 && <5
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.5
-    , plutus-tx:plutus-tx-testlib                     ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib}   ^>=1.5
+    , plutus-tx:plutus-tx-testlib                      ^>=1.5
     , script-contexts-internal
     , tasty
     , tasty-hunit

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -50,7 +50,7 @@ library
     , directory
     , filepath
     , lens
-    , plutus-core             ^>=1.5
+    , plutus-core              ^>=1.5
     , tasty
     , tasty-expected-failure
     , tasty-golden
@@ -66,7 +66,7 @@ executable test-utils
     , base                  >=4.9 && <5
     , optparse-applicative
     , plutus-conformance
-    , plutus-core           ^>=1.5
+    , plutus-core            ^>=1.5
     , plutus-metatheory
     , tasty-golden
     , text
@@ -105,7 +105,7 @@ test-suite haskell-steppable-conformance
     , base                >=4.9 && <5
     , lens
     , plutus-conformance
-    , plutus-core         ^>=1.5
+    , plutus-core          ^>=1.5
 
 test-suite agda-conformance
   import:         lang
@@ -116,6 +116,6 @@ test-suite agda-conformance
   build-depends:
     , base                >=4.9 && <5
     , plutus-conformance
-    , plutus-core         ^>=1.5
+    , plutus-core          ^>=1.5
     , plutus-metatheory
     , transformers

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-core
-version:            1.5.0.1
+version:            1.5.0.2
 license:            Apache-2.0
 license-files:
   LICENSE
@@ -343,7 +343,7 @@ test-suite plutus-core-test
     , hex-text
     , mmorph
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib}   ^>=1.5
     , prettyprinter
     , serialise
     , tasty
@@ -390,7 +390,7 @@ test-suite untyped-plutus-core-test
     , index-envs
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib}   ^>=1.5
     , pretty-show
     , prettyprinter
     , QuickCheck
@@ -410,8 +410,8 @@ executable plc
     , base                  >=4.9 && <5
     , deepseq
     , optparse-applicative
-    , plutus-core           ^>=1.5
-    , plutus-core-execlib   ^>=1.5
+    , plutus-core            ^>=1.5
+    , plutus-core-execlib    ^>=1.5
     , text
 
 executable uplc
@@ -424,8 +424,8 @@ executable uplc
     , haskeline
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.5
-    , plutus-core-execlib   ^>=1.5
+    , plutus-core            ^>=1.5
+    , plutus-core-execlib    ^>=1.5
     , prettyprinter
     , split
     , text
@@ -503,7 +503,7 @@ library plutus-ir
     , mtl
     , multiset
     , parser-combinators   >=0.4.0
-    , plutus-core          ^>=1.5
+    , plutus-core           ^>=1.5
     , prettyprinter        >=1.1.0.1
     , semigroupoids
     , semigroups           >=0.19.1
@@ -538,7 +538,7 @@ test-suite plutus-ir-test
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}   ^>=1.5
     , QuickCheck
     , serialise
     , tasty
@@ -559,8 +559,8 @@ executable pir
     , lens
     , megaparsec
     , optparse-applicative
-    , plutus-core-execlib                   ^>=1.5
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.5
+    , plutus-core-execlib                    ^>=1.5
+    , plutus-core:{plutus-core, plutus-ir}   ^>=1.5
     , text
     , transformers
 
@@ -589,7 +589,7 @@ library plutus-core-execlib
     , monoidal-containers
     , mtl
     , optparse-applicative
-    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}   ^>=1.5
     , prettyprinter
     , text
 
@@ -646,7 +646,7 @@ library plutus-core-testlib
     , mmorph
     , mtl
     , multiset
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-ir}   ^>=1.5
     , prettyprinter                         >=1.1.0.1
     , prettyprinter-configurable
     , QuickCheck
@@ -690,8 +690,8 @@ executable debugger
     , mono-traversable
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.5
-    , plutus-core-execlib   ^>=1.5
+    , plutus-core            ^>=1.5
+    , plutus-core-execlib    ^>=1.5
     , prettyprinter
     , text
     , text-zipper
@@ -771,7 +771,7 @@ executable cost-model-budgeting-bench
     , hedgehog
     , mtl
     , optparse-applicative
-    , plutus-core            ^>=1.5
+    , plutus-core             ^>=1.5
     , QuickCheck
     , quickcheck-instances
     , random
@@ -802,7 +802,7 @@ executable generate-cost-model
     , extra
     , inline-r              >=1.0.0.0
     , optparse-applicative
-    , plutus-core           ^>=1.5
+    , plutus-core            ^>=1.5
     , text
     , vector
 
@@ -837,7 +837,7 @@ benchmark cost-model-test
     , hedgehog
     , inline-r          >=1.0.0.0
     , mmorph
-    , plutus-core       ^>=1.5
+    , plutus-core        ^>=1.5
     , template-haskell
     , text
     , vector

--- a/plutus-core/plutus-core/src/PlutusCore/Version.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Version.hs
@@ -68,7 +68,7 @@ plcVersion110 = Version 1 1 0
 
 -- | The latest version of Plutus Core supported by this library.
 latestVersion :: Version
-latestVersion = plcVersion110
+latestVersion = plcVersion100
 
 -- | The set of versions that are "known", i.e. that have been released
 -- and have actual differences associated with them.

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-ledger-api
-version:         1.5.0.1
+version:         1.5.0.2
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -95,8 +95,8 @@ library
     , lens
     , mtl
     , nothunks
-    , plutus-core        ^>=1.5
-    , plutus-tx          ^>=1.5
+    , plutus-core         ^>=1.5
+    , plutus-tx           ^>=1.5
     , prettyprinter
     , serialise
     , tagged
@@ -116,9 +116,9 @@ library plutus-ledger-api-testlib
     , base               >=4.9      && <5
     , base64-bytestring
     , bytestring
-    , plutus-core        ^>=1.5
-    , plutus-ledger-api  ^>=1.5
-    , plutus-tx          ^>=1.5
+    , plutus-core         ^>=1.5
+    , plutus-ledger-api   ^>=1.5
+    , plutus-tx           ^>=1.5
     , prettyprinter
     , PyF                >=0.11.1.0
     , serialise
@@ -144,9 +144,9 @@ test-suite plutus-ledger-api-test
     , hedgehog
     , mtl
     , nothunks
-    , plutus-core                                                       ^>=1.5
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.5
-    , plutus-tx:plutus-tx-testlib                                       ^>=1.5
+    , plutus-core                                                        ^>=1.5
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}   ^>=1.5
+    , plutus-tx:plutus-tx-testlib                                        ^>=1.5
     , tasty
     , tasty-hedgehog
     , tasty-hunit
@@ -166,8 +166,8 @@ executable evaluation-test
     , extra
     , filepath
     , mtl
-    , plutus-core                                                       ^>=1.5
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.5
+    , plutus-core                                                        ^>=1.5
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}   ^>=1.5
     , serialise
     , tasty
     , tasty-hunit

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -60,7 +60,7 @@ library
     , megaparsec
     , memory
     , optparse-applicative
-    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-execlib}   ^>=1.5
     , process
     , text
     , transformers
@@ -458,8 +458,8 @@ executable plc-agda
 test-suite test1
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.5
-    , plutus-core:uplc  ^>=1.5
+    , plutus-core:plc    ^>=1.5
+    , plutus-core:uplc   ^>=1.5
 
   hs-source-dirs:     test
   build-depends:
@@ -474,8 +474,8 @@ test-suite test1
 test-suite test2
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.5
-    , plutus-core:uplc  ^>=1.5
+    , plutus-core:plc    ^>=1.5
+    , plutus-core:uplc   ^>=1.5
 
   hs-source-dirs:     test
   type:               detailed-0.9
@@ -499,7 +499,7 @@ test-suite test3
     , base
     , lazy-search
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib}   ^>=1.5
     , plutus-metatheory
     , size-based
     , Stream

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx-plugin
-version:         1.5.0.1
+version:         1.5.0.2
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -81,8 +81,8 @@ library
     , flat                                  <0.5
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.5
-    , plutus-tx                             ^>=1.5
+    , plutus-core:{plutus-core, plutus-ir}   ^>=1.5
+    , plutus-tx                              ^>=1.5
     , prettyprinter
     , PyF                                   >=0.11.1.0
     , template-haskell
@@ -110,7 +110,7 @@ executable gen-plugin-opts-doc
     , containers
     , lens
     , optparse-applicative
-    , plutus-tx-plugin      ^>=1.5
+    , plutus-tx-plugin        ^>=1.5
     , prettyprinter
     , PyF                   >=0.11.1.0
     , text
@@ -162,9 +162,9 @@ test-suite plutus-tx-tests
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.5
-    , plutus-tx-plugin                                ^>=1.5
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib}   ^>=1.5
+    , plutus-tx-plugin                                  ^>=1.5
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}         ^>=1.5
     , tasty
     , tasty-hedgehog
     , tasty-hunit
@@ -187,7 +187,7 @@ test-suite size
   hs-source-dirs: test/size
   build-depends:
     , base                                      >=4.9 && <5.0
-    , plutus-tx-plugin                          ^>=1.5
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}  ^>=1.5
+    , plutus-tx-plugin                            ^>=1.5
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}   ^>=1.5
     , tagged
     , tasty

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx
-version:         1.5.0.1
+version:         1.5.0.2
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -106,7 +106,7 @@ library
     , lens
     , memory
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.5
+    , plutus-core:{plutus-core, plutus-ir}   ^>=1.5
     , prettyprinter
     , serialise
     , template-haskell                      >=2.13.0.0
@@ -133,8 +133,8 @@ library plutus-tx-testlib
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.5
-    , plutus-tx                                                  ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}   ^>=1.5
+    , plutus-tx                                                   ^>=1.5
     , prettyprinter
     , tagged
     , tasty
@@ -174,8 +174,8 @@ test-suite plutus-tx-test
     , filepath
     , hedgehog
     , hedgehog-fn
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.5
-    , plutus-tx                                       ^>=1.5
+    , plutus-core:{plutus-core, plutus-core-testlib}   ^>=1.5
+    , plutus-tx                                        ^>=1.5
     , pretty-show
     , serialise
     , tasty


### PR DESCRIPTION
This is simpler than backporting the `target-version` stuff, which came in a big PR. This instead just forgets about version 1.1.0, so it will go back to using 1.0.0 by default. People can use `target-version` later.