### PR TITLE
fix: haddock parse error in GHC 8.10

### DIFF
--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -171,8 +171,8 @@ See Note [Inlining and global uniqueness]
 inline ::
   forall name uni fun m a.
   (ExternalConstraints name uni fun m) =>
+  -- | inline constants
   Bool ->
-  -- ^ inline constants
   InlineHints name a ->
   Term name uni fun a ->
   m (Term name uni fun a)


### PR DESCRIPTION
Fixes  the following error (GHC 8.10.7)
```
untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs:175:3: error:
    parse error on input '-- ^ inline constants'
    |
175 |   -- ^ inline constants
    |   ^^^^^^^^^^^^^^^^^^^^^
Warning: Failed to build documentation for plutus-core-1.22.0.0.
```