### PR TITLE
Remove plutus-metatheory from plutus-benchmark-common

### DIFF
--- a/plutus-benchmark/agda-common/PlutusBenchmark/Agda/Common.hs
+++ b/plutus-benchmark/agda-common/PlutusBenchmark/Agda/Common.hs
@@ -1,0 +1,33 @@
+module PlutusBenchmark.Agda.Common
+  ( benchTermAgdaCek
+  , benchProgramAgdaCek
+  )
+where
+
+import PlutusCore qualified as PLC
+import PlutusCore.Default (DefaultFun, DefaultUni)
+import UntypedPlutusCore qualified as UPLC
+
+import MAlonzo.Code.Evaluator.Term (runUAgda)
+
+import Criterion.Main
+
+-- This code is in its own file so that we only build the metatheory when we really need it.
+
+type Term = UPLC.Term PLC.NamedDeBruijn DefaultUni DefaultFun ()
+type Program = UPLC.Program PLC.NamedDeBruijn DefaultUni DefaultFun ()
+
+---------------- Run a term or program using the plutus-metatheory CEK evaluator ----------------
+
+benchTermAgdaCek :: Term -> Benchmarkable
+benchTermAgdaCek term =
+    nf unsafeRunAgdaCek $! term
+
+benchProgramAgdaCek :: Program -> Benchmarkable
+benchProgramAgdaCek (UPLC.Program _ _ term) =
+    nf unsafeRunAgdaCek $! term
+
+unsafeRunAgdaCek :: Term -> PLC.EvaluationResult Term
+unsafeRunAgdaCek =
+    either (error . \e -> "Agda evaluation error: " ++ show e) PLC.EvaluationSuccess . runUAgda
+

--- a/plutus-benchmark/agda-common/PlutusBenchmark/Agda/Common.hs
+++ b/plutus-benchmark/agda-common/PlutusBenchmark/Agda/Common.hs
@@ -10,7 +10,7 @@ import UntypedPlutusCore qualified as UPLC
 
 import MAlonzo.Code.Evaluator.Term (runUAgda)
 
-import Criterion.Main
+import Criterion.Main (Benchmarkable, nf)
 
 -- This code is in its own file so that we only build the metatheory when we really need it.
 

--- a/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
+++ b/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
@@ -44,6 +44,7 @@ where
 import PlutusCore (DefaultFun, DefaultUni)
 import PlutusLedgerApi.V1.Bytes qualified as P (bytes, fromHex)
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import UntypedPlutusCore qualified as UPLC
 
 import PlutusTx.Prelude as Tx hiding (sort, (<>))

--- a/plutus-benchmark/cek-calibration/Main.hs
+++ b/plutus-benchmark/cek-calibration/Main.hs
@@ -22,6 +22,7 @@ import PlutusCore
 import PlutusCore.Pretty qualified as PP
 import PlutusLedgerApi.Common (EvaluationContext)
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 import UntypedPlutusCore as UPLC
 

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -16,8 +16,6 @@ module PlutusBenchmark.Common
     , unsafeRunTermCek
     , runTermCek
     , cekResultMatchesHaskellValue
-    , benchTermAgdaCek
-    , benchProgramAgdaCek
     , TestSize (..)
     , printHeader
     , printSizeStatistics
@@ -37,8 +35,6 @@ import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import PlutusTx qualified as Tx
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
-
-import MAlonzo.Code.Evaluator.Term (runUAgda)
 
 import Criterion.Main
 import Criterion.Types (Config (..))
@@ -156,20 +152,6 @@ cekResultMatchesHaskellValue
 cekResultMatchesHaskellValue term matches value =
     (unsafeRunTermCek term) `matches` (unsafeRunTermCek $ haskellValueToTerm value)
 
-
----------------- Run a term or program using the plutus-metatheory CEK evaluator ----------------
-
-benchTermAgdaCek :: Term -> Benchmarkable
-benchTermAgdaCek term =
-    nf unsafeRunAgdaCek $! term
-
-benchProgramAgdaCek :: Program -> Benchmarkable
-benchProgramAgdaCek (UPLC.Program _ _ term) =
-    nf unsafeRunAgdaCek $! term
-
-unsafeRunAgdaCek :: Term -> EvaluationResult Term
-unsafeRunAgdaCek =
-    either (error . \e -> "Agda evaluation error: " ++ show e) EvaluationSuccess . runUAgda
 
 ---------------- Printing tables of information about costs ----------------
 

--- a/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
+++ b/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
@@ -21,6 +21,7 @@ import System.IO (Handle)
 import PlutusCore (DefaultFun, DefaultUni)
 import PlutusCore.Crypto.Hash qualified as Hash
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import UntypedPlutusCore qualified as UPLC
 
 import PlutusTx.IsData (toData, unstableMakeIsData)

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Lookup/Compiled.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Lookup/Compiled.hs
@@ -9,6 +9,7 @@ import PlutusTx.Builtins qualified as B
 import PlutusTx.Builtins.Internal qualified as BI
 import PlutusTx.Lift ()
 import PlutusTx.List qualified as L
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude qualified as P
 
 {-

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/GhcSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/GhcSort.hs
@@ -10,6 +10,7 @@ import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 import PlutusBenchmark.Lists.Sort.MergeSort (mergeSortWorstCase)
 
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 
 {- | GHC's 'sort' algorithm specialised to Integer.

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/InsertionSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/InsertionSort.hs
@@ -8,6 +8,7 @@ module PlutusBenchmark.Lists.Sort.InsertionSort where
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx hiding (sort)
 
 {-# INLINABLE insertionSort #-}

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/MergeSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/MergeSort.hs
@@ -8,6 +8,7 @@ module PlutusBenchmark.Lists.Sort.MergeSort where
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 
 {-# INLINABLE merge #-}

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/QuickSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/QuickSort.hs
@@ -8,6 +8,7 @@ module PlutusBenchmark.Lists.Sort.QuickSort where
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 
 {-# INLINABLE quickSort #-}

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/Compiled.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/Compiled.hs
@@ -9,6 +9,7 @@ import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 import PlutusTx qualified as Tx
 import PlutusTx.Builtins qualified as B
 import PlutusTx.Builtins.Internal qualified as BI
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Plutus
 
 import Prelude (($!))

--- a/plutus-benchmark/marlowe/bench/BenchAgdaCek.hs
+++ b/plutus-benchmark/marlowe/bench/BenchAgdaCek.hs
@@ -2,7 +2,7 @@
 
 module Main where
 
-import PlutusBenchmark.Common (benchProgramAgdaCek)
+import PlutusBenchmark.Agda.Common (benchProgramAgdaCek)
 import Shared (runBenchmarks)
 
 main :: IO ()

--- a/plutus-benchmark/nofib/bench/BenchAgdaCek.hs
+++ b/plutus-benchmark/nofib/bench/BenchAgdaCek.hs
@@ -1,7 +1,8 @@
 {- | Plutus benchmarks for the Agda CEK machine based on some nofib examples. -}
+
 module Main where
 
-import PlutusBenchmark.Common (benchTermAgdaCek)
+import PlutusBenchmark.Agda.Common (benchTermAgdaCek)
 import Shared (benchWith)
 
 main :: IO ()

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
@@ -13,6 +13,7 @@ module PlutusBenchmark.NoFib.Clausify where
 import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Plutus
 import Prelude qualified as Haskell
 

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights.hs
@@ -17,6 +17,7 @@ import PlutusBenchmark.NoFib.Knights.Queue
 
 import PlutusCore.Pretty qualified as PLC
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 import Prelude qualified as Haskell
 

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
@@ -27,6 +27,7 @@ import Data.Char (isSpace)
 import PlutusCore.Pretty qualified as PLC
 import PlutusTx as PlutusTx
 import PlutusTx.Builtins as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as PLC hiding (Semigroup (..), check, foldMap)
 import Prelude qualified as Haskell
 

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
@@ -31,6 +31,7 @@ import Prelude qualified as Haskell
 import PlutusCore.Pretty qualified as PLC
 import PlutusTx qualified as Tx
 import PlutusTx.Builtins (divideInteger, modInteger)
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx hiding (even)
 
 ---------------- Extras ----------------

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
@@ -32,6 +32,7 @@ import PlutusBenchmark.Common (Term, compiledCodeToTerm)
 
 import PlutusCore.Pretty qualified as PLC
 import PlutusTx qualified as Tx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude as TxPrelude hiding (abs, sortBy)
 
 -----------------------------

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -93,7 +93,6 @@ library plutus-benchmark-common
     , flat               ^>=0.6
     , plutus-core        ^>=1.25
     , plutus-ledger-api  ^>=1.25
-    , plutus-metatheory
     , plutus-tx          ^>=1.25
     , tasty
     , tasty-golden

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -37,7 +37,7 @@ common turn-off-plugin-warning
 -- transitively.  If you miss it out somewhere then nix will probably produce an
 -- error message saying "the component is not buildable in the current
 -- environment" if eg the nix shell supplies an unsupported GCH version.
--- See the section on GHC versions in CONTRIBUTING
+-- See the section on GHC versions in CONTRIBUTING.
 common ghc-version-support
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
@@ -84,16 +84,17 @@ library plutus-benchmark-common
 
   other-modules:   Paths_plutus_benchmark
   build-depends:
-    , base          >=4.9   && <5
+    , base               >=4.9   && <5
     , bytestring
     , criterion
     , deepseq
     , directory
     , filepath
-    , flat          ^>=0.6
-    , plutus-core   ^>=1.25
+    , flat               ^>=0.6
+    , plutus-core        ^>=1.25
+    , plutus-ledger-api  ^>=1.25
     , plutus-metatheory
-    , plutus-tx     ^>=1.25
+    , plutus-tx          ^>=1.25
     , tasty
     , tasty-golden
     , temporary

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -139,7 +139,7 @@ benchmark nofib
   hs-source-dirs: nofib/bench
   other-modules:  Shared
   build-depends:
-    , base                     >=4.9 && <5
+    , base                     >=4.9     && <5
     , criterion                >=1.5.9.0
     , nofib-internal
     , plutus-benchmark-common
@@ -163,7 +163,7 @@ test-suite plutus-benchmark-nofib-tests
   hs-source-dirs: nofib/test
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-    , base                                            >=4.9 && <5
+    , base                                            >=4.9   && <5
     , nofib-internal
     , plutus-benchmark-common
     , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.25

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -542,7 +542,7 @@ test-suite plutus-benchmark-marlowe-tests
 -- TODO: Add benchmarks for the executable semantics when we have a UPLC version
 
 library agda-internal
-  import:          lang, turn-off-plugin-warning, ghc-version-support
+  import:          lang
   hs-source-dirs:  agda-common
   exposed-modules: PlutusBenchmark.Agda.Common
   build-depends:
@@ -550,10 +550,9 @@ library agda-internal
     , criterion
     , plutus-core        ^>=1.25
     , plutus-metatheory
-    , plutus-tx-plugin   ^>=1.25
 
 benchmark validation-agda-cek
-  import:         lang, ghc-version-support
+  import:         lang
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   hs-source-dirs: validation/bench
@@ -572,7 +571,7 @@ benchmark validation-agda-cek
     , plutus-core              ^>=1.25
 
 benchmark nofib-agda-cek
-  import:         lang, ghc-version-support
+  import:         lang, turn-off-plugin-warning, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   hs-source-dirs: nofib/bench
@@ -583,9 +582,10 @@ benchmark nofib-agda-cek
     , criterion                >=1.5.9.0
     , nofib-internal
     , plutus-benchmark-common
+    , plutus-tx-plugin         ^>=1.25
 
 benchmark marlowe-agda-cek
-  import:         lang, ghc-version-support
+  import:         lang, turn-off-plugin-warning, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   other-modules:  Shared
@@ -598,3 +598,4 @@ benchmark marlowe-agda-cek
     , plutus-benchmark-common
     , plutus-ledger-api        ^>=1.25
     , plutus-tx                ^>=1.25
+    , plutus-tx-plugin         ^>=1.25

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -24,20 +24,19 @@ source-repository head
   type:     git
   location: https://github.com/iohk/plutus
 
--- In a number of places where we use plutus-tx-plugin you get a warning that
--- it's unused despite the fact that it _is_ used, and this causes failures in
--- CI.  Use this to stop that happening and make it clear why we're turning the
--- warnings off.  It's a bit of a blunt instrument because it turns off genuine
--- warnings, but it doesn't seem to be possible to solve the problem in a more
--- fine-grained way.
-common turn-off-plugin-warning
-  ghc-options: -Wno-unused-packages
+-- Any files that use a `$$(...)` splice from the plugin should mention
+-- `PlutusTx.Plugin()` somewhere, even if it's just `import PlutusTx.Plugin()`.
+-- If none of your files mention the plugin explicitly then the code will still
+-- compile (assuming that there's a dependence on `plutus-tx-plugin`) but you'll
+-- get a warning that `plutus-tx-plugin` was not needed for compilation, and
+-- that will cause a CI failure.
+
 
 -- This should be used for anything that depends on plutus-tx-plugin, even
 -- transitively.  If you miss it out somewhere then nix will probably produce an
 -- error message saying "the component is not buildable in the current
--- environment" if eg the nix shell supplies an unsupported GCH version.
--- See the section on GHC versions in CONTRIBUTING.
+-- environment" if e.g. the nix shell supplies an unsupported GCH version.  See
+-- the section on GHC versions in `CONTRIBUTING.md`.
 common ghc-version-support
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
@@ -102,7 +101,7 @@ library plutus-benchmark-common
 ---------------- nofib ----------------
 
 library nofib-internal
-  import:          lang, turn-off-plugin-warning, ghc-version-support
+  import:          lang, ghc-version-support
   hs-source-dirs:  nofib/src
   exposed-modules:
     PlutusBenchmark.NoFib.Clausify
@@ -185,7 +184,7 @@ test-suite plutus-benchmark-nofib-tests
 ---------------- lists ----------------
 
 library lists-internal
-  import:          lang, turn-off-plugin-warning, ghc-version-support
+  import:          lang, ghc-version-support
   hs-source-dirs:  lists/src
   exposed-modules:
     PlutusBenchmark.Lists.Lookup.Compiled
@@ -316,7 +315,7 @@ benchmark validation-full
 ---------------- Cek cost model calibration ----------------
 
 benchmark cek-calibration
-  import:           lang, turn-off-plugin-warning, ghc-version-support
+  import:           lang, ghc-version-support
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:          Main.hs
@@ -324,7 +323,6 @@ benchmark cek-calibration
   build-depends:
     , base                     >=4.9     && <5
     , criterion                >=1.5.9.0
-    , deepseq
     , lens
     , mtl
     , plutus-benchmark-common
@@ -336,7 +334,7 @@ benchmark cek-calibration
 ---------------- Signature verification throughput ----------------
 
 executable ed25519-costs
-  import:           lang, turn-off-plugin-warning, ghc-version-support
+  import:           lang, ghc-version-support
   default-language: Haskell2010
   hs-source-dirs:   ed25519-costs/exe ed25519-costs/src
   main-is:          Main.hs
@@ -354,7 +352,7 @@ executable ed25519-costs
 -- Calculate the predicted costs of sequences of ed25519 signature verification
 -- operations and compare them with a golden file.
 test-suite ed25519-costs-test
-  import:         lang, turn-off-plugin-warning, ghc-version-support
+  import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: ed25519-costs/test ed25519-costs/src
@@ -375,7 +373,7 @@ test-suite ed25519-costs-test
 library bls12-381lib-internal
   -- bls12-381-internal isn't allowed: you must have at least one letter in each
   -- component.
-  import:          lang, turn-off-plugin-warning, ghc-version-support
+  import:          lang, ghc-version-support
   hs-source-dirs:  bls12-381-costs/src
   exposed-modules:
     PlutusBenchmark.BLS12_381.RunTests
@@ -432,7 +430,7 @@ benchmark bls12-381-benchmarks
 ---------------- script contexts ----------------
 
 library script-contexts-internal
-  import:          lang, turn-off-plugin-warning, ghc-version-support
+  import:          lang, ghc-version-support
   hs-source-dirs:  script-contexts/src
   exposed-modules: PlutusBenchmark.ScriptContexts
   build-depends:
@@ -571,7 +569,7 @@ benchmark validation-agda-cek
     , plutus-core              ^>=1.25
 
 benchmark nofib-agda-cek
-  import:         lang, turn-off-plugin-warning, ghc-version-support
+  import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   hs-source-dirs: nofib/bench
@@ -582,10 +580,9 @@ benchmark nofib-agda-cek
     , criterion                >=1.5.9.0
     , nofib-internal
     , plutus-benchmark-common
-    , plutus-tx-plugin         ^>=1.25
 
 benchmark marlowe-agda-cek
-  import:         lang, turn-off-plugin-warning, ghc-version-support
+  import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   other-modules:  Shared
@@ -598,4 +595,3 @@ benchmark marlowe-agda-cek
     , plutus-benchmark-common
     , plutus-ledger-api        ^>=1.25
     , plutus-tx                ^>=1.25
-    , plutus-tx-plugin         ^>=1.25

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -552,6 +552,7 @@ test-suite plutus-benchmark-marlowe-tests
 
 library agda-benchmarks-internal
   import:          lang, ghc-version-support
+  ghc-options:     -Wno-unused-packages
   hs-source-dirs:  agda-common
   exposed-modules: PlutusBenchmark.Agda.Common
   build-depends:

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -24,6 +24,24 @@ source-repository head
   type:     git
   location: https://github.com/iohk/plutus
 
+-- In a number of places where we use plutus-tx-plugin you get a warning that
+-- it's unused despite the fact that it _is_ used, and this causes failures in
+-- CI.  Use this to stop that happening and make it clear why we're turning the
+-- warnings off It's a bit of a blunt instrument because it turns off genuine
+-- warnings, but it doesn't seem to be possible to solve the problem in a more
+-- fine-grained way.
+common turn-off-plugin-warning
+  ghc-options: -Wno-unused-packages
+
+-- This should be used for anything that depends on plutus-tx-plugin, even
+-- transitively.  If you miss it out somewhere then nix will probably produce an
+-- error message saying "the component is not buildable in the current
+-- environment" if eg the nix shell supplies an unsupported GCH version.
+-- See the section on GHC versions in CONTRIBUTING
+common ghc-version-support
+  if (impl(ghc <9.6) || impl(ghc >=9.7))
+    buildable: False
+
 common lang
   default-language:   Haskell2010
   default-extensions:
@@ -54,16 +72,10 @@ common lang
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -Wunused-packages -Wmissing-deriving-strategies
 
-common ghc-version-support
-  -- See the section on GHC versions in CONTRIBUTING
-  if (impl(ghc <9.6) || impl(ghc >=9.7))
-    buildable: False
-
 ---------------- Common code for benchmarking ----------------
 
 library plutus-benchmark-common
   import:          lang
-  ghc-options:     -Wno-unused-packages
   hs-source-dirs:  common
   exposed-modules:
     PlutusBenchmark.Common
@@ -72,15 +84,14 @@ library plutus-benchmark-common
 
   other-modules:   Paths_plutus_benchmark
   build-depends:
-    , base               >=4.9   && <5
+    , base          >=4.9   && <5
     , bytestring
     , criterion
     , directory
     , filepath
-    , flat               ^>=0.6
-    , plutus-core        ^>=1.25
-    , plutus-metatheory
-    , plutus-tx          ^>=1.25
+    , flat          ^>=0.6
+    , plutus-core   ^>=1.25
+    , plutus-tx     ^>=1.25
     , tasty
     , tasty-golden
     , temporary
@@ -89,11 +100,7 @@ library plutus-benchmark-common
 ---------------- nofib ----------------
 
 library nofib-internal
-  import:          lang, ghc-version-support
-
-  -- Something weird causes this to sometimes report
-  -- the plugin package as unused...
-  ghc-options:     -Wno-unused-packages
+  import:          lang, turn-off-plugin-warning, ghc-version-support
   hs-source-dirs:  nofib/src
   exposed-modules:
     PlutusBenchmark.NoFib.Clausify
@@ -175,11 +182,7 @@ test-suite plutus-benchmark-nofib-tests
 ---------------- lists ----------------
 
 library lists-internal
-  import:          lang, ghc-version-support
-
-  -- Something weird causes this to sometimes report
-  -- the plugin package as unused...
-  ghc-options:     -Wno-unused-packages
+  import:          lang, turn-off-plugin-warning, ghc-version-support
   hs-source-dirs:  lists/src
   exposed-modules:
     PlutusBenchmark.Lists.Lookup.Compiled
@@ -309,11 +312,7 @@ benchmark validation-full
 ---------------- Cek cost model calibration ----------------
 
 benchmark cek-calibration
-  import:           lang, ghc-version-support
-
-  -- Something weird causes this to sometimes report
-  -- the plugin package as unused...
-  ghc-options:      -Wno-unused-packages
+  import:           lang, turn-off-plugin-warning, ghc-version-support
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:          Main.hs
@@ -330,11 +329,8 @@ benchmark cek-calibration
 ---------------- Signature verification throughput ----------------
 
 executable ed25519-costs
-  import:           lang, ghc-version-support
+  import:           lang, turn-off-plugin-warning, ghc-version-support
   default-language: Haskell2010
-
-  -- Without the line below we get a warning that plutus-tx-plugin is unused which causes a CI failure.
-  ghc-options:      -Wno-unused-packages
   hs-source-dirs:   ed25519-costs/exe ed25519-costs/src
   main-is:          Main.hs
   other-modules:    PlutusBenchmark.Ed25519.Common
@@ -351,9 +347,8 @@ executable ed25519-costs
 -- Calculate the predicted costs of sequences of ed25519 signature verification
 -- operations and compare them with a golden file.
 test-suite ed25519-costs-test
-  import:         lang, ghc-version-support
+  import:         lang, turn-off-plugin-warning, ghc-version-support
   type:           exitcode-stdio-1.0
-  ghc-options:    -Wno-unused-packages
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: ed25519-costs/test ed25519-costs/src
   main-is:        Spec.hs
@@ -373,11 +368,7 @@ test-suite ed25519-costs-test
 library bls12-381lib-internal
   -- bls12-381-internal isn't allowed: you must have at least one letter in each
   -- component.
-  import:          lang, ghc-version-support
-
-  -- Something weird causes this to sometimes report
-  -- the plugin package as unused...
-  ghc-options:     -Wno-unused-packages
+  import:          lang, turn-off-plugin-warning, ghc-version-support
   hs-source-dirs:  bls12-381-costs/src
   exposed-modules:
     PlutusBenchmark.BLS12_381.RunTests
@@ -386,9 +377,6 @@ library bls12-381lib-internal
   build-depends:
     , base                     >=4.9   && <5
     , bytestring
-    , cardano-crypto-class
-    , deepseq
-    , flat                     ^>=0.6
     , hedgehog
     , plutus-benchmark-common
     , plutus-core              ^>=1.25
@@ -437,11 +425,7 @@ benchmark bls12-381-benchmarks
 ---------------- script contexts ----------------
 
 library script-contexts-internal
-  import:          lang, ghc-version-support
-
-  -- Something weird causes this to sometimes report
-  -- the plugin package as unused...
-  ghc-options:     -Wno-unused-packages
+  import:          lang, turn-off-plugin-warning, ghc-version-support
   hs-source-dirs:  script-contexts/src
   exposed-modules: PlutusBenchmark.ScriptContexts
   build-depends:
@@ -551,8 +535,7 @@ test-suite plutus-benchmark-marlowe-tests
 -- TODO: Add benchmarks for the executable semantics when we have a UPLC version
 
 library agda-internal
-  import:          lang, ghc-version-support
-  ghc-options:     -Wno-unused-packages
+  import:          lang, turn-off-plugin-warning, ghc-version-support
   hs-source-dirs:  agda-common
   exposed-modules: PlutusBenchmark.Agda.Common
   build-depends:
@@ -560,9 +543,10 @@ library agda-internal
     , criterion
     , plutus-core        ^>=1.25
     , plutus-metatheory
+    , plutus-tx-plugin   ^>=1.25
 
 benchmark validation-agda-cek
-  import:         lang
+  import:         lang, ghc-version-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   hs-source-dirs: validation/bench

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -550,7 +550,7 @@ test-suite plutus-benchmark-marlowe-tests
 
 -- TODO: Add benchmarks for the executable semantics when we have a UPLC version
 
-library agda-benchmarks-internal
+library agda-internal
   import:          lang, ghc-version-support
   ghc-options:     -Wno-unused-packages
   hs-source-dirs:  agda-common
@@ -568,18 +568,18 @@ benchmark validation-agda-cek
   hs-source-dirs: validation/bench
   other-modules:  Common
   build-depends:
-    , agda-benchmarks-internal
-    , base                      >=4.9     && <5
+    , agda-internal
+    , base                     >=4.9     && <5
     , bytestring
-    , criterion                 >=1.5.9.0
+    , criterion                >=1.5.9.0
     , deepseq
     , directory
     , filepath
-    , flat                      ^>=0.6
+    , flat                     ^>=0.6
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core               ^>=1.25
-    , plutus-ledger-api         ^>=1.25
+    , plutus-core              ^>=1.25
+    , plutus-ledger-api        ^>=1.25
 
 benchmark nofib-agda-cek
   import:         lang, ghc-version-support
@@ -588,9 +588,9 @@ benchmark nofib-agda-cek
   hs-source-dirs: nofib/bench
   other-modules:  Shared
   build-depends:
-    , agda-benchmarks-internal
-    , base                      >=4.9     && <5
-    , criterion                 >=1.5.9.0
+    , agda-internal
+    , base                     >=4.9     && <5
+    , criterion                >=1.5.9.0
     , nofib-internal
     , plutus-benchmark-common
 
@@ -601,10 +601,10 @@ benchmark marlowe-agda-cek
   other-modules:  Shared
   hs-source-dirs: marlowe/bench
   build-depends:
-    , agda-benchmarks-internal
-    , base                      >=4.9   && <5
+    , agda-internal
+    , base                     >=4.9   && <5
     , criterion
     , marlowe-internal
     , plutus-benchmark-common
-    , plutus-ledger-api         ^>=1.25
-    , plutus-tx                 ^>=1.25
+    , plutus-ledger-api        ^>=1.25
+    , plutus-tx                ^>=1.25

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -27,7 +27,7 @@ source-repository head
 -- In a number of places where we use plutus-tx-plugin you get a warning that
 -- it's unused despite the fact that it _is_ used, and this causes failures in
 -- CI.  Use this to stop that happening and make it clear why we're turning the
--- warnings off It's a bit of a blunt instrument because it turns off genuine
+-- warnings off.  It's a bit of a blunt instrument because it turns off genuine
 -- warnings, but it doesn't seem to be possible to solve the problem in a more
 -- fine-grained way.
 common turn-off-plugin-warning

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -72,15 +72,14 @@ library plutus-benchmark-common
 
   other-modules:   Paths_plutus_benchmark
   build-depends:
-    , base               >=4.9   && <5
+    , base          >=4.9   && <5
     , bytestring
     , criterion
     , directory
     , filepath
-    , flat               ^>=0.6
-    , plutus-core        ^>=1.24
-    , plutus-metatheory
-    , plutus-tx          ^>=1.24
+    , flat          ^>=0.6
+    , plutus-core   ^>=1.24
+    , plutus-tx     ^>=1.24
     , tasty
     , tasty-golden
     , temporary
@@ -550,6 +549,16 @@ test-suite plutus-benchmark-marlowe-tests
 
 -- TODO: Add benchmarks for the executable semantics when we have a UPLC version
 
+library agda-benchmarks-internal
+  import:          lang, ghc-version-support
+  hs-source-dirs:  agda-common
+  exposed-modules: PlutusBenchmark.Agda.Common
+  build-depends:
+    , base               >=4.9   && <5
+    , criterion
+    , plutus-core        ^>=1.24
+    , plutus-metatheory
+
 benchmark validation-agda-cek
   import:         lang
   type:           exitcode-stdio-1.0
@@ -557,17 +566,18 @@ benchmark validation-agda-cek
   hs-source-dirs: validation/bench
   other-modules:  Common
   build-depends:
-    , base                     >=4.9     && <5
+    , agda-benchmarks-internal
+    , base                      >=4.9     && <5
     , bytestring
-    , criterion                >=1.5.9.0
+    , criterion                 >=1.5.9.0
     , deepseq
     , directory
     , filepath
-    , flat                     ^>=0.6
+    , flat                      ^>=0.6
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.24
-    , plutus-ledger-api        ^>=1.24
+    , plutus-core               ^>=1.24
+    , plutus-ledger-api         ^>=1.24
 
 benchmark nofib-agda-cek
   import:         lang, ghc-version-support
@@ -576,8 +586,9 @@ benchmark nofib-agda-cek
   hs-source-dirs: nofib/bench
   other-modules:  Shared
   build-depends:
-    , base                     >=4.9     && <5
-    , criterion                >=1.5.9.0
+    , agda-benchmarks-internal
+    , base                      >=4.9     && <5
+    , criterion                 >=1.5.9.0
     , nofib-internal
     , plutus-benchmark-common
 
@@ -588,9 +599,10 @@ benchmark marlowe-agda-cek
   other-modules:  Shared
   hs-source-dirs: marlowe/bench
   build-depends:
-    , base                     >=4.9   && <5
+    , agda-benchmarks-internal
+    , base                      >=4.9   && <5
     , criterion
     , marlowe-internal
     , plutus-benchmark-common
-    , plutus-ledger-api        ^>=1.24
-    , plutus-tx                ^>=1.24
+    , plutus-ledger-api         ^>=1.24
+    , plutus-tx                 ^>=1.24

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/ScriptContexts.hs
@@ -13,6 +13,7 @@ import PlutusLedgerApi.V3 (OutputDatum (NoOutputDatum), PubKeyHash (..), ScriptC
 import PlutusTx qualified
 import PlutusTx.AssocMap qualified as Map
 import PlutusTx.Builtins qualified as PlutusTx
+import PlutusTx.Plugin ()
 import PlutusTx.Prelude qualified as PlutusTx
 
 -- | A very crude deterministic generator for 'ScriptContext's with size

--- a/plutus-benchmark/validation/bench/BenchAgdaCek.hs
+++ b/plutus-benchmark/validation/bench/BenchAgdaCek.hs
@@ -4,7 +4,8 @@
 module Main where
 
 import Common (benchWith, unsafeUnflat)
-import PlutusBenchmark.Common (benchTermAgdaCek, toNamedDeBruijnTerm)
+import PlutusBenchmark.Agda.Common (benchTermAgdaCek)
+import PlutusBenchmark.Common (toNamedDeBruijnTerm)
 import UntypedPlutusCore qualified as UPLC
 
 import Control.DeepSeq (force)


### PR DESCRIPTION
`plutus-benchmarks` contains a library called `plutus-benchmark-common` that contains some shared code.  Some of the benchmarks are for the Agda evaluator in `plutus-metatheory`, so `plutus-benchmark-common` depended on that.  This sometimes caused `plutus-metatheory` to be built for things like the validation benchmarks, which don't care about the benchmarks: this takes a long time and is very annoying.  This PR removes the `plutus-metatheory` dependency and puts the relevant code into a library of its own, so the lengthy Agda build only happens when you really need it.