### PR TITLE
Kwxm/agda conformance/better cost model (PLT-9449)

### DIFF
--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -53,12 +53,12 @@ toRawCostModel params =
 
     in (machineCosts, toSimpleBuiltinCostModel costKeyMap)
 
-{- Note [Evaluation with and without costing] We provide two evaluators, one with
-   costing and one without: normally the tests should be run with costing
-   enabled.  It may occasionally be necessary to turn the costing off, for
-   example if the Haskell costing implementation has changed and the Agda
-   implementation has not yet caught up: to do this, change `WithCosting`
-   to `WithoutCosting` in `main`.
+{- Note [Evaluation with and without costing]
+   We provide two evaluators, one with costing and one without: normally the
+   tests should be run with costing enabled.  It may occasionally be necessary
+   to turn the costing off, for example if the Haskell costing implementation
+   has changed and the Agda implementation has not yet caught up: to do this,
+   change `WithCosting` to `WithoutCosting` in `main`.
 -}
 data CostOrNot = WithCosting | WithoutCosting
 

--- a/plutus-conformance/haskell/Spec.hs
+++ b/plutus-conformance/haskell/Spec.hs
@@ -2,7 +2,27 @@
 
 module Main (main) where
 
-import PlutusConformance.Common
+import PlutusConformance.Common (UplcEvaluator (..), runUplcEvalTests)
+import PlutusCore.Evaluation.Machine.MachineParameters.Default
+import PlutusPrelude (def)
+import UntypedPlutusCore qualified as UPLC
+import UntypedPlutusCore.Evaluation.Machine.Cek (CountingSt (..), counting, runCekNoEmit)
+
+-- | Our `evaluator` for the Haskell UPLC tests is the CEK machine.
+evalUplcProg :: UplcEvaluator
+evalUplcProg = UplcEvaluatorWithCosting $ \modelParams (UPLC.Program a v t) ->
+    do
+        params <- case mkMachineParametersFor def modelParams of
+          Left _  -> Nothing
+          Right p -> Just p
+        -- runCek-like functions (e.g. evaluateCekNoEmit) are partial on term's with free variables,
+        -- that is why we manually check first for any free vars
+        case UPLC.deBruijnTerm t of
+            Left (_ :: UPLC.FreeVariableError) -> Nothing
+            Right _                            -> Just ()
+        case runCekNoEmit params counting t of
+            (Left _, _)                   -> Nothing
+            (Right prog, CountingSt cost) -> Just (UPLC.Program a v prog, cost)
 
 failingTests :: [FilePath]
 failingTests = []

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -70,8 +70,9 @@ test-suite haskell-conformance
   hs-source-dirs: haskell test-cases
   other-modules:
   build-depends:
-    , base                >=4.9 && <5
+    , base                >=4.9   && <5
     , plutus-conformance
+    , plutus-core         ^>=1.21
 
 test-suite haskell-steppable-conformance
   import:         lang
@@ -94,6 +95,7 @@ test-suite agda-conformance
   hs-source-dirs: agda test-cases
   other-modules:
   build-depends:
+    , aeson
     , base                >=4.9   && <5
     , plutus-conformance
     , plutus-core         ^>=1.21

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -5,19 +5,22 @@
 {- | Plutus conformance test suite library. -}
 module PlutusConformance.Common where
 
-import Data.Maybe (fromJust)
-import Data.Text qualified as T
-import Data.Text.IO qualified as T
 import PlutusCore.Annotation
 import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Error (ParserErrorBundle)
 import PlutusCore.Evaluation.Machine.CostModelInterface
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCostModelParams)
-import PlutusCore.Evaluation.Machine.MachineParameters.Default
 import PlutusCore.Name (Name)
 import PlutusCore.Quote (runQuoteT)
-import PlutusPrelude (Pretty (pretty), def, display, void)
+import PlutusPrelude (Pretty (pretty), display, void)
+import UntypedPlutusCore qualified as UPLC
+import UntypedPlutusCore.Parser qualified as UPLC
+
+
+import Data.Maybe (fromJust)
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
 import System.Directory
 import System.FilePath (takeBaseName, (<.>), (</>))
 import Test.Tasty (defaultMain, testGroup)
@@ -26,9 +29,6 @@ import Test.Tasty.Extras (goldenVsDocM)
 import Test.Tasty.Golden (findByExtension)
 import Test.Tasty.Golden.Advanced (goldenTest)
 import Test.Tasty.Providers (TestTree)
-import UntypedPlutusCore qualified as UPLC
-import UntypedPlutusCore.Evaluation.Machine.Cek (CountingSt (..), counting, runCekNoEmit)
-import UntypedPlutusCore.Parser qualified as UPLC
 import Witherable (Witherable (wither))
 
 -- Common functions for all tests
@@ -210,23 +210,6 @@ updateGoldenFile ::
     -> Either T.Text UplcProg -> IO ()
 updateGoldenFile goldenPath (Left txt) = T.writeFile goldenPath txt
 updateGoldenFile goldenPath (Right p)  = T.writeFile goldenPath (display p)
-
--- | Our `evaluator` for the Haskell UPLC tests is the CEK machine.
-evalUplcProg :: UplcEvaluator
-evalUplcProg = UplcEvaluatorWithCosting $ \modelParams (UPLC.Program a v t) ->
-    do
-        params <- case mkMachineParametersFor def modelParams of
-          Left _  -> Nothing
-          Right p -> Just p
-        -- runCek-like functions (e.g. evaluateCekNoEmit) are partial on term's with free variables,
-        -- that is why we manually check first for any free vars
-        case UPLC.deBruijnTerm t of
-            Left (_ :: UPLC.FreeVariableError) -> Nothing
-            Right _                            -> Just ()
-        case runCekNoEmit params counting t of
-            (Left _, _)                   -> Nothing
-            (Right prog, CountingSt cost) -> Just (UPLC.Program a v prog, cost)
-
 
 -- | Run the UPLC evaluation tests given an `evaluator` that evaluates UPLC programs.
 runUplcEvalTests ::

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1299,6 +1299,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             -- execution times, so it's safe to use the same costing function for
             -- both.
             (runCostingFunThreeArguments . paramVerifyEd25519Signature)
+
     {- Note [ECDSA secp256k1 signature verification].  An ECDSA signature
        consists of a pair of values (r,s), and for each value of r there are in
        fact two valid values of s, one effectively the negative of the other.
@@ -1315,7 +1316,6 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
 
           https://github.com/bitcoin-core/secp256k1.
      -}
-
     toBuiltinMeaning _semvar VerifyEcdsaSecp256k1Signature =
         let verifyEcdsaSecp256k1SignatureDenotation
                 :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BuiltinResult Bool

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/SimpleBuiltinCostModel.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/SimpleBuiltinCostModel.hs
@@ -6,9 +6,10 @@
    executables -}
 module PlutusCore.Evaluation.Machine.SimpleBuiltinCostModel
    ( BuiltinCostMap
+   , BuiltinCostKeyMap
+   , toSimpleBuiltinCostModel
    , defaultSimpleBuiltinCostModel
    ) where
-
 
 import Data.Aeson.Key as Key (toText)
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -19,15 +20,19 @@ import PlutusCore.DataFilePaths qualified as DFP
 import PlutusCore.Evaluation.Machine.CostingFun.SimpleJSON
 
 type BuiltinCostMap = [(Text, CpuAndMemoryModel)]
+type BuiltinCostKeyMap = KeyMap.KeyMap CpuAndMemoryModel
 
 -- | The default builtin cost map.
-builtinCostKeyMap :: KeyMap.KeyMap CpuAndMemoryModel
-builtinCostKeyMap =
+defaultBuiltinCostKeyMap :: BuiltinCostKeyMap
+defaultBuiltinCostKeyMap =
     $$(readJSONFromFile DFP.builtinCostModelFile)
 
 -- replace underscores _ by dashes -
 builtinName :: Text -> Text
 builtinName = replace "_" "-"
 
+toSimpleBuiltinCostModel :: BuiltinCostKeyMap -> BuiltinCostMap
+toSimpleBuiltinCostModel m = map (first (builtinName . toText)) (KeyMap.toList m)
+
 defaultSimpleBuiltinCostModel :: BuiltinCostMap
-defaultSimpleBuiltinCostModel = map (first (builtinName . toText)) (KeyMap.toList builtinCostKeyMap)
+defaultSimpleBuiltinCostModel = toSimpleBuiltinCostModel defaultBuiltinCostKeyMap


### PR DESCRIPTION
#5758 ("Add a costing evaluator to agda-conformance") contained a comment saying
```
TODO: In processModelParams construct the pair in the result from the argument.
Here, we ignore the argument and just return a default set.
```

This PR fixes that. The problem is that the Agda evualator uses a simplified cost model representation and we have to convert a set of `CostModelParams` in to that format.  We have [multiple cost model representations](https://github.com/IntersectMBO/plutus/tree/master/doc/notes/cost-model-representations) and it was a little difficult to find the best way of doing the conversion.  There's a comment explaining what I eventually did, and why.