### PR TITLE
Fix missing Agda import

### DIFF
--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -38,7 +38,7 @@ import PlutusTx qualified as Tx
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
 
-import MAlonzo.Code.Main (runUAgda)
+import MAlonzo.Code.Evaluator.Term (runUAgda)
 
 import Criterion.Main
 import Criterion.Types (Config (..))


### PR DESCRIPTION
This is just fixing an import that became outdated after merging #5730: see the comments there for more details.  I'll auto-merge it to get `master` working again.