### PR TITLE
PT20: reciprocalOfZeroError

### DIFF
--- a/doc/read-the-docs-site/troubleshooting.rst
+++ b/doc/read-the-docs-site/troubleshooting.rst
@@ -96,12 +96,10 @@ To reduce code size, on-chain errors only output codes. Here's what they mean:
   - ``Li: DecodingError``
 
 - Prelude errors
-
   - ``PT1: TH Generation of Indexed Data Error``
-  - ``PT2: Void is not supported``
-  - ``PT3: Ratio number can't have a zero denominator``
-  - ``PT4: 'round' got an incorrect input``
-  - ``PT5: 'check' input is 'False'``
+  - ``PT2: PlutusTx.IsData.Class.unsafeFromBuiltinData: Void is not supported``
+  - ``PT3: PlutusTx.Ratio: zero denominator``
+  - ``PT5: PlutusTx.Prelude.check: input is 'False'``
   - ``PT6: PlutusTx.List.!!: negative index``
   - ``PT7: PlutusTx.List.!!: index too large``
   - ``PT8: PlutusTx.List.head: empty list``
@@ -115,6 +113,8 @@ To reduce code size, on-chain errors only output codes. Here's what they mean:
   - ``PT16: PlutusTx.Enum.Ordering.succ: bad argument``
   - ``PT17: PlutusTx.Enum.Ordering.pred: bad argument``
   - ``PT18: PlutusTx.Enum.Ordering.toEnum: bad argument``
+  - ``PT19: PlutusTx.List.last: empty list``
+  - ``PT20: PlutusTx.Ratio.recip: reciprocal of zero``
 
 - State machine errors
 

--- a/plutus-tx/changelog.d/20240405_144845_Yuriy.Lazaryev_error_codes.md
+++ b/plutus-tx/changelog.d/20240405_144845_Yuriy.Lazaryev_error_codes.md
@@ -1,0 +1,3 @@
+### Added
+
+- An error code "PT20" for the `recip` function in the `PlutusTx.Ratio` module.

--- a/plutus-tx/src/PlutusTx/ErrorCodes.hs
+++ b/plutus-tx/src/PlutusTx/ErrorCodes.hs
@@ -2,7 +2,6 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.ErrorCodes where
 
-import Control.Lens (isn't)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import PlutusTx.Builtins as Builtins

--- a/plutus-tx/src/PlutusTx/ErrorCodes.hs
+++ b/plutus-tx/src/PlutusTx/ErrorCodes.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.ErrorCodes where
 
+import Control.Lens (isn't)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import PlutusTx.Builtins as Builtins
@@ -10,36 +11,52 @@ import Prelude (String)
 {-
 All error codes in this module should be unique and can be used only once!
 They help to trace the errors in on-chain code.
+
+Error codes (e.g. "PT1") become a part of the compiled contract contributing to its size,
+therefore we keep them short; On the other hand, the error description isn't part of the
+compiled contract, so it doesn't have to be minimal, just short enough, clear and informative.
+
+Adding new error codes should be done without changing the existing ones:
+- Add a new error code to the list `plutusPreludeErrorCodes` by incrementing the last error code.
+- Add a new function with the error code name and a human-readable description.
+- Update the `troubleshooting.rst` file with the new error code and its description.
+
+When writing a new error description please follow existing patterns:
+  - If an error is expected to be thrown in a specific function,
+    use the fully qualified name of the function.
+  - Describe the invariant which is failed.
+  - Avoid using the word "error" in the description as it is redundant.
 -}
 
-{- Note [allErrorCodes]
+{- Note [plutusPreludeErrorCodes]
    This list contains all error codes used in the plutus prelude and it is
    important that when an error code is added to the prelude it is also added
    to this list.
 -}
 
--- | A list of all error codes used in the plutus prelude
-allErrorCodes :: Map Builtins.BuiltinString String
-allErrorCodes = Map.fromList [ ("PT1", "TH Generation of Indexed Data Error")
-                             , ("PT2", "Void is not supported")
-                             , ("PT3", "Ratio number can't have a zero denominator")
-                             , ("PT4", "'round' got an incorrect input")
-                             , ("PT5", "'check' input is 'False'")
-                             , ("PT6", "PlutusTx.List.!!: negative index")
-                             , ("PT7", "PlutusTx.List.!!: index too large")
-                             , ("PT8", "PlutusTx.List.head: empty list")
-                             , ("PT9", "PlutusTx.List.tail: empty list")
-                             , ("PT10", "PlutusTx.Enum.().succ: bad argument")
-                             , ("PT11", "PlutusTx.Enum.().pred: bad argument")
-                             , ("PT12", "PlutusTx.Enum.().toEnum: bad argument")
-                             , ("PT13", "PlutusTx.Enum.Bool.succ: bad argument")
-                             , ("PT14", "PlutusTx.Enum.Bool.pred: bad argument")
-                             , ("PT15", "PlutusTx.Enum.Bool.toEnum: bad argument")
-                             , ("PT16", "PlutusTx.Enum.Ordering.succ: bad argument")
-                             , ("PT17", "PlutusTx.Enum.Ordering.pred: bad argument")
-                             , ("PT18", "PlutusTx.Enum.Ordering.toEnum: bad argument")
-                             , ("PT19", "PlutusTx.List.last: empty list")
-                             ]
+-- | All error codes used in the plutus prelude associated with a human-readable description.
+plutusPreludeErrorCodes :: Map Builtins.BuiltinString String
+plutusPreludeErrorCodes = Map.fromDistinctAscList
+  [ ("PT1", "TH Generation of Indexed Data Error")
+  , ("PT2", "PlutusTx.IsData.Class.unsafeFromBuiltinData: Void is not supported")
+  , ("PT3", "PlutusTx.Ratio: zero denominator")
+  , ("PT5", "PlutusTx.Prelude.check: input is 'False'")
+  , ("PT6", "PlutusTx.List.!!: negative index")
+  , ("PT7", "PlutusTx.List.!!: index too large")
+  , ("PT8", "PlutusTx.List.head: empty list")
+  , ("PT9", "PlutusTx.List.tail: empty list")
+  , ("PT10", "PlutusTx.Enum.().succ: bad argument")
+  , ("PT11", "PlutusTx.Enum.().pred: bad argument")
+  , ("PT12", "PlutusTx.Enum.().toEnum: bad argument")
+  , ("PT13", "PlutusTx.Enum.Bool.succ: bad argument")
+  , ("PT14", "PlutusTx.Enum.Bool.pred: bad argument")
+  , ("PT15", "PlutusTx.Enum.Bool.toEnum: bad argument")
+  , ("PT16", "PlutusTx.Enum.Ordering.succ: bad argument")
+  , ("PT17", "PlutusTx.Enum.Ordering.pred: bad argument")
+  , ("PT18", "PlutusTx.Enum.Ordering.toEnum: bad argument")
+  , ("PT19", "PlutusTx.List.last: empty list")
+  , ("PT20", "PlutusTx.Ratio.recip: reciprocal of zero")
+  ]
 
 -- | The error happens in TH generation of indexed data
 {-# INLINABLE reconstructCaseError #-}
@@ -55,11 +72,6 @@ voidIsNotSupportedError = "PT2"
 {-# INLINABLE ratioHasZeroDenominatorError #-}
 ratioHasZeroDenominatorError :: Builtins.BuiltinString
 ratioHasZeroDenominatorError = "PT3"
-
--- | 'round' got an incorrect input
-{-# INLINABLE roundDefaultDefnError #-}
-roundDefaultDefnError :: Builtins.BuiltinString
-roundDefaultDefnError = "PT4"
 
 -- | 'check' input is 'False'
 {-# INLINABLE checkHasFailedError #-}
@@ -135,3 +147,8 @@ toEnumOrderingBadArgumentError = "PT18"
 {-# INLINABLE lastEmptyListError #-}
 lastEmptyListError :: Builtins.BuiltinString
 lastEmptyListError = "PT19"
+
+-- | PlutusTx.Ratio.recip: reciprocal of zero
+{-# INLINABLE reciprocalOfZeroError #-}
+reciprocalOfZeroError :: Builtins.BuiltinString
+reciprocalOfZeroError = "PT20"

--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -292,7 +292,7 @@ properFraction (Rational n d) =
 {-# INLINABLE recip #-}
 recip :: Rational -> Rational
 recip (Rational n d)
-  | n P.== P.zero = Builtins.error ()
+  | n P.== P.zero = P.traceError P.reciprocalOfZeroError
   | n P.< P.zero = Rational (P.negate d) (P.negate n)
   | P.True = Rational d n
 


### PR DESCRIPTION
- [x] Add a new error code `reciprocalOfZeroError = "PT20"`.
- [x] Remove unused error code "PT4".
- [x] Chores in the `ErrorCodes` module, add comments.
- [x] Update relevant sections in the RTD site.