### PR TITLE
PlutusLedgerApi.V3.TxInInfo

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -93,7 +93,7 @@ module PlutusLedgerApi.V3 (
   TxInfo (..),
   V2.TxOut (..),
   TxOutRef (..),
-  V2.TxInInfo (..),
+  TxInInfo (..),
   V2.OutputDatum (..),
 
   -- *** Intervals

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/Contexts.hs
@@ -12,7 +12,42 @@
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-strictness #-}
 
-module PlutusLedgerApi.V3.Contexts where
+module PlutusLedgerApi.V3.Contexts
+  ( ColdCommitteeCredential (..)
+  , HotCommitteeCredential (..)
+  , DRepCredential (..)
+  , DRep (..)
+  , Delegatee (..)
+  , TxCert (..)
+  , Voter (..)
+  , Vote (..)
+  , GovernanceActionId (..)
+  , Committee (..)
+  , Constitution (..)
+  , ProtocolVersion (..)
+  , ChangedParameters (..)
+  , GovernanceAction (..)
+  , ProposalProcedure (..)
+  , ScriptPurpose (..)
+  , TxInInfo (..)
+  , TxInfo (..)
+  , ScriptContext (..)
+  , findOwnInput
+  , findDatum
+  , findDatumHash
+  , findTxInByTxOutRef
+  , findContinuingOutputs
+  , getContinuingOutputs
+  , txSignedBy
+
+    -- * Validator functions
+  , pubKeyOutputsAt
+  , valuePaidTo
+  , valueSpent
+  , valueProduced
+  , ownCurrencySymbol
+  , spendsOutput
+  ) where
 
 import GHC.Generics (Generic)
 import Prettyprinter (nest, vsep, (<+>))


### PR DESCRIPTION
Switching from `V2.TxId` to `V3.TxId` also requires switching from `V2.TxInInfo` to `V3.TxInInfo` as it contains `TxId`
