### PR TITLE
Remove obsolete edge case for GHC98/HSL from shell.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1607,11 +1607,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1709222966,
-        "narHash": "sha256-XS6qdSm3nIZue+gniKV4r29PNg5EWZ6oQURMwhlc/8Y=",
+        "lastModified": 1712148863,
+        "narHash": "sha256-ZN1YrEuhZm8H8+82pRWbIxI+8i1qTifOvPU9l1y1UVg=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "fee2fb63921d14dedfe33390ded3ac2db7b35cfd",
+        "rev": "fc71e6c2c55e876dd8b71896b3c18774465dd490",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -4,9 +4,6 @@ cabalProject:
 
 let
 
-  compiler-nix-name = cabalProject.args.compiler-nix-name;
-  isGhc98 = lib.hasPrefix "ghc98" compiler-nix-name;
-
   # We need some environment variables from the various ocaml and coq pacakges
   # that the certifier code needs.
   # Devshell doesn't run setup hooks from other packages, so just extract
@@ -61,17 +58,6 @@ in
     pkgs.nodejs_20
   ];
 
-  # Current HLS doesn't build on 9.8, see https://github.com/input-output-hk/iogx/issues/25
-  # This other stuff all depends on HLS.
-  # FIXME: This is insanely broken somehow. I don't think the module merging is working properly.
-  # There is no way to turn off HLS, so I set it to be git. Nonetheless, we somehow end up with
-  # a HLS in the 9.8 shell... but a HLS compiled for 9.6.
-  tools.haskell-language-server-wrapper =
-    lib.mkIf isGhc98 (lib.mkForce pkgs.git);
-  tools.haskell-language-server = lib.mkIf isGhc98 (lib.mkForce pkgs.git);
-  tools.cabal-install = lib.mkIf isGhc98 (lib.mkForce pkgs.git);
-  tools.stylish-haskell = lib.mkIf isGhc98 (lib.mkForce pkgs.git);
-  tools.hlint = lib.mkIf isGhc98 (lib.mkForce pkgs.git);
 
   scripts.assemble-changelog = {
     description = "Assembles the changelog for PACKAGE at VERSION";
@@ -98,9 +84,7 @@ in
   '';
 
   preCommit = {
-    # can't do stylish-haskell pre-commit if we don't
-    # have stylish-haskell
-    stylish-haskell.enable = !isGhc98;
+    stylish-haskell.enable = true;
     cabal-fmt.enable = true;
     shellcheck.enable = false;
     editorconfig-checker.enable = true;


### PR DESCRIPTION
Recent versions of iogx use HSL v2.7 for ghc94 and ghc98. 

This PR addresses this issue in iogx https://github.com/input-output-hk/iogx/issues/25 and makes the conditionals in `shell.nix` obsolete 

```
> nix develop .#ghc96
> ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.6.4
> haskell-language-server --version
haskell-language-server version: 2.7.0.0 (GHC: 9.6.4)
```
And 
```
> nix develop .#ghc98
> ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.8.1
> haskell-language-server --version
haskell-language-server version: 2.7.0.0 (GHC: 9.8.1)