### PR TITLE
[Plugin] Warn about missing builtins

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Convert.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Convert.hs
@@ -31,7 +31,7 @@ integerToByteStringWrapper ::
 integerToByteStringWrapper endiannessArg lengthArg input
   -- Check that we are within the Int range on the non-negative side.
   | lengthArg < 0 || lengthArg >= 536870912 = do
-      emit "builtinIntegerToByteString: inappropriate length argument"
+      emit "integerToByteString: inappropriate length argument"
       emit $ "Length requested: " <> (pack . show $ input)
       pure EvaluationFailure
   -- As this builtin hasn't been costed yet, we have to impose a temporary limit of 10KiB on requested
@@ -40,7 +40,7 @@ integerToByteStringWrapper endiannessArg lengthArg input
   --
   -- TODO: Cost this builtin.
   | lengthArg > 10240 = do
-      emit "builtinIntegerToByteString: padding argument too large"
+      emit "integerToByteString: padding argument too large"
       emit "If you are seeing this, it is a bug: please report this!"
       pure EvaluationFailure
   | otherwise = let endianness = endiannessArgToByteOrder endiannessArg in
@@ -50,13 +50,13 @@ integerToByteStringWrapper endiannessArg lengthArg input
     case integerToByteString endianness (fromIntegral lengthArg) input of
       Left err -> case err of
         NegativeInput -> do
-          emit "builtinIntegerToByteString: cannot convert negative Integer"
+          emit "integerToByteString: cannot convert negative Integer"
           -- This does work proportional to the size of input. However, we're in a failing case
           -- anyway, and the user's paid for work proportional to this size in any case.
           emit $ "Input: " <> (pack . show $ input)
           pure EvaluationFailure
         NotEnoughDigits -> do
-          emit "builtinIntegerToByteString: cannot represent Integer in given number of bytes"
+          emit "integerToByteString: cannot represent Integer in given number of bytes"
           -- This does work proportional to the size of input. However, we're in a failing case
           -- anyway, and the user's paid for work proportional to this size in any case.
           emit $ "Input: " <> (pack . show $ input)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Conversion.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Conversion.hs
@@ -42,7 +42,7 @@ import Text.Show.Pretty (ppShow)
 -- - https://github.com/mlabs-haskell/CIPs/tree/koz/to-from-bytestring/CIP-XXXX#builtinintegertobytestring
 -- - https://github.com/mlabs-haskell/CIPs/tree/koz/to-from-bytestring/CIP-XXXX#builtinbytestringtointeger
 
--- lengthOfByteString (builtinIntegerToByteString e d 0) = d
+-- lengthOfByteString (integerToByteString e d 0) = d
 i2bProperty1 :: PropertyT IO ()
 i2bProperty1 = do
   e <- forAllWith ppShow Gen.bool
@@ -63,7 +63,7 @@ i2bProperty1 = do
         ]
   evaluateAndVerify (mkConstant @Bool () True) compareExp
 
--- indexByteString (builtinIntegerToByteString e k 0) j = 0
+-- indexByteString (integerToByteString e k 0) j = 0
 i2bProperty2 :: PropertyT IO ()
 i2bProperty2 = do
   e <- forAllWith ppShow Gen.bool
@@ -82,7 +82,7 @@ i2bProperty2 = do
         ]
   evaluateAndVerify (mkConstant @Integer () 0) indexExp
 
--- lengthOfByteString (builtinIntegerToByteString e 0 p) > 0
+-- lengthOfByteString (integerToByteString e 0 p) > 0
 i2bProperty3 :: PropertyT IO ()
 i2bProperty3 = do
   e <- forAllWith ppShow Gen.bool
@@ -101,8 +101,8 @@ i2bProperty3 = do
         ]
   evaluateAndVerify (mkConstant @Bool () True) compareExp
 
--- builtinIntegerToByteString False 0 (multiplyInteger p 256) = consByteString
--- 0 (builtinIntegerToByteString False 0 p)
+-- nntegerToByteString False 0 (multiplyInteger p 256) = consByteString
+-- 0 (integerToByteString False 0 p)
 i2bProperty4 :: PropertyT IO ()
 i2bProperty4 = do
   p <- forAllWith ppShow genP
@@ -126,8 +126,8 @@ i2bProperty4 = do
                       ]
   evaluateAndVerify2 expectedExp actualExp
 
--- builtinIntegerToByteString True 0 (multiplyInteger p 256) = appendByteString
--- (builtinIntegerToByteString True 0 p) (singleton 0)
+-- integerToByteString True 0 (multiplyInteger p 256) = appendByteString
+-- (integerToByteString True 0 p) (singleton 0)
 i2bProperty5 :: PropertyT IO ()
 i2bProperty5 = do
   p <- forAllWith ppShow genP
@@ -151,8 +151,8 @@ i2bProperty5 = do
                       ]
   evaluateAndVerify2 expectedExp actualExp
 
--- builtinIntegerToByteString False 0 (plusInteger (multiplyInteger q 256) r) =
--- appendByteString (builtinIntegerToByteString False 0 r) (builtinIntegerToByteString False 0 q)
+-- integerToByteString False 0 (plusInteger (multiplyInteger q 256) r) =
+-- appendByteString (integerToByteString False 0 r) (integerToByteString False 0 q)
 i2bProperty6 :: PropertyT IO ()
 i2bProperty6 = do
   q <- forAllWith ppShow genQ
@@ -186,9 +186,9 @@ i2bProperty6 = do
                       ]
   evaluateAndVerify2 expectedExp actualExp
 
--- builtinIntegerToByteString True 0 (plusInteger (multiplyInteger q 256) r) =
--- appendByteString (builtinIntegerToByteString False 0 q)
--- (builtinIntegerToByteString False 0 r)
+-- integerToByteString True 0 (plusInteger (multiplyInteger q 256) r) =
+-- appendByteString (integerToByteString False 0 q)
+-- (integerToByteString False 0 r)
 i2bProperty7 :: PropertyT IO ()
 i2bProperty7 = do
   q <- forAllWith ppShow genQ
@@ -222,7 +222,7 @@ i2bProperty7 = do
                       ]
   evaluateAndVerify2 expectedExp actualExp
 
--- builtinByteStringToInteger b (builtinIntegerToByteString b 0 q) = q
+-- byteStringToInteger b (integerToByteString b 0 q) = q
 b2iProperty1 :: PropertyT IO ()
 b2iProperty1 = do
   b <- forAllWith ppShow Gen.bool
@@ -238,7 +238,7 @@ b2iProperty1 = do
         ]
   evaluateAndVerify (mkConstant @Integer () q) convertedExp
 
--- builtinByteStringToInteger b (consByteString w8 emptyByteString) = w8
+-- byteStringToInteger b (consByteString w8 emptyByteString) = w8
 b2iProperty2 :: PropertyT IO ()
 b2iProperty2 = do
   w8 :: Integer <- fromIntegral <$> forAllWith ppShow (Gen.enumBounded @_ @Word8)
@@ -253,7 +253,7 @@ b2iProperty2 = do
         ]
   evaluateAndVerify (mkConstant @Integer () w8) actualExp
 
--- builtinIntegerToByteString b (lengthOfByteString bs) (builtinByteStringToInteger b bs) = bs
+-- integerToByteString b (lengthOfByteString bs) (byteStringToInteger b bs) = bs
 b2iProperty3 :: PropertyT IO ()
 b2iProperty3 = do
   b <- forAllWith ppShow Gen.bool
@@ -274,42 +274,42 @@ b2iProperty3 = do
 
 i2bCipExamples :: [TestTree]
 i2bCipExamples = [
-  -- builtinIntegerToByteString False 0 (-1) => failure
+  -- integerToByteString False 0 (-1) => failure
   testCase "example 1" (let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 0,
                                 mkConstant @Integer () (-1)
                                 ]
                             in evaluateShouldFail actualExp),
-  -- builtinIntegerToByteString True 0 (-1) => failure
+  -- integerToByteString True 0 (-1) => failure
   testCase "example 2" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () True,
                                 mkConstant @Integer () 0,
                                 mkConstant @Integer () (-1)
                                 ]
                             in evaluateShouldFail actualExp,
-  -- builtinIntegerToByteString False 100 (-1) => failure
+  -- integerToByteString False 100 (-1) => failure
   testCase "example 3" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 100,
                                 mkConstant @Integer () (-1)
                                 ]
                             in evaluateShouldFail actualExp,
-  -- builtinIntegerToByteString False 0 0 => [ ]
+  -- integerToByteString False 0 0 => [ ]
   testCase "example 4" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 0,
                                 mkConstant @Integer () 0
                                 ]
                             in evaluateAssertEqual (mkConstant @ByteString () "") actualExp,
-  -- builtinIntegerToByteString True 0 0 => [ ]
+  -- integerToByteString True 0 0 => [ ]
   testCase "example 5" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () True,
                                 mkConstant @Integer () 0,
                                 mkConstant @Integer () 0
                                 ]
                           in evaluateAssertEqual (mkConstant @ByteString () "") actualExp,
-  -- builtinIntegerToByteString False 5 0 => [ 0x00, 0x00, 0x00, 0x00, 0x00]
+  -- integerToByteString False 5 0 => [ 0x00, 0x00, 0x00, 0x00, 0x00]
   testCase "example 6" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                               mkConstant @Bool () False,
                               mkConstant @Integer () 5,
@@ -317,7 +317,7 @@ i2bCipExamples = [
                               ]
                              expectedExp = mkConstant @ByteString () "\NUL\NUL\NUL\NUL\NUL"
                           in evaluateAssertEqual expectedExp actualExp,
-  -- builtinIntegerToByteString True 5 0 => [ 0x00, 0x00, 0x00, 0x00, 0x00]
+  -- integerToByteString True 5 0 => [ 0x00, 0x00, 0x00, 0x00, 0x00]
   testCase "example 7" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                               mkConstant @Bool () True,
                               mkConstant @Integer () 5,
@@ -325,35 +325,35 @@ i2bCipExamples = [
                               ]
                              expectedExp = mkConstant @ByteString () "\NUL\NUL\NUL\NUL\NUL"
                           in evaluateAssertEqual expectedExp actualExp,
-  -- builtinIntegerToByteString False 536870912 0 => failure
+  -- integerToByteString False 536870912 0 => failure
   testCase "example 8" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 536870912,
                                 mkConstant @Integer () 0
                                 ]
                             in evaluateShouldFail actualExp,
-  -- builtinIntegerToByteString True 536870912 0 => failure
+  -- integerToByteString True 536870912 0 => failure
   testCase "example 9"  $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () True,
                                 mkConstant @Integer () 536870912,
                                 mkConstant @Integer () 0
                                 ]
                             in evaluateShouldFail actualExp,
-  -- builtinIntegerToByteString False 1 404 => failure
+  -- integerToByteString False 1 404 => failure
   testCase "example 10" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 1,
                                 mkConstant @Integer () 404
                                 ]
                             in evaluateShouldFail actualExp,
-  -- builtinIntegerToByteString True 1 404 => failure
+  -- integerToByteString True 1 404 => failure
   testCase "example 11" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () True,
                                 mkConstant @Integer () 1,
                                 mkConstant @Integer () 404
                                 ]
                             in evaluateShouldFail actualExp,
-  -- builtinIntegerToByteString False 2 404 => [ 0x94, 0x01 ]
+  -- integerToByteString False 2 404 => [ 0x94, 0x01 ]
   testCase "example 12" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 2,
@@ -361,7 +361,7 @@ i2bCipExamples = [
                                 ]
                               expectedExp = mkConstant @ByteString () (fromList [0x94, 0x01])
                             in evaluateAssertEqual expectedExp actualExp,
-  -- builtinIntegerToByteString False 0 404 => [ 0x94, 0x01 ]
+  -- integerToByteString False 0 404 => [ 0x94, 0x01 ]
   testCase "example 13" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 0,
@@ -369,7 +369,7 @@ i2bCipExamples = [
                                 ]
                               expectedExp = mkConstant @ByteString () (fromList [0x94, 0x01])
                             in evaluateAssertEqual expectedExp actualExp,
-  -- builtinIntegerToByteString True 2 404 => [ 0x01, 0x94 ]
+  -- integerToByteString True 2 404 => [ 0x01, 0x94 ]
   testCase "example 14" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () True,
                                 mkConstant @Integer () 2,
@@ -377,7 +377,7 @@ i2bCipExamples = [
                                 ]
                               expectedExp = mkConstant @ByteString () (fromList [0x01, 0x94])
                             in evaluateAssertEqual expectedExp actualExp,
-  -- builtinIntegerToByteString True 0 404 => [ 0x01, 0x94 ]
+  -- integerToByteString True 0 404 => [ 0x01, 0x94 ]
   testCase "example 15" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () True,
                                 mkConstant @Integer () 0,
@@ -385,7 +385,7 @@ i2bCipExamples = [
                                 ]
                               expectedExp = mkConstant @ByteString () (fromList [0x01, 0x94])
                             in evaluateAssertEqual expectedExp actualExp,
-  -- builtinIntegerToByteString False 5 404 => [ 0x94, 0x01, 0x00, 0x00, 0x00 ]
+  -- integerToByteString False 5 404 => [ 0x94, 0x01, 0x00, 0x00, 0x00 ]
   testCase "example 16" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () False,
                                 mkConstant @Integer () 5,
@@ -393,7 +393,7 @@ i2bCipExamples = [
                                 ]
                               expectedExp = mkConstant @ByteString () (fromList [0x94, 0x01, 0x00, 0x00, 0x00])
                             in evaluateAssertEqual expectedExp actualExp,
-  -- builtinIntegerToByteString True 5 404 => [ 0x00, 0x00, 0x00, 0x01, 0x94 ]
+  -- integerToByteString True 5 404 => [ 0x00, 0x00, 0x00, 0x01, 0x94 ]
   testCase "example 17" $ let actualExp = mkIterAppNoAnn (builtin () PLC.IntegerToByteString) [
                                 mkConstant @Bool () True,
                                 mkConstant @Integer () 5,
@@ -405,21 +405,21 @@ i2bCipExamples = [
 
 b2iCipExamples :: [TestTree]
 b2iCipExamples = [
-  -- builtinByteStringToInteger False emptyByteString => 0
+  -- byteStringToInteger False emptyByteString => 0
   testCase "example 1" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                 mkConstant @Bool () False,
                                 mkConstant @ByteString () ""
                                 ]
                              expectedExp = mkConstant @Integer () 0
                           in evaluateAssertEqual expectedExp actualExp,
-  -- builtinByteStringToInteger True emptyByteString => 0
+  -- byteStringToInteger True emptyByteString => 0
   testCase "example 2" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                   mkConstant @Bool () True,
                                   mkConstant @ByteString () ""
                                   ]
                              expectedExp = mkConstant @Integer () 0
                             in evaluateAssertEqual expectedExp actualExp,
-  -- builtinByteStringToInteger False (consByteString 0x01 (consByteString 0x01 emptyByteString)) =>
+  -- byteStringToInteger False (consByteString 0x01 (consByteString 0x01 emptyByteString)) =>
   -- 257
   testCase "example 3" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                 mkConstant @Bool () False,
@@ -427,7 +427,7 @@ b2iCipExamples = [
                                 ]
                              expectedExp = mkConstant @Integer () 257
                           in evaluateAssertEqual expectedExp actualExp,
-  -- builtinByteStringToInteger True (consByteString 0x01 (consByteString 0x01 emptyByteString)) =>
+  -- byteStringToInteger True (consByteString 0x01 (consByteString 0x01 emptyByteString)) =>
   -- 257
   testCase "example 4" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                 mkConstant @Bool () True,
@@ -435,7 +435,7 @@ b2iCipExamples = [
                                 ]
                              expectedExp = mkConstant @Integer () 257
                             in evaluateAssertEqual expectedExp actualExp,
-  -- builtinByteStringToInteger True (consByteString 0x00 (consByteString 0x01 (consByteString 0x01
+  -- byteStringToInteger True (consByteString 0x00 (consByteString 0x01 (consByteString 0x01
   -- emptyByteString))) => 257
   testCase "example 5" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                 mkConstant @Bool () True,
@@ -443,7 +443,7 @@ b2iCipExamples = [
                                 ]
                              expectedExp = mkConstant @Integer () 257
                           in evaluateAssertEqual expectedExp actualExp,
-  -- builtinByteStringToInteger False (consByteString 0x00 (consByteString 0x01 (consByteString 0x01
+  -- byteStringToInteger False (consByteString 0x00 (consByteString 0x01 (consByteString 0x01
   -- emptyByteString))) => 65792
   testCase "example 6" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                 mkConstant @Bool () False,
@@ -451,7 +451,7 @@ b2iCipExamples = [
                                 ]
                              expectedExp = mkConstant @Integer () 65792
                           in evaluateAssertEqual expectedExp actualExp,
-  -- builtinByteStringToInteger False (consByteString 0x01 (consByteString 0x01 (consByteString 0x00
+  -- byteStringToInteger False (consByteString 0x01 (consByteString 0x01 (consByteString 0x00
   -- emptyByteString))) => 257
   testCase "example 7" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                 mkConstant @Bool () False,
@@ -459,7 +459,7 @@ b2iCipExamples = [
                                 ]
                              expectedExp = mkConstant @Integer () 257
                           in evaluateAssertEqual expectedExp actualExp,
-  -- builtinByteStringToInteger True (consByteString 0x01 (consByteString 0x01 (consByteString 0x00
+  -- byteStringToInteger True (consByteString 0x01 (consByteString 0x01 (consByteString 0x00
   -- emptyByteString))) => 65792
   testCase "example 8" $ let actualExp = mkIterAppNoAnn (builtin () PLC.ByteStringToInteger) [
                                 mkConstant @Bool () True,

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -820,33 +820,33 @@ test_Conversion =
     adjustOption (\x -> max x . HedgehogTestLimit . Just $ 8000) .
     testGroup "Integer <-> ByteString conversions" $ [
       testGroup "Integer -> ByteString" [
-        --- lengthOfByteString (builtinIntegerToByteString e d 0) = d
+        --- lengthOfByteString (integerToByteString e d 0) = d
         testPropertyNamed "property 1" "i2b_prop1" . property $ Conversion.i2bProperty1,
-        -- indexByteString (builtinIntegerToByteString e k 0) j = 0
+        -- indexByteString (integerToByteString e k 0) j = 0
         testPropertyNamed "property 2" "i2b_prop2" . property $ Conversion.i2bProperty2,
-        -- lengthOfByteString (builtinIntegerToByteString e 0 p) > 0
+        -- lengthOfByteString (integerToByteString e 0 p) > 0
         testPropertyNamed "property 3" "i2b_prop3" . property $ Conversion.i2bProperty3,
-        -- builtinIntegerToByteString False 0 (multiplyInteger p 256) = consByteString
-        -- 0 (builtinIntegerToByteString False 0 p)
+        -- integerToByteString False 0 (multiplyInteger p 256) = consByteString
+        -- 0 (integerToByteString False 0 p)
         testPropertyNamed "property 4" "i2b_prop4" . property $ Conversion.i2bProperty4,
-        -- builtinIntegerToByteString True 0 (multiplyInteger p 256) = appendByteString
-        -- (builtinIntegerToByteString True 0 p) (singleton 0)
+        -- integerToByteString True 0 (multiplyInteger p 256) = appendByteString
+        -- (integerToByteString True 0 p) (singleton 0)
         testPropertyNamed "property 5" "i2b_prop5" . property $ Conversion.i2bProperty5,
-        -- builtinIntegerToByteString False 0 (plusInteger (multiplyInteger q 256) r) =
-        -- appendByteString (builtinIntegerToByteString False 0 r) (builtinIntegerToByteString False 0 q)
+        -- integerToByteString False 0 (plusInteger (multiplyInteger q 256) r) =
+        -- appendByteString (integerToByteString False 0 r) (integerToByteString False 0 q)
         testPropertyNamed "property 6" "i2b_prop6" . property $ Conversion.i2bProperty6,
-        -- builtinIntegerToByteString True 0 (plusInteger (multiplyInteger q 256) r) =
-        -- appendByteString (builtinIntegerToByteString False 0 q)
-        -- (builtinIntegerToByteString False 0 r)
+        -- integerToByteString True 0 (plusInteger (multiplyInteger q 256) r) =
+        -- appendByteString (integerToByteString False 0 q)
+        -- (integerToByteString False 0 r)
         testPropertyNamed "property 7" "i2b_prop7" . property $ Conversion.i2bProperty7,
         testGroup "CIP-0087 examples" Conversion.i2bCipExamples
         ],
       testGroup "ByteString -> Integer" [
-        -- builtinByteStringToInteger b (builtinIntegerToByteString b d q) = q
+        -- byteStringToInteger b (integerToByteString b d q) = q
         testPropertyNamed "property 1" "b2i_prop1" . property $ Conversion.b2iProperty1,
-        -- builtinByteStringToInteger b (consByteString w8 emptyByteString) = w8
+        -- byteStringToInteger b (consByteString w8 emptyByteString) = w8
         testPropertyNamed "property 2" "b2i_prop2" . property $ Conversion.b2iProperty2,
-        -- builtinIntegerToByteString b (lengthOfByteString bs) (builtinByteStringToInteger b bs) = bs
+        -- integerToByteString b (lengthOfByteString bs) (byteStringToInteger b bs) = bs
         testPropertyNamed "property 3" "b2i_prop3" . property $ Conversion.b2iProperty3,
         testGroup "CIP-0087 examples" Conversion.b2iCipExamples
         ]

--- a/plutus-ledger-api/test-plugin/Spec/Value.hs
+++ b/plutus-ledger-api/test-plugin/Spec/Value.hs
@@ -68,21 +68,21 @@ patternOptions =
     , [(1,9), (2,2), (6,10), (2,3), (1,0), (4,10), (3,5), (5,0), (3,6), (2,4), (1,1), (2,7), (4,8)]
     ]
 
-{-# INLINEABLE integerToByteString #-}
-integerToByteString :: Integer -> BuiltinByteString
-integerToByteString n =
+{-# INLINEABLE i2Bs #-}
+i2Bs :: Integer -> BuiltinByteString
+i2Bs n =
     if n < 0
-        then "-" `appendByteString` integerToByteString (negate n)
+        then "-" `appendByteString` i2Bs (negate n)
         -- @48@ is the ASCII code of @0@.
         else ListTx.foldr (consByteString . (48 +)) emptyByteString $ toDigits n
 
 {-# INLINEABLE replicateToByteString #-}
--- | Like 'integerToByteString' but generates longer bytestrings, so that repeated recalculations of
+-- | Like 'i2Bs but generates longer bytestrings, so that repeated recalculations of
 -- currency/token name comparisons get reflected in the budget tests in a visible manner.
 replicateToByteString :: Integer -> BuiltinByteString
 replicateToByteString i =
     ListTx.foldr id emptyByteString $
-        ListTx.replicate iTo6 (appendByteString $ integerToByteString i)
+        ListTx.replicate iTo6 (appendByteString $ i2Bs i)
   where
     iTo2 = i * i
     iTo4 = iTo2 * iTo2

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -49,9 +49,11 @@ import Language.Haskell.TH.Syntax qualified as TH
 import Control.Monad.Reader (ask, asks)
 
 import Data.ByteString qualified as BS
+import Data.Foldable (for_)
 import Data.Functor
 import Data.Proxy
 import Data.Text (Text)
+import PlutusPrelude (enumerate)
 
 {- Note [Mapping builtins]
 We want the user to be able to call the Plutus builtins as normal Haskell functions.
@@ -296,134 +298,155 @@ defineBuiltinTerms :: CompilingDefault uni fun m ann => m ()
 defineBuiltinTerms = do
     CompileContext {ccOpts=compileOpts} <- ask
 
-    -- See Note [Builtin terms and values]
-    -- Bool
-    defineBuiltinTerm annMayInline 'Builtins.ifThenElse $ mkBuiltin PLC.IfThenElse
-    defineBuiltinTerm annMayInline 'Builtins.true       $ PIR.mkConstant annMayInline True
-    defineBuiltinTerm annMayInline 'Builtins.false      $ PIR.mkConstant annMayInline False
-
-    defineBuiltinTerm annMayInline 'Builtins.unitval    $ PIR.mkConstant annMayInline ()
-    defineBuiltinTerm annMayInline 'Builtins.chooseUnit $ mkBuiltin PLC.ChooseUnit
-
-    -- Bytestring builtins
-    defineBuiltinTerm annMayInline 'Builtins.appendByteString                $ mkBuiltin PLC.AppendByteString
-    defineBuiltinTerm annMayInline 'Builtins.consByteString                  $ mkBuiltin PLC.ConsByteString
-    defineBuiltinTerm annMayInline 'Builtins.sliceByteString                 $ mkBuiltin PLC.SliceByteString
-    defineBuiltinTerm annMayInline 'Builtins.lengthOfByteString              $ mkBuiltin PLC.LengthOfByteString
-    defineBuiltinTerm annMayInline 'Builtins.indexByteString                 $ mkBuiltin PLC.IndexByteString
-    defineBuiltinTerm annMayInline 'Builtins.sha2_256                        $ mkBuiltin PLC.Sha2_256
-    defineBuiltinTerm annMayInline 'Builtins.sha3_256                        $ mkBuiltin PLC.Sha3_256
-    defineBuiltinTerm annMayInline 'Builtins.blake2b_224                     $ mkBuiltin PLC.Blake2b_224
-    defineBuiltinTerm annMayInline 'Builtins.blake2b_256                     $ mkBuiltin PLC.Blake2b_256
-    defineBuiltinTerm annMayInline 'Builtins.keccak_256                      $ mkBuiltin PLC.Keccak_256
-    defineBuiltinTerm annMayInline 'Builtins.equalsByteString                $ mkBuiltin PLC.EqualsByteString
-    defineBuiltinTerm annMayInline 'Builtins.lessThanByteString              $ mkBuiltin PLC.LessThanByteString
-    defineBuiltinTerm annMayInline 'Builtins.lessThanEqualsByteString        $ mkBuiltin PLC.LessThanEqualsByteString
-    defineBuiltinTerm annMayInline 'Builtins.emptyByteString                 $ PIR.mkConstant annMayInline BS.empty
-    defineBuiltinTerm annMayInline 'Builtins.decodeUtf8                      $ mkBuiltin PLC.DecodeUtf8
-    defineBuiltinTerm annMayInline 'Builtins.verifyEcdsaSecp256k1Signature   $ mkBuiltin PLC.VerifyEcdsaSecp256k1Signature
-    defineBuiltinTerm annMayInline 'Builtins.verifySchnorrSecp256k1Signature $ mkBuiltin PLC.VerifySchnorrSecp256k1Signature
-
-    -- Crypto
-    defineBuiltinTerm annMayInline 'Builtins.verifyEd25519Signature $ mkBuiltin PLC.VerifyEd25519Signature
-
-    -- Integer builtins
-    defineBuiltinTerm annMayInline 'Builtins.addInteger             $ mkBuiltin PLC.AddInteger
-    defineBuiltinTerm annMayInline 'Builtins.subtractInteger        $ mkBuiltin PLC.SubtractInteger
-    defineBuiltinTerm annMayInline 'Builtins.multiplyInteger        $ mkBuiltin PLC.MultiplyInteger
-    defineBuiltinTerm annMayInline 'Builtins.divideInteger          $ mkBuiltin PLC.DivideInteger
-    defineBuiltinTerm annMayInline 'Builtins.modInteger             $ mkBuiltin PLC.ModInteger
-    defineBuiltinTerm annMayInline 'Builtins.quotientInteger        $ mkBuiltin PLC.QuotientInteger
-    defineBuiltinTerm annMayInline 'Builtins.remainderInteger       $ mkBuiltin PLC.RemainderInteger
-    defineBuiltinTerm annMayInline 'Builtins.lessThanInteger        $ mkBuiltin PLC.LessThanInteger
-    defineBuiltinTerm annMayInline 'Builtins.lessThanEqualsInteger  $ mkBuiltin PLC.LessThanEqualsInteger
-    defineBuiltinTerm annMayInline 'Builtins.equalsInteger          $ mkBuiltin PLC.EqualsInteger
-
     -- Error
     -- See Note [Delaying error]
     func <- delayedErrorFunc
     -- We always want to inline `error :: forall a . () -> a`, hence `annAlwaysInline`.
     defineBuiltinTerm annAlwaysInline 'Builtins.error func
 
-    -- Strings and chars
-    defineBuiltinTerm annMayInline 'Builtins.appendString $ mkBuiltin PLC.AppendString
-    defineBuiltinTerm annMayInline 'Builtins.emptyString  $ PIR.mkConstant annMayInline ("" :: Text)
-    defineBuiltinTerm annMayInline 'Builtins.equalsString $ mkBuiltin PLC.EqualsString
-    defineBuiltinTerm annMayInline 'Builtins.encodeUtf8   $ mkBuiltin PLC.EncodeUtf8
+    -- Unit constant
+    defineBuiltinTerm annMayInline 'Builtins.unitval $ PIR.mkConstant annMayInline ()
 
-    -- Tracing
-    -- When `remove-trace` is specified, we define `trace` as `\_ a -> a` instead of the builtin version.
-    (traceTerm, ann) <-
-        if coRemoveTrace compileOpts
-            then liftQuote $ do
-                ta <- freshTyName "a"
-                t <- freshName "t"
-                a <- freshName "a"
-                pure
-                    ( PIR.tyAbs annMayInline ta (PLC.Type annMayInline) $
-                        PIR.mkIterLamAbs
-                            [ PIR.VarDecl annMayInline t (PIR.mkTyBuiltin @_ @Text annMayInline)
-                            , PIR.VarDecl annMayInline a (PLC.TyVar annMayInline ta)
-                            ]
-                            $ PIR.Var annMayInline a
-                    , annMayInline
-                    )
-            else pure (mkBuiltin PLC.Trace, annMayInline)
-    defineBuiltinTerm ann 'Builtins.trace traceTerm
+    -- Bool constants
+    defineBuiltinTerm annMayInline 'Builtins.true  $ PIR.mkConstant annMayInline True
+    defineBuiltinTerm annMayInline 'Builtins.false $ PIR.mkConstant annMayInline False
 
-    -- Pairs
-    defineBuiltinTerm annMayInline 'Builtins.fst        $ mkBuiltin PLC.FstPair
-    defineBuiltinTerm annMayInline 'Builtins.snd        $ mkBuiltin PLC.SndPair
-    defineBuiltinTerm annMayInline 'Builtins.mkPairData $ mkBuiltin PLC.MkPairData
+    -- ByteString constant
+    defineBuiltinTerm annMayInline 'Builtins.emptyByteString $ PIR.mkConstant annMayInline BS.empty
 
-    -- List
-    defineBuiltinTerm annMayInline 'Builtins.null          $ mkBuiltin PLC.NullList
-    defineBuiltinTerm annMayInline 'Builtins.head          $ mkBuiltin PLC.HeadList
-    defineBuiltinTerm annMayInline 'Builtins.tail          $ mkBuiltin PLC.TailList
-    defineBuiltinTerm annMayInline 'Builtins.chooseList    $ mkBuiltin PLC.ChooseList
-    defineBuiltinTerm annMayInline 'Builtins.mkNilData     $ mkBuiltin PLC.MkNilData
-    defineBuiltinTerm annMayInline 'Builtins.mkNilPairData $ mkBuiltin PLC.MkNilPairData
-    defineBuiltinTerm annMayInline 'Builtins.mkCons        $ mkBuiltin PLC.MkCons
+    -- Text constant
+    defineBuiltinTerm annMayInline 'Builtins.emptyString $ PIR.mkConstant annMayInline ("" :: Text)
 
-    -- Data
-    defineBuiltinTerm annMayInline 'Builtins.chooseData         $ mkBuiltin PLC.ChooseData
-    defineBuiltinTerm annMayInline 'Builtins.equalsData         $ mkBuiltin PLC.EqualsData
-    defineBuiltinTerm annMayInline 'Builtins.mkConstr           $ mkBuiltin PLC.ConstrData
-    defineBuiltinTerm annMayInline 'Builtins.mkMap              $ mkBuiltin PLC.MapData
-    defineBuiltinTerm annMayInline 'Builtins.mkList             $ mkBuiltin PLC.ListData
-    defineBuiltinTerm annMayInline 'Builtins.mkI                $ mkBuiltin PLC.IData
-    defineBuiltinTerm annMayInline 'Builtins.mkB                $ mkBuiltin PLC.BData
-    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsConstr $ mkBuiltin PLC.UnConstrData
-    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsMap    $ mkBuiltin PLC.UnMapData
-    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsList   $ mkBuiltin PLC.UnListData
-    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsB      $ mkBuiltin PLC.UnBData
-    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsI      $ mkBuiltin PLC.UnIData
-    defineBuiltinTerm annMayInline 'Builtins.serialiseData      $ mkBuiltin PLC.SerialiseData
-
-    -- BLS
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_equals               $ mkBuiltin PLC.Bls12_381_G1_equal
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_add                  $ mkBuiltin PLC.Bls12_381_G1_add
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_neg                  $ mkBuiltin PLC.Bls12_381_G1_neg
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_scalarMul            $ mkBuiltin PLC.Bls12_381_G1_scalarMul
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_compress             $ mkBuiltin PLC.Bls12_381_G1_compress
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_uncompress           $ mkBuiltin PLC.Bls12_381_G1_uncompress
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_hashToGroup          $ mkBuiltin PLC.Bls12_381_G1_hashToGroup
     -- The next two constants are 48 bytes long, so in fact we may not want to inline them.
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_compressed_generator $ PIR.mkConstant annMayInline BLS12_381.G1.compressed_generator
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_compressed_zero      $ PIR.mkConstant annMayInline BLS12_381.G1.compressed_zero
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_equals               $ mkBuiltin PLC.Bls12_381_G2_equal
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_add                  $ mkBuiltin PLC.Bls12_381_G2_add
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_scalarMul            $ mkBuiltin PLC.Bls12_381_G2_scalarMul
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_neg                  $ mkBuiltin PLC.Bls12_381_G2_neg
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_compress             $ mkBuiltin PLC.Bls12_381_G2_compress
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_uncompress           $ mkBuiltin PLC.Bls12_381_G2_uncompress
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_hashToGroup          $ mkBuiltin PLC.Bls12_381_G2_hashToGroup
+    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_compressed_generator $
+        PIR.mkConstant annMayInline BLS12_381.G1.compressed_generator
+    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G1_compressed_zero $
+        PIR.mkConstant annMayInline BLS12_381.G1.compressed_zero
+
     -- The next two constants are 96 bytes long, so in fact we may not want to inline them.
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_compressed_generator $ PIR.mkConstant annMayInline BLS12_381.G2.compressed_generator
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_compressed_zero      $ PIR.mkConstant annMayInline BLS12_381.G2.compressed_zero
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_millerLoop              $ mkBuiltin PLC.Bls12_381_millerLoop
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_mulMlResult             $ mkBuiltin PLC.Bls12_381_mulMlResult
-    defineBuiltinTerm annMayInline 'Builtins.bls12_381_finalVerify             $ mkBuiltin PLC.Bls12_381_finalVerify
+    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_compressed_generator $
+        PIR.mkConstant annMayInline BLS12_381.G2.compressed_generator
+    defineBuiltinTerm annMayInline 'Builtins.bls12_381_G2_compressed_zero $
+        PIR.mkConstant annMayInline BLS12_381.G2.compressed_zero
+
+    -- See Note [Builtin terms and values]
+    for_ enumerate $ \fun ->
+        let defineBuiltinInl impl = defineBuiltinTerm annMayInline impl $ mkBuiltin fun
+        in case fun of
+            PLC.IfThenElse -> defineBuiltinInl 'Builtins.ifThenElse
+            PLC.ChooseUnit -> defineBuiltinInl 'Builtins.chooseUnit
+
+            -- Bytestrings
+            PLC.AppendByteString -> defineBuiltinInl 'Builtins.appendByteString
+            PLC.ConsByteString -> defineBuiltinInl 'Builtins.consByteString
+            PLC.SliceByteString -> defineBuiltinInl 'Builtins.sliceByteString
+            PLC.LengthOfByteString -> defineBuiltinInl 'Builtins.lengthOfByteString
+            PLC.IndexByteString -> defineBuiltinInl 'Builtins.indexByteString
+            PLC.Sha2_256 -> defineBuiltinInl 'Builtins.sha2_256
+            PLC.Sha3_256 -> defineBuiltinInl 'Builtins.sha3_256
+            PLC.Blake2b_224 -> defineBuiltinInl 'Builtins.blake2b_224
+            PLC.Blake2b_256 -> defineBuiltinInl 'Builtins.blake2b_256
+            PLC.Keccak_256 -> defineBuiltinInl 'Builtins.keccak_256
+            PLC.EqualsByteString -> defineBuiltinInl 'Builtins.equalsByteString
+            PLC.LessThanByteString -> defineBuiltinInl 'Builtins.lessThanByteString
+            PLC.LessThanEqualsByteString -> defineBuiltinInl 'Builtins.lessThanEqualsByteString
+            PLC.DecodeUtf8 -> defineBuiltinInl 'Builtins.decodeUtf8
+
+            -- Strings and chars
+            PLC.AppendString -> defineBuiltinInl 'Builtins.appendString
+            PLC.EqualsString -> defineBuiltinInl 'Builtins.equalsString
+            PLC.EncodeUtf8 -> defineBuiltinInl 'Builtins.encodeUtf8
+
+            -- Crypto
+            PLC.VerifyEd25519Signature -> defineBuiltinInl 'Builtins.verifyEd25519Signature
+            PLC.VerifyEcdsaSecp256k1Signature -> defineBuiltinInl 'Builtins.verifyEcdsaSecp256k1Signature
+            PLC.VerifySchnorrSecp256k1Signature -> defineBuiltinInl 'Builtins.verifySchnorrSecp256k1Signature
+
+            -- Integers
+            PLC.AddInteger -> defineBuiltinInl 'Builtins.addInteger
+            PLC.SubtractInteger -> defineBuiltinInl 'Builtins.subtractInteger
+            PLC.MultiplyInteger -> defineBuiltinInl 'Builtins.multiplyInteger
+            PLC.DivideInteger -> defineBuiltinInl 'Builtins.divideInteger
+            PLC.ModInteger -> defineBuiltinInl 'Builtins.modInteger
+            PLC.QuotientInteger -> defineBuiltinInl 'Builtins.quotientInteger
+            PLC.RemainderInteger -> defineBuiltinInl 'Builtins.remainderInteger
+            PLC.LessThanInteger -> defineBuiltinInl 'Builtins.lessThanInteger
+            PLC.LessThanEqualsInteger -> defineBuiltinInl 'Builtins.lessThanEqualsInteger
+            PLC.EqualsInteger -> defineBuiltinInl 'Builtins.equalsInteger
+
+            -- Tracing
+            -- When `remove-trace` is specified, we define `trace` as `\_ a -> a` instead of the
+            -- version.
+            PLC.Trace -> do
+                (traceTerm, ann) <-
+                    if coRemoveTrace compileOpts
+                        then liftQuote $ do
+                            ta <- freshTyName "a"
+                            t <- freshName "t"
+                            a <- freshName "a"
+                            pure
+                                ( PIR.tyAbs annMayInline ta (PLC.Type annMayInline) $
+                                    PIR.mkIterLamAbs
+                                        [ PIR.VarDecl annMayInline t $
+                                            PIR.mkTyBuiltin @_ @Text annMayInline
+                                        , PIR.VarDecl annMayInline a $
+                                            PLC.TyVar annMayInline ta
+                                        ]
+                                        $ PIR.Var annMayInline a
+                                , annMayInline
+                                )
+                        else pure (mkBuiltin PLC.Trace, annMayInline)
+                defineBuiltinTerm ann 'Builtins.trace traceTerm
+
+            -- Pairs
+            PLC.FstPair -> defineBuiltinInl 'Builtins.fst
+            PLC.SndPair -> defineBuiltinInl 'Builtins.snd
+            PLC.MkPairData -> defineBuiltinInl 'Builtins.mkPairData
+
+            -- List
+            PLC.NullList -> defineBuiltinInl 'Builtins.null
+            PLC.HeadList -> defineBuiltinInl 'Builtins.head
+            PLC.TailList -> defineBuiltinInl 'Builtins.tail
+            PLC.ChooseList -> defineBuiltinInl 'Builtins.chooseList
+            PLC.MkNilData -> defineBuiltinInl 'Builtins.mkNilData
+            PLC.MkNilPairData -> defineBuiltinInl 'Builtins.mkNilPairData
+            PLC.MkCons -> defineBuiltinInl 'Builtins.mkCons
+
+            -- Data
+            PLC.ChooseData -> defineBuiltinInl 'Builtins.chooseData
+            PLC.EqualsData -> defineBuiltinInl 'Builtins.equalsData
+            PLC.ConstrData -> defineBuiltinInl 'Builtins.mkConstr
+            PLC.MapData -> defineBuiltinInl 'Builtins.mkMap
+            PLC.ListData -> defineBuiltinInl 'Builtins.mkList
+            PLC.IData -> defineBuiltinInl 'Builtins.mkI
+            PLC.BData -> defineBuiltinInl 'Builtins.mkB
+            PLC.UnConstrData -> defineBuiltinInl 'Builtins.unsafeDataAsConstr
+            PLC.UnMapData -> defineBuiltinInl 'Builtins.unsafeDataAsMap
+            PLC.UnListData -> defineBuiltinInl 'Builtins.unsafeDataAsList
+            PLC.UnBData -> defineBuiltinInl 'Builtins.unsafeDataAsB
+            PLC.UnIData -> defineBuiltinInl 'Builtins.unsafeDataAsI
+            PLC.SerialiseData -> defineBuiltinInl 'Builtins.serialiseData
+
+            -- BLS
+            PLC.Bls12_381_G1_equal -> defineBuiltinInl 'Builtins.bls12_381_G1_equals
+            PLC.Bls12_381_G1_add -> defineBuiltinInl 'Builtins.bls12_381_G1_add
+            PLC.Bls12_381_G1_neg -> defineBuiltinInl 'Builtins.bls12_381_G1_neg
+            PLC.Bls12_381_G1_scalarMul -> defineBuiltinInl 'Builtins.bls12_381_G1_scalarMul
+            PLC.Bls12_381_G1_compress -> defineBuiltinInl 'Builtins.bls12_381_G1_compress
+            PLC.Bls12_381_G1_uncompress -> defineBuiltinInl 'Builtins.bls12_381_G1_uncompress
+            PLC.Bls12_381_G1_hashToGroup -> defineBuiltinInl 'Builtins.bls12_381_G1_hashToGroup
+
+            PLC.Bls12_381_G2_equal -> defineBuiltinInl 'Builtins.bls12_381_G2_equals
+            PLC.Bls12_381_G2_add -> defineBuiltinInl 'Builtins.bls12_381_G2_add
+            PLC.Bls12_381_G2_scalarMul -> defineBuiltinInl 'Builtins.bls12_381_G2_scalarMul
+            PLC.Bls12_381_G2_neg -> defineBuiltinInl 'Builtins.bls12_381_G2_neg
+            PLC.Bls12_381_G2_compress -> defineBuiltinInl 'Builtins.bls12_381_G2_compress
+            PLC.Bls12_381_G2_uncompress -> defineBuiltinInl 'Builtins.bls12_381_G2_uncompress
+            PLC.Bls12_381_G2_hashToGroup -> defineBuiltinInl 'Builtins.bls12_381_G2_hashToGroup
+
+            PLC.Bls12_381_millerLoop -> defineBuiltinInl 'Builtins.bls12_381_millerLoop
+            PLC.Bls12_381_mulMlResult -> defineBuiltinInl 'Builtins.bls12_381_mulMlResult
+            PLC.Bls12_381_finalVerify -> defineBuiltinInl 'Builtins.bls12_381_finalVerify
 
 
 defineBuiltinTypes

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -203,8 +203,8 @@ builtinNames = [
     , 'Builtins.emptyString
     , 'Builtins.equalsString
     , 'Builtins.encodeUtf8
-    , 'Builtins.builtinIntegerToByteString
-    , 'Builtins.builtinByteStringToInteger
+    , 'Builtins.integerToByteString
+    , 'Builtins.byteStringToInteger
     -- This one is special
     , 'Builtins.stringToBuiltinString
 
@@ -353,8 +353,8 @@ defineBuiltinTerms = do
             PLC.LessThanByteString -> defineBuiltinInl 'Builtins.lessThanByteString
             PLC.LessThanEqualsByteString -> defineBuiltinInl 'Builtins.lessThanEqualsByteString
             PLC.DecodeUtf8 -> defineBuiltinInl 'Builtins.decodeUtf8
-            PLC.IntegerToByteString -> defineBuiltinInl 'Builtins.builtinIntegerToByteString
-            PLC.ByteStringToInteger -> defineBuiltinInl 'Builtins.builtinByteStringToInteger
+            PLC.IntegerToByteString -> defineBuiltinInl 'Builtins.integerToByteString
+            PLC.ByteStringToInteger -> defineBuiltinInl 'Builtins.byteStringToInteger
 
             -- Strings and chars
             PLC.AppendString -> defineBuiltinInl 'Builtins.appendString

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -203,6 +203,8 @@ builtinNames = [
     , 'Builtins.emptyString
     , 'Builtins.equalsString
     , 'Builtins.encodeUtf8
+    , 'Builtins.builtinIntegerToByteString
+    , 'Builtins.builtinByteStringToInteger
     -- This one is special
     , 'Builtins.stringToBuiltinString
 
@@ -351,6 +353,8 @@ defineBuiltinTerms = do
             PLC.LessThanByteString -> defineBuiltinInl 'Builtins.lessThanByteString
             PLC.LessThanEqualsByteString -> defineBuiltinInl 'Builtins.lessThanEqualsByteString
             PLC.DecodeUtf8 -> defineBuiltinInl 'Builtins.decodeUtf8
+            PLC.IntegerToByteString -> defineBuiltinInl 'Builtins.builtinIntegerToByteString
+            PLC.ByteStringToInteger -> defineBuiltinInl 'Builtins.builtinByteStringToInteger
 
             -- Strings and chars
             PLC.AppendString -> defineBuiltinInl 'Builtins.appendString

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/patternMatching.uplc.golden
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/patternMatching.uplc.golden
@@ -35,10 +35,10 @@ program
                                   (addInteger cse))
                                (addInteger cse))
                             (addInteger cse))
-                         (case cse [(\x y z w -> y)]))
+                         (case cse [(\x y z w -> z)]))
                       (case cse [(\x y z w -> x)]))
-                   (case cse [(\x y z w -> z)]))
-                (case cse [(\x y z w -> w)]))
+                   (case cse [(\x y z w -> w)]))
+                (case cse [(\x y z w -> y)]))
              (\x y -> addInteger x y))
           (\x y ->
              force ifThenElse

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -104,8 +104,8 @@ module PlutusTx.Builtins (
                          -- * Conversions
                          , fromBuiltin
                          , toBuiltin
-                         , builtinIntegerToByteString
-                         , builtinByteStringToInteger
+                         , integerToByteString
+                         , byteStringToInteger
                          ) where
 
 import Data.Maybe
@@ -603,12 +603,13 @@ bls12_381_finalVerify a b = fromBuiltin (BI.bls12_381_finalVerify a b)
 
 -- | Convert a 'BuiltinInteger' into a 'BuiltinByteString', as described in
 -- [CIP-0087](https://github.com/mlabs-haskell/CIPs/tree/koz/to-from-bytestring/CIP-XXXX).
-{-# INLINEABLE builtinIntegerToByteString #-}
-builtinIntegerToByteString :: Bool -> Integer -> Integer -> BuiltinByteString
-builtinIntegerToByteString endiannessArg = BI.builtinIntegerToByteString (toBuiltin endiannessArg)
+{-# INLINEABLE integerToByteString #-}
+integerToByteString :: Bool -> Integer -> Integer -> BuiltinByteString
+integerToByteString endiannessArg = BI.integerToByteString (toBuiltin endiannessArg)
 
 -- | Convert a 'BuiltinByteString' to a 'BuiltinInteger', as described in
 -- [CIP-0087](https://github.com/mlabs-haskell/CIPs/tree/koz/to-from-bytestring/CIP-XXXX).
-builtinByteStringToInteger :: Bool -> BuiltinByteString -> Integer
-builtinByteStringToInteger statedEndiannessArg =
-  BI.builtinByteStringToInteger (toBuiltin statedEndiannessArg)
+{-# INLINEABLE byteStringToInteger #-}
+byteStringToInteger :: Bool -> BuiltinByteString -> Integer
+byteStringToInteger statedEndiannessArg =
+  BI.byteStringToInteger (toBuiltin statedEndiannessArg)

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -686,23 +686,23 @@ bls12_381_finalVerify (BuiltinBLS12_381_MlResult a) (BuiltinBLS12_381_MlResult b
 CONVERSION
 -}
 
-{-# NOINLINE builtinIntegerToByteString #-}
-builtinIntegerToByteString ::
+{-# NOINLINE integerToByteString #-}
+integerToByteString ::
   BuiltinBool ->
   BuiltinInteger ->
   BuiltinInteger ->
   BuiltinByteString
-builtinIntegerToByteString (BuiltinBool endiannessArg) paddingArg input =
+integerToByteString (BuiltinBool endiannessArg) paddingArg input =
   case Convert.integerToByteStringWrapper endiannessArg paddingArg input of
     Emitter f -> case runWriter f of
       (result, logs) -> traceAll logs $ case result of
         EvaluationFailure    -> mustBeReplaced "Integer to ByteString conversion errored."
         EvaluationSuccess bs -> BuiltinByteString bs
 
-{-# NOINLINE builtinByteStringToInteger #-}
-builtinByteStringToInteger ::
+{-# NOINLINE byteStringToInteger #-}
+byteStringToInteger ::
   BuiltinBool ->
   BuiltinByteString ->
   BuiltinInteger
-builtinByteStringToInteger (BuiltinBool statedEndiannessArg) (BuiltinByteString input) =
+byteStringToInteger (BuiltinBool statedEndiannessArg) (BuiltinByteString input) =
   Convert.byteStringToIntegerWrapper statedEndiannessArg input


### PR DESCRIPTION
This makes it so that an unhandled built-in function in the plugin causes a compile-time warning. 

In particular, it gives me

```
warning: [GHC-62161] [-Wincomplete-patterns]
    Pattern match(es) are non-exhaustive
    In a case alternative:
        Patterns of type ‘PLC.DefaultFun’ not matched:
            PLC.IntegerToByteString
            PLC.ByteStringToInteger
```