### PR TITLE
Kwxm/flat/canonincal data encoding (PLT-9705)

### DIFF
--- a/plutus-core/changelog.d/20240405_015609_kenneth.mackenzie_canonincal_data_encoding.md
+++ b/plutus-core/changelog.d/20240405_015609_kenneth.mackenzie_canonincal_data_encoding.md
@@ -1,0 +1,4 @@
+### Changed
+
+- The `flat` encoding of the `Data` type has been modified slightly to make sure that 
+  the result is always in the canonical format described in the Plutus Core specification.

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -138,7 +138,7 @@ instance Serialise a => Flat (AsSerialize a) where
         case errOrX of
             Left err -> fail $ show err  -- Here we embed a 'Serialise' error into a 'Flat' one.
             Right x  -> pure x
-    size = size . serialise
+    size = size . BSL.toStrict . serialise
 
 safeEncodeBits :: NumBits -> Word8 -> Encoding
 safeEncodeBits maxBits v =

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -22,7 +22,7 @@ import PlutusCore.DeBruijn
 import PlutusCore.Name.Unique
 
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
-import Data.ByteString qualified as BS (toStrict)
+import Data.ByteString.Lazy qualified as BSL (toStrict)
 import Data.Proxy
 import Flat
 import Flat.Decoder
@@ -132,7 +132,7 @@ newtype AsSerialize a = AsSerialize
 
 instance Serialise a => Flat (AsSerialize a) where
     -- See Note [Flat serialisation for strict and lazy bytestrings]
-    encode = encode . BS.toStrict . serialise
+    encode = encode . BSL.toStrict . serialise
     decode = do
         errOrX <- deserialiseOrFail <$> decode
         case errOrX of

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -106,27 +106,24 @@ so the nodes' behavior does not change.
 -}
 
 {- Note [Flat serialisation for strict and lazy bytestrings]
-The `flat` serialisation of a bytestring consists of a sequence of chunks, with
-each chunk preceded by a single byte saying how long it is.  The end of a
-serialised bytestring is marked by a zero-length chunk.  In the Plutus Core
-specification we recommend that all bytestrings should be serialised in a
-canonical way as a sequence of zero or more 255-byte chunks followed by an
-optional final chunk of length less than 255 followed by a zero-length chunk
-(ie, a 0x00 byte). We do allow the decoder to accept non-canonical encodings.
-The `flat` library always encodes strict Haskell bytestrings in this way, but
-lazy bytestrings, which are essentially lists of strict bytestrings, may be
-encoded non-canonically since it's more efficient just to emit a short chunk as
-is.  The Plutus Core `bytestring` type is strict so bytestring values are always
-encoded canonically.  However, we serialise `Data` objects (and perhaps objects
-of other types as well) by encoding them to CBOR and then flat-serialising the
-resulting bytestring; but the `serialise` method from `Codec.Serialise` produces
-lazy bytestrings and if we were to serialise them directly then we could end up
-with non-canonical encodings, which would mean that identical `Data` objects
-might be serialised into different bytestrings.  To avoid this we convert the
-output of `serialise` into a strict bytestring before flat-encoding it.  This
-may lead to a small loss of efficiency during encoding (which can even be
-performed on the chain by the `serialiseData` builtin), but canonicity is
-perhaps more important than efficiency. -}
+The `flat` serialisation of a bytestring consists of a sequence of chunks, with each chunk preceded
+by a single byte saying how long it is.  The end of a serialised bytestring is marked by a
+zero-length chunk.  In the Plutus Core specification we recommend that all bytestrings should be
+serialised in a canonical way as a sequence of zero or more 255-byte chunks followed by an optional
+final chunk of length less than 255 followed by a zero-length chunk (ie, a 0x00 byte). We do allow
+the decoder to accept non-canonical encodings.  The `flat` library always encodes strict Haskell
+bytestrings in this way, but lazy bytestrings, which are essentially lists of strict bytestrings,
+may be encoded non-canonically since it's more efficient just to emit a short chunk as is.  The
+Plutus Core `bytestring` type is strict so bytestring values are always encoded canonically.
+However, we serialise `Data` objects (and perhaps objects of other types as well) by encoding them
+to CBOR and then flat-serialising the resulting bytestring; but the `serialise` method from
+`Codec.Serialise` produces lazy bytestrings and if we were to serialise them directly then we could
+end up with non-canonical encodings, which would mean that identical `Data` objects might be
+serialised into different bytestrings.  To avoid this we convert the output of `serialise` into a
+strict bytestring before flat-encoding it.  This may lead to a small loss of efficiency during
+encoding, but this doesn't matter because we only ever do flat serialisation off the chain.  We can
+convert `Data` objects to bytestrings on the chain using the `serialiseData` builtin, but this
+performs CBOR serialisation and the result is always in a canonical form. -}
 
 -- | For deriving 'Flat' instances via 'Serialize'.
 newtype AsSerialize a = AsSerialize

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -22,6 +22,7 @@ import PlutusCore.DeBruijn
 import PlutusCore.Name.Unique
 
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
+import Data.ByteString qualified as BS (toStrict)
 import Data.Proxy
 import Flat
 import Flat.Decoder
@@ -104,6 +105,28 @@ This phase-1 validation is in place both for normal (locked scripts) and for inl
 so the nodes' behavior does not change.
 -}
 
+{- Note [Flat serialisation for strict and lazy bytestrings]
+The `flat` serialisation of a bytestring consists of a sequence of chunks, with
+each chunk preceded by a single byte saying how long it is.  The end of a
+serialised bytestring is marked by a zero-length chunk.  In the Plutus Core
+specification we recommend that all bytestrings should be serialised in a
+canonical way as a sequence of zero or more 255-byte chunks followed by an
+optional final chunk of length less than 255 followed by a zero-length chunk
+(ie, a 0x00 byte). We do allow the decoder to accept non-canonical encodings.
+The `flat` library always encodes strict Haskell bytestrings in this way, but
+lazy bytestrings, which are essentially lists of strict bytestrings, may be
+encoded non-canonically since it's more efficient just to emit a short chunk as
+is.  The Plutus Core `bytestring` type is strict so bytestring values are always
+encoded canonically.  However, we serialise `Data` objects (and perhaps objects
+of other types as well) by encoding them to CBOR and then flat-serialising the
+resulting bytestring; but the `serialise` method from `Codec.Serialise` produces
+lazy bytestrings and if we were to serialise them directly then we could end up
+with non-canonical encodings, which would mean that identical `Data` objects
+might be serialised into different bytestrings.  To avoid this we convert the
+output of `serialise` into a strict bytestring before flat-encoding it.  This
+may lead to a small loss of efficiency during encoding (which can even be
+performed on the chain by the `serialiseData` builtin), but canonicity is
+perhaps more important than efficiency. -}
 
 -- | For deriving 'Flat' instances via 'Serialize'.
 newtype AsSerialize a = AsSerialize
@@ -111,7 +134,8 @@ newtype AsSerialize a = AsSerialize
     } deriving newtype (Serialise)
 
 instance Serialise a => Flat (AsSerialize a) where
-    encode = encode . serialise
+    -- See Note [Flat serialisation for strict and lazy bytestrings]
+    encode = encode . BS.toStrict . serialise
     decode = do
         errOrX <- deserialiseOrFail <$> decode
         case errOrX of

--- a/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
@@ -54,11 +54,11 @@ isCanonicalFlatEncodedByteString :: BS.ByteString -> Bool
 isCanonicalFlatEncodedByteString bs =
   case BS.unpack bs of
     []  -> False   -- Should never happen.
-    1:a -> go a   -- 1 is the tag for encoded bytestring.
-    _   -> False    -- Not the encoding of a bytestring.
+    1:a -> go a    -- 1 is the tag for an encoded bytestring.
+    _   -> False   -- Not the encoding of a bytestring.
   where
-    go [] = False -- We've fallen off the end, possibly due to having dropped too many bytes.
-    go l@(w:ws) = -- w = purported size of chunk.
+    go [] = False  -- We've fallen off the end, possibly due to having dropped too many bytes.
+    go l@(w:ws) =  -- w = purported size of chunk.
       if w == 255
       then go (drop 255 ws)   -- Throw away any initial 255-byte chunks.
       else l == end || drop (fromIntegral w) ws == end

--- a/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
@@ -58,7 +58,7 @@ isCanonicalFlatEncodedByteString bs =
     _      -> False   -- Not the encoding of a bytestring.
   where
     go [] = False  -- We've fallen off the end, possibly due to having dropped too many bytes.
-    go l@(w:ws) =  -- w is the purported size of chunk.
+    go l@(w:ws) =  -- w is the purported size of the next chunk.
       if w == 0xFF
       then go (drop 255 ws)   -- Throw away any initial 255-byte chunks.
       else l == end || drop (fromIntegral w) ws == end

--- a/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
@@ -53,13 +53,13 @@ bytestrings]. -}
 isCanonicalFlatEncodedByteString :: BS.ByteString -> Bool
 isCanonicalFlatEncodedByteString bs =
   case BS.unpack bs of
-    []  -> False   -- Should never happen.
-    1:a -> go a    -- 1 is the tag for an encoded bytestring.
-    _   -> False   -- Not the encoding of a bytestring.
+    []     -> False   -- Should never happen.
+    0x01:r -> go r    -- 0x01 is the tag for an encoded bytestring.
+    _      -> False   -- Not the encoding of a bytestring.
   where
     go [] = False  -- We've fallen off the end, possibly due to having dropped too many bytes.
-    go l@(w:ws) =  -- w = purported size of chunk.
-      if w == 255
+    go l@(w:ws) =  -- w is the purported size of chunk.
+      if w == 0xFF
       then go (drop 255 ws)   -- Throw away any initial 255-byte chunks.
       else l == end || drop (fromIntegral w) ws == end
       -- Either we've arrived exactly at the end or we have a single short chunk before the end.

--- a/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Flat/Spec.hs
@@ -1,11 +1,17 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
 module Flat.Spec (test_flat) where
 
+import Data.ByteString qualified as BS
 import Data.Word
 import Flat
+import PlutusCore.Data (Data)
 import PlutusCore.DeBruijn
+import PlutusCore.Generators.QuickCheck.Builtin ()
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import UntypedPlutusCore ()
@@ -37,6 +43,48 @@ test_binderFake = testProperty "binderFake" $ \bf ->
     -- binders should always decode as init binder
     Right (toFake <$> initB) === unflat (flat @(Binder FakeNamedDeBruijn) bf)
 
+{- Check that a bytestring is the canonical flat encoding of another bytestring.
+A bytestring is encoded as sequence of chunks where each chunk is preceded by a
+single byte giving its length and the end of the bytestring is marked by a
+zero-length chunk.  The encoding is canonical if it consists of a (possibly
+empty) sequence of 255-byte chunks followed by an optional smaller block
+followed by an empty block.  See Note [Flat serialisation for strict and lazy
+bytestrings]. -}
+isCanonicalFlatEncodedByteString :: BS.ByteString -> Bool
+isCanonicalFlatEncodedByteString bs =
+  case BS.unpack bs of
+    []  -> False   -- Should never happen.
+    1:a -> go a   -- 1 is the tag for encoded bytestring.
+    _   -> False    -- Not the encoding of a bytestring.
+  where
+    go [] = False -- We've fallen off the end, possibly due to having dropped too many bytes.
+    go l@(w:ws) = -- w = purported size of chunk.
+      if w == 255
+      then go (drop 255 ws)   -- Throw away any initial 255-byte chunks.
+      else l == end || drop (fromIntegral w) ws == end
+      -- Either we've arrived exactly at the end or we have a single short chunk before the end.
+      where end = [0x00, 0x01] -- An empty chunk followed by a padding byte.
+
+test_canonicalEncoding :: forall a . (Arbitrary a, Flat a, Show a) => String -> Int -> TestTree
+test_canonicalEncoding s n =
+  testProperty s $
+  withMaxSuccess n $
+  forAll (arbitrary @a) (isCanonicalFlatEncodedByteString . flat @a)
+
+-- Data objects are encoded by first being converted to a bytestring using CBOR.
+-- This is the case that we're really interested in, since we get a lazy
+-- bytestring from CBOR and it has to converted into a strict one to ensure that
+-- the encoding's canonical.
+test_canonicalData :: TestTree
+test_canonicalData =
+  test_canonicalEncoding @Data "flat encodes Data canonically" 10000
+
+-- We may as well check that it does the right thing for strict bytestrings
+-- while we're here.
+test_canonicalByteString :: TestTree
+test_canonicalByteString =
+  test_canonicalEncoding @BS.ByteString "flat encodes ByteStrings canonically" 1000
+
 test_flat :: TestTree
 test_flat = testGroup "FlatProp"
     [ test_deBruijnIso
@@ -45,6 +93,8 @@ test_flat = testGroup "FlatProp"
     , test_fakeTripping
     , test_binderDeBruijn
     , test_binderFake
+    , test_canonicalData
+    , test_canonicalByteString
     ]
 
 -- Helpers
@@ -58,4 +108,3 @@ instance Arbitrary FakeNamedDeBruijn where
     arbitrary= toFake <$> arbitrary -- via debruijn
 deriving newtype instance Arbitrary (Binder DeBruijn)
 deriving newtype instance Arbitrary (Binder FakeNamedDeBruijn)
-


### PR DESCRIPTION
As described in https://github.com/IntersectMBO/plutus/issues/5852, the `flat` encoding of `Data` objects did not always have the canonical format described in the Plutus Core specification, which is arguably a bug. This should fix the problem.  See the code comments for details.  The actual fix only requires one extra word, but I've added some tests too.