### PR TITLE
Metatheory for bitwise conversion builtins (PLT-8188)

### DIFF
--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -41,54 +41,9 @@ agdaEvalUplcProg (UPLC.Program () version tmU) =
 -- The entries of the list should be paths from the root of plutus-conformance
 -- to the directory containing the test, eg
 --   "test-cases/uplc/evaluation/builtin/semantics/addInteger/addInteger1"
-
 failingTests :: [FilePath]
 failingTests =
     [
-     --- byteStringToInteger
-      "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/big-endian/all-zeros"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/big-endian/leading-zeros"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/big-endian/correct-output"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/big-endian/empty"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/little-endian/all-zeros"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/little-endian/correct-output"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/little-endian/trailing-zeros"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/little-endian/empty"
-    , "test-cases/uplc/evaluation/builtin/semantics/byteStringToInteger/both-endian"
-
-    -- integerToByteString
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/negative-input"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/negative-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/correct-output-exact-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/correct-output-extra-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/too-narrow"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/maximum-width-zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/width-too-big-zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/max-input-width-too-small"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/max-input-fits-max-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/bounded/max-width-input-too-big"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/unbounded/zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/unbounded/negative-input"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/unbounded/maximum-input"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/unbounded/input-too-big"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/big-endian/unbounded/correct-output"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/negative-input"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/negative-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/correct-output-exact-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/correct-output-extra-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/too-narrow"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/maximum-width-zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/width-too-big-zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/max-input-width-too-small"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/max-input-fits-max-width"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/bounded/max-width-input-too-big"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/unbounded/zero"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/unbounded/negative-input"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/unbounded/maximum-input"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/unbounded/input-too-big"
-    , "test-cases/uplc/evaluation/builtin/semantics/integerToByteString/little-endian/unbounded/correct-output"
     ]
 
 main :: IO ()

--- a/plutus-metatheory/data/builtinCostModel.json
+++ b/plutus-metatheory/data/builtinCostModel.json
@@ -85,7 +85,7 @@
     },
     "bls12_381_G1_add": {
         "cpu": {
-            "arguments": 1046420,
+            "arguments": 832808,
             "type": "constant_cost"
         },
         "memory": {
@@ -95,7 +95,7 @@
     },
     "bls12_381_G1_compress": {
         "cpu": {
-            "arguments": 3387741,
+            "arguments": 3209094,
             "type": "constant_cost"
         },
         "memory": {
@@ -105,7 +105,7 @@
     },
     "bls12_381_G1_equal": {
         "cpu": {
-            "arguments": 545063,
+            "arguments": 331451,
             "type": "constant_cost"
         },
         "memory": {
@@ -116,7 +116,7 @@
     "bls12_381_G1_hashToGroup": {
         "cpu": {
             "arguments": {
-                "intercept": 66311195,
+                "intercept": 65990684,
                 "slope": 23097
             },
             "type": "linear_in_x"
@@ -128,7 +128,7 @@
     },
     "bls12_381_G1_neg": {
         "cpu": {
-            "arguments": 292890,
+            "arguments": 114242,
             "type": "constant_cost"
         },
         "memory": {
@@ -139,7 +139,7 @@
     "bls12_381_G1_scalarMul": {
         "cpu": {
             "arguments": {
-                "intercept": 94607019,
+                "intercept": 94393407,
                 "slope": 87060
             },
             "type": "linear_in_x"
@@ -151,7 +151,7 @@
     },
     "bls12_381_G1_uncompress": {
         "cpu": {
-            "arguments": 16598737,
+            "arguments": 16420089,
             "type": "constant_cost"
         },
         "memory": {
@@ -161,7 +161,7 @@
     },
     "bls12_381_G2_add": {
         "cpu": {
-            "arguments": 2359410,
+            "arguments": 2145798,
             "type": "constant_cost"
         },
         "memory": {
@@ -171,7 +171,7 @@
     },
     "bls12_381_G2_compress": {
         "cpu": {
-            "arguments": 3973992,
+            "arguments": 3795345,
             "type": "constant_cost"
         },
         "memory": {
@@ -181,7 +181,7 @@
     },
     "bls12_381_G2_equal": {
         "cpu": {
-            "arguments": 1102635,
+            "arguments": 889023,
             "type": "constant_cost"
         },
         "memory": {
@@ -192,7 +192,7 @@
     "bls12_381_G2_hashToGroup": {
         "cpu": {
             "arguments": {
-                "intercept": 204557793,
+                "intercept": 204237282,
                 "slope": 23271
             },
             "type": "linear_in_x"
@@ -204,7 +204,7 @@
     },
     "bls12_381_G2_neg": {
         "cpu": {
-            "arguments": 307813,
+            "arguments": 129165,
             "type": "constant_cost"
         },
         "memory": {
@@ -215,7 +215,7 @@
     "bls12_381_G2_scalarMul": {
         "cpu": {
             "arguments": {
-                "intercept": 190191402,
+                "intercept": 189977790,
                 "slope": 85902
             },
             "type": "linear_in_x"
@@ -227,7 +227,7 @@
     },
     "bls12_381_G2_uncompress": {
         "cpu": {
-            "arguments": 33191512,
+            "arguments": 33012864,
             "type": "constant_cost"
         },
         "memory": {
@@ -237,7 +237,7 @@
     },
     "bls12_381_finalVerify": {
         "cpu": {
-            "arguments": 388656972,
+            "arguments": 388443360,
             "type": "constant_cost"
         },
         "memory": {
@@ -245,9 +245,9 @@
             "type": "constant_cost"
         }
     },
-    "bls12_381_mulMlResult": {
+    "bls12_381_millerLoop": {
         "cpu": {
-            "arguments": 2544991,
+            "arguments": 401885761,
             "type": "constant_cost"
         },
         "memory": {
@@ -255,14 +255,31 @@
             "type": "constant_cost"
         }
     },
-    "bls12_381_millerLoop": {
+    "bls12_381_mulMlResult": {
         "cpu": {
-            "arguments": 402099373,
+            "arguments": 2331379,
             "type": "constant_cost"
         },
         "memory": {
             "arguments": 72,
             "type": "constant_cost"
+        }
+    },
+    "byteStringToInteger": {
+        "cpu": {
+            "arguments": {
+                "c0": 936157,
+                "c1": 49601,
+                "c2": 237
+            },
+            "type": "quadratic_in_y"
+        },
+        "memory": {
+            "arguments": {
+                "intercept": 0,
+                "slope": 1
+            },
+            "type": "linear_in_y"
         }
     },
     "chooseData": {
@@ -478,6 +495,23 @@
         "memory": {
             "arguments": 4,
             "type": "constant_cost"
+        }
+    },
+    "integerToByteString": {
+        "cpu": {
+            "arguments": {
+                "c0": 1292075,
+                "c1": 24469,
+                "c2": 74
+            },
+            "type": "quadratic_in_z"
+        },
+        "memory": {
+            "arguments": {
+                "intercept": 0,
+                "slope": 1
+            },
+            "type": "literal_in_y_or_linear_in_z"
         }
     },
     "keccak_256": {

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -140,6 +140,7 @@ library
     MAlonzo.Code.Cost.Base
     MAlonzo.Code.Cost.Model
     MAlonzo.Code.Cost.Raw
+    MAlonzo.Code.Cost.Size
     MAlonzo.Code.Data.Bool.Base
     MAlonzo.Code.Data.Bool.Properties
     MAlonzo.Code.Data.Char.Base
@@ -368,6 +369,7 @@ library
     MAlonzo.Code.Cost.Base
     MAlonzo.Code.Cost.Model
     MAlonzo.Code.Cost.Raw
+    MAlonzo.Code.Cost.Size
     MAlonzo.Code.Data.Bool.Base
     MAlonzo.Code.Data.Bool.Properties
     MAlonzo.Code.Data.Char.Base

--- a/plutus-metatheory/src/Algorithmic/CEK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CEK.lagda.md
@@ -311,6 +311,10 @@ BUILTIN bls12-381-G2-uncompress (base $ V-con b) with BLS12-381-G2-uncompress b
 BUILTIN bls12-381-millerLoop (base $ V-con e1 $ V-con e2) = inj₂ (V-con (BLS12-381-millerLoop e1 e2))
 BUILTIN bls12-381-mulMlResult (base $ V-con r $ V-con r') = inj₂ (V-con (BLS12-381-mulMlResult r r'))
 BUILTIN bls12-381-finalVerify (base $ V-con r $ V-con r') = inj₂ (V-con (BLS12-381-finalVerify r r'))
+BUILTIN byteStringToInteger (base $ V-con e $ V-con s) = inj₂ (V-con (BStoI e s))
+BUILTIN integerToByteString (base $ V-con e $ V-con w $ V-con n) with ItoBS e w n
+... | just s = inj₂ (V-con s)
+... | nothing = inj₁ (con (ne (^ (atomic aBytestring))))
 
 BUILTIN' : ∀ b {A}
   → ∀{tn} → {pt : tn ∔ 0 ≣ fv (signature b)}
@@ -427,5 +431,4 @@ stepper (suc n) st | (s ; ρ ▻ M) = stepper n (s ; ρ ▻ M)
 stepper (suc n) st | (s ◅ V) = stepper n (s ◅ V)
 stepper (suc n) st | (□ V)   = return (□ V)
 stepper (suc n) st | ◆ A     = return (◆ A)
--- -}
-    
+

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -129,6 +129,9 @@ data Builtin : Set where
   -- Keccak-256, Blake2b-224
   keccak-256                      : Builtin
   blake2b-224                     : Builtin
+  -- Bitwise operations
+  byteStringToInteger             : Builtin
+  integerToByteString             : Builtin
 ```
 
 ## Signatures
@@ -295,6 +298,8 @@ hence need to be embedded into `n⋆ / n♯ ⊢⋆` using the postfix constructo
     signature bls12-381-millerLoop            = ∙ [ bls12-381-g1-element ↑ , bls12-381-g2-element ↑ ]⟶ bls12-381-mlresult ↑
     signature bls12-381-mulMlResult           = ∙ [ bls12-381-mlresult ↑ , bls12-381-mlresult ↑ ]⟶ bls12-381-mlresult ↑
     signature bls12-381-finalVerify           = ∙ [ bls12-381-mlresult ↑ , bls12-381-mlresult ↑ ]⟶ bool ↑
+    signature byteStringToInteger             = ∙ [ bool ↑ , bytestring ↑ ]⟶ integer ↑
+    signature integerToByteString             = ∙ [ bool ↑ , integer ↑ , integer ↑ ]⟶  bytestring ↑
 
 open SugaredSignature using (signature) public
 
@@ -383,6 +388,8 @@ Each Agda built-in name must be mapped to a Haskell name.
                                           | Bls12_381_finalVerify
                                           | Keccak_256
                                           | Blake2b_224
+                                          | ByteStringToInteger
+                                          | IntegerToByteString
                                           ) #-}
 ```
 
@@ -436,6 +443,8 @@ postulate
   BLS12-381-finalVerify     : Bls12-381-MlResult → Bls12-381-MlResult → Bool
   KECCAK-256                : ByteString → ByteString
   BLAKE2B-224               : ByteString → ByteString
+  BStoI                     : Bool -> ByteString -> Int
+  ItoBS                     : Bool -> Int -> Int -> Maybe ByteString
 ```
 
 ### What builtin operations should be compiled to if we compile to Haskell
@@ -525,6 +534,10 @@ postulate
 
 {-# COMPILE GHC KECCAK-256 = Hash.keccak_256 #-}
 {-# COMPILE GHC BLAKE2B-224 = Hash.blake2b_224 #-}
+
+{-# FOREIGN GHC import PlutusCore.Bitwise.Convert qualified as Convert #-}
+{-# COMPILE GHC BStoI = Convert.byteStringToIntegerWrapper #-}
+{-# COMPILE GHC ItoBS = \e w n -> builtinResultToMaybe $ Convert.integerToByteStringWrapper e w n #-}
 
 -- no binding needed for appendStr
 -- no binding needed for traceStr

--- a/plutus-metatheory/src/Cost/Base.lagda.md
+++ b/plutus-metatheory/src/Cost/Base.lagda.md
@@ -18,6 +18,7 @@ open import Relation.Binary.PropositionalEquality using (_≡_)
 open import Utils.Reflection using (defDec;defShow;defListConstructors)
 open import RawU using (TmCon)
 open import Builtin using (Builtin;arity)
+open import Untyped.CEK using (Value)
 ```
 
 We will represent costs with Naturals. In the implementation `SatInt` is used, (integers that don't overflow, but saturate). 
@@ -71,7 +72,7 @@ data ExBudgetCategory : Set where
     BStep       : StepKind → ExBudgetCategory
 
      -- Cost of evaluating a fully applied builtin function
-    BBuiltinApp : (b : Builtin) → Vec CostingNat (arity b) → ExBudgetCategory  
+    BBuiltinApp : (b : Builtin) → Vec Value (arity b) → ExBudgetCategory  
 
     -- Startup Cost
     BStartup    : ExBudgetCategory
@@ -88,9 +89,7 @@ record MachineParameters (Cost : Set) : Set where
       ε : Cost
       _∙_ : Cost → Cost → Cost
       costMonoid : IsMonoid _≡_ _∙_ ε
-      constantMeasure : TmCon → CostingNat
 
     startupCost : Cost 
     startupCost = cekMachineCost BStartup
-  
 ``` 

--- a/plutus-metatheory/src/Cost/Model.lagda.md
+++ b/plutus-metatheory/src/Cost/Model.lagda.md
@@ -135,9 +135,9 @@ convertRawModel {suc (suc n)} (QuadraticInY (mkQF c0 c1 c2)) = just (quadraticCo
 convertRawModel {suc (suc (suc n))}(LinearInZ (mkLF intercept slope)) = just (linearCostIn (suc (suc zero)) intercept slope)
 convertRawModel {suc (suc (suc n))} (QuadraticInZ (mkQF c0 c1 c2)) = just (quadraticCostIn (suc (suc zero)) c0 c1 c2)
 convertRawModel {suc (suc (suc n))} (LiteralInYOrLinearInZ (mkLF intercept slope)) = just (linearCostIn (suc (suc zero)) intercept slope)
--- **** FIXME ****: for LiteralInYOrLinearInZ, the cost should be exactly 8*y (the parameter is a
--- number of bytes, but the size is a number of words) if y > 0, and the linear function applied to
--- z if y == 0.
+-- **** FIXME ****: for LiteralInYOrLinearInZ, the cost should be exactly ((y-1) `div` 8)+1) (the
+-- parameter is a number of bytes, but the size is a number of words) if y > 0, and the linear
+-- function applied to z if y == 0.
 convertRawModel {2} (SubtractedSizes (mkLF intercept slope) c) = just (twoArgumentsSubtractedSizes intercept slope c)
 convertRawModel {2} (ConstAboveDiagonal c m) = map (twoArgumentsConstAboveDiagonal c) (convertRawModel m)
 convertRawModel {2} (ConstBelowDiagonal c m) = map (twoArgumentsConstBelowDiagonal c) (convertRawModel m)

--- a/plutus-metatheory/src/Cost/Model.lagda.md
+++ b/plutus-metatheory/src/Cost/Model.lagda.md
@@ -131,11 +131,13 @@ convertRawModel {suc n} (MaxSize (mkLF intercept slope)) = just (maxSize interce
 convertRawModel {suc n} (LinearCost (mkLF intercept slope)) = just (linearCostIn zero intercept slope)
 convertRawModel {suc n} (LinearInX (mkLF intercept slope)) = just (linearCostIn zero intercept slope)
 convertRawModel {suc (suc n)} (LinearInY (mkLF intercept slope)) = just (linearCostIn (suc zero) intercept slope)
-convertRawModel {suc (suc (suc n))}(LinearInZ (mkLF intercept slope)) = just (linearCostIn (suc (suc zero)) intercept slope)
 convertRawModel {suc (suc n)} (QuadraticInY (mkQF c0 c1 c2)) = just (quadraticCostIn (suc zero) c0 c1 c2)
+convertRawModel {suc (suc (suc n))}(LinearInZ (mkLF intercept slope)) = just (linearCostIn (suc (suc zero)) intercept slope)
 convertRawModel {suc (suc (suc n))} (QuadraticInZ (mkQF c0 c1 c2)) = just (quadraticCostIn (suc (suc zero)) c0 c1 c2)
 convertRawModel {suc (suc (suc n))} (LiteralInYOrLinearInZ (mkLF intercept slope)) = just (linearCostIn (suc (suc zero)) intercept slope)
--- **** FIXME: for LiteralInYOrLinearInZ, the cost is exactly y if y > 0, and the linear function applied to z if y == 0
+-- **** FIXME ****: for LiteralInYOrLinearInZ, the cost should be exactly 8*y (the parameter is a
+-- number of bytes, but the size is a number of words) if y > 0, and the linear function applied to
+-- z if y == 0.
 convertRawModel {2} (SubtractedSizes (mkLF intercept slope) c) = just (twoArgumentsSubtractedSizes intercept slope c)
 convertRawModel {2} (ConstAboveDiagonal c m) = map (twoArgumentsConstAboveDiagonal c) (convertRawModel m)
 convertRawModel {2} (ConstBelowDiagonal c m) = map (twoArgumentsConstBelowDiagonal c) (convertRawModel m)

--- a/plutus-metatheory/src/Cost/Model.lagda.md
+++ b/plutus-metatheory/src/Cost/Model.lagda.md
@@ -196,4 +196,4 @@ createMap bmap =
       let modelMaybeList = L.map (λ b → getModel b bmap) builtinList 
           maybeModelList = allJust modelMaybeList
       in map lookupModel maybeModelList
-``` 
+```

--- a/plutus-metatheory/src/Cost/Raw.lagda.md
+++ b/plutus-metatheory/src/Cost/Raw.lagda.md
@@ -1,16 +1,16 @@
 # Raw Cost structures to inferface with Haskell
 
 ```
-module Cost.Raw where 
+module Cost.Raw where
 ```
 
-## Imports 
+## Imports
 
-``` 
+```
 open import Cost.Base using (CostingNat)
 open import Data.String
 open import Utils
-``` 
+```
 
 ## Interface with Haskell Machine Parameters
 
@@ -22,8 +22,8 @@ open import Utils
 {-# FOREIGN GHC import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekMachineCosts) #-}
 {-# FOREIGN GHC import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts (CekMachineCostsBase(..)) #-}
 
-postulate HCekMachineCosts : Set 
-postulate HExBudget : Set 
+postulate HCekMachineCosts : Set
+postulate HExBudget : Set
 
 {-# COMPILE GHC HCekMachineCosts = type CekMachineCostsBase Identity #-}
 {-# COMPILE GHC HExBudget = type ExBudget #-}
@@ -59,7 +59,7 @@ postulate getMemoryCost : HExBudget → CostingNat
 -- postulate defaultHCekMachineCosts : HCekMachineCosts
 
 -- {-# COMPILE GHC defaultHCekMachineCosts = defaultCekMachineCosts #-}
-``` 
+```
 
 ## Interface with Builtin model from JSON
 
@@ -68,24 +68,24 @@ postulate getMemoryCost : HExBudget → CostingNat
 
 record LinearFunction : Set where
     constructor mkLinearFunction
-    field 
-        intercept : CostingNat 
+    field
+        intercept : CostingNat
         slope : CostingNat
 
 {-# COMPILE GHC LinearFunction = data LinearFunction(LinearFunction) #-}
 
 record QuadraticFunction : Set where
     constructor mkQuadraticFunction
-    field 
-        coeff0 : CostingNat 
+    field
+        coeff0 : CostingNat
         coeff1 : CostingNat
         coeff2 : CostingNat
-        
+
 {-# COMPILE GHC QuadraticFunction = data QuadraticFunction(QuadraticFunction) #-}
 
-data RawModel : Set where 
-    ConstantCost          : CostingNat → RawModel 
-    AddedSizes            : LinearFunction → RawModel 
+data RawModel : Set where
+    ConstantCost          : CostingNat → RawModel
+    AddedSizes            : LinearFunction → RawModel
     MultipliedSizes       : LinearFunction → RawModel
     MinSize               : LinearFunction → RawModel
     MaxSize               : LinearFunction → RawModel
@@ -107,19 +107,19 @@ data RawModel : Set where
                                    QuadraticInZ | SubtractedSizes | ConstAboveDiagonal |
                                    ConstBelowDiagonal | LinearOnDiagonal)  #-}
 
-record CpuAndMemoryModel : Set where 
-     constructor mkCpuAndMemoryModel 
-     field 
+record CpuAndMemoryModel : Set where
+     constructor mkCpuAndMemoryModel
+     field
         cpuModel : RawModel
-        memoryModel : RawModel  
+        memoryModel : RawModel
 
-{-# COMPILE GHC CpuAndMemoryModel = data CpuAndMemoryModel (CpuAndMemoryModel) #-}         
+{-# COMPILE GHC CpuAndMemoryModel = data CpuAndMemoryModel (CpuAndMemoryModel) #-}
 
-BuiltinCostMap : Set                                
+BuiltinCostMap : Set
 BuiltinCostMap = List (String × CpuAndMemoryModel)
 ```
 
 ```
-RawCostModel : Set 
+RawCostModel : Set
 RawCostModel = HCekMachineCosts × BuiltinCostMap
-```  
+```

--- a/plutus-metatheory/src/Cost/Raw.lagda.md
+++ b/plutus-metatheory/src/Cost/Raw.lagda.md
@@ -74,24 +74,37 @@ record LinearFunction : Set where
 
 {-# COMPILE GHC LinearFunction = data LinearFunction(LinearFunction) #-}
 
+record QuadraticFunction : Set where
+    constructor mkQuadraticFunction
+    field 
+        coeff0 : CostingNat 
+        coeff1 : CostingNat
+        coeff2 : CostingNat
+        
+{-# COMPILE GHC QuadraticFunction = data QuadraticFunction(QuadraticFunction) #-}
+
 data RawModel : Set where 
-    ConstantCost       : CostingNat → RawModel 
-    AddedSizes         : LinearFunction → RawModel 
-    MultipliedSizes    : LinearFunction → RawModel
-    MinSize            : LinearFunction → RawModel
-    MaxSize            : LinearFunction → RawModel
-    LinearCost         : LinearFunction → RawModel
-    LinearInX          : LinearFunction → RawModel
-    LinearInY          : LinearFunction → RawModel
-    LinearInZ          : LinearFunction → RawModel
-    SubtractedSizes    : LinearFunction → CostingNat → RawModel
-    ConstAboveDiagonal : CostingNat → RawModel → RawModel
-    ConstBelowDiagonal : CostingNat → RawModel → RawModel
-    LinearOnDiagonal   : LinearFunction → CostingNat → RawModel
+    ConstantCost          : CostingNat → RawModel 
+    AddedSizes            : LinearFunction → RawModel 
+    MultipliedSizes       : LinearFunction → RawModel
+    MinSize               : LinearFunction → RawModel
+    MaxSize               : LinearFunction → RawModel
+    LinearCost            : LinearFunction → RawModel
+    LinearInX             : LinearFunction → RawModel
+    LinearInY             : LinearFunction → RawModel
+    LinearInZ             : LinearFunction → RawModel
+    LiteralInYOrLinearInZ : LinearFunction → RawModel
+    QuadraticInY          : QuadraticFunction → RawModel
+    QuadraticInZ          : QuadraticFunction → RawModel
+    SubtractedSizes       : LinearFunction → CostingNat → RawModel
+    ConstAboveDiagonal    : CostingNat → RawModel → RawModel
+    ConstBelowDiagonal    : CostingNat → RawModel → RawModel
+    LinearOnDiagonal      : LinearFunction → CostingNat → RawModel
 
 {-# COMPILE GHC RawModel = data Model (ConstantCost | AddedSizes | MultipliedSizes |
                                    MinSize | MaxSize | LinearCost | LinearInX | LinearInY |
-                                   LinearInZ | SubtractedSizes | ConstAboveDiagonal |
+                                   LinearInZ | LiteralInYOrLinearInZ | QuadraticInY |
+                                   QuadraticInZ | SubtractedSizes | ConstAboveDiagonal |
                                    ConstBelowDiagonal | LinearOnDiagonal)  #-}
 
 record CpuAndMemoryModel : Set where 

--- a/plutus-metatheory/src/Cost/Size.lagda.md
+++ b/plutus-metatheory/src/Cost/Size.lagda.md
@@ -1,0 +1,86 @@
+# Size of Constants
+
+```
+module Cost.Size where 
+
+```
+
+# Imports
+
+```
+open import Data.Bool using (Bool)
+open import Data.Unit using (⊤)
+open import Data.Nat using (ℕ;_+_)
+open import Data.Integer using (ℤ)
+open import Data.String using (String)
+
+open import Utils using (_,_;_∷_;[];DATA;List;ByteString)
+open import Builtin.Signature using (_⊢♯)
+open _⊢♯
+open import Builtin.Constant.AtomicType using (AtomicTyCon)
+open AtomicTyCon
+open import Cost.Base
+open import Untyped.CEK using (Value;V-con)
+open import RawU using (TmCon;tmCon) 
+```
+
+## Memory usage of type constants
+
+For each type constant we calculate its size, as a measure of memory usage.
+
+First we bring some functions from Haskell world.
+
+```
+postulate integerSize : ℤ → CostingNat
+postulate byteStringSize : ByteString → CostingNat
+postulate g1ElementSize : Utils.Bls12-381-G1-Element → CostingNat
+postulate g2ElementSize : Utils.Bls12-381-G2-Element → CostingNat
+postulate mlResultElementSize : Utils.Bls12-381-MlResult → CostingNat
+postulate dataSize : DATA → CostingNat
+postulate boolSize : Bool → CostingNat
+postulate unitSize : ⊤ → CostingNat
+postulate stringSize : String → CostingNat
+
+{-# FOREIGN GHC import PlutusCore.Evaluation.Machine.ExMemoryUsage #-}
+{-# FOREIGN GHC import PlutusCore.Evaluation.Machine.CostStream #-}
+{-# FOREIGN GHC import Data.SatInt #-}
+{-# FOREIGN GHC size = fromSatInt . sumCostStream . flattenCostRose . memoryUsage #-}
+{-# COMPILE GHC integerSize = size  #-}
+{-# COMPILE GHC byteStringSize = size  #-}
+{-# COMPILE GHC g1ElementSize = size #-}
+{-# COMPILE GHC g2ElementSize = size #-}
+{-# COMPILE GHC mlResultElementSize = size #-}
+{-# COMPILE GHC dataSize  = size #-}
+{-# COMPILE GHC boolSize = size #-}
+{-# COMPILE GHC unitSize = size #-}
+{-# COMPILE GHC stringSize  = size #-}
+```
+
+For each constant we return the corresponding size.
+
+```
+defaultConstantMeasure : TmCon → CostingNat
+defaultConstantMeasure (tmCon (atomic aInteger) x) = integerSize x
+defaultConstantMeasure (tmCon (atomic aBytestring) x) = byteStringSize x
+defaultConstantMeasure (tmCon (atomic aString) x) = stringSize x
+defaultConstantMeasure (tmCon (atomic aUnit) x) = unitSize x
+defaultConstantMeasure (tmCon (atomic aBool) x) = boolSize x
+defaultConstantMeasure (tmCon (atomic aData) d) = dataSize d
+defaultConstantMeasure (tmCon (atomic aBls12-381-g1-element) x) = g1ElementSize x
+defaultConstantMeasure (tmCon (atomic aBls12-381-g2-element) x) = g2ElementSize x
+defaultConstantMeasure (tmCon (atomic aBls12-381-mlresult) x) = mlResultElementSize x
+defaultConstantMeasure (tmCon (list t) []) = 0
+defaultConstantMeasure (tmCon (list t) (x ∷ xs)) = 
+       defaultConstantMeasure (tmCon t x) 
+     + defaultConstantMeasure (tmCon (list t) xs)
+defaultConstantMeasure (tmCon (pair t u) (x , y)) = 
+      1 + defaultConstantMeasure (tmCon t x) 
+        + defaultConstantMeasure (tmCon u y)
+
+-- This is the main sizing function for Values
+-- It only measures constants. Other types should use models where the size 
+-- of the non-constant does not matter.
+defaultValueMeasure : Value → CostingNat 
+defaultValueMeasure (V-con ty x) = defaultConstantMeasure (tmCon ty x)
+defaultValueMeasure _ = 0
+```

--- a/plutus-metatheory/src/Untyped/CEK.lagda.md
+++ b/plutus-metatheory/src/Untyped/CEK.lagda.md
@@ -491,6 +491,17 @@ BUILTIN blake2b-224 = λ
   { (app base (V-con bytestring b)) -> inj₂ (V-con bytestring (BLAKE2B-224 b))
   ; _ -> inj₁ userError
   }
+BUILTIN byteStringToInteger = λ
+  { (app (app base (V-con bool e)) (V-con bytestring s)) -> inj₂ (V-con integer (BStoI e s))
+  ; _ -> inj₁ userError
+  }
+BUILTIN integerToByteString = λ
+  { (app (app (app base (V-con bool e)) (V-con integer w)) (V-con integer n)) -> case ItoBS e w n of λ
+      { (just s) -> inj₂ (V-con bytestring s)
+      ; nothing -> inj₁ userError
+      }
+  ; _ -> inj₁ userError
+  }
 
 -- Take an apparently more general index and show that it is a fully applied builtin.
 mkFullyAppliedBuiltin : ∀ { b }

--- a/plutus-metatheory/src/Untyped/CEKWithCost.lagda.md
+++ b/plutus-metatheory/src/Untyped/CEKWithCost.lagda.md
@@ -30,6 +30,7 @@ open StepKind
 open ExBudgetCategory
 
 open import Untyped.CEK
+
 ```
 
 ## Cost Monad
@@ -71,19 +72,17 @@ The function `extractArgSizes` get the arguments in inverse order, so we reverse
 them in the `spendBuiltin` function. 
 
 ```
-extractArgSizes : ∀{b}
+extractConstants : ∀{b}
           → ∀{tn tm} → {pt : tn ∔ tm ≣ fv (signature b)}
           → ∀{an am} → {pa : an ∔ am ≣ args♯ (signature b)}
-          → BApp b pt pa → Vec CostingNat an
-extractArgSizes base = []
-extractArgSizes (app bapp (V-con ty x)) = constantMeasure (tmCon ty x) 
-                                        ∷ extractArgSizes bapp
-extractArgSizes (app bapp _) = 0 ∷ extractArgSizes bapp 
-extractArgSizes (app⋆ bapp) = extractArgSizes bapp 
+          → BApp b pt pa → Vec Value an
+extractConstants base = []
+extractConstants (app bapp v) = v ∷ extractConstants bapp
+extractConstants (app⋆ bapp) = extractConstants bapp 
 
 spendBuiltin : (b : Builtin) → fullyAppliedBuiltin b → CekM ⊤
 spendBuiltin b bapp = tell (cekMachineCost (BBuiltinApp b argsizes))
-     where argsizes = reverse (extractArgSizes bapp)
+     where argsizes = reverse (extractConstants bapp)
 ```
 
 ## Step with costs


### PR DESCRIPTION
This adds the `byteStringToInteger` and `integerToByteString` builtins to the Agda metatheory, along with some extensions to the costing infrastructure required by them.  I've cherry-picked the relevant commits from [this branch](https://github.com/IntersectMBO/plutus/tree/kwxm/bitwise-conversions/metatheory) to keep the history tidy.