### PR TITLE
Make 'paste' use spaces as delimiters: tabs confuse awk formatting

### DIFF
--- a/plutus-benchmark/bench-compare-markdown
+++ b/plutus-benchmark/bench-compare-markdown
@@ -39,7 +39,7 @@ trap 'rm -f "$TMP1" "$TMP2"' EXIT
 awk '/^bench/ {printf ("%-40s ", $2)}
      /^time/ {printf ("%10s %-2s\n", $2, $3)}' "$INPUT1" > "$TMP1"  # %-2s to get the units properly aligned
 awk '/^time/ {printf ("%10s %-2s\n", $2, $3)}' "$INPUT2" > "$TMP2"
-paste "$TMP1" "$TMP2" |
+paste -d " " "$TMP1" "$TMP2" |
   awk -v hdr1="${3:-Old}" -v hdr2="${4:-New}" 'BEGIN {
        # Initialise array of unit conversion factors
        ps["s"]  = 12  # 1 s = 10^12 ps

--- a/plutus-benchmark/nofib-compare
+++ b/plutus-benchmark/nofib-compare
@@ -38,7 +38,7 @@ trap 'rm -f "$TMP1" "$TMP2"' EXIT
 awk 'afterHdr >= 1 { print} /-------/ {afterHdr = 1}' "$INPUT1" > "$TMP1"
 awk 'afterHdr >= 1 { print} /-------/ {afterHdr = 1}' "$INPUT2" > "$TMP2"
       
-paste "$TMP1" "$TMP2" |
+paste -d " " "$TMP1" "$TMP2" |
    awk '
       function diff (n1, n2) {
         d = (n2-n1)/n1 * 100


### PR DESCRIPTION
The `bench-compare` scripts use `paste`, which by default uses tabs as separators in the output.  This can confuse the formatting `awk` does later in the scripts, so this PR makes `paste` use spaces as delimiters instead.

I'm going to take the opportunity to run the benchmarks multiple times (nothing to do with the PR really, just checking consistency).