### PR TITLE
Build all tasty tests with the threaded runtime and some capabilities

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -161,6 +161,7 @@ test-suite plutus-benchmark-nofib-tests
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   hs-source-dirs: nofib/test
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     , base                                            >=4.9   && <5
     , nofib-internal
@@ -226,6 +227,7 @@ test-suite plutus-benchmark-lists-tests
   import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: lists/test
   other-modules:
     Lookup.Spec
@@ -352,6 +354,7 @@ test-suite ed25519-costs-test
   import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   ghc-options:    -Wno-unused-packages
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: ed25519-costs/test ed25519-costs/src
   main-is:        Spec.hs
   other-modules:  PlutusBenchmark.Ed25519.Common
@@ -409,6 +412,7 @@ test-suite bls12-381-costs-test
   import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: bls12-381-costs/test
   build-depends:
     , base                             >=4.9   && <5
@@ -450,6 +454,7 @@ test-suite plutus-benchmark-script-contexts-tests
   import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: script-contexts/test
   other-modules:
   build-depends:
@@ -530,6 +535,7 @@ test-suite plutus-benchmark-marlowe-tests
   import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: marlowe/test
   other-modules:
   build-depends:

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -89,6 +89,7 @@ test-suite haskell-conformance
   import:         lang
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: haskell test-cases
   other-modules:
   build-depends:
@@ -99,6 +100,7 @@ test-suite haskell-steppable-conformance
   import:         lang
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: haskell-steppable test-cases
   other-modules:
   build-depends:
@@ -111,6 +113,7 @@ test-suite agda-conformance
   import:         lang
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: agda test-cases
   other-modules:
   build-depends:

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -584,6 +584,7 @@ test-suite plutus-ir-test
   type:               exitcode-stdio-1.0
   main-is:            Driver.hs
   hs-source-dirs:     plutus-ir/test
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
   other-modules:
     PlutusCore.Generators.QuickCheck.BuiltinsTests
     PlutusCore.Generators.QuickCheck.SubstitutionTests
@@ -839,6 +840,7 @@ test-suite traceToStacks-test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   executables/traceToStacks
   default-language: Haskell2010
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
   main-is:          TestGetStacks.hs
   other-modules:    Common
   build-depends:
@@ -1064,6 +1066,7 @@ test-suite index-envs-test
   default-language: Haskell2010
   main-is:          Spec.hs
   other-modules:    RAList.Spec
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     , base                  >=4.9 && <5
     , index-envs

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -143,6 +143,7 @@ test-suite plutus-ledger-api-test
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   hs-source-dirs: test
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   other-modules:
     Spec.CBOR.DeserialiseFailureInfo
     Spec.ContextDecoding
@@ -181,6 +182,7 @@ test-suite plutus-ledger-api-plugin-test
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   hs-source-dirs: test-plugin
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   other-modules:
     Spec.Budget
     Spec.Value

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -583,6 +583,7 @@ test-suite test3
   hs-source-dirs: test
   type:           exitcode-stdio-1.0
   main-is:        TestNEAT.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     , base
     , lazy-search

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -178,6 +178,7 @@ test-suite plutus-tx-plugin-tests
     , text
 
   default-extensions: Strict
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
 
   -- NOTE: -g makes the plugin give better errors
   -- See Note [-fno-full-laziness in Plutus Tx]
@@ -202,6 +203,7 @@ test-suite size
     , tasty
 
   default-extensions: Strict
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
 
   -- See Note [-fno-full-laziness in Plutus Tx]
   ghc-options:

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -128,6 +128,7 @@ library plutus-tx-testlib
   import:          lang
   visibility:      public
   hs-source-dirs:  testlib
+  ghc-options:     -threaded -rtsopts -with-rtsopts=-N
   exposed-modules:
     Hedgehog.Laws.Common
     Hedgehog.Laws.Eq
@@ -157,6 +158,7 @@ test-suite plutus-tx-test
 
   type:               exitcode-stdio-1.0
   main-is:            Spec.hs
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
   other-modules:
     List.Spec
     Rational.Laws

--- a/prettyprinter-configurable/prettyprinter-configurable.cabal
+++ b/prettyprinter-configurable/prettyprinter-configurable.cabal
@@ -71,6 +71,7 @@ test-suite prettyprinter-configurable-test
   import:         lang
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: test
   other-modules:
     Default


### PR DESCRIPTION
This ensures that tasty actually runs tests in parallel. This makes a small but noticeable difference.