### PR TITLE
Remove unnecessary for a library ghc options

### DIFF
--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -128,7 +128,6 @@ library plutus-tx-testlib
   import:          lang
   visibility:      public
   hs-source-dirs:  testlib
-  ghc-options:     -threaded -rtsopts -with-rtsopts=-N
   exposed-modules:
     Hedgehog.Laws.Common
     Hedgehog.Laws.Eq


### PR DESCRIPTION
This tiny PR fixes the following warning

```
Warning: 'ghc-options: -rtsopts' has no effect for libraries. It should only be used for executables.
```

by removing the `ghc-option` from the plutus-tx-testlib

