### PR TITLE
nix flake update iogx

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1607,11 +1607,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1712148863,
-        "narHash": "sha256-ZN1YrEuhZm8H8+82pRWbIxI+8i1qTifOvPU9l1y1UVg=",
+        "lastModified": 1711386892,
+        "narHash": "sha256-Au/7A2sh0NwqARvv+N3/Wxr14XODD+CCvZGJva1tvPg=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "fc71e6c2c55e876dd8b71896b3c18774465dd490",
+        "rev": "b8d2456daf9d85a55a62cc59744105d5bfcbf82e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`nix flake update iogx --override-input iogx github:input-output-hk/iogx/b8d2456daf9d85a55a62cc59744105d5bfcbf82e`

(I tried `nix flake update iogx` first,  but it updates to the latest commit which breaks the nix shell in a way I don't know how to fix).