### PR TITLE
Add pointer to issue on the ledger's cost model interface

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -137,6 +137,9 @@ and create the internal (nameful) representation of cost model parameters, by as
 to its value: see `PlutusLedgerApi.Common.ParamName.tagWithParamNames` and the `ParamName` datatypes in
 plutus-ledger-api.
 
+See https://github.com/IntersectMBO/cardano-ledger/issues/2902 for a discussion
+of these issues and the rationale for adopting the system described above.
+
 -}
 
 


### PR DESCRIPTION
The interface between the ledger and the Plutus Core cost model is quite complicated (see [this Note)](https://github.com/IntersectMBO/plutus/blob/ce4bcc4c709681c1ec085ad1f132b5fb9f5a4c5a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs#L86).  This adds a link to the issue where the current form of the interface was decided.