### PR TITLE
CIP-0057: ContractBlueprint with derived schema definitions and safe schema refs

### DIFF
--- a/plutus-tx-plugin/test/Blueprint/Acme.golden.json
+++ b/plutus-tx-plugin/test/Blueprint/Acme.golden.json
@@ -15,17 +15,12 @@
   },
   "validators": [
     {
-      "title": "Acme Validator",
+      "title": "Acme Validator #1",
       "description": "A validator that does something awesome",
       "redeemer": {
         "title": "Acme Redeemer",
         "description": "A redeemer that does something awesome",
-        "purpose": {
-          "oneOf": [
-            "spend",
-            "mint"
-          ]
-        },
+        "purpose": "spend",
         "schema": {
           "$ref": "#/definitions/String"
         }
@@ -48,8 +43,40 @@
           }
         }
       ],
-      "compiledCode": "58ec01010032222323232300349103505435003232325333573466e1d200000218000a999ab9a3370e90010010c00cc8c8c94ccd5cd19b874800000860026eb4d5d0800cdd71aba13574400213008491035054310035573c0046aae74004dd51aba100109802a481035054310035573c0046aae74004dd50029919192999ab9a3370e90000010c0004c0112401035054310035573c0046aae74004dd5001119319ab9c001800199999a8911199a891199a89100111111400401600900380140044252005001001400084a400a0020038004008848a400e0050012410101010101010101000498101030048810001",
-      "hash": "21a5bbebc42a3d916719c975f622508a2c940ced5cd867cd3d87a019"
+      "compiledCode": "584f01010032222801199999a8911199a891199a89100111111400401600900380140044252005001001400084a400a0020038004008848a400e0050012410101010101010101000498101030048810001",
+      "hash": "a0a2b4161839094c666e8ea1952510e7f337aa10786cef62706244ba"
+    },
+    {
+      "title": "Acme Validator #2",
+      "description": "Another validator that does something awesome",
+      "redeemer": {
+        "purpose": "mint",
+        "schema": {
+          "$ref": "#/definitions/Integer"
+        }
+      },
+      "datum": {
+        "purpose": "mint",
+        "schema": {
+          "$ref": "#/definitions/Integer"
+        }
+      },
+      "parameters": [
+        {
+          "purpose": "spend",
+          "schema": {
+            "$ref": "#/definitions/Param2a"
+          }
+        },
+        {
+          "purpose": "mint",
+          "schema": {
+            "$ref": "#/definitions/Param2b"
+          }
+        }
+      ],
+      "compiledCode": "58290101003322222800199a89110014002004424520070028008ccd4488800e0010022122900380140041",
+      "hash": "67923a88b5dfccdef62abd8b3f4ff857d7582b52cde4c07b8cd34175"
     }
   ],
   "definitions": {
@@ -103,6 +130,24 @@
     },
     "Integer": {
       "dataType": "integer"
+    },
+    "Param2a": {
+      "dataType": "constructor",
+      "fields": [
+        {
+          "$ref": "#/definitions/Bool"
+        }
+      ],
+      "index": 0
+    },
+    "Param2b": {
+      "dataType": "constructor",
+      "fields": [
+        {
+          "$ref": "#/definitions/Bool"
+        }
+      ],
+      "index": 0
     },
     "Params": {
       "dataType": "constructor",

--- a/plutus-tx-plugin/test/Blueprint/Tests.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests.hs
@@ -1,20 +1,21 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
 
 module Blueprint.Tests where
 
 import Prelude
 
-import Blueprint.Tests.Lib (Datum, Params, Redeemer, goldenJson, serialisedScript)
+import Blueprint.Tests.Lib (Datum, Datum2, Param2a, Param2b, Params, Redeemer, Redeemer2,
+                            goldenJson, serialisedScript, validatorScript1, validatorScript2)
 import Data.Set qualified as Set
-import PlutusTx.Blueprint.Argument (ArgumentBlueprint (..))
 import PlutusTx.Blueprint.Contract (ContractBlueprint (..))
 import PlutusTx.Blueprint.Definition (definitionRef, deriveDefinitions)
-import PlutusTx.Blueprint.Parameter (ParameterBlueprint (..))
 import PlutusTx.Blueprint.PlutusVersion (PlutusVersion (PlutusV3))
 import PlutusTx.Blueprint.Preamble (Preamble (..))
 import PlutusTx.Blueprint.Purpose qualified as Purpose
+import PlutusTx.Blueprint.TH (deriveArgumentBlueprint, deriveParameterBlueprint)
 import PlutusTx.Blueprint.Validator (ValidatorBlueprint (..))
 import PlutusTx.Blueprint.Write (writeBlueprint)
 import Test.Tasty.Extras (TestNested, testNested)
@@ -35,34 +36,38 @@ contractBlueprint =
           , preambleLicense = Just "MIT"
           }
     , contractValidators =
-        Set.singleton
-          MkValidatorBlueprint
-            { validatorTitle = "Acme Validator"
-            , validatorDescription = Just "A validator that does something awesome"
-            , validatorParameters =
-                [ MkParameterBlueprint
-                    { parameterTitle = Just "Acme Parameter"
-                    , parameterDescription = Just "A parameter that does something awesome"
-                    , parameterPurpose = Set.singleton Purpose.Spend
-                    , parameterSchema = definitionRef @Params
-                    }
-                ]
-            , validatorRedeemer =
-                MkArgumentBlueprint
-                  { argumentTitle = Just "Acme Redeemer"
-                  , argumentDescription = Just "A redeemer that does something awesome"
-                  , argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint]
-                  , argumentSchema = definitionRef @Redeemer
-                  }
-            , validatorDatum =
-                Just
-                  MkArgumentBlueprint
-                    { argumentTitle = Just "Acme Datum"
-                    , argumentDescription = Just "A datum that contains something awesome"
-                    , argumentPurpose = Set.singleton Purpose.Spend
-                    , argumentSchema = definitionRef @Datum
-                    }
-            , validatorCompiledCode = Just serialisedScript
-            }
-    , contractDefinitions = deriveDefinitions @[Params, Redeemer, Datum]
+        Set.fromList
+          [ MkValidatorBlueprint
+              { validatorTitle =
+                  "Acme Validator #1"
+              , validatorDescription =
+                  Just "A validator that does something awesome"
+              , validatorParameters =
+                  [$(deriveParameterBlueprint ''Params (Set.singleton Purpose.Spend))]
+              , validatorRedeemer =
+                  $(deriveArgumentBlueprint ''Redeemer (Set.singleton Purpose.Spend))
+              , validatorDatum =
+                  Just $(deriveArgumentBlueprint ''Datum (Set.singleton Purpose.Spend))
+              , validatorCompiledCode =
+                  Just (serialisedScript validatorScript1)
+              }
+          , MkValidatorBlueprint
+              { validatorTitle =
+                  "Acme Validator #2"
+              , validatorDescription =
+                  Just "Another validator that does something awesome"
+              , validatorParameters =
+                  [ $(deriveParameterBlueprint ''Param2a (Set.singleton Purpose.Spend))
+                  , $(deriveParameterBlueprint ''Param2b (Set.singleton Purpose.Mint))
+                  ]
+              , validatorRedeemer =
+                  $(deriveArgumentBlueprint ''Redeemer2 (Set.singleton Purpose.Mint))
+              , validatorDatum =
+                  Just $(deriveArgumentBlueprint ''Datum2 (Set.singleton Purpose.Mint))
+              , validatorCompiledCode =
+                  Just (serialisedScript validatorScript2)
+              }
+          ]
+    , contractDefinitions =
+        deriveDefinitions @[Params, Redeemer, Datum, Param2a, Param2b, Redeemer2, Datum2]
     }

--- a/plutus-tx-plugin/test/Blueprint/Tests.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests.hs
@@ -1,73 +1,68 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module Blueprint.Tests where
 
-import Blueprint.Tests.Lib (goldenJson)
-import Blueprint.Tests.Lib qualified as Fixture
-import Data.Set qualified as Set
-import PlutusTx.Blueprint
-import PlutusTx.Blueprint.Purpose qualified as Purpose
 import Prelude
+
+import Blueprint.Tests.Lib (Datum, Params, Redeemer, goldenJson, serialisedScript)
+import Data.Set qualified as Set
+import PlutusTx.Blueprint.Argument (ArgumentBlueprint (..))
+import PlutusTx.Blueprint.Contract (ContractBlueprint (..))
+import PlutusTx.Blueprint.Definition (definitionRef, deriveDefinitions)
+import PlutusTx.Blueprint.Parameter (ParameterBlueprint (..))
+import PlutusTx.Blueprint.PlutusVersion (PlutusVersion (PlutusV3))
+import PlutusTx.Blueprint.Preamble (Preamble (..))
+import PlutusTx.Blueprint.Purpose qualified as Purpose
+import PlutusTx.Blueprint.Validator (ValidatorBlueprint (..))
+import PlutusTx.Blueprint.Write (writeBlueprint)
 import Test.Tasty.Extras (TestNested, testNested)
 
 goldenTests :: TestNested
 goldenTests = testNested "Blueprint" [goldenJson "Acme" (`writeBlueprint` contractBlueprint)]
 
--- | All the data types exposed (directly or indirectly) by the type signature of the validator
--- This type level list is used to:
--- 1. derive the schema definitions for the contract.
--- 2. make "safe" references to the [derived] schema definitions.
-contractBlueprint :: Blueprint [Fixture.Params, Fixture.Redeemer, Fixture.Datum]
+contractBlueprint :: ContractBlueprint
 contractBlueprint =
   MkContractBlueprint
-    { contractId = Nothing,
-      contractPreamble =
+    { contractId = Nothing
+    , contractPreamble =
         MkPreamble
-          { preambleTitle = "Acme Contract",
-            preambleDescription = Just "A contract that does something awesome",
-            preambleVersion = "1.1.0",
-            preamblePlutusVersion = PlutusV3,
-            preambleLicense = Just "MIT"
-          },
-      contractValidators =
+          { preambleTitle = "Acme Contract"
+          , preambleDescription = Just "A contract that does something awesome"
+          , preambleVersion = "1.1.0"
+          , preamblePlutusVersion = PlutusV3
+          , preambleLicense = Just "MIT"
+          }
+    , contractValidators =
         Set.singleton
           MkValidatorBlueprint
-            { validatorTitle = "Acme Validator",
-              validatorDescription = Just "A validator that does something awesome",
-              validatorParameters =
-                Just $
-                  pure
-                    MkParameterBlueprint
-                      { parameterTitle = Just "Acme Parameter",
-                        parameterDescription = Just "A parameter that does something awesome",
-                        parameterPurpose = Set.singleton Purpose.Spend,
-                        parameterSchema = definitionRef @Fixture.Params
-                      },
-              validatorRedeemer =
+            { validatorTitle = "Acme Validator"
+            , validatorDescription = Just "A validator that does something awesome"
+            , validatorParameters =
+                [ MkParameterBlueprint
+                    { parameterTitle = Just "Acme Parameter"
+                    , parameterDescription = Just "A parameter that does something awesome"
+                    , parameterPurpose = Set.singleton Purpose.Spend
+                    , parameterSchema = definitionRef @Params
+                    }
+                ]
+            , validatorRedeemer =
                 MkArgumentBlueprint
-                  { argumentTitle = Just "Acme Redeemer",
-                    argumentDescription = Just "A redeemer that does something awesome",
-                    argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint],
-                    argumentSchema = definitionRef @Fixture.Redeemer
-                  },
-              validatorDatum =
+                  { argumentTitle = Just "Acme Redeemer"
+                  , argumentDescription = Just "A redeemer that does something awesome"
+                  , argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint]
+                  , argumentSchema = definitionRef @Redeemer
+                  }
+            , validatorDatum =
                 Just
                   MkArgumentBlueprint
-                    { argumentTitle = Just "Acme Datum",
-                      argumentDescription = Just "A datum that contains something awesome",
-                      argumentPurpose = Set.singleton Purpose.Spend,
-                      argumentSchema = definitionRef @Fixture.Datum
-                    },
-              validatorCompiledCode = Just Fixture.serialisedScript
-            },
-      contractDefinitions = deriveSchemaDefinitions
+                    { argumentTitle = Just "Acme Datum"
+                    , argumentDescription = Just "A datum that contains something awesome"
+                    , argumentPurpose = Set.singleton Purpose.Spend
+                    , argumentSchema = definitionRef @Datum
+                    }
+            , validatorCompiledCode = Just serialisedScript
+            }
+    , contractDefinitions = deriveDefinitions @[Params, Redeemer, Datum]
     }

--- a/plutus-tx-plugin/test/Blueprint/Tests.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests.hs
@@ -11,75 +11,63 @@
 
 module Blueprint.Tests where
 
-import PlutusTx.Blueprint
-import Prelude
-
+import Blueprint.Tests.Lib (goldenJson)
 import Blueprint.Tests.Lib qualified as Fixture
-import Control.Monad.Reader (asks)
 import Data.Set qualified as Set
+import PlutusTx.Blueprint
 import PlutusTx.Blueprint.Purpose qualified as Purpose
-import System.FilePath ((</>))
-import Test.Tasty (TestName)
+import Prelude
 import Test.Tasty.Extras (TestNested, testNested)
-import Test.Tasty.Golden (goldenVsFile)
 
 goldenTests :: TestNested
-goldenTests = testNested "Blueprint" [goldenBlueprint "Acme" contractBlueprint]
+goldenTests = testNested "Blueprint" [goldenJson "Acme" (`writeBlueprint` contractBlueprint)]
 
-goldenBlueprint :: TestName -> ContractBlueprint types -> TestNested
-goldenBlueprint name blueprint = do
-  goldenPath <- asks $ foldr (</>) name
-  let actual = goldenPath ++ ".actual.json"
-  let golden = goldenPath ++ ".golden.json"
-  pure $ goldenVsFile name golden actual (writeBlueprint actual blueprint)
-
-{- | All the data types exposed (directly or indirectly) by the type signature of the validator
-This type level list is used to:
-1. derive the schema definitions for the contract.
-2. make "safe" references to the [derived] schema definitions.
--}
+-- | All the data types exposed (directly or indirectly) by the type signature of the validator
+-- This type level list is used to:
+-- 1. derive the schema definitions for the contract.
+-- 2. make "safe" references to the [derived] schema definitions.
 contractBlueprint :: Blueprint [Fixture.Params, Fixture.Redeemer, Fixture.Datum]
 contractBlueprint =
   MkContractBlueprint
-    { contractId = Nothing
-    , contractPreamble =
+    { contractId = Nothing,
+      contractPreamble =
         MkPreamble
-          { preambleTitle = "Acme Contract"
-          , preambleDescription = Just "A contract that does something awesome"
-          , preambleVersion = "1.1.0"
-          , preamblePlutusVersion = PlutusV3
-          , preambleLicense = Just "MIT"
-          }
-    , contractValidators =
+          { preambleTitle = "Acme Contract",
+            preambleDescription = Just "A contract that does something awesome",
+            preambleVersion = "1.1.0",
+            preamblePlutusVersion = PlutusV3,
+            preambleLicense = Just "MIT"
+          },
+      contractValidators =
         Set.singleton
           MkValidatorBlueprint
-            { validatorTitle = "Acme Validator"
-            , validatorDescription = Just "A validator that does something awesome"
-            , validatorParameters =
+            { validatorTitle = "Acme Validator",
+              validatorDescription = Just "A validator that does something awesome",
+              validatorParameters =
                 Just $
                   pure
                     MkParameterBlueprint
-                      { parameterTitle = Just "Acme Parameter"
-                      , parameterDescription = Just "A parameter that does something awesome"
-                      , parameterPurpose = Set.singleton Purpose.Spend
-                      , parameterSchema = definitionRef @Fixture.Params
-                      }
-            , validatorRedeemer =
+                      { parameterTitle = Just "Acme Parameter",
+                        parameterDescription = Just "A parameter that does something awesome",
+                        parameterPurpose = Set.singleton Purpose.Spend,
+                        parameterSchema = definitionRef @Fixture.Params
+                      },
+              validatorRedeemer =
                 MkArgumentBlueprint
-                  { argumentTitle = Just "Acme Redeemer"
-                  , argumentDescription = Just "A redeemer that does something awesome"
-                  , argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint]
-                  , argumentSchema = definitionRef @Fixture.Redeemer
-                  }
-            , validatorDatum =
+                  { argumentTitle = Just "Acme Redeemer",
+                    argumentDescription = Just "A redeemer that does something awesome",
+                    argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint],
+                    argumentSchema = definitionRef @Fixture.Redeemer
+                  },
+              validatorDatum =
                 Just
                   MkArgumentBlueprint
-                    { argumentTitle = Just "Acme Datum"
-                    , argumentDescription = Just "A datum that contains something awesome"
-                    , argumentPurpose = Set.singleton Purpose.Spend
-                    , argumentSchema = definitionRef @Fixture.Datum
-                    }
-            , validatorCompiledCode = Just Fixture.serialisedScript
-            }
-    , contractDefinitions = deriveSchemaDefinitions
+                    { argumentTitle = Just "Acme Datum",
+                      argumentDescription = Just "A datum that contains something awesome",
+                      argumentPurpose = Set.singleton Purpose.Spend,
+                      argumentSchema = definitionRef @Fixture.Datum
+                    },
+              validatorCompiledCode = Just Fixture.serialisedScript
+            },
+      contractDefinitions = deriveSchemaDefinitions
     }

--- a/plutus-tx-plugin/test/Blueprint/Tests/Lib.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests/Lib.hs
@@ -14,6 +14,7 @@
 
 module Blueprint.Tests.Lib where
 
+import PlutusTx hiding (Typeable)
 import Prelude
 
 import Codec.Serialise (serialise)
@@ -23,14 +24,14 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.Kind (Type)
 import Data.Void (Void)
 import Flat qualified
+import GHC.Generics (Generic)
 import PlutusCore.Version (plcVersion110)
-import PlutusTx hiding (Typeable)
 import PlutusTx.Blueprint.Class (HasSchema (..))
 import PlutusTx.Blueprint.Definition (AsDefinitionId, definitionRef)
 import PlutusTx.Blueprint.Schema (Schema (SchemaBytes), emptyBytesSchema)
 import PlutusTx.Blueprint.Schema.Annotation (SchemaComment (..), SchemaDescription (..),
                                              SchemaInfo (..), SchemaTitle (..), emptySchemaInfo)
-import PlutusTx.Builtins (BuiltinByteString, BuiltinString, emptyByteString)
+import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinString, emptyByteString)
 import PlutusTx.Prelude qualified as PlutusTx
 import UntypedPlutusCore qualified as UPLC
 
@@ -41,14 +42,16 @@ data Params = MkParams
   , myBuiltinData       :: BuiltinData
   , myBuiltinByteString :: BuiltinByteString
   }
+  deriving stock (Generic)
   deriving anyclass (AsDefinitionId)
 
 $(PlutusTx.makeLift ''Params)
 $(makeIsDataSchemaIndexed ''Params [('MkParams, 0)])
 
 newtype Bytes (phantom :: Type) = MkAcmeBytes BuiltinByteString
-  deriving newtype (ToData, FromData, UnsafeFromData)
+  deriving stock (Generic)
   deriving anyclass (AsDefinitionId)
+  deriving newtype (ToData, FromData, UnsafeFromData)
 
 instance HasSchema (Bytes phantom) ts where
   schema = SchemaBytes emptySchemaInfo { title = Just "SchemaBytes" } emptyBytesSchema
@@ -58,6 +61,7 @@ data DatumPayload = MkDatumPayload
   { myAwesomeDatum1 :: Integer
   , myAwesomeDatum2 :: Bytes Void
   }
+  deriving stock (Generic)
   deriving anyclass (AsDefinitionId)
 
 {-# ANN DatumLeft (SchemaTitle "Datum") #-}
@@ -67,6 +71,7 @@ data DatumPayload = MkDatumPayload
 {-# ANN DatumRight (SchemaDescription "DatumRight") #-}
 {-# ANN DatumRight (SchemaComment "This constructor has a payload") #-}
 data Datum = DatumLeft | DatumRight DatumPayload
+  deriving stock (Generic)
   deriving anyclass (AsDefinitionId)
 
 type Redeemer = BuiltinString

--- a/plutus-tx-plugin/test/Blueprint/Tests/Lib.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests/Lib.hs
@@ -24,15 +24,17 @@ import Data.Kind (Type)
 import Data.Void (Void)
 import Flat qualified
 import GHC.Generics (Generic)
-import PlutusCore.Version (plcVersion110)
-import PlutusTx hiding (Typeable)
 import PlutusTx.Blueprint.Class (HasSchema (..))
 import PlutusTx.Blueprint.Definition (AsDefinitionId, definitionRef)
 import PlutusTx.Blueprint.Schema (Schema (..), emptyBytesSchema)
 import PlutusTx.Blueprint.Schema.Annotation (SchemaComment (..), SchemaDescription (..),
                                              SchemaInfo (..), SchemaTitle (..), emptySchemaInfo)
-import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinString, emptyByteString)
-import PlutusTx.Prelude qualified as PlutusTx
+import PlutusTx.Blueprint.TH (makeIsDataSchemaIndexed)
+import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData, BuiltinString, emptyByteString)
+import PlutusTx.Code qualified as PlutusTx
+import PlutusTx.IsData (FromData, ToData (..), UnsafeFromData (..))
+import PlutusTx.Lift qualified as PlutusTx
+import PlutusTx.TH qualified as PlutusTx
 import Prelude
 import System.FilePath ((</>))
 import Test.Tasty (TestName)
@@ -40,13 +42,11 @@ import Test.Tasty.Extras (TestNested)
 import Test.Tasty.Golden (goldenVsFile)
 import UntypedPlutusCore qualified as UPLC
 
-goldenJson :: TestName -> (FilePath -> IO ()) -> TestNested
-goldenJson name cb = do
-  goldenPath <- asks $ foldr (</>) name
-  let actual = goldenPath ++ ".actual.json"
-  let golden = goldenPath ++ ".golden.json"
-  pure $ goldenVsFile name golden actual (cb actual)
+----------------------------------------------------------------------------------------------------
+-- Validator 1 for testing blueprints --------------------------------------------------------------
 
+{-# ANN type Params (SchemaTitle "Acme Parameter") #-}
+{-# ANN type Params (SchemaDescription "A parameter that does something awesome") #-}
 data Params = MkParams
   { myUnit              :: ()
   , myBool              :: Bool
@@ -69,6 +69,7 @@ instance HasSchema (Bytes phantom) ts where
   schema = SchemaBytes emptySchemaInfo{title = Just "SchemaBytes"} emptyBytesSchema
 
 {-# ANN MkDatumPayload (SchemaComment "MkDatumPayload") #-}
+
 data DatumPayload = MkDatumPayload
   { myAwesomeDatum1 :: Integer
   , myAwesomeDatum2 :: Bytes Void
@@ -76,56 +77,93 @@ data DatumPayload = MkDatumPayload
   deriving stock (Generic)
   deriving anyclass (AsDefinitionId)
 
+{-# ANN type Datum (SchemaTitle "Acme Datum") #-}
+{-# ANN type Datum (SchemaDescription "A datum that contains something awesome") #-}
+
 {-# ANN DatumLeft (SchemaTitle "Datum") #-}
 {-# ANN DatumLeft (SchemaDescription "DatumLeft") #-}
 {-# ANN DatumLeft (SchemaComment "This constructor is parameterless") #-}
+
 {-# ANN DatumRight (SchemaTitle "Datum") #-}
 {-# ANN DatumRight (SchemaDescription "DatumRight") #-}
 {-# ANN DatumRight (SchemaComment "This constructor has a payload") #-}
+
 data Datum = DatumLeft | DatumRight DatumPayload
   deriving stock (Generic)
   deriving anyclass (AsDefinitionId)
+
+{-# ANN type Redeemer (SchemaTitle "Acme Redeemer") #-}
+{-# ANN type Redeemer (SchemaDescription "A redeemer that does something awesome") #-}
 
 type Redeemer = BuiltinString
 
 type ScriptContext = ()
 
-type Validator = Params -> Datum -> Redeemer -> ScriptContext -> Bool
-
 $(makeIsDataSchemaIndexed ''DatumPayload [('MkDatumPayload, 0)])
 $(makeIsDataSchemaIndexed ''Datum [('DatumLeft, 0), ('DatumRight, 1)])
 
-serialisedScript :: ByteString
-serialisedScript =
+{-# INLINEABLE typedValidator1 #-}
+typedValidator1 :: Params -> Datum -> Redeemer -> ScriptContext -> Bool
+typedValidator1 _params _datum _redeemer _context = False
+
+validatorScript1 :: PlutusTx.CompiledCode (Datum -> Redeemer -> ScriptContext -> Bool)
+validatorScript1 =
+  $$(PlutusTx.compile [||typedValidator1||])
+    `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef
+      MkParams
+        { myUnit = ()
+        , myBool = True
+        , myInteger = fromIntegral (maxBound @Int) + 1
+        , myBuiltinData = toBuiltinData (3 :: Integer)
+        , myBuiltinByteString = emptyByteString
+        }
+
+----------------------------------------------------------------------------------------------------
+-- Validator 2 for testing blueprints --------------------------------------------------------------
+
+newtype Param2a = MkParam2a Bool
+  deriving stock (Generic)
+  deriving anyclass (AsDefinitionId)
+
+$(PlutusTx.makeLift ''Param2a)
+$(makeIsDataSchemaIndexed ''Param2a [('MkParam2a, 0)])
+
+newtype Param2b = MkParam2b Bool
+  deriving stock (Generic)
+  deriving anyclass (AsDefinitionId)
+
+$(PlutusTx.makeLift ''Param2b)
+$(makeIsDataSchemaIndexed ''Param2b [('MkParam2b, 0)])
+
+type Datum2 = Integer
+
+type Redeemer2 = Integer
+
+{-# INLINEABLE typedValidator2 #-}
+typedValidator2 :: Param2a -> Param2b -> Datum2 -> Redeemer2 -> ScriptContext -> Bool
+typedValidator2 _p1 _p2 _datum _redeemer _context = True
+
+validatorScript2 :: PlutusTx.CompiledCode (Datum2 -> Redeemer2 -> ScriptContext -> Bool)
+validatorScript2 =
+  $$(PlutusTx.compile [||typedValidator2||])
+    `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef (MkParam2a False)
+    `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef (MkParam2b True)
+
+----------------------------------------------------------------------------------------------------
+-- Helper functions --------------------------------------------------------------------------------
+
+serialisedScript :: PlutusTx.CompiledCode t -> ByteString
+serialisedScript validatorScript =
   PlutusTx.getPlcNoAnn validatorScript
     & over UPLC.progTerm (UPLC.termMapNames UPLC.unNameDeBruijn)
     & UPLC.UnrestrictedProgram
     & Flat.flat
     & serialise
     & LBS.toStrict
- where
-  {-# INLINEABLE typedValidator #-}
-  typedValidator :: Validator
-  typedValidator _params _datum _redeemer _context = False
 
-  {-# INLINEABLE untypedValidator #-}
-  untypedValidator :: Params -> BuiltinData -> BuiltinString -> BuiltinData -> ()
-  untypedValidator params datum redeemer ctx =
-    PlutusTx.check $ typedValidator params acmeDatum acmeRedeemer scriptContext
-   where
-    acmeDatum :: Datum = PlutusTx.unsafeFromBuiltinData datum
-    acmeRedeemer :: Redeemer = redeemer
-    scriptContext :: ScriptContext = PlutusTx.unsafeFromBuiltinData ctx
-
-  validatorScript :: PlutusTx.CompiledCode (BuiltinData -> BuiltinString -> BuiltinData -> ())
-  validatorScript =
-    $$(PlutusTx.compile [||untypedValidator||])
-      `PlutusTx.unsafeApplyCode` PlutusTx.liftCode
-        plcVersion110
-        MkParams
-          { myUnit = ()
-          , myBool = True
-          , myInteger = fromIntegral (maxBound @Int) + 1
-          , myBuiltinData = PlutusTx.toBuiltinData (3 :: Integer)
-          , myBuiltinByteString = emptyByteString
-          }
+goldenJson :: TestName -> (FilePath -> IO ()) -> TestNested
+goldenJson name cb = do
+  goldenPath <- asks $ foldr (</>) name
+  let actual = goldenPath ++ ".actual.json"
+  let golden = goldenPath ++ ".golden.json"
+  pure $ goldenVsFile name golden actual (cb actual)

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -179,6 +179,7 @@ test-suite plutus-tx-test
   other-modules:
     Blueprint.Definition.Fixture
     Blueprint.Definition.Spec
+    Blueprint.Spec
     List.Spec
     Rational.Laws
     Rational.Laws.Additive

--- a/plutus-tx/src/PlutusTx/Blueprint/Argument.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Argument.hs
@@ -28,7 +28,7 @@ data ArgumentBlueprint (referencedTypes :: [Type]) = MkArgumentBlueprint
   , argumentSchema      :: Schema referencedTypes
   -- ^ A Plutus Data Schema.
   }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Ord)
 
 instance ToJSON (ArgumentBlueprint referencedTypes) where
   toJSON MkArgumentBlueprint{..} =

--- a/plutus-tx/src/PlutusTx/Blueprint/Contract.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Contract.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs              #-}
 {-# LANGUAGE KindSignatures     #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
@@ -12,78 +13,36 @@ import Data.Aeson (ToJSON (..), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Extra (optionalField, requiredField)
 import Data.Aeson.Extra qualified as Aeson
-import Data.Kind (Type)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import PlutusPrelude (ensure)
-import PlutusTx.Blueprint.Definition (DefinitionId, UnrollAll)
+import PlutusTx.Blueprint.Definition (DefinitionId, Definitions, definitionsToMap)
 import PlutusTx.Blueprint.Preamble (Preamble)
-import PlutusTx.Blueprint.Schema (Schema)
 import PlutusTx.Blueprint.Validator (ValidatorBlueprint)
 
 {- | A blueprint of a smart contract, as defined by the CIP-0057
 
-The 'referencedTypes' phantom type parameter is used to track the types used in the contract
+The 'referencedTypes' type variable is used to track the types used in the contract
 making sure their schemas are included in the blueprint and that they are referenced
-in a type-safe way.
+in a type-safe way. See the note ["Unrolling" types] for more details.
 -}
-data ContractBlueprint (referencedTypes :: [Type]) = MkContractBlueprint
-  { contractId          :: Maybe Text
-  -- ^ An optional identifier for the contract.
-  , contractPreamble    :: Preamble
-  -- ^ An object with meta-information about the contract.
-  , contractValidators  :: Set (ValidatorBlueprint referencedTypes)
-  -- ^ A set of validator blueprints that are part of the contract.
-  , contractDefinitions :: Map DefinitionId (Schema referencedTypes)
-  -- ^ A registry of schema definitions used across the blueprint.
-  }
-  deriving stock (Show)
+data ContractBlueprint where
+  MkContractBlueprint ::
+    forall referencedTypes.
+    { contractId :: Maybe Text
+    -- ^ An optional identifier for the contract.
+    , contractPreamble :: Preamble
+    -- ^ An object with meta-information about the contract.
+    , contractValidators :: Set (ValidatorBlueprint referencedTypes)
+    -- ^ A set of validator blueprints that are part of the contract.
+    , contractDefinitions :: Definitions referencedTypes
+    -- ^ A registry of schema definitions used across the blueprint.
+    } ->
+    ContractBlueprint
 
-{- Note ["Unrolling" types]
-
-ContractBlueprint needs to be parameterized by a list of types used in
-a contract's type signature (including nested types) in order to:
-  a) produce a JSON-schema definition for every type used.
-  b) ensure that the schema definitions are referenced in a type-safe way.
-
-Given the following contract validator's type signature:
-
-  typedValidator :: Redeemer -> Datum -> ScriptContext -> Bool
-
-and the following data type definitions:
-
-  data Redeemer = MkRedeemer MyStruct
-  data MyStruct = MkMyStruct { field1 :: Integer, field2 :: Bool }
-  type Datum = ()
-
-The ContractBlueprint type should be:
-
-  ContractBlueprint '[Redeemer, MyStruct, Integer, Bool, ()]
-
-However, for contract blurprints authors specifying all the nested types manually is
-cumbersome and error-prone. To make it easier to work with, we provide the Unroll type family
-that can be used to traverse a type accumulating all types nested within it:
-
-  Unroll Redeemer ~ '[Redeemer, MyStruct, Integer, Bool]
-  UnrollAll '[Redeemer, Datum] ~ '[Redeemer, MyStruct, Integer, Bool, ()]
-
-This way blueprint authors can specify the top-level types used in a contract and the UnrollAll
-type family will take care of discovering all the nested types:
-
-  Blueprint '[Redeemer, Datum]
-
-  is equivalent to
-
-  ContractBlueprint '[Redeemer, MyStruct, Integer, Bool, ()]
-
--}
-
--- | A contract blueprint with all (nested) types discovered from a list of top-level types.
-type Blueprint topTypes = ContractBlueprint (UnrollAll topTypes)
-
-instance ToJSON (ContractBlueprint referencedTypes) where
+instance ToJSON ContractBlueprint where
   toJSON MkContractBlueprint{..} =
     Aeson.buildObject $
       requiredField "$schema" schemaUrl
@@ -99,7 +58,10 @@ instance ToJSON (ContractBlueprint referencedTypes) where
         . requiredField "preamble" contractPreamble
         . requiredField "validators" contractValidators
         . optionalField "$id" contractId
-        . optionalField "definitions" (ensure (not . Map.null) contractDefinitions)
+        . optionalField "definitions" definitions
    where
     schemaUrl :: String
     schemaUrl = "https://cips.cardano.org/cips/cip57/schemas/plutus-blueprint.json"
+
+    definitions :: Maybe (Map DefinitionId Aeson.Value)
+    definitions = ensure (not . Map.null) (definitionsToMap contractDefinitions toJSON)

--- a/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
@@ -15,18 +15,84 @@
 -- | This module provides a functionality to derive and reference schema definitions.
 module PlutusTx.Blueprint.Definition (
   module DefinitionId,
+  Unroll,
+  UnrollAll,
   HasSchemaDefinition,
   definitionRef,
   deriveSchemaDefinitions,
 ) where
 
+import Prelude
+
 import Data.Kind (Constraint, Type)
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Text (Text)
+import GHC.Generics (Generic (Rep), K1, M1, U1, type (:*:), type (:+:))
 import GHC.TypeLits qualified as GHC
 import PlutusTx.Blueprint.Class (HasSchema, schema)
-import PlutusTx.Blueprint.Definition.Id as DefinitionId
+import PlutusTx.Blueprint.Definition.Id as DefinitionId (AsDefinitionId (..), DefinitionId (..))
 import PlutusTx.Blueprint.Schema (Schema (..))
+import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData, BuiltinList, BuiltinString,
+                                   BuiltinUnit)
+
+type family UnrollAll xs :: [Type] where
+  UnrollAll '[] = '[]
+  UnrollAll (x ': xs) = Unroll x ++ UnrollAll xs
+
+{- | Unroll a type into a list of all nested types (including the type itself).
+
+  If a type doesn't have a generic representation, then this type family gets "stuck".
+  The good news is that for the purpose of deriving schema definitions, we only need to
+  consider types that are either end-user defined (and therefore have a generic representation) or
+  built-in types that we explicitly list here as terminals in order not to get "stuck".
+-}
+type family Unroll (p :: Type) :: [Type] where
+  Unroll Int = '[Int]
+  Unroll Integer = '[Integer]
+  Unroll Text = '[Text]
+  Unroll BuiltinData = '[BuiltinData]
+  Unroll BuiltinUnit = '[BuiltinUnit]
+  Unroll BuiltinString = '[BuiltinString]
+  Unroll (BuiltinList a) = Insert (BuiltinList a) (GUnroll (Rep a))
+  Unroll BuiltinByteString = '[BuiltinByteString]
+  Unroll p = Insert p (GUnroll (Break (NoGeneric p) (Rep p)))
+
+-- | Detect stuck type family: https://blog.csongor.co.uk/report-stuck-families/#custom-type-errors
+type family Break e (rep :: Type -> Type) :: Type -> Type where
+  Break _ (M1 a b c) = M1 a b c
+  Break _ (f :*: g) = f :*: g
+  Break _ (f :+: g) = f :+: g
+  Break _ (K1 a b) = K1 a b
+  Break e U1 = U1
+  Break e x = e
+
+type family NoGeneric t where
+  NoGeneric x = GHC.TypeError (GHC.Text "No instance for " GHC.:<>: GHC.ShowType (Generic x))
+
+-- | Unroll a generic representation of a type into a list of all nested types.
+type family GUnroll (t :: Type -> Type) :: [Type] where
+  GUnroll (M1 _ _ f) = GUnroll f
+  GUnroll (f :*: g) = GUnroll f ++ GUnroll g
+  GUnroll (f :+: g) = GUnroll f ++ GUnroll g
+  GUnroll (K1 _ c) = Unroll c
+  GUnroll U1 = '[]
+
+-- | Insert @x@ into @xs@ unless it's already there.
+type Insert :: forall k. k -> [k] -> [k]
+type family Insert x xs where
+  Insert x '[] = '[x]
+  Insert x (x : xs) = x ': xs
+  Insert x (y : xs) = y ': Insert x xs
+
+-- | Concatenates two type-level lists removing duplicates.
+type (++) :: forall k. [k] -> [k] -> [k]
+type family (as :: [k]) ++ (bs :: [k]) :: [k] where
+  '[] ++ bs = bs
+  as ++ '[] = as
+  (a : as) ++ bs = Insert a (as ++ bs)
+
+infixr 5 ++
 
 -- | Construct a schema that is a reference to a schema definition.
 definitionRef ::
@@ -95,7 +161,6 @@ lookupSchema :: Typ -> [Typ] -> Schema
 lookupSchema t allTypes | t `elem` allTypes = "Schema for " ++ t
 lookupSchema t _ = error $ "Type " ++ show t ++ " not found"
 @
-
 -}
 class AsDefinitionsEntries (allTypes :: [Type]) (remainingTypes :: [Type]) where
   definitionEntries :: [(DefinitionId, Schema allTypes)]

--- a/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
@@ -36,6 +36,8 @@ import PlutusTx.Blueprint.Schema (Schema (..))
 import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData, BuiltinList, BuiltinString,
                                    BuiltinUnit)
 
+-- For more context see the note ["Unrolling" types]
+
 type family UnrollAll xs :: [Type] where
   UnrollAll '[] = '[]
   UnrollAll (x ': xs) = Unroll x ++ UnrollAll xs

--- a/plutus-tx/src/PlutusTx/Blueprint/Definition/Id.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Definition/Id.hs
@@ -1,8 +1,16 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DefaultSignatures   #-}
-{-# LANGUAGE DeriveDataTypeable  #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DefaultSignatures    #-}
+{-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module PlutusTx.Blueprint.Definition.Id (
   DefinitionId,
@@ -18,7 +26,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Typeable (Proxy (..), Typeable, typeRep)
 import GHC.Generics (Generic)
-import PlutusTx.Builtins (BuiltinByteString, BuiltinData, BuiltinString)
+import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData, BuiltinList, BuiltinString)
 
 -- | A reference to a Schema definition.
 newtype DefinitionId = MkDefinitionId {definitionIdToText :: Text}
@@ -35,11 +43,19 @@ class AsDefinitionId a where
 
 instance AsDefinitionId () where
   definitionId = MkDefinitionId "Unit"
+
 instance AsDefinitionId Bool
+
 instance AsDefinitionId Integer
+
 instance AsDefinitionId BuiltinData where
   definitionId = MkDefinitionId "Data"
+
 instance AsDefinitionId BuiltinString where
   definitionId = MkDefinitionId "String"
+
 instance AsDefinitionId BuiltinByteString where
   definitionId = MkDefinitionId "ByteString"
+
+instance (AsDefinitionId a) => AsDefinitionId (BuiltinList a) where
+  definitionId = MkDefinitionId $ "List_" <> definitionIdToText (definitionId @a)

--- a/plutus-tx/src/PlutusTx/Blueprint/Parameter.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Parameter.hs
@@ -34,7 +34,7 @@ data ParameterBlueprint (referencedTypes :: [Type]) = MkParameterBlueprint
   , parameterSchema      :: Schema referencedTypes
   -- ^ A Plutus Data Schema.
   }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Ord)
 
 instance ToJSON (ParameterBlueprint referencedTypes) where
   toJSON MkParameterBlueprint{..} =

--- a/plutus-tx/src/PlutusTx/Blueprint/Purpose.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Purpose.hs
@@ -9,13 +9,14 @@ import Prelude
 import Data.Aeson (ToJSON (..))
 import Data.Aeson qualified as Json
 import Data.Text (Text)
+import Language.Haskell.TH.Syntax (Lift)
 
 {- |
   As per CIP-57, a validator arguments (redeemer, datum) and validator parameters
   all must specify a purpose that indicates in which context they are used.
 -}
 data Purpose = Spend | Mint | Withdraw | Publish
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Lift)
 
 instance ToJSON Purpose where
   toJSON = Json.String . purposeToText

--- a/plutus-tx/src/PlutusTx/Blueprint/Schema.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Schema.hs
@@ -59,7 +59,7 @@ data Schema (referencedTypes :: [Type])
   | SchemaAllOf (NonEmpty (Schema referencedTypes))
   | SchemaNot (Schema referencedTypes)
   | SchemaDefinitionRef DefinitionId
-  deriving stock (Eq, Show, Generic, Data)
+  deriving stock (Eq, Ord, Show, Generic, Data)
 
 deriving anyclass instance (Typeable referencedTypes) => Plated (Schema referencedTypes)
 
@@ -155,7 +155,7 @@ data IntegerSchema = MkIntegerSchema
   , exclusiveMaximum :: Maybe Integer
   -- ^ An instance is valid only if it is strictly less than "exclusiveMaximum".
   }
-  deriving stock (Eq, Show, Generic, Data)
+  deriving stock (Eq, Ord, Show, Generic, Data)
 
 emptyIntegerSchema :: IntegerSchema
 emptyIntegerSchema =
@@ -176,7 +176,7 @@ data BytesSchema = MkBytesSchema
   , maxLength :: Maybe Natural
   -- ^ An instance is valid if its length is less than, or equal to, this value.
   }
-  deriving stock (Eq, Show, Generic, Data)
+  deriving stock (Eq, Ord, Show, Generic, Data)
 
 emptyBytesSchema :: BytesSchema
 emptyBytesSchema = MkBytesSchema{enum = [], minLength = Nothing, maxLength = Nothing}
@@ -192,7 +192,7 @@ data ListSchema (referencedTypes :: [Type]) = MkListSchema
   -- ^ If this value is false, the instance validates successfully.
   -- If it is set to True, the instance validates successfully if all of its elements are unique.
   }
-  deriving stock (Eq, Show, Generic, Data)
+  deriving stock (Eq, Ord, Show, Generic, Data)
 
 mkListSchema :: Schema referencedTypes -> ListSchema referencedTypes
 mkListSchema schema =
@@ -213,7 +213,7 @@ data MapSchema (referencedTypes :: [Type]) = MkMapSchema
   , maxItems    :: Maybe Natural
   -- ^ A map instance is valid if its size is less than, or equal to, this value.
   }
-  deriving stock (Eq, Show, Generic, Data)
+  deriving stock (Eq, Ord, Show, Generic, Data)
 
 data ConstructorSchema (referencedTypes :: [Type]) = MkConstructorSchema
   { index        :: Natural
@@ -221,7 +221,7 @@ data ConstructorSchema (referencedTypes :: [Type]) = MkConstructorSchema
   , fieldSchemas :: [Schema referencedTypes]
   -- ^ Field schemas
   }
-  deriving stock (Eq, Show, Generic, Data)
+  deriving stock (Eq, Ord, Show, Generic, Data)
 
 data PairSchema (referencedTypes :: [Type]) = MkPairSchema
   { left  :: Schema referencedTypes
@@ -229,4 +229,4 @@ data PairSchema (referencedTypes :: [Type]) = MkPairSchema
   , right :: Schema referencedTypes
   -- ^ Schema of the second element
   }
-  deriving stock (Eq, Show, Generic, Data)
+  deriving stock (Eq, Ord, Show, Generic, Data)

--- a/plutus-tx/src/PlutusTx/Blueprint/Schema/Annotation.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Schema/Annotation.hs
@@ -27,7 +27,7 @@ data SchemaInfo = MkSchemaInfo
   , description :: Maybe String
   , comment     :: Maybe String
   }
-  deriving stock (Eq, Show, Generic, Data, Lift)
+  deriving stock (Eq, Ord, Show, Generic, Data, Lift)
 
 emptySchemaInfo :: SchemaInfo
 emptySchemaInfo = MkSchemaInfo Nothing Nothing Nothing
@@ -69,7 +69,7 @@ This annotation could be attached to a type or constructor:
 newtype MyFoo = MkMyFoo Int
 @
 -}
-newtype SchemaTitle = SchemaTitle String
+newtype SchemaTitle = SchemaTitle {schemaTitleToString :: String}
   deriving newtype (Eq, Ord, Show, Typeable, ToJSON)
   deriving stock (Data, Lift)
 
@@ -82,7 +82,7 @@ This annotation could be attached to a type or constructor:
 newtype MyFoo = MkMyFoo Int
 @
 -}
-newtype SchemaDescription = SchemaDescription String
+newtype SchemaDescription = SchemaDescription {schemaDescriptionToString :: String}
   deriving newtype (Eq, Ord, Show, Typeable, ToJSON)
   deriving stock (Data, Lift)
 
@@ -95,6 +95,6 @@ This annotation could be attached to a type or constructor:
 newtype MyFoo = MkMyFoo Int
 @
 -}
-newtype SchemaComment = SchemaComment String
+newtype SchemaComment = SchemaComment {schemaCommentToString :: String}
   deriving newtype (Eq, Ord, Show, Typeable, ToJSON)
   deriving stock (Data, Lift)

--- a/plutus-tx/src/PlutusTx/Blueprint/Validator.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Validator.hs
@@ -13,7 +13,7 @@ import Data.Aeson.Extra (buildObject, optionalField, requiredField)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as Base16
 import Data.Kind (Type)
-import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
 import PlutusCore.Crypto.Hash (blake2b_224)
@@ -35,7 +35,7 @@ data ValidatorBlueprint (referencedTypes :: [Type]) = MkValidatorBlueprint
   -- ^ A description of the redeemer format expected by this validator.
   , validatorDatum        :: Maybe (ArgumentBlueprint referencedTypes)
   -- ^ A description of the datum format expected by this validator.
-  , validatorParameters   :: Maybe (NonEmpty (ParameterBlueprint referencedTypes))
+  , validatorParameters   :: [ParameterBlueprint referencedTypes]
   -- ^ A list of parameters required by the script.
   , validatorCompiledCode :: Maybe ByteString
   -- ^ A full compiled and CBOR-encoded serialized flat script.
@@ -49,7 +49,7 @@ instance ToJSON (ValidatorBlueprint referencedTypes) where
         . requiredField "redeemer" validatorRedeemer
         . optionalField "description" validatorDescription
         . optionalField "datum" validatorDatum
-        . optionalField "parameters" validatorParameters
+        . optionalField "parameters" (NE.nonEmpty validatorParameters)
         . optionalField "compiledCode" (toHex <$> validatorCompiledCode)
         . optionalField "hash" (toHex . blake2b_224 <$> validatorCompiledCode)
    where

--- a/plutus-tx/src/PlutusTx/Blueprint/Validator.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Validator.hs
@@ -22,9 +22,9 @@ import PlutusTx.Blueprint.Parameter (ParameterBlueprint)
 
 {- | A blueprint of a validator, as defined by the CIP-0057
 
-  The 'referencedTypes' phantom type parameter is used to track the types used in the contract
-  making sure their schemas are included in the blueprint and that they are referenced
-  in a type-safe way.
+The 'referencedTypes' phantom type parameter is used to track the types used in the contract
+making sure their schemas are included in the blueprint and that they are referenced
+in a type-safe way.
 -}
 data ValidatorBlueprint (referencedTypes :: [Type]) = MkValidatorBlueprint
   { validatorTitle        :: Text
@@ -40,7 +40,7 @@ data ValidatorBlueprint (referencedTypes :: [Type]) = MkValidatorBlueprint
   , validatorCompiledCode :: Maybe ByteString
   -- ^ A full compiled and CBOR-encoded serialized flat script.
   }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Ord)
 
 instance ToJSON (ValidatorBlueprint referencedTypes) where
   toJSON MkValidatorBlueprint{..} =

--- a/plutus-tx/src/PlutusTx/Blueprint/Write.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Write.hs
@@ -12,10 +12,10 @@ import Data.ByteString.Lazy qualified as LBS
 import PlutusTx.Blueprint.Contract (ContractBlueprint)
 import Prelude
 
-writeBlueprint :: FilePath -> ContractBlueprint types -> IO ()
-writeBlueprint f = LBS.writeFile f . encodeBlueprint
+writeBlueprint :: FilePath -> ContractBlueprint -> IO ()
+writeBlueprint f blueprint = LBS.writeFile f (encodeBlueprint blueprint)
 
-encodeBlueprint :: ContractBlueprint types -> LBS.ByteString
+encodeBlueprint :: ContractBlueprint -> LBS.ByteString
 encodeBlueprint =
   encodePretty'
     Pretty.defConfig

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -10,6 +10,9 @@
 -- they're NOINLINE!
 {-# OPTIONS_GHC -O0 #-}
 
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use newtype instead of data" #-} -- See Note [Opaque builtin types]
+
 -- | This module contains the special Haskell names that are used to map to builtin types or functions
 -- in Plutus Core.
 --
@@ -22,13 +25,13 @@ import Data.ByteArray qualified as BA
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Coerce (coerce)
-import Data.Data
+import Data.Data (Data)
 import Data.Foldable qualified as Foldable
 import Data.Hashable (Hashable (..))
 import Data.Kind (Type)
 import Data.Text as Text (Text, empty)
 import Data.Text.Encoding as Text (decodeUtf8, encodeUtf8)
-import GHC.Generics
+import GHC.Generics (Generic)
 import PlutusCore.Bitwise.Convert qualified as Convert
 import PlutusCore.Builtin (BuiltinResult (..))
 import PlutusCore.Crypto.BLS12_381.G1 qualified as BLS12_381.G1
@@ -397,7 +400,7 @@ tail (BuiltinList (_:xs)) = BuiltinList xs
 tail (BuiltinList [])     = Haskell.error "empty list"
 
 {-# NOINLINE chooseList #-}
-chooseList :: BuiltinList a -> b -> b-> b
+chooseList :: BuiltinList a -> b -> b -> b
 chooseList (BuiltinList [])    b1 _ = b1
 chooseList (BuiltinList (_:_)) _ b2 = b2
 
@@ -470,7 +473,7 @@ mkConstr i (BuiltinList args) = BuiltinData (PLC.Constr i (fmap builtinDataToDat
 
 {-# NOINLINE mkMap #-}
 mkMap :: BuiltinList (BuiltinPair BuiltinData BuiltinData) -> BuiltinData
-mkMap (BuiltinList es) = BuiltinData (PLC.Map $ (fmap p2p es))
+mkMap (BuiltinList es) = BuiltinData (PLC.Map (fmap p2p es))
   where
       p2p (BuiltinPair (d, d')) = (builtinDataToData d, builtinDataToData d')
 

--- a/plutus-tx/test/Blueprint/Definition/Fixture.hs
+++ b/plutus-tx/test/Blueprint/Definition/Fixture.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
@@ -12,15 +11,18 @@ module Blueprint.Definition.Fixture where
 
 import Prelude
 
+import GHC.Generics (Generic)
 import PlutusTx.Blueprint.Definition (AsDefinitionId, definitionRef)
 import PlutusTx.Blueprint.TH (makeIsDataSchemaIndexed)
 
 newtype T1 = MkT1 Integer
+  deriving stock (Generic)
 
 deriving anyclass instance (AsDefinitionId T1)
 $(makeIsDataSchemaIndexed ''T1 [('MkT1, 0)])
 
 data T2 = MkT2 T1 T1
+  deriving stock (Generic)
 
 deriving anyclass instance (AsDefinitionId T2)
 $(makeIsDataSchemaIndexed ''T2 [('MkT2, 0)])

--- a/plutus-tx/test/Blueprint/Definition/Fixture.hs
+++ b/plutus-tx/test/Blueprint/Definition/Fixture.hs
@@ -16,10 +16,11 @@ import PlutusTx.Blueprint.Definition (AsDefinitionId, definitionRef)
 import PlutusTx.Blueprint.TH (makeIsDataSchemaIndexed)
 
 newtype T1 = MkT1 Integer
-  deriving anyclass (AsDefinitionId)
+
+deriving anyclass instance (AsDefinitionId T1)
+$(makeIsDataSchemaIndexed ''T1 [('MkT1, 0)])
 
 data T2 = MkT2 T1 T1
-  deriving anyclass (AsDefinitionId)
 
-$(makeIsDataSchemaIndexed ''T1 [('MkT1, 0)])
+deriving anyclass instance (AsDefinitionId T2)
 $(makeIsDataSchemaIndexed ''T2 [('MkT2, 0)])

--- a/plutus-tx/test/Blueprint/Definition/Spec.hs
+++ b/plutus-tx/test/Blueprint/Definition/Spec.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
@@ -13,10 +16,11 @@ import Prelude
 
 import Blueprint.Definition.Fixture qualified as Fixture
 import Control.Lens.Plated (universe)
+import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (isSubsetOf)
 import Data.Set qualified as Set
-import PlutusTx.Blueprint.Definition (deriveSchemaDefinitions)
+import PlutusTx.Blueprint.Definition (DefinitionId, definitionsToMap, deriveDefinitions)
 import PlutusTx.Blueprint.Schema (Schema (..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?), (@?=))
@@ -27,7 +31,7 @@ tests =
     "PlutusTx.Blueprint.Definition"
     [ testCase
         "Derived definitions are empty when no types are provided."
-        (deriveSchemaDefinitions @'[] @?= Map.empty)
+        (definitionsToMap (deriveDefinitions @'[]) (const ()) @?= mempty)
     , testCase
         "There are not less schema definitions than listed domain types."
         atLeastAsManyDefinitionsAsTypes
@@ -41,8 +45,7 @@ atLeastAsManyDefinitionsAsTypes =
   (length (Map.keys definitions) >= 3)
     @? "Not enough schema definitions: < 3"
  where
-  definitions =
-    deriveSchemaDefinitions @[Fixture.T1, Fixture.T2, Integer]
+  definitions = definitionsToMap (deriveDefinitions @[Fixture.T1, Fixture.T2, Integer]) (const ())
 
 allReferencedDefinitionsAreDefined :: Assertion
 allReferencedDefinitionsAreDefined =
@@ -53,11 +56,15 @@ allReferencedDefinitionsAreDefined =
     Set.fromList
       [ ref
       | schemas <- universe (Map.elems definitions)
-      , SchemaDefinitionRef ref <- schemas
+      , SomeSchema (SchemaDefinitionRef ref) <- schemas
       ]
-  definedIds =
-    Set.fromList (Map.keys definitions)
+  definedIds = Set.fromList (Map.keys definitions)
+
+  definitions :: Map DefinitionId SomeSchema
   definitions =
     -- Here T2 depends on T1 (and not vice-versa) but we intentionally provide them out of order
     -- to prove that any order is valid.
-    deriveSchemaDefinitions @[Fixture.T1, Fixture.T2, Integer]
+    definitionsToMap (deriveDefinitions @[Fixture.T1, Fixture.T2, Integer]) SomeSchema
+
+data SomeSchema where
+  SomeSchema :: Schema xs -> SomeSchema

--- a/plutus-tx/test/Blueprint/Definition/Spec.hs
+++ b/plutus-tx/test/Blueprint/Definition/Spec.hs
@@ -16,7 +16,7 @@ import Control.Lens.Plated (universe)
 import Data.Map qualified as Map
 import Data.Set (isSubsetOf)
 import Data.Set qualified as Set
-import PlutusTx.Blueprint.Definition
+import PlutusTx.Blueprint.Definition (deriveSchemaDefinitions)
 import PlutusTx.Blueprint.Schema (Schema (..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?), (@?=))

--- a/plutus-tx/test/Blueprint/Spec.hs
+++ b/plutus-tx/test/Blueprint/Spec.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module Blueprint.Spec where
+
+import Prelude
+
+import Data.Set qualified as Set
+import GHC.Generics (Generic)
+import PlutusTx.Blueprint.Class (HasSchema (..))
+import PlutusTx.Blueprint.Contract (Blueprint, ContractBlueprint (..))
+import PlutusTx.Blueprint.Definition (AsDefinitionId, Unroll, UnrollAll, deriveSchemaDefinitions)
+import PlutusTx.Blueprint.PlutusVersion (PlutusVersion (PlutusV3))
+import PlutusTx.Blueprint.Preamble (Preamble (MkPreamble))
+import PlutusTx.Blueprint.Schema (Schema (..))
+import PlutusTx.Blueprint.Schema.Annotation (emptySchemaInfo)
+
+contract :: Blueprint [Foo, Bar, Baz]
+contract =
+  MkContractBlueprint
+    { contractId = Nothing
+    , contractPreamble = MkPreamble "" Nothing "" PlutusV3 Nothing
+    , contractValidators = Set.empty
+    , contractDefinitions = deriveSchemaDefinitions
+    }
+
+testUnrollNop :: Unroll Nop :~: '[Nop]
+testUnrollNop = Refl
+
+testUnrollBaz :: Unroll Baz :~: [Integer, Baz]
+testUnrollBaz = Refl
+
+testUnrollZap :: Unroll Zap :~: [Nop, Integer, Bool, Zap]
+testUnrollZap = Refl
+
+testUnrollBar :: Unroll Bar :~: [Nop, Integer, Bool, Zap, Baz, Bar]
+testUnrollBar = Refl
+
+testUnrollFoo :: Unroll Foo :~: [Nop, Integer, Bool, Zap, Baz, Bar, Foo]
+testUnrollFoo = Refl
+
+testUnrollAll :: UnrollAll [Nop, Baz] :~: [Integer, Baz, Nop]
+testUnrollAll = Refl
+
+----------------------------------------------------------------------------------------------------
+-- Helper types/functions --------------------------------------------------------------------------
+
+{- | Evidence that @a@ is the same type as @b@.
+
+  The @'Functor'@, @'Applicative'@, and @'Monad'@ instances of @Maybe@
+  are very useful for working with values of type @Maybe (a :~: b)@.
+-}
+data a :~: b where
+  Refl :: (a ~ b) => a :~: b
+
+----------------------------------------------------------------------------------------------------
+-- Test fixture ------------------------------------------------------------------------------------
+
+newtype Foo = MkFoo Bar
+deriving stock instance (Generic Foo)
+deriving anyclass instance (AsDefinitionId Foo)
+instance HasSchema Foo ts where
+  schema = SchemaBuiltInUnit emptySchemaInfo
+
+data Bar = MkBar Baz Zap
+deriving stock instance (Generic Bar)
+deriving anyclass instance (AsDefinitionId Bar)
+instance HasSchema Bar ts where
+  schema = SchemaBuiltInUnit emptySchemaInfo
+
+data Baz = MkBaz Integer Integer
+deriving stock instance (Generic Baz)
+deriving anyclass instance (AsDefinitionId Baz)
+instance HasSchema Baz ts where
+  schema = SchemaBuiltInUnit emptySchemaInfo
+
+data Zap = MkZap Bool Integer Nop
+deriving stock instance (Generic Zap)
+deriving anyclass instance (AsDefinitionId Zap)
+instance HasSchema Zap ts where
+  schema = SchemaBuiltInUnit emptySchemaInfo
+
+data Nop = MkNop
+deriving stock instance (Generic Nop)
+deriving anyclass instance (AsDefinitionId Nop)
+instance HasSchema Nop ts where
+  schema = SchemaBuiltInUnit emptySchemaInfo

--- a/plutus-tx/test/Blueprint/Spec.hs
+++ b/plutus-tx/test/Blueprint/Spec.hs
@@ -2,67 +2,42 @@
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 module Blueprint.Spec where
 
 import Prelude
 
-import Data.Set qualified as Set
+import Data.Typeable ((:~:) (Refl))
 import GHC.Generics (Generic)
 import PlutusTx.Blueprint.Class (HasSchema (..))
-import PlutusTx.Blueprint.Contract (Blueprint, ContractBlueprint (..))
-import PlutusTx.Blueprint.Definition (AsDefinitionId, Unroll, UnrollAll, deriveSchemaDefinitions)
-import PlutusTx.Blueprint.PlutusVersion (PlutusVersion (PlutusV3))
-import PlutusTx.Blueprint.Preamble (Preamble (MkPreamble))
+import PlutusTx.Blueprint.Definition (AsDefinitionId, Definitions, Unroll, UnrollAll,
+                                      Unrollable (..))
 import PlutusTx.Blueprint.Schema (Schema (..))
 import PlutusTx.Blueprint.Schema.Annotation (emptySchemaInfo)
-
-contract :: Blueprint [Foo, Bar, Baz]
-contract =
-  MkContractBlueprint
-    { contractId = Nothing
-    , contractPreamble = MkPreamble "" Nothing "" PlutusV3 Nothing
-    , contractValidators = Set.empty
-    , contractDefinitions = deriveSchemaDefinitions
-    }
 
 testUnrollNop :: Unroll Nop :~: '[Nop]
 testUnrollNop = Refl
 
-testUnrollBaz :: Unroll Baz :~: [Integer, Baz]
+testUnrollBaz :: Unroll Baz :~: [Baz, Integer]
 testUnrollBaz = Refl
 
-testUnrollZap :: Unroll Zap :~: [Nop, Integer, Bool, Zap]
+testUnrollZap :: Unroll Zap :~: [Zap, Nop, Integer, Bool]
 testUnrollZap = Refl
 
-testUnrollBar :: Unroll Bar :~: [Nop, Integer, Bool, Zap, Baz, Bar]
+testUnrollBar :: Unroll Bar :~: [Bar, Zap, Nop, Integer, Bool, Baz]
 testUnrollBar = Refl
 
-testUnrollFoo :: Unroll Foo :~: [Nop, Integer, Bool, Zap, Baz, Bar, Foo]
+testUnrollFoo :: Unroll Foo :~: [Foo, Bar, Zap, Nop, Integer, Bool, Baz]
 testUnrollFoo = Refl
 
-testUnrollAll :: UnrollAll [Nop, Baz] :~: [Integer, Baz, Nop]
+testUnrollAll :: UnrollAll [Nop, Baz] :~: [Nop, Baz, Integer]
 testUnrollAll = Refl
 
-----------------------------------------------------------------------------------------------------
--- Helper types/functions --------------------------------------------------------------------------
-
-{- | Evidence that @a@ is the same type as @b@.
-
-  The @'Functor'@, @'Applicative'@, and @'Monad'@ instances of @Maybe@
-  are very useful for working with values of type @Maybe (a :~: b)@.
--}
-data a :~: b where
-  Refl :: (a ~ b) => a :~: b
+definitions :: Definitions [Foo, Bar, Zap, Nop, Integer, Bool, Baz]
+definitions = unroll @(UnrollAll '[Foo])
 
 ----------------------------------------------------------------------------------------------------
 -- Test fixture ------------------------------------------------------------------------------------


### PR DESCRIPTION
The idea is that user specifies at most 3 types: Param, Datum, Redeemer and all the types nested withing them are extracted automatically (un-rolled).