### PR TITLE
Adding a Costing Evaluator to agda-conformance

### DIFF
--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -4,17 +4,21 @@
 module Main (main) where
 
 import Control.Monad.Trans.Except
-import MAlonzo.Code.Evaluator.Term (runUAgda)
+import MAlonzo.Code.Evaluator.Term (runUAgda, runUCountingAgda)
 import PlutusConformance.Common
 import PlutusCore (Error (..))
 import PlutusCore.Default
+import PlutusCore.Evaluation.Machine.ExBudget
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekMachineCosts)
+import PlutusCore.Evaluation.Machine.ExMemory
+import PlutusCore.Evaluation.Machine.SimpleBuiltinCostModel
 import PlutusCore.Quote
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.DeBruijn
 
--- | Our `evaluator` for the Agda UPLC tests is the CEK machine.
-agdaEvalUplcProg :: UplcEvaluator
-agdaEvalUplcProg = UplcEvaluatorWithoutCosting $ \(UPLC.Program () version tmU) ->
+-- | Our `evaluator` for the Agda UPLC tests is the CEK machine without costs.
+agdaEvalUplcProgNoCost :: UplcEvaluator
+agdaEvalUplcProgNoCost = UplcEvaluatorWithoutCosting $ \(UPLC.Program () version tmU) ->
     let
         -- turn it into an untyped de Bruijn term
         tmUDB :: ExceptT FreeVariableError Quote (UPLC.Term NamedDeBruijn DefaultUni DefaultFun ())
@@ -35,6 +39,41 @@ agdaEvalUplcProg = UplcEvaluatorWithoutCosting $ \(UPLC.Program () version tmU) 
                     case tmNamed of
                         Left _          -> Nothing
                         Right namedTerm -> Just $ UPLC.Program () version namedTerm
+
+-- | Our `evaluator` for the Agda UPLC tests is the CEK machine with costs.
+agdaEvalUplcProg :: UplcEvaluator
+agdaEvalUplcProg = UplcEvaluatorWithCosting $ \(UPLC.Program () version tmU) ->
+    let
+        -- turn it into an untyped de Bruijn term
+        tmUDB :: ExceptT FreeVariableError Quote (UPLC.Term NamedDeBruijn DefaultUni DefaultFun ())
+        tmUDB = deBruijnTerm tmU
+    in
+    case runQuote $ runExceptT $ withExceptT FreeVariableErrorE tmUDB of
+        -- if there's an exception, evaluation failed, should return `Nothing`.
+        Left _ -> Nothing
+        -- evaluate the untyped term with CEK
+        Right tmUDBSuccess ->
+             {- In the following hole we need to plug in a BuiltinCostMap
+             type BuiltinCostMap = [(Text, CpuAndMemoryModel)]
+
+            see `plutus-metatheory/src/Cost/JSON.hs`
+
+            but currently we get it from a json file in the plutus-metatheory project
+            (which itself is copied from a file in the plutus-core project).
+            We need to wait for a fix in which plutus-core exports this map without IO (using Template Haskell).
+
+             -}
+            case runUCountingAgda (defaultCekMachineCosts , defaultSimpleBuiltinCostModel) tmUDBSuccess of
+                Left _ -> Nothing
+                Right (tmEvaluated,(cpuCost,memCost)) ->
+                    let tmNamed = runQuote $ runExceptT $
+                            withExceptT FreeVariableErrorE $ unDeBruijnTerm tmEvaluated
+                        cost = ExBudget (ExCPU (fromInteger cpuCost)) (ExMemory (fromInteger memCost))
+                    in
+                    -- turn it back into a named term
+                    case tmNamed of
+                        Left _          -> Nothing
+                        Right namedTerm -> Just (UPLC.Program () version namedTerm , cost)
 
 -- | These tests are currently failing so they are marked as expected to fail.
 -- Once a fix for a test is pushed, the test will fail. Remove it from this list.

--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -4,66 +4,67 @@
 module Main (main) where
 
 import Control.Monad.Trans.Except
-import MAlonzo.Code.Evaluator.Term (runUAgda, runUCountingAgda)
+import MAlonzo.Code.Evaluator.Term (runUCountingAgda)
 import PlutusConformance.Common
 import PlutusCore (Error (..))
 import PlutusCore.Default
+import PlutusCore.Evaluation.Machine.CostModelInterface
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekMachineCosts)
 import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Evaluation.Machine.SimpleBuiltinCostModel
+
 import PlutusCore.Quote
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.DeBruijn
 
--- | Our `evaluator` for the Agda UPLC tests is the CEK machine without costs.
-agdaEvalUplcProgNoCost :: UplcEvaluator
-agdaEvalUplcProgNoCost = UplcEvaluatorWithoutCosting $ \(UPLC.Program () version tmU) ->
-    let
-        -- turn it into an untyped de Bruijn term
-        tmUDB :: ExceptT FreeVariableError Quote (UPLC.Term NamedDeBruijn DefaultUni DefaultFun ())
-        tmUDB = deBruijnTerm tmU
-    in
-    case runQuote $ runExceptT $ withExceptT FreeVariableErrorE tmUDB of
-        -- if there's an exception, evaluation failed, should return `Nothing`.
-        Left _ -> Nothing
-        -- evaluate the untyped term with CEK
-        Right tmUDBSuccess ->
-            case runUAgda tmUDBSuccess of
-                Left _ -> Nothing
-                Right tmEvaluated ->
-                    let tmNamed = runQuote $ runExceptT $
-                            withExceptT FreeVariableErrorE $ unDeBruijnTerm tmEvaluated
-                    in
-                    -- turn it back into a named term
-                    case tmNamed of
-                        Left _          -> Nothing
-                        Right namedTerm -> Just $ UPLC.Program () version namedTerm
+-- -- | Our `evaluator` for the Agda UPLC tests is the CEK machine without costs.
+-- agdaEvalUplcProgNoCost :: UplcEvaluator
+-- agdaEvalUplcProgNoCost = UplcEvaluatorWithoutCosting $ \(UPLC.Program () version tmU) ->
+--     let
+--         -- turn it into an untyped de Bruijn term
+--         tmUDB :: ExceptT FreeVariableError Quote (UPLC.Term NamedDeBruijn DefaultUni DefaultFun ())
+--         tmUDB = deBruijnTerm tmU
+--     in
+--     case runQuote $ runExceptT $ withExceptT FreeVariableErrorE tmUDB of
+--         -- if there's an exception, evaluation failed, should return `Nothing`.
+--         Left _ -> Nothing
+--         -- evaluate the untyped term with CEK
+--         Right tmUDBSuccess ->
+--             case runUAgda tmUDBSuccess of
+--                 Left _ -> Nothing
+--                 Right tmEvaluated ->
+--                     let tmNamed = runQuote $ runExceptT $
+--                             withExceptT FreeVariableErrorE $ unDeBruijnTerm tmEvaluated
+--                     in
+--                     -- turn it back into a named term
+--                     case tmNamed of
+--                         Left _          -> Nothing
+--                         Right namedTerm -> Just $ UPLC.Program () version namedTerm
 
 -- | Our `evaluator` for the Agda UPLC tests is the CEK machine with costs.
 agdaEvalUplcProg :: UplcEvaluator
-agdaEvalUplcProg = UplcEvaluatorWithCosting $ \(UPLC.Program () version tmU) ->
+agdaEvalUplcProg = UplcEvaluatorWithCosting $ \ modelParams (UPLC.Program () version tmU) ->
     let
         -- turn it into an untyped de Bruijn term
         tmUDB :: ExceptT FreeVariableError Quote (UPLC.Term NamedDeBruijn DefaultUni DefaultFun ())
         tmUDB = deBruijnTerm tmU
+
+        {- TODO: In processModelParams construct the pair in the result from the argument.
+          Here, we ignore the argument and just return a default set.
+        -}
+        processModelParams  :: CostModelParams -> (CekMachineCosts ,  BuiltinCostMap)
+        processModelParams _ = (defaultCekMachineCosts , defaultSimpleBuiltinCostModel)
+
+        defaultModelParams :: (CekMachineCosts ,  BuiltinCostMap)
+        defaultModelParams = processModelParams modelParams
     in
     case runQuote $ runExceptT $ withExceptT FreeVariableErrorE tmUDB of
         -- if there's an exception, evaluation failed, should return `Nothing`.
         Left _ -> Nothing
         -- evaluate the untyped term with CEK
         Right tmUDBSuccess ->
-             {- In the following hole we need to plug in a BuiltinCostMap
-             type BuiltinCostMap = [(Text, CpuAndMemoryModel)]
-
-            see `plutus-metatheory/src/Cost/JSON.hs`
-
-            but currently we get it from a json file in the plutus-metatheory project
-            (which itself is copied from a file in the plutus-core project).
-            We need to wait for a fix in which plutus-core exports this map without IO (using Template Haskell).
-
-             -}
-            case runUCountingAgda (defaultCekMachineCosts , defaultSimpleBuiltinCostModel) tmUDBSuccess of
+            case runUCountingAgda defaultModelParams tmUDBSuccess of
                 Left _ -> Nothing
                 Right (tmEvaluated,(cpuCost,memCost)) ->
                     let tmNamed = runQuote $ runExceptT $


### PR DESCRIPTION
This PR adds an agda evaluator which return costing. 

It currently doesn't use the provided `CostModelParams`, but rather default ones. Since default parameters are the ones used for creating the `upc.budget.expected` files this is not a problem right now, and all test pass. 

A final implementation should really get the parameters from the provided `CostModelParams`, by correctly implementing the function
```haskell
processModelParams  :: CostModelParams -> (CekMachineCosts ,  BuiltinCostMap)
```
to actually use its argument. 
 
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Changelog fragments have been written (if appropriate)
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [X] Targeting master unless this is a cherry-pick backport
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
