### PR TITLE
Kwxm/costing/read model type from r

### DIFF
--- a/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
+++ b/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
@@ -325,7 +325,6 @@ loadTwoVariableCostingFunction e = do
     "linear_in_y"          -> ModelTwoArgumentsLinearInY          <$> readOneVariableLinearFunction "y_mem" e
     "linear_in_x_and_y"    -> ModelTwoArgumentsLinearInXAndY      <$> readTwoVariableLinearFunction "x_mem" "y_mem" e
     "added_sizes"          -> ModelTwoArgumentsAddedSizes         <$> readOneVariableLinearFunction "I(x_mem + y_mem)" e
-    "subtracted_sizes"     -> ModelTwoArgumentsSubtractedSizes    <$> error "subtracted sizes"
     "multiplied_sizes"     -> ModelTwoArgumentsMultipliedSizes    <$> readOneVariableLinearFunction "I(x_mem * y_mem)" e
     "min_size"             -> ModelTwoArgumentsMinSize            <$> readOneVariableLinearFunction "pmin(x_mem, y_mem)" e
     "max_size"             -> ModelTwoArgumentsMaxSize            <$> readOneVariableLinearFunction "pmax(x_mem, y_mem)" e

--- a/plutus-core/cost-model/data/builtinCostModel.json
+++ b/plutus-core/cost-model/data/builtinCostModel.json
@@ -357,10 +357,16 @@
     "divideInteger": {
         "cpu": {
             "arguments": {
-                "intercept": 453240,
-                "slope": 220
+                "constant": 196500,
+                "model": {
+                    "arguments": {
+                        "intercept": 453240,
+                        "slope": 220
+                    },
+                    "type": "multiplied_sizes"
+                }
             },
-            "type": "multiplied_sizes"
+            "type": "const_above_diagonal"
         },
         "memory": {
             "arguments": {
@@ -646,10 +652,16 @@
     "modInteger": {
         "cpu": {
             "arguments": {
-                "intercept": 453240,
-                "slope": 220
+                "constant": 196500,
+                "model": {
+                    "arguments": {
+                        "intercept": 453240,
+                        "slope": 220
+                    },
+                    "type": "multiplied_sizes"
+                }
             },
-            "type": "multiplied_sizes"
+            "type": "const_above_diagonal"
         },
         "memory": {
             "arguments": {
@@ -689,10 +701,16 @@
     "quotientInteger": {
         "cpu": {
             "arguments": {
-                "intercept": 453240,
-                "slope": 220
+                "constant": 196500,
+                "model": {
+                    "arguments": {
+                        "intercept": 453240,
+                        "slope": 220
+                    },
+                    "type": "multiplied_sizes"
+                }
             },
-            "type": "multiplied_sizes"
+            "type": "const_above_diagonal"
         },
         "memory": {
             "arguments": {
@@ -706,10 +724,16 @@
     "remainderInteger": {
         "cpu": {
             "arguments": {
-                "intercept": 453240,
-                "slope": 220
+                "constant": 196500,
+                "model": {
+                    "arguments": {
+                        "intercept": 453240,
+                        "slope": 220
+                    },
+                    "type": "multiplied_sizes"
+                }
             },
-            "type": "multiplied_sizes"
+            "type": "const_above_diagonal"
         },
         "memory": {
             "arguments": {

--- a/plutus-core/cost-model/data/builtinCostModel.json
+++ b/plutus-core/cost-model/data/builtinCostModel.json
@@ -49,7 +49,7 @@
     },
     "bData": {
         "cpu": {
-            "arguments": 1000,
+            "arguments": 1001,
             "type": "constant_cost"
         },
         "memory": {
@@ -357,16 +357,10 @@
     "divideInteger": {
         "cpu": {
             "arguments": {
-                "constant": 196500,
-                "model": {
-                    "arguments": {
-                        "intercept": 453240,
-                        "slope": 220
-                    },
-                    "type": "multiplied_sizes"
-                }
+                "intercept": 453240,
+                "slope": 220
             },
-            "type": "const_above_diagonal"
+            "type": "multiplied_sizes"
         },
         "memory": {
             "arguments": {
@@ -469,7 +463,7 @@
     },
     "iData": {
         "cpu": {
-            "arguments": 1000,
+            "arguments": 1001,
             "type": "constant_cost"
         },
         "memory": {
@@ -652,16 +646,10 @@
     "modInteger": {
         "cpu": {
             "arguments": {
-                "constant": 196500,
-                "model": {
-                    "arguments": {
-                        "intercept": 453240,
-                        "slope": 220
-                    },
-                    "type": "multiplied_sizes"
-                }
+                "intercept": 453240,
+                "slope": 220
             },
-            "type": "const_above_diagonal"
+            "type": "multiplied_sizes"
         },
         "memory": {
             "arguments": {
@@ -701,16 +689,10 @@
     "quotientInteger": {
         "cpu": {
             "arguments": {
-                "constant": 196500,
-                "model": {
-                    "arguments": {
-                        "intercept": 453240,
-                        "slope": 220
-                    },
-                    "type": "multiplied_sizes"
-                }
+                "intercept": 453240,
+                "slope": 220
             },
-            "type": "const_above_diagonal"
+            "type": "multiplied_sizes"
         },
         "memory": {
             "arguments": {
@@ -724,16 +706,10 @@
     "remainderInteger": {
         "cpu": {
             "arguments": {
-                "constant": 196500,
-                "model": {
-                    "arguments": {
-                        "intercept": 453240,
-                        "slope": 220
-                    },
-                    "type": "multiplied_sizes"
-                }
+                "intercept": 453240,
+                "slope": 220
             },
-            "type": "const_above_diagonal"
+            "type": "multiplied_sizes"
         },
         "memory": {
             "arguments": {
@@ -789,8 +765,8 @@
     "sliceByteString": {
         "cpu": {
             "arguments": {
-                "intercept": 265318,
-                "slope": 0
+                "intercept": 266994,
+                "slope": 11
             },
             "type": "linear_in_z"
         },
@@ -914,7 +890,7 @@
                 "intercept": 57996947,
                 "slope": 18975
             },
-            "type": "linear_in_z"
+            "type": "linear_in_y"
         },
         "memory": {
             "arguments": 10,

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -29,8 +29,8 @@ seconds.to.microseconds <- function(x) { x * 1e6 }
 ## Discard any datapoints whose execution time is greater than 1.5 times the
 ## interquartile range above the third quartile, as is done in boxplots.  In our
 ## benchmark results we occasionally get atypically large times which throw the
-## models off and discarding the outliers helps to get a reasonable model
-   #
+## models off and discarding the outliers helps to get a reasonable model.
+#
 ## This should only be used on data which can reasonably be assumed to be
 ## relatively uniformly distributed., and this depends on how the benchmarking
 ## data was generated.  A warning will be issued by discard.upper.outliers if
@@ -177,7 +177,7 @@ get.bench.data <- function(path) {
 }
 
 filter.and.check.nonempty <- function (frame, fname) {
-##    cat (sprintf ("Reading data for %s\n", fname))
+    ##    cat (sprintf ("Reading data for %s\n", fname))
     filtered <- filter (frame, name == fname)
     if (nrow(filtered) == 0) {
         stop ("No data found for ", fname)
@@ -540,7 +540,7 @@ modelFun <- function(path) {
 
     ## Similar to VerifyEd25519Signature.
     verifySchnorrSecp256k1SignatureModel <- linearInY ("VerifySchnorrSecp256k1Signature")
-    
+
     ## All of the arguments of VerifyEcdsaSecp256k1Signature are of fixed size.
     ## The "message" (usually a hash of the real message) is always 32 bytes
     ## long.

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -1,6 +1,6 @@
 ## Suppress some annoying warnings
 library(MASS,    quietly=TRUE, warn.conflicts=FALSE)
-suppressWarnings(library(stringr, quietly=TRUE, warn.conflicts=FALSE))
+library(stringr, quietly=TRUE, warn.conflicts=FALSE)
 library(dplyr,   quietly=TRUE, warn.conflicts=FALSE)
 library(broom,   quietly=TRUE, warn.conflicts=FALSE)
 

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -177,7 +177,7 @@ get.bench.data <- function(path) {
 }
 
 filter.and.check.nonempty <- function (frame, fname) {
-    ##    cat (sprintf ("Reading data for %s\n", fname))
+    ##  cat (sprintf ("Reading data for %s\n", fname))
     filtered <- filter (frame, name == fname)
     if (nrow(filtered) == 0) {
         stop ("No data found for ", fname)
@@ -295,7 +295,11 @@ fit.fan <- function(f, threshold=0.9, limit=20, do.plot=FALSE) {
 modelFun <- function(path) {
     data <- get.bench.data(path)
 
-    mk.result <- function(model, type, ...) { list(type=type, coefficients = coefficients(model), ...) }
+    ## Pair the coefficients of a model together with a type tag and possibly
+    ## some other data.  We return one of these to Haskell for every builtin.
+    mk.result <- function(model, type, ...) {
+        list(type=type, coefficients = coefficients(model), ...)
+    }
 
     ## Look for a single entry with the given name and return the 't' value
     ## (ie, the mean execution time) for that entry.  If <name> occurs multiple

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -432,8 +432,8 @@ modelFun <- function(path) {
             filter (x_mem > y_mem) %>%
             discard.overhead ()
         m <- lm(t ~ I(x_mem * y_mem), filtered)
-        mk.result(m, "multiplied_sizes", default=0.1965)
-        ## FIXME.  The `default` value above is the above-diagonal cost: infer it from the data.
+        mk.result(m, "const_above_diagonal", const=0.1965, subtype="multiplied_sizes")
+        ## FIXME.  The `const` value above is the above-diagonal cost: infer it from the data.
     }
 
     quotientIntegerModel  <- divideIntegerModel
@@ -492,8 +492,8 @@ modelFun <- function(path) {
     ## Depends on the size of the second argument, which has to be copied into
     ## the destination.
 
-    sliceByteStringModel <- linearInZ ("SliceByteString") ## Bytetrings are
-    immutable arrays with a pointer to the start and a length.
+    sliceByteStringModel <- linearInZ ("SliceByteString")
+    ## Bytetrings are immutable arrays with a pointer to the start and a length.
     ## SliceByteString just adjusts the pointer and length, so should be constant
     ## cost.  We've kept the linear model for compatibility reasons.
 
@@ -507,8 +507,8 @@ modelFun <- function(path) {
             filter(x_mem == y_mem) %>%
             discard.overhead ()
         m <- lm(t ~ x_mem, filtered)
-        mk.result(m, "linear_on_diagonal", default=0.245)
-        ## FIXME.  The `default` value above is the above-diagonal cost: infer it from the data.
+        mk.result(m, "linear_on_diagonal", const=0.245)
+        ## FIXME.  The `const` value above is the above-diagonal cost: infer it from the data.
     }
 
     lessThanByteStringModel <- {
@@ -566,8 +566,8 @@ modelFun <- function(path) {
             filter(x_mem == y_mem) %>%
             discard.overhead ()
         m <- lm(t ~ x_mem, filtered)
-        mk.result(m, "linear_on_diagonal", default=0.187)
-        ## FIXME.  The `default` value above is the above-diagonal cost: infer it from the data.
+        mk.result(m, "linear_on_diagonal", const=0.187)
+        ## FIXME.  The `const` value above is the above-diagonal cost: infer it from the data.
     }
 
     decodeUtf8Model <- linearInX ("DecodeUtf8")

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -386,6 +386,13 @@ modelFun <- function(path) {
         return (mk.result(m, "linear_in_y"))
    }
 
+   linearInZ <- function (fname) {
+        filtered <- data %>%
+            filter.and.check.nonempty(fname) %>%
+            discard.overhead ()
+        m <- lm(t ~ z_mem, filtered)
+        return (mk.result(m, "linear_in_z"))
+   }
 
     ##### Integers #####
 
@@ -425,8 +432,8 @@ modelFun <- function(path) {
             filter (x_mem > y_mem) %>%
             discard.overhead ()
         m <- lm(t ~ I(x_mem * y_mem), filtered)
-        mk.result(m, "multiplied_sizes", default=196500)
-        ## FIXME.  The constant above is the above-diagonal cost: infer it from the data
+        mk.result(m, "multiplied_sizes", default=0.1965)
+        ## FIXME.  The `default` value above is the above-diagonal cost: infer it from the data.
     }
 
     quotientIntegerModel  <- divideIntegerModel
@@ -485,9 +492,10 @@ modelFun <- function(path) {
     ## Depends on the size of the second argument, which has to be copied into
     ## the destination.
 
-    sliceByteStringModel <- constantModel ("SliceByteString")
-    ## Bytetrings are immutable arrays with a pointer to the start and a length.
-    ## This just adjusts the pointer and length.
+    sliceByteStringModel <- linearInZ ("SliceByteString") ## Bytetrings are
+    immutable arrays with a pointer to the start and a length.
+    ## SliceByteString just adjusts the pointer and length, so should be constant
+    ## cost.  We've kept the linear model for compatibility reasons.
 
     lengthOfByteStringModel <- constantModel ("LengthOfByteString")  ## Just returns a field
     indexByteStringModel    <- constantModel ("IndexByteString")     ## Constant-time array access
@@ -499,8 +507,8 @@ modelFun <- function(path) {
             filter(x_mem == y_mem) %>%
             discard.overhead ()
         m <- lm(t ~ x_mem, filtered)
-        mk.result(m, "linear_on_diagonal", default=245000)
-        ## FIXME.  The constant above is the off-diagonal cost: infer it from the data
+        mk.result(m, "linear_on_diagonal", default=0.245)
+        ## FIXME.  The `default` value above is the above-diagonal cost: infer it from the data.
     }
 
     lessThanByteStringModel <- {
@@ -558,8 +566,8 @@ modelFun <- function(path) {
             filter(x_mem == y_mem) %>%
             discard.overhead ()
         m <- lm(t ~ x_mem, filtered)
-        mk.result(m, "linear_on_diagonal", default=187000)
-        ## FIXME.  The constant above is the off-diagonal cost: infer it from the data
+        mk.result(m, "linear_on_diagonal", default=0.187)
+        ## FIXME.  The `default` value above is the above-diagonal cost: infer it from the data.
     }
 
     decodeUtf8Model <- linearInX ("DecodeUtf8")

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -928,16 +928,13 @@ executable generate-cost-model
     , barbies
     , base                  >=4.9   && <5
     , bytestring
-    , cassava
     , directory
-    , exceptions
-    , extra
     , inline-r              >=1.0.1
     , optparse-applicative
     , plutus-core           ^>=1.23
     , text
-    , vector
 
+  --    , exceptions
   other-modules:  CreateBuiltinCostModel
 
 -- The cost models for builtins are generated using R and converted into a JSON

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -317,11 +317,11 @@ data ModelTwoArguments =
   | ModelTwoArgumentsLinearInX          OneVariableLinearFunction
   | ModelTwoArgumentsLinearInY          OneVariableLinearFunction
   | ModelTwoArgumentsLinearInXAndY      TwoVariableLinearFunction
-  | ModelTwoArgumentsAddedSizes         ModelAddedSizes
+  | ModelTwoArgumentsAddedSizes         OneVariableLinearFunction
   | ModelTwoArgumentsSubtractedSizes    ModelSubtractedSizes
-  | ModelTwoArgumentsMultipliedSizes    ModelMultipliedSizes
-  | ModelTwoArgumentsMinSize            ModelMinSize
-  | ModelTwoArgumentsMaxSize            ModelMaxSize
+  | ModelTwoArgumentsMultipliedSizes    OneVariableLinearFunction
+  | ModelTwoArgumentsMinSize            OneVariableLinearFunction
+  | ModelTwoArgumentsMaxSize            OneVariableLinearFunction
   | ModelTwoArgumentsLinearOnDiagonal   ModelConstantOrLinear
   | ModelTwoArgumentsConstAboveDiagonal ModelConstantOrTwoArguments
   | ModelTwoArgumentsConstBelowDiagonal ModelConstantOrTwoArguments
@@ -371,7 +371,7 @@ runTwoArgumentModel
 runTwoArgumentModel
     (ModelTwoArgumentsConstantCost c) = lazy $ \_ _ -> CostLast c
 runTwoArgumentModel
-    (ModelTwoArgumentsAddedSizes (ModelAddedSizes intercept slope)) =
+    (ModelTwoArgumentsAddedSizes (OneVariableLinearFunction intercept slope)) =
         lazy $ \costs1 costs2 ->
             scaleLinearly intercept slope $ addCostStream costs1 costs2
 runTwoArgumentModel
@@ -381,17 +381,17 @@ runTwoArgumentModel
                 !size2 = sumCostStream costs2
             scaleLinearly intercept slope $ CostLast (max minSize $ size1 - size2)
 runTwoArgumentModel
-    (ModelTwoArgumentsMultipliedSizes (ModelMultipliedSizes intercept slope)) =
+    (ModelTwoArgumentsMultipliedSizes (OneVariableLinearFunction intercept slope)) =
         lazy $ \costs1 costs2 -> do
             let !size1 = sumCostStream costs1
                 !size2 = sumCostStream costs2
             scaleLinearly intercept slope $ CostLast (size1 * size2)
 runTwoArgumentModel
-    (ModelTwoArgumentsMinSize (ModelMinSize intercept slope)) =
+    (ModelTwoArgumentsMinSize (OneVariableLinearFunction intercept slope)) =
         lazy $ \costs1 costs2 -> do
             scaleLinearly intercept slope $ minCostStream costs1 costs2
 runTwoArgumentModel
-    (ModelTwoArgumentsMaxSize (ModelMaxSize intercept slope)) =
+    (ModelTwoArgumentsMaxSize (OneVariableLinearFunction intercept slope)) =
         lazy $ \costs1 costs2 -> do
             let !size1 = sumCostStream costs1
                 !size2 = sumCostStream costs2


### PR DESCRIPTION
This demonstrates how to simplify the cost modelling procedure somewhat by simplifying the interface between Haskell and the R code (it's a step towards PLT-408, amongst other things).  In particular, the "shapes" of the CPU costing functions used to be hard-coded into the Haskell source despite the fact that there's a tag in the JSON file that tells you what the shape is. This now gets the R code to return a similar tag to Haskell so the during cost model generation the Haskell code can look at the tag and parse the R model objects appropriately.  I'm also passing a much simpler structure from R to Haskell.

While I was at it I took the opportunity to improve a couple of other things. One noticeable change is that some functions (`equalsString` for example) are very fast if the argument have different sizes (since in that case they can't possibly be equal) so there's a linear costing function on the diagonal where the sizes of the two arguments are the same, and there's a constant cost off the diagonal.  Previously the off-diagonal constant costs were hard-coded into the Haskell code, but now they're passed in from the R code (and could be _inferred_ there, although I haven't gone that far yet).  They're also stored in `builtinCostModel.json`, which introduces some new cost model parameters that the ledger would have to know about.  I tidied up a couple of other things (and I'd like to do more along the same lines) which has led to the tags in the JSON file changing, and hence also the names of some of the cost model parameters.