### PR TITLE
Kwxm/uplc-criterion

### DIFF
--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -16,12 +16,11 @@ import PlutusCore.MkPlc (mkConstant)
 import PlutusCore.Pretty qualified as PP
 import PlutusPrelude
 
-import Control.DeepSeq (rnf)
 import Data.ByteString.Lazy qualified as BSL (readFile)
 import Data.Text.IO qualified as T
 import Flat (unflat)
 import Options.Applicative
-import System.Exit (exitSuccess)
+import System.Exit (exitFailure, exitSuccess)
 
 plcHelpText :: String
 plcHelpText = helpText "Typed Plutus Core"
@@ -35,7 +34,6 @@ data EvalOptions =
       Input
       Format
       PrintMode
-      TimingMode
       (BuiltinSemanticsVariant PLC.DefaultFun)
 data EraseOptions     = EraseOptions Input Format Output Format PrintMode
 
@@ -63,7 +61,7 @@ eraseOpts = EraseOptions <$> input <*> inputformat <*> output <*> outputformat <
 
 evalOpts :: Parser EvalOptions
 evalOpts =
-  EvalOptions <$> input <*> inputformat <*> printmode <*> timingmode <*> builtinSemanticsVariant
+  EvalOptions <$> input <*> inputformat <*> printmode <*> builtinSemanticsVariant
 
 plutus ::
   -- | The @helpText@
@@ -186,21 +184,17 @@ runOptimisations (OptimiseOptions inp ifmt outp ofmt mode) = do
 ---------------- Evaluation ----------------
 
 runEval :: EvalOptions -> IO ()
-runEval (EvalOptions inp ifmt printMode timingMode semvar) = do
+runEval (EvalOptions inp ifmt printMode semvar) = do
   prog <- readProgram ifmt inp
   let evaluate = Ck.evaluateCkNoEmit (PLC.defaultBuiltinsRuntimeForSemanticsVariant semvar)
       term = void $ prog ^. PLC.progTerm
-      !_ = rnf term
-      -- Force evaluation of body to ensure that we're not timing parsing/deserialisation.
-      -- The parser apparently returns a fully-evaluated AST, but let's be on the safe side.
-  case timingMode of
-    NoTiming -> evaluate term & handleEResult printMode
-    Timing n -> timeEval n evaluate term >>= handleTimingResults term
+  case evaluate term of
+    Right v  -> print (getPrintMethod printMode v) >> exitSuccess
+    Left err -> print err *> exitFailure
 
 ----------------- Print examples -----------------------
 
-runPlcPrintExample ::
-    ExampleOptions -> IO ()
+runPlcPrintExample :: ExampleOptions -> IO ()
 runPlcPrintExample = runPrintExample getPlcExamples
 
 ---------------- Erasure ----------------

--- a/plutus-core/executables/src/PlutusCore/Executable/Common.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Common.hs
@@ -16,8 +16,6 @@ module PlutusCore.Executable.Common
     , getPlcExamples
     , getPrintMethod
     , getUplcExamples
-    , handleEResult
-    , handleTimingResults
     , helpText
     , loadASTfromFlat
     , parseInput
@@ -29,7 +27,6 @@ module PlutusCore.Executable.Common
     , runPrint
     , runPrintBuiltinSignatures
     , runPrintExample
-    , timeEval
     , topSrcSpan
     , writeFlat
     , writePrettyToFileOrStd
@@ -71,14 +68,13 @@ import PlutusIR.Check.Uniques as PIR (checkProgram)
 import PlutusIR.Core.Instance.Pretty ()
 import PlutusIR.Parser qualified as PIR (parse, program)
 
-import Control.DeepSeq (rnf)
 import Control.Monad.Except
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BSL
 import Data.Foldable (traverse_)
 import Data.HashMap.Monoidal qualified as H
 import Data.Kind (Type)
-import Data.List (intercalate, nub)
+import Data.List (intercalate)
 import Data.List qualified as List
 import Data.Maybe (fromJust)
 import Data.Proxy (Proxy (..))
@@ -89,9 +85,6 @@ import Flat (Flat)
 import GHC.TypeLits (symbolVal)
 import Prettyprinter ((<+>))
 
-import System.CPUTime (getCPUTime)
-import System.Exit (exitFailure, exitSuccess)
-import System.Mem (performGC)
 import Text.Megaparsec (errorBundlePretty)
 import Text.Printf (printf)
 
@@ -142,6 +135,15 @@ instance ProgramLike UplcProg where
 
 
 ---------------- Printing budgets and costs ----------------
+
+-- Convert a time in picoseconds into a readable format with appropriate units
+formatTimePicoseconds :: Double -> String
+formatTimePicoseconds t
+    | t >= 1e12 = printf "%.3f s" (t / 1e12)
+    | t >= 1e9 = printf "%.3f ms" (t / 1e9)
+    | t >= 1e6 = printf "%.3f μs" (t / 1e6)
+    | t >= 1e3 = printf "%.3f ns" (t / 1e3)
+    | otherwise = printf "%f ps" t
 
 printBudgetStateBudget :: CekModel -> ExBudget -> IO ()
 printBudgetStateBudget model b =
@@ -464,58 +466,6 @@ getUplcExamples =
 -- is requested and at each lookup of a particular example. I.e. each time we generate distinct
 -- terms. But types of those terms must not change across requests, so we're safe.
 
----------------- Timing ----------------
-
--- Convert a time in picoseconds into a readable format with appropriate units
-formatTimePicoseconds :: Double -> String
-formatTimePicoseconds t
-    | t >= 1e12 = printf "%.3f s" (t / 1e12)
-    | t >= 1e9 = printf "%.3f ms" (t / 1e9)
-    | t >= 1e6 = printf "%.3f μs" (t / 1e6)
-    | t >= 1e3 = printf "%.3f ns" (t / 1e3)
-    | otherwise = printf "%f ps" t
-
-{- | Apply an evaluator to a program a number of times and report the mean execution
-time.  The first measurement is often significantly larger than the rest
-(perhaps due to warm-up effects), and this can distort the mean.  To avoid this
-we measure the evaluation time (n+1) times and discard the first result.
--}
-timeEval :: NFData a => Integer -> (t -> a) -> t -> IO [a]
-timeEval n evaluate prog
-    | n <= 0 = error "Error: the number of repetitions should be at least 1"
-    | otherwise = do
-        (results, times) <-
-            unzip . tail <$> for (replicate (fromIntegral (n + 1)) prog) (timeOnce evaluate)
-        let mean = fromIntegral (sum times) / fromIntegral n :: Double
-            runs :: String = if n == 1 then "run" else "runs"
-        printf "Mean evaluation time (%d %s): %s\n" n runs (formatTimePicoseconds mean)
-        pure results
-  where
-    timeOnce eval prg = do
-        start <- performGC >> getCPUTime
-        let result = eval prg
-            !_ = rnf result
-        end <- getCPUTime
-        pure (result, end - start)
-
------------- Aux functions for @runEval@ ------------------
-
-handleEResult ::
-    (PP.PrettyBy PP.PrettyConfigPlc a1, Show a2) =>
-    PrintMode ->
-    Either a2 a1 ->
-    IO b
-handleEResult printMode result =
-    case result of
-        Right v  -> print (getPrintMethod printMode v) >> exitSuccess
-        Left err -> print err *> exitFailure
-handleTimingResults :: (Eq a1, Eq b, Show a1) => p -> [Either a1 b] -> IO a2
-handleTimingResults _ results =
-    case nub results of
-        [Right _]  -> exitSuccess -- We don't want to see the result here
-        [Left err] -> print err >> exitFailure
-        -- Should never happen
-        _          -> error "Timing evaluations returned inconsistent results"
 
 ----------------- Print examples -----------------------
 

--- a/plutus-core/executables/src/PlutusCore/Executable/Parsers.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Parsers.hs
@@ -82,28 +82,6 @@ outputformat = option (maybeReader formatReader)
   <> showDefault
   <> help ("Output format: " ++ formatHelp))
 
--- -x -> run 100 times and print the mean time
-timing1 :: Parser TimingMode
-timing1 = flag NoTiming (Timing 100)
-  (  short 'x'
-  <> help "Report mean execution time of program over 100 repetitions"
-  )
-
--- -X N -> run N times and print the mean time
-timing2 :: Parser TimingMode
-timing2 = Timing <$> option auto
-  (  long "time-execution"
-  <> short 'X'
-  <> metavar "N"
-  <> help ("Report mean execution time of program over N repetitions. "
-  <> " Use a large value of N if possible to get accurate results.")
-  )
-
--- We really do need two separate parsers here.
--- See https://github.com/pcapriotti/optparse-applicative/issues/194#issuecomment-205103230
-timingmode :: Parser TimingMode
-timingmode = timing1 <|> timing2
-
 tracemode :: Parser TraceMode
 tracemode = option auto
   (  long "trace-mode"

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -38,7 +38,7 @@ import Criterion (benchmarkWith, whnf)
 import Criterion.Main (defaultConfig)
 import Criterion.Types (Config (..))
 import Data.ByteString.Lazy as BSL (readFile)
-import Data.Foldable (asum)
+import Data.Foldable
 import Data.List.Split (splitOn)
 import Data.Text qualified as T
 import Flat (unflat)

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -37,6 +37,7 @@ import Criterion (benchmarkWith, whnf)
 import Criterion.Main (defaultConfig)
 import Criterion.Types (Config (..))
 import Data.ByteString.Lazy as BSL (readFile)
+import Data.Foldable (asum)
 import Data.List.Split (splitOn)
 import Data.Text qualified as T
 import Flat (unflat)

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -115,10 +115,11 @@ benchmarkOpts =
   <*> builtinSemanticsVariant
   <*> option auto
           (  long "time-limit"
-          <> short 'l'
+          <> short 'T'
           <> metavar "TIME LIMIT"
           <> value 5.0
-          <> help "Time limit for benchmarking.")
+          <> showDefault
+          <> help "Time limit (in seconds) for benchmarking.")
 
 evalOpts :: Parser EvalOptions
 evalOpts =

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -37,7 +37,7 @@ import Criterion (benchmarkWith, whnf)
 import Criterion.Main (defaultConfig)
 import Criterion.Types (Config (..))
 import Data.ByteString.Lazy as BSL (readFile)
-import Data.Foldable (asum)
+import Data.Foldable
 import Data.List.Split (splitOn)
 import Data.Text qualified as T
 import Flat (unflat)

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -38,7 +38,7 @@ import Criterion (benchmarkWith, whnf)
 import Criterion.Main (defaultConfig)
 import Criterion.Types (Config (..))
 import Data.ByteString.Lazy as BSL (readFile)
-import Data.Foldable
+import Data.Foldable (asum)
 import Data.List.Split (splitOn)
 import Data.Text qualified as T
 import Flat (unflat)

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -1,5 +1,6 @@
 -- editorconfig-checker-disable
 {-# LANGUAGE BangPatterns              #-}
+{-# LANGUAGE DeriveAnyClass            #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE MultiParamTypeClasses     #-}
@@ -49,6 +50,18 @@ import Text.Read (readMaybe)
 
 import Control.Monad.ST (RealWorld)
 import System.Console.Haskeline qualified as Repl
+
+-- Extra imports for experimental benchmarking code
+import Codec.Serialise (Serialise)
+import Control.Exception qualified as E
+import Control.Monad.Except (MonadError)
+import Data.ByteString qualified as BS
+import NoThunks.Class
+import PlutusCore.Default qualified as PLC (BuiltinSemanticsVariant (DefaultFunSemanticsVariant1))
+import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
+import PlutusCore.Evaluation.Machine.ExBudget as Plutus
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus
+import PlutusCore.Evaluation.Machine.MachineParameters.Default
 
 uplcHelpText :: String
 uplcHelpText = helpText "Untyped Plutus Core"
@@ -295,8 +308,117 @@ runApplyToData (ApplyOptions inputfiles ifmt outp ofmt mode) =
 
 ---------------- Benchmarking ----------------
 
-runBenchmark :: BenchmarkOptions -> IO ()
-runBenchmark (BenchmarkOptions inp ifmt semvar timeLim) = do
+-- Lots of stuff copied out of plutus-ledger-api and plutus-benchmark to try to
+-- reproduce the normal benchmarking behaviour.
+
+newtype MajorProtocolVersion = MajorProtocolVersion { getMajorProtocolVersion :: Int }
+  deriving newtype (Eq, Ord, Show, Serialise)
+  deriving stock (Generic)
+
+toMachineParameters :: MajorProtocolVersion -> EvaluationContext -> DefaultMachineParameters
+toMachineParameters _ = machineParameters
+
+newtype EvaluationContext = EvaluationContext
+    { machineParameters :: DefaultMachineParameters
+    }
+    deriving stock Generic
+    deriving anyclass (NFData, NoThunks)
+
+data VerboseMode =
+    Verbose2 -- ^ accumulate all traces
+    | Quiet -- ^ don't accumulate anything
+    deriving stock (Eq)
+
+
+evaluateTerm
+    :: Cek.ExBudgetMode cost UPLC.DefaultUni UPLC.DefaultFun
+    -> MajorProtocolVersion
+    -> VerboseMode
+    -> EvaluationContext
+    -> UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
+    -> ( Either
+            (Cek.CekEvaluationException UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun)
+            (UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
+       , cost
+       , [T.Text]
+       )
+
+evaluateTerm budgetMode pv verbose ectx =
+    Cek.runCekDeBruijn
+        (toMachineParameters pv ectx)
+        budgetMode
+        (if verbose == Verbose2 then Cek.logEmitter else Cek.noEmitter)
+-- Just replicating the old behavior, probably doesn't matter.
+{-# INLINE evaluateTerm #-}
+
+data PlutusLedgerLanguage =
+      PlutusV1 -- ^ introduced in shelley era
+    | PlutusV2 -- ^ introduced in vasil era
+    | PlutusV3 -- ^ not yet enabled
+   deriving stock (Eq, Ord, Show, Generic, Enum, Bounded)
+
+alonzoPV :: MajorProtocolVersion
+alonzoPV = MajorProtocolVersion 5
+
+-- | Vasil era was introduced in protocol version 7.0
+vasilPV :: MajorProtocolVersion
+vasilPV = MajorProtocolVersion 7
+
+-- | Conway era was introduced in protocol version 9.0
+conwayPV :: MajorProtocolVersion
+conwayPV = MajorProtocolVersion 9
+
+ledgerLanguageIntroducedIn :: PlutusLedgerLanguage -> MajorProtocolVersion
+ledgerLanguageIntroducedIn = \case
+    PlutusV1 -> alonzoPV
+    PlutusV2 -> vasilPV
+    PlutusV3 -> conwayPV
+
+evaluateCekLikeInProd
+    :: EvaluationContext
+    -> UPLC.Term PLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ()
+    -> Either
+            (Cek.CekEvaluationException UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun)
+            (UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
+evaluateCekLikeInProd evalCtx term = do
+    let (getRes, _, _) =
+            -- The validation benchmarks were all created from PlutusV1 scripts
+            evaluateTerm Cek.restrictingEnormous (ledgerLanguageIntroducedIn PlutusV1) Quiet evalCtx term
+    getRes
+
+unsafeUnflat :: String -> BS.ByteString -> UPLC.Program UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
+unsafeUnflat file contents =
+    case unflat contents of
+        Left e     -> errorWithoutStackTrace $ "Flat deserialisation failure for " ++ file ++ ": " ++ show e
+        Right (UPLC.UnrestrictedProgram prog) -> prog
+
+
+toNamedDeBruijnTerm
+    :: UPLC.Term UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
+    -> UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
+toNamedDeBruijnTerm = UPLC.termMapNames UPLC.fakeNameDeBruijn
+
+mkDynEvaluationContext
+    :: MonadError CostModelApplyError m
+    => BuiltinSemanticsVariant UPLC.DefaultFun
+    -> Plutus.CostModelParams
+    -> m EvaluationContext
+mkDynEvaluationContext semvar newCMP =
+    EvaluationContext <$> mkMachineParametersFor semvar newCMP
+
+
+mkEvalCtx :: EvaluationContext
+mkEvalCtx =
+    case PLC.defaultCostModelParams of
+        -- The validation benchmarks were all created from PlutusV1 scripts
+        Just p -> case mkDynEvaluationContext PLC.DefaultFunSemanticsVariant1 p of
+            Right ec -> ec
+            Left err -> error $ show err
+        Nothing -> error "Couldn't get cost model params"
+
+-- The original version of the benchmarking function.
+_runBenchmark :: BenchmarkOptions -> IO ()
+_runBenchmark (BenchmarkOptions inp ifmt semvar timeLim) = do
   prog <- readProgram ifmt inp
   let criterionConfig = defaultConfig {reportFile = Nothing, timeLimit = timeLim}
       cekparams = mkMachineParameters semvar PLC.defaultCekCostModel
@@ -311,6 +433,25 @@ runBenchmark (BenchmarkOptions inp ifmt semvar timeLim) = do
       -- Big annotations slow things down
       !unitAnnTerm = force (() <$ anonTerm)
   benchmarkWith criterionConfig $! whnf evaluate unitAnnTerm
+
+-- Try to do the same as plutus-benchmark
+runBenchmark :: BenchmarkOptions -> IO ()
+runBenchmark (BenchmarkOptions inp ifmt semvar timeLim) = do
+  evalCtx <- E.evaluate $ force mkEvalCtx
+  let file = case inp of
+               FileInput path -> path
+               _              -> error "Want a file"
+  contents <- BS.readFile file
+  let criterionConfig = defaultConfig {reportFile = Nothing, timeLimit = timeLim}
+      -- readProgam throws away De Bruijn indices and returns an AST with Names;
+      -- we have to put them back to get an AST with NamedDeBruijn names.
+      mkCekBM  =
+          -- don't count the undebruijn . unflat cost
+          -- `force` to try to ensure that deserialiation is not included in benchmarking time.
+          let !benchTerm = force . toNamedDeBruijnTerm . UPLC._progTerm $  unsafeUnflat file contents
+              eval = either (error . show) (\_ -> ()) . evaluateCekLikeInProd evalCtx
+          in whnf eval benchTerm
+  benchmarkWith criterionConfig $ mkCekBM
 
 ---------------- Evaluation ----------------
 

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -673,7 +673,6 @@ library plutus-core-execlib
     , aeson
     , base                                                       >=4.9   && <5
     , bytestring
-    , deepseq
     , flat                                                       ^>=0.6
     , lens
     , megaparsec

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -447,7 +447,6 @@ executable plc
   build-depends:
     , base                  >=4.9   && <5
     , bytestring
-    , deepseq
     , flat                  ^>=0.6
     , optparse-applicative
     , plutus-core           ^>=1.21
@@ -461,6 +460,7 @@ executable uplc
   build-depends:
     , base                  >=4.9   && <5
     , bytestring
+    , criterion
     , deepseq
     , flat                  ^>=0.6
     , haskeline

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -465,10 +465,12 @@ executable uplc
     , flat                  ^>=0.6
     , haskeline
     , mtl
+    , nothunks
     , optparse-applicative
     , plutus-core           ^>=1.21
     , plutus-core-execlib   ^>=1.21
     , prettyprinter
+    , serialise
     , split
     , text
 

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -465,12 +465,10 @@ executable uplc
     , flat                  ^>=0.6
     , haskeline
     , mtl
-    , nothunks
     , optparse-applicative
     , plutus-core           ^>=1.21
     , plutus-core-execlib   ^>=1.21
     , prettyprinter
-    , serialise
     , split
     , text
 


### PR DESCRIPTION
The `uplc` executable had a `-x` option that let you measure the execution time of a script.  That didn't give good results, so here I've replaced it with a `benchmark` command that runs a Criterion benchmark instead.  This gives much better results, but they're not directly comparable with the validation benchmarks in `plutus-benchmark`: see the attached comparison.  In general the benchmarks here are maybe 15-20% faster than the ones in `plutus-benchmark` (but see `multisig-sm` 2, 5, 6, and 10!).  I think the difference is probably due to all the extra stuff that [evaluateCekLikeInProd](https://github.com/IntersectMBO/plutus/blob/6bbf2aab80880247192f8a5c28702778dcb3a11e/plutus-benchmark/validation/bench/Common.hs#L147) has to do: I pasted all of the extra code into `uplc` and the results mostly seemed to at least be in the same ballpark: I'll try that again with the final version.  There also seems to be some inverse correlation between the difference of the two sets of results and the size of the script (ie, the bigger the script, the smaller the difference between the `uplc` results and the `plutus-benchmark` ones). 

```
Script                        plutus-benchmark     uplc        Change
------------------------------------------------------------------------
auction_1-1                       215.7 μs	 184.5 μs     -14.5%
auction_1-2                       848.4 μs	 725.1 μs     -14.5%
auction_1-3                       839.1 μs	 718.9 μs     -14.3%
auction_1-4                       291.5 μs	 239.0 μs     -18.0%
auction_2-1                       224.6 μs	 185.0 μs     -17.6%
auction_2-2                       844.6 μs	 726.8 μs     -13.9%
auction_2-3                       1.097 ms	 959.9 μs     -12.5%
auction_2-4                       837.9 μs	 717.9 μs     -14.3%
auction_2-5                       289.9 μs	 237.8 μs     -18.0%
crowdfunding-success-1            264.4 μs	 217.3 μs     -17.8%
crowdfunding-success-2            264.1 μs	 217.1 μs     -17.8%
crowdfunding-success-3            265.1 μs	 217.1 μs     -18.1%
currency-1                        321.5 μs	 272.9 μs     -15.1%
escrow-redeem_1-1                 448.0 μs	 375.1 μs     -16.3%
escrow-redeem_1-2                 453.6 μs	 375.4 μs     -17.2%
escrow-redeem_2-1                 518.1 μs	 441.5 μs     -14.8%
escrow-redeem_2-2                 518.8 μs	 439.1 μs     -15.4%
escrow-redeem_2-3                 517.8 μs	 441.6 μs     -14.7%
escrow-refund-1                   195.5 μs	 161.7 μs     -17.3%
future-increase-margin-1          322.3 μs	 274.8 μs     -14.7%
future-increase-margin-2          698.1 μs	 599.0 μs     -14.2%
future-increase-margin-3          700.0 μs	 599.6 μs     -14.3%
future-increase-margin-4          652.0 μs	 549.0 μs     -15.8%
future-increase-margin-5          1.109 ms	 1.039 ms      -6.3%
future-pay-out-1                  322.0 μs	 273.8 μs     -15.0%
future-pay-out-2                  694.7 μs	 596.2 μs     -14.2%
future-pay-out-3                  694.8 μs	 599.3 μs     -13.7%
future-pay-out-4                  1.108 ms	 1.032 ms      -6.9%
future-settle-early-1             320.7 μs	 275.3 μs     -14.2%
future-settle-early-2             699.6 μs	 597.8 μs     -14.6%
future-settle-early-3             697.4 μs	 598.7 μs     -14.2%
future-settle-early-4             812.7 μs	 772.2 μs      -5.0%
game-sm-success_1-1               495.1 μs	 425.9 μs     -14.0%
game-sm-success_1-2               250.2 μs	 205.0 μs     -18.1%
game-sm-success_1-3               847.3 μs	 755.2 μs     -10.9%
game-sm-success_1-4               284.8 μs	 230.4 μs     -19.1%
game-sm-success_2-1               499.1 μs	 425.7 μs     -14.7%
game-sm-success_2-2               251.8 μs	 205.0 μs     -18.6%
game-sm-success_2-3               848.1 μs	 749.2 μs     -11.7%
game-sm-success_2-4               284.1 μs	 230.3 μs     -18.9%
game-sm-success_2-5               848.9 μs	 759.7 μs     -10.5%
game-sm-success_2-6               285.2 μs	 231.2 μs     -18.9%
multisig-sm-1                     513.7 μs	 438.7 μs     -14.6%
multisig-sm-2                     499.4 μs	 624.0 μs     +24.9%
multisig-sm-3                     509.0 μs	 421.6 μs     -17.2%
multisig-sm-4                     510.6 μs	 428.4 μs     -16.1%
multisig-sm-5                     738.0 μs	 433.3 μs     -41.3%
multisig-sm-6                     512.4 μs	 628.5 μs     +22.7%
multisig-sm-7                     498.6 μs	 438.2 μs     -12.1%
multisig-sm-8                     502.7 μs	 422.0 μs     -16.1%
multisig-sm-9                     510.7 μs	 428.1 μs     -16.2%
multisig-sm-10                    733.9 μs	 431.8 μs     -41.2%
ping-pong-1                       420.8 μs	 356.8 μs     -15.2%
ping-pong-2                       421.9 μs	 356.1 μs     -15.6%
ping-pong_2-1                     255.1 μs	 210.5 μs     -17.5%
prism-1                           210.5 μs	 169.4 μs     -19.5%
prism-2                           535.7 μs	 451.7 μs     -15.7%
prism-3                           470.1 μs	 398.9 μs     -15.1%
pubkey-1                          177.7 μs	 143.2 μs     -19.4%
stablecoin_1-1                    1.222 ms	 1.167 ms      -4.5%
stablecoin_1-2                    245.2 μs	 198.3 μs     -19.1%
stablecoin_1-3                    1.421 ms	 1.344 ms      -5.4%
stablecoin_1-4                    261.4 μs	 211.5 μs     -19.1%
stablecoin_1-5                    1.855 ms	 1.714 ms      -7.6%
stablecoin_1-6                    321.7 μs	 258.9 μs     -19.5%
stablecoin_2-1                    1.222 ms	 1.167 ms      -4.5%
stablecoin_2-2                    244.7 μs	 198.5 μs     -18.9%
stablecoin_2-3                    1.423 ms	 1.342 ms      -5.7%
stablecoin_2-4                    259.8 μs	 211.9 μs     -18.4%
token-account-1                   242.9 μs	 203.0 μs     -16.4%
token-account-2                   427.2 μs	 361.2 μs     -15.4%
uniswap-1                         533.0 μs	 458.2 μs     -14.0%
uniswap-2                         283.4 μs	 240.0 μs     -15.3%
uniswap-3                         2.377 ms	 2.189 ms      -7.9%
uniswap-4                         421.8 μs	 345.9 μs     -18.0%
uniswap-5                         1.539 ms	 1.427 ms      -7.3%
uniswap-6                         400.5 μs	 330.5 μs     -17.5%
vesting-1                         447.1 μs	 383.8 μs     -14.2%
```
