### PR TITLE
CIP-0057: Alternative approach to deriving and referencing schema definitons.

### DIFF
--- a/plutus-tx-plugin/test/Blueprint/Tests.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests.hs
@@ -15,6 +15,8 @@ import PlutusTx.Blueprint.Parameter (ParameterBlueprint (..))
 import PlutusTx.Blueprint.PlutusVersion (PlutusVersion (PlutusV3))
 import PlutusTx.Blueprint.Preamble (Preamble (..))
 import PlutusTx.Blueprint.Purpose qualified as Purpose
+import PlutusTx.Blueprint.Validator (ValidatorBlueprint (..))
+import PlutusTx.Blueprint.Write (writeBlueprint)
 import Test.Tasty.Extras (TestNested, testNested)
 
 goldenTests :: TestNested

--- a/plutus-tx-plugin/test/Blueprint/Tests.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests.hs
@@ -1,91 +1,66 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module Blueprint.Tests where
 
-import Blueprint.Tests.Lib (goldenJson)
-import Blueprint.Tests.Lib qualified as Fixture
-import Data.Set qualified as Set
-import Data.Void (Void)
-import PlutusTx.Blueprint
-import PlutusTx.Blueprint.Purpose qualified as Purpose
-import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData)
 import Prelude
+
+import Blueprint.Tests.Lib (Datum, Params, Redeemer, goldenJson, serialisedScript)
+import Data.Set qualified as Set
+import PlutusTx.Blueprint.Argument (ArgumentBlueprint (..))
+import PlutusTx.Blueprint.Contract (ContractBlueprint (..))
+import PlutusTx.Blueprint.Definition (definitionRef, deriveDefinitions)
+import PlutusTx.Blueprint.Parameter (ParameterBlueprint (..))
+import PlutusTx.Blueprint.PlutusVersion (PlutusVersion (PlutusV3))
+import PlutusTx.Blueprint.Preamble (Preamble (..))
+import PlutusTx.Blueprint.Purpose qualified as Purpose
 import Test.Tasty.Extras (TestNested, testNested)
 
 goldenTests :: TestNested
 goldenTests = testNested "Blueprint" [goldenJson "Acme" (`writeBlueprint` contractBlueprint)]
 
-{- | The contract blueprint is indexed by a type-level list of schema definitions.
-
-This list is inferred automatically from the contract definitions, and is used to make references
-to the schema definitions safe.
--}
-contractBlueprint :: Blueprint
+contractBlueprint :: ContractBlueprint
 contractBlueprint =
-  MkBlueprint
-    MkContractBlueprint
-      { contractId = Nothing
-      , contractPreamble =
-          MkPreamble
-            { preambleTitle = "Acme Contract"
-            , preambleDescription = Just "A contract that does something awesome"
-            , preambleVersion = "1.1.0"
-            , preamblePlutusVersion = PlutusV3
-            , preambleLicense = Just "MIT"
-            }
-      , contractValidators =
-          Set.singleton
-            MkValidatorBlueprint
-              { validatorTitle = "Acme Validator"
-              , validatorDescription = Just "A validator that does something awesome"
-              , validatorParameters =
-                  Just $
-                    pure
-                      MkParameterBlueprint
-                        { parameterTitle = Just "Acme Parameter"
-                        , parameterDescription = Just "A parameter that does something awesome"
-                        , parameterPurpose = Set.singleton Purpose.Spend
-                        , parameterSchema = definitionRef @Fixture.Params
-                        }
-              , validatorRedeemer =
-                  MkArgumentBlueprint
-                    { argumentTitle = Just "Acme Redeemer"
-                    , argumentDescription = Just "A redeemer that does something awesome"
-                    , argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint]
-                    , argumentSchema = definitionRef @Fixture.Redeemer
+  MkContractBlueprint
+    { contractId = Nothing
+    , contractPreamble =
+        MkPreamble
+          { preambleTitle = "Acme Contract"
+          , preambleDescription = Just "A contract that does something awesome"
+          , preambleVersion = "1.1.0"
+          , preamblePlutusVersion = PlutusV3
+          , preambleLicense = Just "MIT"
+          }
+    , contractValidators =
+        Set.singleton
+          MkValidatorBlueprint
+            { validatorTitle = "Acme Validator"
+            , validatorDescription = Just "A validator that does something awesome"
+            , validatorParameters =
+                [ MkParameterBlueprint
+                    { parameterTitle = Just "Acme Parameter"
+                    , parameterDescription = Just "A parameter that does something awesome"
+                    , parameterPurpose = Set.singleton Purpose.Spend
+                    , parameterSchema = definitionRef @Params
                     }
-              , validatorDatum =
-                  Just
-                    MkArgumentBlueprint
-                      { argumentTitle = Just "Acme Datum"
-                      , argumentDescription = Just "A datum that contains something awesome"
-                      , argumentPurpose = Set.singleton Purpose.Spend
-                      , argumentSchema = definitionRef @Fixture.Datum
-                      }
-              , validatorCompiledCode = Just Fixture.serialisedScript
-              }
-      , contractDefinitions =
-          NoDefinitions
-            `addDefinition` definition @()
-            `addDefinition` definition @Bool
-            `addDefinition` definition @Integer
-            `addDefinition` definition @BuiltinData
-            `addDefinition` definition @BuiltinByteString
-            `addDefinition` definition @Fixture.Params
-            `addDefinition` definition @Fixture.Redeemer
-            `addDefinition` definition @(Fixture.Bytes Void)
-            `addDefinition` definition @Fixture.DatumPayload
-            `addDefinition` definition @Fixture.Datum
-      }
+                ]
+            , validatorRedeemer =
+                MkArgumentBlueprint
+                  { argumentTitle = Just "Acme Redeemer"
+                  , argumentDescription = Just "A redeemer that does something awesome"
+                  , argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint]
+                  , argumentSchema = definitionRef @Redeemer
+                  }
+            , validatorDatum =
+                Just
+                  MkArgumentBlueprint
+                    { argumentTitle = Just "Acme Datum"
+                    , argumentDescription = Just "A datum that contains something awesome"
+                    , argumentPurpose = Set.singleton Purpose.Spend
+                    , argumentSchema = definitionRef @Datum
+                    }
+            , validatorCompiledCode = Just serialisedScript
+            }
+    , contractDefinitions = deriveDefinitions @[Params, Redeemer, Datum]
+    }

--- a/plutus-tx-plugin/test/Blueprint/Tests.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests.hs
@@ -5,69 +5,87 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module Blueprint.Tests where
 
 import Blueprint.Tests.Lib (goldenJson)
 import Blueprint.Tests.Lib qualified as Fixture
 import Data.Set qualified as Set
+import Data.Void (Void)
 import PlutusTx.Blueprint
 import PlutusTx.Blueprint.Purpose qualified as Purpose
+import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData)
 import Prelude
 import Test.Tasty.Extras (TestNested, testNested)
 
 goldenTests :: TestNested
 goldenTests = testNested "Blueprint" [goldenJson "Acme" (`writeBlueprint` contractBlueprint)]
 
--- | All the data types exposed (directly or indirectly) by the type signature of the validator
--- This type level list is used to:
--- 1. derive the schema definitions for the contract.
--- 2. make "safe" references to the [derived] schema definitions.
-contractBlueprint :: Blueprint [Fixture.Params, Fixture.Redeemer, Fixture.Datum]
+{- | The contract blueprint is indexed by a type-level list of schema definitions.
+
+This list is inferred automatically from the contract definitions, and is used to make references
+to the schema definitions safe.
+-}
+contractBlueprint :: Blueprint
 contractBlueprint =
-  MkContractBlueprint
-    { contractId = Nothing,
-      contractPreamble =
-        MkPreamble
-          { preambleTitle = "Acme Contract",
-            preambleDescription = Just "A contract that does something awesome",
-            preambleVersion = "1.1.0",
-            preamblePlutusVersion = PlutusV3,
-            preambleLicense = Just "MIT"
-          },
-      contractValidators =
-        Set.singleton
-          MkValidatorBlueprint
-            { validatorTitle = "Acme Validator",
-              validatorDescription = Just "A validator that does something awesome",
-              validatorParameters =
-                Just $
-                  pure
-                    MkParameterBlueprint
-                      { parameterTitle = Just "Acme Parameter",
-                        parameterDescription = Just "A parameter that does something awesome",
-                        parameterPurpose = Set.singleton Purpose.Spend,
-                        parameterSchema = definitionRef @Fixture.Params
-                      },
-              validatorRedeemer =
-                MkArgumentBlueprint
-                  { argumentTitle = Just "Acme Redeemer",
-                    argumentDescription = Just "A redeemer that does something awesome",
-                    argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint],
-                    argumentSchema = definitionRef @Fixture.Redeemer
-                  },
-              validatorDatum =
-                Just
+  MkBlueprint
+    MkContractBlueprint
+      { contractId = Nothing
+      , contractPreamble =
+          MkPreamble
+            { preambleTitle = "Acme Contract"
+            , preambleDescription = Just "A contract that does something awesome"
+            , preambleVersion = "1.1.0"
+            , preamblePlutusVersion = PlutusV3
+            , preambleLicense = Just "MIT"
+            }
+      , contractValidators =
+          Set.singleton
+            MkValidatorBlueprint
+              { validatorTitle = "Acme Validator"
+              , validatorDescription = Just "A validator that does something awesome"
+              , validatorParameters =
+                  Just $
+                    pure
+                      MkParameterBlueprint
+                        { parameterTitle = Just "Acme Parameter"
+                        , parameterDescription = Just "A parameter that does something awesome"
+                        , parameterPurpose = Set.singleton Purpose.Spend
+                        , parameterSchema = definitionRef @Fixture.Params
+                        }
+              , validatorRedeemer =
                   MkArgumentBlueprint
-                    { argumentTitle = Just "Acme Datum",
-                      argumentDescription = Just "A datum that contains something awesome",
-                      argumentPurpose = Set.singleton Purpose.Spend,
-                      argumentSchema = definitionRef @Fixture.Datum
-                    },
-              validatorCompiledCode = Just Fixture.serialisedScript
-            },
-      contractDefinitions = deriveSchemaDefinitions
-    }
+                    { argumentTitle = Just "Acme Redeemer"
+                    , argumentDescription = Just "A redeemer that does something awesome"
+                    , argumentPurpose = Set.fromList [Purpose.Spend, Purpose.Mint]
+                    , argumentSchema = definitionRef @Fixture.Redeemer
+                    }
+              , validatorDatum =
+                  Just
+                    MkArgumentBlueprint
+                      { argumentTitle = Just "Acme Datum"
+                      , argumentDescription = Just "A datum that contains something awesome"
+                      , argumentPurpose = Set.singleton Purpose.Spend
+                      , argumentSchema = definitionRef @Fixture.Datum
+                      }
+              , validatorCompiledCode = Just Fixture.serialisedScript
+              }
+      , contractDefinitions =
+          NoDefinitions
+            `addDefinition` definition @()
+            `addDefinition` definition @Bool
+            `addDefinition` definition @Integer
+            `addDefinition` definition @BuiltinData
+            `addDefinition` definition @BuiltinByteString
+            `addDefinition` definition @Fixture.Params
+            `addDefinition` definition @Fixture.Redeemer
+            `addDefinition` definition @(Fixture.Bytes Void)
+            `addDefinition` definition @Fixture.DatumPayload
+            `addDefinition` definition @Fixture.Datum
+      }

--- a/plutus-tx/src/PlutusTx/Blueprint/Contract.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Contract.hs
@@ -13,7 +13,6 @@ import Data.Aeson (ToJSON (..), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Extra (optionalField, requiredField)
 import Data.Aeson.Extra qualified as Aeson
-import Data.Kind (Type)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
@@ -25,63 +24,25 @@ import PlutusTx.Blueprint.Validator (ValidatorBlueprint)
 
 {- | A blueprint of a smart contract, as defined by the CIP-0057
 
-The 'referencedTypes' phantom type parameter is used to track the types used in the contract
+The 'referencedTypes' type variable is used to track the types used in the contract
 making sure their schemas are included in the blueprint and that they are referenced
 in a type-safe way. See the note ["Unrolling" types] for more details.
 -}
-data ContractBlueprint (referencedTypes :: [Type]) = MkContractBlueprint
-  { contractId          :: Maybe Text
-  -- ^ An optional identifier for the contract.
-  , contractPreamble    :: Preamble
-  -- ^ An object with meta-information about the contract.
-  , contractValidators  :: Set (ValidatorBlueprint referencedTypes)
-  -- ^ A set of validator blueprints that are part of the contract.
-  , contractDefinitions :: Definitions referencedTypes
-  -- ^ A registry of schema definitions used across the blueprint.
-  }
-  deriving stock (Show)
+data ContractBlueprint where
+  MkContractBlueprint ::
+    forall referencedTypes.
+    { contractId :: Maybe Text
+    -- ^ An optional identifier for the contract.
+    , contractPreamble :: Preamble
+    -- ^ An object with meta-information about the contract.
+    , contractValidators :: Set (ValidatorBlueprint referencedTypes)
+    -- ^ A set of validator blueprints that are part of the contract.
+    , contractDefinitions :: Definitions referencedTypes
+    -- ^ A registry of schema definitions used across the blueprint.
+    } ->
+    ContractBlueprint
 
-{- Note ["Unrolling" types]
-
-ContractBlueprint needs to be parameterized by a list of types used in
-a contract's type signature (including nested types) in order to:
-  a) produce a JSON-schema definition for every type used.
-  b) ensure that the schema definitions are referenced in a type-safe way.
-
-Given the following contract validator's type signature:
-
-  typedValidator :: Redeemer -> Datum -> ScriptContext -> Bool
-
-and the following data type definitions:
-
-  data Redeemer = MkRedeemer MyStruct
-  data MyStruct = MkMyStruct { field1 :: Integer, field2 :: Bool }
-  type Datum = ()
-
-The ContractBlueprint type should be:
-
-  ContractBlueprint '[Redeemer, MyStruct, Integer, Bool, ()]
-
-However, for contract blurprints authors specifying all the nested types manually is
-cumbersome and error-prone. To make it easier to work with, we provide the Unroll type family
-that can be used to traverse a type accumulating all types nested within it:
-
-  Unroll Redeemer ~ '[Redeemer, MyStruct, Integer, Bool]
-  UnrollAll '[Redeemer, Datum] ~ '[Redeemer, MyStruct, Integer, Bool, ()]
-
-This way blueprint authors can specify the top-level types used in a contract and the UnrollAll
-type family will take care of discovering all the nested types:
-
-  Blueprint '[Redeemer, Datum]
-
-  is equivalent to
-
-  ContractBlueprint '[Redeemer, MyStruct, Integer, Bool, ()]
-
--}
-
--- | A contract blueprint with all (nested) types discovered from a list of top-level types.
-instance ToJSON (ContractBlueprint referencedTypes) where
+instance ToJSON ContractBlueprint where
   toJSON MkContractBlueprint{..} =
     Aeson.buildObject $
       requiredField "$schema" schemaUrl
@@ -104,7 +65,3 @@ instance ToJSON (ContractBlueprint referencedTypes) where
 
     definitions :: Maybe (Map DefinitionId Aeson.Value)
     definitions = ensure (not . Map.null) (definitionsToMap contractDefinitions toJSON)
-
--- | 'Blueprint' wrapper to hide the 'referencedTypes' parameter as an existential type.
-data Blueprint where
-  MkBlueprint :: forall ts. ContractBlueprint ts -> Blueprint

--- a/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE AllowAmbiguousTypes      #-}
 {-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DerivingStrategies       #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE GADTs                    #-}
 {-# LANGUAGE MultiParamTypeClasses    #-}
 {-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
@@ -15,11 +18,17 @@
 -- | This module provides a functionality to derive and reference schema definitions.
 module PlutusTx.Blueprint.Definition (
   module DefinitionId,
+  Definitions (..),
+  Definition (..),
+  definition,
+  definitionRef,
+  addDefinition,
+  definitionsToMap,
+  HasSchemaDefinition,
+
+  -- ** Type-level utilities
   Unroll,
   UnrollAll,
-  HasSchemaDefinition,
-  definitionRef,
-  deriveSchemaDefinitions,
 ) where
 
 import Prelude
@@ -36,7 +45,43 @@ import PlutusTx.Blueprint.Schema (Schema (..))
 import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData, BuiltinList, BuiltinString,
                                    BuiltinUnit)
 
--- For more context see the note ["Unrolling" types]
+-- | A schema definition of a type @t@ with a list of referenced types @ts@.
+data Definition t ts = MkDefinition DefinitionId (Schema ts)
+  deriving stock (Show)
+
+-- | A registry of schema definitions.
+data Definitions (ts :: [Type]) where
+  NoDefinitions :: Definitions ts
+  DCons :: SomeDefinition -> Definitions ts -> Definitions (t ': ts)
+
+deriving stock instance Show (Definitions ts)
+
+-- | An existential wrapper for schema definitions that allows to store them in a registry.
+data SomeDefinition where
+  SomeDefinition :: Definition t ts -> SomeDefinition
+
+deriving stock instance Show SomeDefinition
+
+-- | Add a schema definition to a registry.
+addDefinition :: Definitions ts -> Definition t ts -> Definitions (t ': ts)
+addDefinition NoDefinitions d = DCons (SomeDefinition d) NoDefinitions
+addDefinition (DCons t s) d   = DCons (SomeDefinition d) (DCons t s)
+
+definitionsToMap :: Definitions ts -> (forall xs. Schema xs -> v) -> Map DefinitionId v
+definitionsToMap NoDefinitions _k = Map.empty
+definitionsToMap (DCons (SomeDefinition (MkDefinition defId v)) s) k =
+  Map.insert defId (k v) (definitionsToMap s k)
+
+-- | Construct a schema definition.
+definition :: forall t ts. (AsDefinitionId t, HasSchema t ts) => Definition t ts
+definition = MkDefinition (definitionId @t) (schema @t)
+
+-- | Construct a schema that is a reference to a schema definition.
+definitionRef :: forall t ts. (AsDefinitionId t, HasSchemaDefinition t ts) => Schema ts
+definitionRef = SchemaDefinitionRef (definitionId @t)
+
+----------------------------------------------------------------------------------------------------
+-- Functionality to "unroll" types. -- For more context see the note ["Unrolling" types] -----------
 
 type family UnrollAll xs :: [Type] where
   UnrollAll '[] = '[]
@@ -96,13 +141,6 @@ type family (as :: [k]) ++ (bs :: [k]) :: [k] where
 
 infixr 5 ++
 
--- | Construct a schema that is a reference to a schema definition.
-definitionRef ::
-  forall typ types.
-  (AsDefinitionId typ, HasSchemaDefinition typ types) =>
-  Schema types
-definitionRef = SchemaDefinitionRef (definitionId @typ)
-
 {- |
   A constraint that checks if a schema definition is present in a list of schema definitions.
   Gives a user-friendly error message if the schema definition is not found.
@@ -116,67 +154,3 @@ type family HasSchemaDefinition n xs where
       ( GHC.ShowType n
           GHC.:<>: GHC.Text " type was not found in the list of types having schema definitions."
       )
-
--- | Derive a map of schema definitions from a list of types.
-deriveSchemaDefinitions ::
-  forall (types :: [Type]).
-  (AsDefinitionsEntries types types) =>
-  Map DefinitionId (Schema types)
-deriveSchemaDefinitions = Map.fromList (definitionEntries @types @types)
-
-{- | This class is only used internally to derive schema definition entries from a list of types.
-
-It uses 2 instances to iterate a type-level list:
-  * one instance terminates recursion when the list of [remaining] types to iterate is empty.
-  * another instance does a recursive step:
-      taking a head and tail,
-      adds a schema definition entry if the head is in the `allTypes`
-      and recurses on tail as `remainingTypes`.
-
-This way in the beginning of iteration `allTypes` == `remainingTypes` and then
-`allTypes` stays the same list, while `remainingTypes` is shrinking until empty.
-
-Here is an analogy at the value level, where `remainingTypes` serves a similar purpose:
-
-@
-type Typ = String
-type DefinitionId = String
-type Schema = String
-
-asDefinitionEntries :: [Typ] -> [(DefinitionId, Schema)]
-asDefinitionEntries allTypes = go allTypes allTypes
-  where
-    go :: [Typ] -> [Typ] -> [(DefinitionId, Schema)]
-    go allTypes remainingTypes =
-      case remainingTypes of
-        [] -> []
-        (h : t) ->
-          let defId = lookupDefinitionId h allTypes
-              schema = lookupSchema h allTypes
-          in (defId, schema) : go allTypes t
-
-lookupDefinitionId :: Typ -> [Typ] -> DefinitionId
-lookupDefinitionId t allTypes | t `elem` allTypes = "DefinitionId for " ++ t
-lookupDefinitionId t _ = error $ "Type " ++ show t ++ " not found"
-
-lookupSchema :: Typ -> [Typ] -> Schema
-lookupSchema t allTypes | t `elem` allTypes = "Schema for " ++ t
-lookupSchema t _ = error $ "Type " ++ show t ++ " not found"
-@
--}
-class AsDefinitionsEntries (allTypes :: [Type]) (remainingTypes :: [Type]) where
-  definitionEntries :: [(DefinitionId, Schema allTypes)]
-
-instance AsDefinitionsEntries allTypes '[] where
-  definitionEntries = []
-
-instance
-  ( AsDefinitionId t
-  , HasSchema t allTypes
-  , AsDefinitionsEntries allTypes ts
-  ) =>
-  AsDefinitionsEntries allTypes (t ': ts)
-  where
-  definitionEntries =
-    (definitionId @t, schema @t @allTypes)
-      : definitionEntries @allTypes @ts

--- a/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Definition.hs
@@ -29,6 +29,8 @@ module PlutusTx.Blueprint.Definition (
   -- ** Type-level utilities
   Unroll,
   UnrollAll,
+  Unrollable (..),
+  deriveDefinitions,
 ) where
 
 import Prelude
@@ -51,25 +53,19 @@ data Definition t ts = MkDefinition DefinitionId (Schema ts)
 
 -- | A registry of schema definitions.
 data Definitions (ts :: [Type]) where
-  NoDefinitions :: Definitions ts
-  DCons :: SomeDefinition -> Definitions ts -> Definitions (t ': ts)
+  NoDefinitions :: Definitions '[]
+  AddDefinition :: Definition t ts -> Definitions ts -> Definitions (t ': ts)
 
 deriving stock instance Show (Definitions ts)
 
--- | An existential wrapper for schema definitions that allows to store them in a registry.
-data SomeDefinition where
-  SomeDefinition :: Definition t ts -> SomeDefinition
-
-deriving stock instance Show SomeDefinition
-
 -- | Add a schema definition to a registry.
 addDefinition :: Definitions ts -> Definition t ts -> Definitions (t ': ts)
-addDefinition NoDefinitions d = DCons (SomeDefinition d) NoDefinitions
-addDefinition (DCons t s) d   = DCons (SomeDefinition d) (DCons t s)
+addDefinition NoDefinitions d       = AddDefinition d NoDefinitions
+addDefinition (AddDefinition t s) d = AddDefinition d (AddDefinition t s)
 
 definitionsToMap :: Definitions ts -> (forall xs. Schema xs -> v) -> Map DefinitionId v
 definitionsToMap NoDefinitions _k = Map.empty
-definitionsToMap (DCons (SomeDefinition (MkDefinition defId v)) s) k =
+definitionsToMap (AddDefinition (MkDefinition defId v) s) k =
   Map.insert defId (k v) (definitionsToMap s k)
 
 -- | Construct a schema definition.
@@ -83,9 +79,48 @@ definitionRef = SchemaDefinitionRef (definitionId @t)
 ----------------------------------------------------------------------------------------------------
 -- Functionality to "unroll" types. -- For more context see the note ["Unrolling" types] -----------
 
+{- Note ["Unrolling" types]
+
+ContractBlueprint needs to be parameterized by a list of types used in
+a contract's type signature (including nested types) in order to:
+  a) produce a JSON-schema definition for every type used.
+  b) ensure that the schema definitions are referenced in a type-safe way.
+
+Given the following contract validator's type signature:
+
+  typedValidator :: Redeemer -> Datum -> ScriptContext -> Bool
+
+and the following data type definitions:
+
+  data Redeemer = MkRedeemer MyStruct
+  data MyStruct = MkMyStruct { field1 :: Integer, field2 :: Bool }
+  type Datum = ()
+
+The ContractBlueprint type should be:
+
+  ContractBlueprint '[Redeemer, MyStruct, Integer, Bool, ()]
+
+However, for contract blurprints authors specifying all the nested types manually is
+cumbersome and error-prone. To make it easier to work with, we provide the Unroll type family
+that can be used to traverse a type accumulating all types nested within it:
+
+  Unroll Redeemer ~ '[Redeemer, MyStruct, Integer, Bool]
+  UnrollAll '[Redeemer, Datum] ~ '[Redeemer, MyStruct, Integer, Bool, ()]
+
+This way blueprint authors can specify the top-level types used in a contract and the UnrollAll
+type family will take care of discovering all the nested types:
+
+  Blueprint '[Redeemer, Datum]
+
+  is equivalent to
+
+  ContractBlueprint '[Redeemer, MyStruct, Integer, Bool, ()]
+
+-}
+
 type family UnrollAll xs :: [Type] where
   UnrollAll '[] = '[]
-  UnrollAll (x ': xs) = Unroll x ++ UnrollAll xs
+  UnrollAll (x ': xs) = Concat (Unroll x) (UnrollAll xs)
 
 {- | Unroll a type into a list of all nested types (including the type itself).
 
@@ -101,9 +136,9 @@ type family Unroll (p :: Type) :: [Type] where
   Unroll BuiltinData = '[BuiltinData]
   Unroll BuiltinUnit = '[BuiltinUnit]
   Unroll BuiltinString = '[BuiltinString]
-  Unroll (BuiltinList a) = Insert (BuiltinList a) (GUnroll (Rep a))
+  Unroll (BuiltinList a) = Prepend (BuiltinList a) (GUnroll (Rep a))
   Unroll BuiltinByteString = '[BuiltinByteString]
-  Unroll p = Insert p (GUnroll (Break (NoGeneric p) (Rep p)))
+  Unroll p = Prepend p (GUnroll (Break (NoGeneric p) (Rep p)))
 
 -- | Detect stuck type family: https://blog.csongor.co.uk/report-stuck-families/#custom-type-errors
 type family Break e (rep :: Type -> Type) :: Type -> Type where
@@ -132,6 +167,19 @@ type family Insert x xs where
   Insert x (x : xs) = x ': xs
   Insert x (y : xs) = y ': Insert x xs
 
+type Prepend :: forall k. k -> [k] -> [k]
+type family Prepend x xs where
+  Prepend x '[] = '[x]
+  Prepend x (x : xs) = x ': xs
+  Prepend x (y : xs) = x ': y ': xs
+
+-- | Concatenates two type-level lists
+type Concat :: forall k. [k] -> [k] -> [k]
+type family Concat (as :: [k]) (bs :: [k]) :: [k] where
+  Concat '[] bs = bs
+  Concat as '[] = as
+  Concat (a : as) bs = a ': Concat as bs
+
 -- | Concatenates two type-level lists removing duplicates.
 type (++) :: forall k. [k] -> [k] -> [k]
 type family (as :: [k]) ++ (bs :: [k]) :: [k] where
@@ -154,3 +202,18 @@ type family HasSchemaDefinition n xs where
       ( GHC.ShowType n
           GHC.:<>: GHC.Text " type was not found in the list of types having schema definitions."
       )
+
+{- | This class and its two instances are used internally to derive
+'Definitions' for a given list of types.
+-}
+class Unrollable ts where
+  unroll :: Definitions ts
+
+instance Unrollable '[] where
+  unroll = NoDefinitions
+
+instance (Unrollable ts, AsDefinitionId t, HasSchema t ts) => Unrollable (t : ts) where
+  unroll = addDefinition (unroll @ts) (definition @t)
+
+deriveDefinitions :: forall ts. (Unrollable (UnrollAll ts)) => Definitions (UnrollAll ts)
+deriveDefinitions = unroll @(UnrollAll ts)

--- a/plutus-tx/src/PlutusTx/Blueprint/Validator.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Validator.hs
@@ -13,7 +13,7 @@ import Data.Aeson.Extra (buildObject, optionalField, requiredField)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as Base16
 import Data.Kind (Type)
-import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
 import PlutusCore.Crypto.Hash (blake2b_224)
@@ -35,7 +35,7 @@ data ValidatorBlueprint (referencedTypes :: [Type]) = MkValidatorBlueprint
   -- ^ A description of the redeemer format expected by this validator.
   , validatorDatum        :: Maybe (ArgumentBlueprint referencedTypes)
   -- ^ A description of the datum format expected by this validator.
-  , validatorParameters   :: Maybe (NonEmpty (ParameterBlueprint referencedTypes))
+  , validatorParameters   :: [ParameterBlueprint referencedTypes]
   -- ^ A list of parameters required by the script.
   , validatorCompiledCode :: Maybe ByteString
   -- ^ A full compiled and CBOR-encoded serialized flat script.
@@ -49,7 +49,7 @@ instance ToJSON (ValidatorBlueprint referencedTypes) where
         . requiredField "redeemer" validatorRedeemer
         . optionalField "description" validatorDescription
         . optionalField "datum" validatorDatum
-        . optionalField "parameters" validatorParameters
+        . optionalField "parameters" (NE.nonEmpty validatorParameters)
         . optionalField "compiledCode" (toHex <$> validatorCompiledCode)
         . optionalField "hash" (toHex . blake2b_224 <$> validatorCompiledCode)
    where

--- a/plutus-tx/src/PlutusTx/Blueprint/Write.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Write.hs
@@ -9,13 +9,13 @@ import Data.Aeson (toJSON)
 import Data.Aeson.Encode.Pretty (encodePretty')
 import Data.Aeson.Encode.Pretty qualified as Pretty
 import Data.ByteString.Lazy qualified as LBS
-import PlutusTx.Blueprint.Contract (Blueprint (..), ContractBlueprint)
+import PlutusTx.Blueprint.Contract (ContractBlueprint)
 import Prelude
 
-writeBlueprint :: FilePath -> Blueprint -> IO ()
-writeBlueprint f (MkBlueprint blueprint) = LBS.writeFile f (encodeBlueprint blueprint)
+writeBlueprint :: FilePath -> ContractBlueprint -> IO ()
+writeBlueprint f blueprint = LBS.writeFile f (encodeBlueprint blueprint)
 
-encodeBlueprint :: ContractBlueprint types -> LBS.ByteString
+encodeBlueprint :: ContractBlueprint -> LBS.ByteString
 encodeBlueprint =
   encodePretty'
     Pretty.defConfig

--- a/plutus-tx/src/PlutusTx/Blueprint/Write.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Write.hs
@@ -9,11 +9,11 @@ import Data.Aeson (toJSON)
 import Data.Aeson.Encode.Pretty (encodePretty')
 import Data.Aeson.Encode.Pretty qualified as Pretty
 import Data.ByteString.Lazy qualified as LBS
-import PlutusTx.Blueprint.Contract (ContractBlueprint)
+import PlutusTx.Blueprint.Contract (Blueprint (..), ContractBlueprint)
 import Prelude
 
-writeBlueprint :: FilePath -> ContractBlueprint types -> IO ()
-writeBlueprint f = LBS.writeFile f . encodeBlueprint
+writeBlueprint :: FilePath -> Blueprint -> IO ()
+writeBlueprint f (MkBlueprint blueprint) = LBS.writeFile f (encodeBlueprint blueprint)
 
 encodeBlueprint :: ContractBlueprint types -> LBS.ByteString
 encodeBlueprint =

--- a/plutus-tx/test/Blueprint/Definition/Fixture.hs
+++ b/plutus-tx/test/Blueprint/Definition/Fixture.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
@@ -12,15 +11,18 @@ module Blueprint.Definition.Fixture where
 
 import Prelude
 
+import GHC.Generics (Generic)
 import PlutusTx.Blueprint.Definition (AsDefinitionId, definitionRef)
 import PlutusTx.Blueprint.TH (makeIsDataSchemaIndexed)
 
 newtype T1 = MkT1 Integer
+  deriving stock (Generic)
 
 deriving anyclass instance (AsDefinitionId T1)
 $(makeIsDataSchemaIndexed ''T1 [('MkT1, 0)])
 
 data T2 = MkT2 T1 T1
+  deriving stock (Generic)
 
 deriving anyclass instance (AsDefinitionId T2)
 $(makeIsDataSchemaIndexed ''T2 [('MkT2, 0)])

--- a/plutus-tx/test/Blueprint/Definition/Spec.hs
+++ b/plutus-tx/test/Blueprint/Definition/Spec.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
@@ -13,10 +16,11 @@ import Prelude
 
 import Blueprint.Definition.Fixture qualified as Fixture
 import Control.Lens.Plated (universe)
+import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (isSubsetOf)
 import Data.Set qualified as Set
-import PlutusTx.Blueprint.Definition (deriveSchemaDefinitions)
+import PlutusTx.Blueprint.Definition (DefinitionId, definitionsToMap, deriveDefinitions)
 import PlutusTx.Blueprint.Schema (Schema (..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?), (@?=))
@@ -27,7 +31,7 @@ tests =
     "PlutusTx.Blueprint.Definition"
     [ testCase
         "Derived definitions are empty when no types are provided."
-        (deriveSchemaDefinitions @'[] @?= Map.empty)
+        (definitionsToMap (deriveDefinitions @'[]) (const ()) @?= mempty)
     , testCase
         "There are not less schema definitions than listed domain types."
         atLeastAsManyDefinitionsAsTypes
@@ -41,8 +45,7 @@ atLeastAsManyDefinitionsAsTypes =
   (length (Map.keys definitions) >= 3)
     @? "Not enough schema definitions: < 3"
  where
-  definitions =
-    deriveSchemaDefinitions @[Fixture.T1, Fixture.T2, Integer]
+  definitions = definitionsToMap (deriveDefinitions @[Fixture.T1, Fixture.T2, Integer]) (const ())
 
 allReferencedDefinitionsAreDefined :: Assertion
 allReferencedDefinitionsAreDefined =
@@ -53,11 +56,15 @@ allReferencedDefinitionsAreDefined =
     Set.fromList
       [ ref
       | schemas <- universe (Map.elems definitions)
-      , SchemaDefinitionRef ref <- schemas
+      , SomeSchema (SchemaDefinitionRef ref) <- schemas
       ]
-  definedIds =
-    Set.fromList (Map.keys definitions)
+  definedIds = Set.fromList (Map.keys definitions)
+
+  definitions :: Map DefinitionId SomeSchema
   definitions =
     -- Here T2 depends on T1 (and not vice-versa) but we intentionally provide them out of order
     -- to prove that any order is valid.
-    deriveSchemaDefinitions @[Fixture.T1, Fixture.T2, Integer]
+    definitionsToMap (deriveDefinitions @[Fixture.T1, Fixture.T2, Integer]) SomeSchema
+
+data SomeSchema where
+  SomeSchema :: Schema xs -> SomeSchema

--- a/plutus-tx/test/Blueprint/Spec.hs
+++ b/plutus-tx/test/Blueprint/Spec.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -16,24 +15,11 @@ module Blueprint.Spec where
 
 import Prelude
 
-import Data.Set qualified as Set
 import GHC.Generics (Generic)
 import PlutusTx.Blueprint.Class (HasSchema (..))
-import PlutusTx.Blueprint.Contract (Blueprint, ContractBlueprint (..))
-import PlutusTx.Blueprint.Definition (AsDefinitionId, Unroll, UnrollAll, deriveSchemaDefinitions)
-import PlutusTx.Blueprint.PlutusVersion (PlutusVersion (PlutusV3))
-import PlutusTx.Blueprint.Preamble (Preamble (MkPreamble))
+import PlutusTx.Blueprint.Definition (AsDefinitionId, Unroll, UnrollAll)
 import PlutusTx.Blueprint.Schema (Schema (..))
 import PlutusTx.Blueprint.Schema.Annotation (emptySchemaInfo)
-
-contract :: Blueprint [Foo, Bar, Baz]
-contract =
-  MkContractBlueprint
-    { contractId = Nothing
-    , contractPreamble = MkPreamble "" Nothing "" PlutusV3 Nothing
-    , contractValidators = Set.empty
-    , contractDefinitions = deriveSchemaDefinitions
-    }
 
 testUnrollNop :: Unroll Nop :~: '[Nop]
 testUnrollNop = Refl

--- a/plutus-tx/test/Blueprint/Spec.hs
+++ b/plutus-tx/test/Blueprint/Spec.hs
@@ -2,53 +2,42 @@
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 module Blueprint.Spec where
 
 import Prelude
 
+import Data.Typeable ((:~:) (Refl))
 import GHC.Generics (Generic)
 import PlutusTx.Blueprint.Class (HasSchema (..))
-import PlutusTx.Blueprint.Definition (AsDefinitionId, Unroll, UnrollAll)
+import PlutusTx.Blueprint.Definition (AsDefinitionId, Definitions, Unroll, UnrollAll,
+                                      Unrollable (..))
 import PlutusTx.Blueprint.Schema (Schema (..))
 import PlutusTx.Blueprint.Schema.Annotation (emptySchemaInfo)
 
 testUnrollNop :: Unroll Nop :~: '[Nop]
 testUnrollNop = Refl
 
-testUnrollBaz :: Unroll Baz :~: [Integer, Baz]
+testUnrollBaz :: Unroll Baz :~: [Baz, Integer]
 testUnrollBaz = Refl
 
-testUnrollZap :: Unroll Zap :~: [Nop, Integer, Bool, Zap]
+testUnrollZap :: Unroll Zap :~: [Zap, Nop, Integer, Bool]
 testUnrollZap = Refl
 
-testUnrollBar :: Unroll Bar :~: [Nop, Integer, Bool, Zap, Baz, Bar]
+testUnrollBar :: Unroll Bar :~: [Bar, Zap, Nop, Integer, Bool, Baz]
 testUnrollBar = Refl
 
-testUnrollFoo :: Unroll Foo :~: [Nop, Integer, Bool, Zap, Baz, Bar, Foo]
+testUnrollFoo :: Unroll Foo :~: [Foo, Bar, Zap, Nop, Integer, Bool, Baz]
 testUnrollFoo = Refl
 
-testUnrollAll :: UnrollAll [Nop, Baz] :~: [Integer, Baz, Nop]
+testUnrollAll :: UnrollAll [Nop, Baz] :~: [Nop, Baz, Integer]
 testUnrollAll = Refl
 
-----------------------------------------------------------------------------------------------------
--- Helper types/functions --------------------------------------------------------------------------
-
-{- | Evidence that @a@ is the same type as @b@.
-
-  The @'Functor'@, @'Applicative'@, and @'Monad'@ instances of @Maybe@
-  are very useful for working with values of type @Maybe (a :~: b)@.
--}
-data a :~: b where
-  Refl :: (a ~ b) => a :~: b
+definitions :: Definitions [Foo, Bar, Zap, Nop, Integer, Bool, Baz]
+definitions = unroll @(UnrollAll '[Foo])
 
 ----------------------------------------------------------------------------------------------------
 -- Test fixture ------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR implements @michaelpj 's [suggestion](https://github.com/IntersectMBO/plutus/pull/5824#discussion_r1524647268) to derive schema definitions "bottom-up" in contrast with the "top-down" derivation approach from [this PR](https://github.com/IntersectMBO/plutus/pull/5824#):
1. User lists top-level contract types, e.g.:
   `[Params, Redeemer, Datum]`.
2. User uses this list to derive schema definitions:
   `deriveDefinitions @[Params, Redeemer, Datum]`:
    - before deriving, top-level types are un-rolled to include all nested types, e.g.:    
       `@[Params, Bool, Integer, Redeemer, Datum, (), ...]`.
4. Schema references checked against the un-rolled list, e.g.:  
   - `definitionRef @Datum`
   - `definitionRef @Bool`
5. The `referencedTypes` type variable in the `ContractBlueprint referencedTypes` which holds un-rolled list is existentially hidden using a wrapper data type;

Lets chose which one we like more and merge it.