### PR TITLE
Fix blake2b_224 in plutus-tx

### DIFF
--- a/plutus-tx/changelog.d/20240112_125800_kenneth.mackenzie.md
+++ b/plutus-tx/changelog.d/20240112_125800_kenneth.mackenzie.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The `blake2b_224` function in the plutus-tx plugin was erroneously
+  calling `blake2b_256` instead.  Now fixed.
+

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -161,7 +161,7 @@ sha3_256 = BI.sha3_256
 {-# INLINABLE blake2b_224 #-}
 -- | The BLAKE2B-224 hash of a 'ByteString'
 blake2b_224 :: BuiltinByteString -> BuiltinByteString
-blake2b_224 = BI.blake2b_256
+blake2b_224 = BI.blake2b_224
 
 {-# INLINABLE blake2b_256 #-}
 -- | The BLAKE2B-256 hash of a 'ByteString'


### PR DESCRIPTION
The implementation of `blake2b_224` in the plugin was actually calling `blake2b_256`.  This fixes that.  The problem only affects the plugin: the Plutus Core implementation is correct.