### PR TITLE
Add some text about how to deal with bad CHaP timestamps in RELEASE.adoc

### DIFF
--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -93,6 +93,8 @@ cp ./result/bin/uplc ./uplc-x86_64-linux-ghc96
 It is desirable to minimize the amount of change between `rc1` and `rc2`, because it may reduce the tests and checks that need to be performed against `rc2`.
 For instance, if `plutus-ledger-api` is the only package changed, there is no need to re-run tests on `plutus-core` or `plutus-tx`.
 Another example is if a security audit is done on `rc1`, and the changes in `rc2` do not modify the audited code, then the audit does not need to be re-done.
+- If another CHaP PR gets merged before yours it will invalidate the timestamps and you won't be able to merge: see the https://github.com/IntersectMBO/cardano-haskell-packages/blob/main/README.md[CHaP README file], in particular https://github.com/IntersectMBO/cardano-haskell-packages/blob/main/README.md#monotonically-increasing-timestamps[this section].  Read https://github.com/IntersectMBO/cardano-haskell-packages/blob/main/README.md#dealing-with-timestamp-conflicts[this section] for advice on how to deal with this problem.
+
 8. Once the CHaP PR has been merged, make a PR to update the version used in `cardano-ledger`. Example: https://github.com/IntersectMBO/cardano-ledger/pull/3563.
 - Update the version bounds in cabal files.
 - Update the CHaP index state in `cabal.project`.

--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -98,7 +98,7 @@ Another example is if a security audit is done on `rc1`, and the changes in `rc2
 8. Once the CHaP PR has been merged, make a PR to update the version used in `cardano-ledger`. Example: https://github.com/IntersectMBO/cardano-ledger/pull/3563.
 - Update the version bounds in cabal files.
 - Update the CHaP index state in `cabal.project`.
-- Update the CHaP flake input with `nix flake lock --update-input CHaP`.
+- Update the CHaP flake input with `nix flake update CHaP`.  If you get "error: cannot find flake 'flake:CHaP' in the flake registries" your nix installation probably needs to be updated.
 
 === Patch Releases
 

--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -98,7 +98,7 @@ Another example is if a security audit is done on `rc1`, and the changes in `rc2
 8. Once the CHaP PR has been merged, make a PR to update the version used in `cardano-ledger`. Example: https://github.com/IntersectMBO/cardano-ledger/pull/3563.
 - Update the version bounds in cabal files.
 - Update the CHaP index state in `cabal.project`.
-- Update the CHaP flake input with `nix flake update CHaP`.
+- Update the CHaP flake input with `nix flake lock --update-input CHaP`.
 
 === Patch Releases
 


### PR DESCRIPTION
I had some difficulty making the 1.25.0.0 release because other people's CHaP PRs kept getting merged before mine.  I've added a warning about that and some links to the CHaP documentation in case it happens to anyone else. Thanks to @michaelpj for the pointers.