### PR TITLE
Kwxm/correct conformance comments

### DIFF
--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc
@@ -1,0 +1,8 @@
+-- This value was obtained by hashing 0x0102030405 to G1 but has had the
+-- compression bit cleared, so uncompression should fail.
+(program 0.0.0
+ [
+  (builtin bls12_381_G1_uncompress)
+  (con bytestring #21e9a0c68985059bd25a5ef05b351ca22f7d7c19e37928583ae12a1f4939440ff754cfd85b23df4a54f66c7089db6deb)
+ ]
+)

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.budget.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.budget.expected
@@ -1,0 +1,1 @@
+evaluation failure

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.expected
@@ -1,0 +1,1 @@
+evaluation failure

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit3-clear/on-curve-bit3-clear.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit3-clear/on-curve-bit3-clear.uplc
@@ -1,5 +1,6 @@
--- This value was obtained by hashing 0x0102030405 to G1 but has had the
--- compression bit cleared, so uncompression should fail.
+-- This value was obtained by hashing 0x0102030405 to G1.  The sign bit was set
+-- but has been cleared: this negates the point, so uncompression should still
+-- succeed.
 (program 0.0.0
  [
   (builtin bls12_381_G1_uncompress)

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit3-set/on-curve-bit3-set.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G1_uncompress/on-curve-bit3-set/on-curve-bit3-set.uplc
@@ -1,5 +1,5 @@
--- This value was obtained by hashing 0x0102030405 to G1 and has the compression
--- bit set, so uncompression should succeed.
+-- This value was obtained by hashing 0x0102030405 to G1.  No changes have been
+-- made, so uncompression should succeed.
 (program 0.0.0
  [
   (builtin bls12_381_G1_uncompress)

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc
@@ -1,0 +1,8 @@
+-- This value was obtained by hashing 0x0102030405 to G2 but has had the
+-- compression bit cleared, so uncompression should fail.
+(program 0.0.0
+ [
+  (builtin bls12_381_G2_uncompress)
+  (con bytestring #28138ebea766d4d1aa64dd3b5826244c32ea3fe9351f9c8d584203716dae151d14bb5d06e245c24877955c79287682ba082d077bbb2afdb1ad1d48d18e2f0c56b001bce207801adfa9fd451fc59d56f0433b02f921ba5a272c58c06536291d07)
+ ]
+)

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.budget.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.budget.expected
@@ -1,0 +1,1 @@
+evaluation failure

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit1-clear/on-curve-bit1-clear.uplc.expected
@@ -1,0 +1,1 @@
+evaluation failure

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit3-clear/on-curve-bit3-clear.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit3-clear/on-curve-bit3-clear.uplc
@@ -1,5 +1,6 @@
--- This value was obtained by hashing 0x0102030405 to G2 but has had the
--- compression bit cleared, so uncompression should fail.
+-- This value was obtained by hashing 0x0102030405 to G2.  The sign bit was set
+-- but has been cleared: this negates the point, so uncompression should still
+-- succeed.
 (program 0.0.0
  [
   (builtin bls12_381_G2_uncompress)

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit3-set/on-curve-bit3-set.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/bls12_381_G2_uncompress/on-curve-bit3-set/on-curve-bit3-set.uplc
@@ -1,5 +1,5 @@
--- This value was obtained by hashing 0x0102030405 to G2 but has had the
--- compression bit cleared, so uncompression should fail.
+-- This value was obtained by hashing 0x0102030405 to G2.  No changes have been
+-- made, so uncompression should succeed.
 (program 0.0.0
  [
   (builtin bls12_381_G2_uncompress)


### PR DESCRIPTION
@perturbing and @[HarmonicLabs](https://github.com/HarmonicLabs) pointed out that there was a problem with the `on-curve-bit3-clear` conformance test for BLS12_381 G1 and G2 uncompression.  The comments didn't describe what the test actually did so I've corrected the comments and added a couple of tests that do do what the comment claimed (I hope).