### PR TITLE
Refer to && and || by their qualified TH names.

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -20,6 +20,7 @@ module PlutusTx.Plugin (plugin, plc) where
 
 import Data.Bifunctor
 import PlutusPrelude
+import PlutusTx.Bool ((&&), (||))
 import PlutusTx.Code
 import PlutusTx.Compiler.Builtins
 import PlutusTx.Compiler.Error
@@ -79,6 +80,7 @@ import Data.ByteString.Unsafe qualified as BSUnsafe
 import Data.Either.Validation
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+import Data.Type.Bool qualified as PlutusTx.Bool
 import GHC.Num.Integer qualified
 import PlutusIR.Analysis.Builtins
 import PlutusIR.Compiler.Provenance (noProvenance, original)
@@ -392,7 +394,15 @@ compileMarkedExpr locStr codeTy origE = do
             GHC.showSDocForUser flags GHC.emptyUnitState GHC.alwaysQualify (GHC.ppr moduleName)
     -- We need to do this out here, since it has to run in CoreM
     nameInfo <- makePrimitiveNameInfo $
-        builtinNames ++ [''Bool, 'False, 'True, 'traceBool, 'GHC.Num.Integer.integerNegate]
+        builtinNames ++
+          [''Bool
+          , 'False
+          , 'True
+          , 'traceBool
+          , 'GHC.Num.Integer.integerNegate
+          , '(PlutusTx.Bool.&&)
+          , '(PlutusTx.Bool.||)
+          ]
     modBreaks <- asks pcModuleModBreaks
     let coverage = CoverageOpts . Set.fromList $
                    [ l | _posCoverageAll opts, l <- [minBound .. maxBound]]

--- a/plutus-tx-plugin/test/Plugin/Coverage/9.6/coverageCode.pir.golden
+++ b/plutus-tx-plugin/test/Plugin/Coverage/9.6/coverageCode.pir.golden
@@ -104,6 +104,27 @@
     )
     (termbind
       (nonstrict)
+      (vardecl `&&` (fun Bool (fun Bool Bool)))
+      (lam
+        ds
+        Bool
+        (lam
+          x
+          Bool
+          {
+            [
+              [
+                { [ Bool_match ds ] (all dead (type) Bool) } (abs dead (type) x)
+              ]
+              (abs dead (type) False)
+            ]
+            (all dead (type) dead)
+          }
+        )
+      )
+    )
+    (termbind
+      (nonstrict)
       (vardecl
         `==`
         (all
@@ -214,123 +235,96 @@
                         (abs
                           dead
                           (type)
-                          {
+                          [
                             [
+                              `&&`
                               [
+                                [
+                                  [
+                                    traceBool
+                                    (con
+                                      string
+                                      "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 14, _covLocEndCol = 24}) True"
+                                    )
+                                  ]
+                                  (con
+                                    string
+                                    "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 14, _covLocEndCol = 24}) False"
+                                  )
+                                ]
                                 {
                                   [
-                                    Bool_match
                                     [
+                                      { (builtin trace) (all dead (type) Bool) }
+                                      (con
+                                        string
+                                        "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 14, _covLocEndCol = 24})"
+                                      )
+                                    ]
+                                    (abs
+                                      dead
+                                      (type)
                                       [
-                                        [
-                                          traceBool
-                                          (con
-                                            string
-                                            "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 14, _covLocEndCol = 24}) True"
-                                          )
-                                        ]
-                                        (con
-                                          string
-                                          "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 14, _covLocEndCol = 24}) False"
-                                        )
-                                      ]
-                                      {
                                         [
                                           [
-                                            {
-                                              (builtin trace)
-                                              (all dead (type) Bool)
-                                            }
-                                            (con
-                                              string
-                                              "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 14, _covLocEndCol = 24})"
-                                            )
+                                            { `==` (con integer) } `$fEqInteger`
                                           ]
-                                          (abs
-                                            dead
-                                            (type)
+                                          {
                                             [
                                               [
-                                                [
-                                                  { `==` (con integer) }
-                                                  `$fEqInteger`
-                                                ]
                                                 {
-                                                  [
-                                                    [
-                                                      {
-                                                        (builtin trace)
-                                                        (all
-                                                          dead
-                                                          (type)
-                                                          (con integer)
-                                                        )
-                                                      }
-                                                      (con
-                                                        string
-                                                        "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 15, _covLocEndCol = 16})"
-                                                      )
-                                                    ]
-                                                    (abs dead (type) x)
-                                                  ]
-                                                  (all dead (type) dead)
-                                                }
-                                              ]
-                                              {
-                                                [
-                                                  [
-                                                    {
-                                                      (builtin trace)
-                                                      (all
-                                                        dead
-                                                        (type)
-                                                        (con integer)
-                                                      )
-                                                    }
-                                                    (con
-                                                      string
-                                                      "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 22, _covLocEndCol = 23})"
-                                                    )
-                                                  ]
-                                                  (abs
-                                                    dead (type) (con integer 5)
+                                                  (builtin trace)
+                                                  (all
+                                                    dead (type) (con integer)
                                                   )
-                                                ]
-                                                (all dead (type) dead)
-                                              }
+                                                }
+                                                (con
+                                                  string
+                                                  "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 15, _covLocEndCol = 16})"
+                                                )
+                                              ]
+                                              (abs dead (type) x)
                                             ]
-                                          )
+                                            (all dead (type) dead)
+                                          }
                                         ]
-                                        (all dead (type) dead)
-                                      }
-                                    ]
-                                  ]
-                                  (all dead (type) Bool)
-                                }
-                                (abs
-                                  dead
-                                  (type)
-                                  {
-                                    [
-                                      [
                                         {
-                                          (builtin trace) (all dead (type) Bool)
+                                          [
+                                            [
+                                              {
+                                                (builtin trace)
+                                                (all dead (type) (con integer))
+                                              }
+                                              (con
+                                                string
+                                                "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 22, _covLocEndCol = 23})"
+                                              )
+                                            ]
+                                            (abs dead (type) (con integer 5))
+                                          ]
+                                          (all dead (type) dead)
                                         }
-                                        (con
-                                          string
-                                          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 28, _covLocEndCol = 32})"
-                                        )
                                       ]
-                                      (abs dead (type) True)
-                                    ]
-                                    (all dead (type) dead)
-                                  }
-                                )
+                                    )
+                                  ]
+                                  (all dead (type) dead)
+                                }
                               ]
-                              (abs dead (type) False)
                             ]
-                            (all dead (type) dead)
-                          }
+                            {
+                              [
+                                [
+                                  { (builtin trace) (all dead (type) Bool) }
+                                  (con
+                                    string
+                                    "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 46, _covLocEndLine = 46, _covLocStartCol = 28, _covLocEndCol = 32})"
+                                  )
+                                ]
+                                (abs dead (type) True)
+                              ]
+                              (all dead (type) dead)
+                            }
+                          ]
                         )
                       ]
                       (all dead (type) dead)

--- a/plutus-tx/src/PlutusTx/Bool.hs
+++ b/plutus-tx/src/PlutusTx/Bool.hs
@@ -8,6 +8,8 @@ import Prelude (Bool (..), otherwise)
 
 {- HLINT ignore -}
 
+-- See Note [Lazy boolean operators] in the plugin.
+
 {-# INLINE (&&) #-}
 -- | Logical AND
 --
@@ -37,31 +39,6 @@ infixr 2 ||
 --
 not :: Bool -> Bool
 not a = if a then False else True
-
-{- Note [Short-circuit evaluation for && and ||]
-TLDR: as it stands, the behaviors of `&&` and `||` are inconsistent: they sometimes
-short-circuit, sometimes don't.
-
-Function applications in Plutus Tx are strictly evaluated. This includes applications of
-`&&` and `||`. There are two problems with this: (1) `&&` and `||` should be made to
-short-circuit, otherwise they are not very useful; (2) in fact, their behaviors are
-not consistent - sometimes they short-circuit, sometimes they don't!
-
-Why do they short-circuit some of the times, but not always? This is due to the effect
-of GHC's inlining. Suppose we run `compile` (which invokes the plugin) in module A:
-
-  - If the module using `&&` is compiled with optimization, and it is an imported
-    module (say module B), then module B is compiled first, during which `&&` is likely
-    inlined, turning `x && y` into `if x then y else False`, thus enabling short-circuit
-    evaluation.
-  - If the module using `&&` is compiled without optimization (specifically,
-    `-O0 -fmax-simplifier-iteration=0`), then GHC does not inline `&&` and it will not
-    short-circuit.
-  - If the module using `&&` is module `A` itself, then GHC will not inline `&&` (and thus
-    it won't short-circuit) even if module `A` is compiled with optimization. This is
-    because the plugin runs before the GHC inliner, and it would have done with
-    compiling `&&` before GHC has a chance to inline it.
--}
 
 {- Note [Lazy patterns on function parameters]
 In theory, Lazy patterns (~) on function parameters shouldn't make any difference.


### PR DESCRIPTION
- [x] Special (lazy) handling of `&&` and `||` is better done by referring to them using their fully-qualified `TH.Name`s.
- [x] `&&` and `||` should not be inlined as Plutus compiler handles them specially.
- [x] Remove outdated note.

Follow-up to [this thread](https://github.com/IntersectMBO/plutus/pull/5863#pullrequestreview-1975184625).
