### PR TITLE
[Generators] Fix 'LamAbs' handling in 'fixupTerm_'

### DIFF
--- a/plutus-core/testlib/PlutusIR/Generators/QuickCheck/ShrinkTerms.hs
+++ b/plutus-core/testlib/PlutusIR/Generators/QuickCheck/ShrinkTerms.hs
@@ -82,7 +82,9 @@ fixupTerm_ :: TypeCtx
 fixupTerm_ tyctxOld ctxOld tyctxNew ctxNew tyNew tm0 =
   case inferTypeInContext tyctxNew ctxNew tm0 of
     Left _ -> case tm0 of
-      LamAbs _ x a tm | TyFun () _ b <- tyNew -> bimap (TyFun () a) (LamAbs () x a)
+      -- Make @a@ the new type of @x@. We can't take the old type of @x@, because it may reference
+      -- a removed binding. And we're trying to change the type of @tm0@ to @tyNew@ anyway.
+      LamAbs _ x _ tm | TyFun () a b <- tyNew -> bimap (TyFun () a) (LamAbs () x a)
                                               $ fixupTerm_ tyctxOld (Map.insert x a ctxOld)
                                                            tyctxNew (Map.insert x a ctxNew) b tm
       Apply _ (Apply _ (TyInst _ (Builtin _ Trace) _) s) tm ->


### PR DESCRIPTION
Before this PR running

```
cabal test plutus-ir-test --test-options "--pattern shrinkTermSound --quickcheck-replay=21373"
```

produces

```
plutus-ir/test/Driver.hs
  PlutusIR
    Generators.QuickCheck.Tests
      shrinkTermSound: FAIL (0.23s)
        *** Failed! Falsified (after 6 tests and 7 shrinks):
        ty,tm = ( all a5_17. a5_17 -> (all a4_19. a5_17)
        , let
          data (d8_8 :: * -> *) a10_10 | m6_6 where
            
        in
        /\a5_8 -> \(x13_13 : a5_8) -> /\a4_11 -> x13_13 )
        [ ( ( a5_8 -> (all a4_19. unit)
        , let
          data (d8_8 :: * -> *) a10_10 | m6_6 where
            
        in
        \(x13_13 : a5_8) -> error {all a4_19. unit} )
        , Error during PIR typechecking:
        Type-level name mismatch at (): d8 is in scope, but a5 having the same Unique 20 is attempted to be referenced ) ]
        Use --quickcheck-replay=21373 to reproduce.
```

After:

```
plutus-ir/test/Driver.hs
  PlutusIR
    Generators.QuickCheck.Tests
      shrinkTermSound: OK (0.08s)
        +++ OK, passed 10 tests.
```