### PR TITLE
Improved error message for the `mustBeReplaced`

### DIFF
--- a/plutus-tx/src/PlutusTx/Utils.hs
+++ b/plutus-tx/src/PlutusTx/Utils.hs
@@ -1,8 +1,12 @@
--- editorconfig-checker-disable-file
 module PlutusTx.Utils where
 
 -- We do not use qualified import because the whole module contains off-chain code
 import Prelude as Haskell
 
 mustBeReplaced :: String -> a
-mustBeReplaced message = error $ "This must be replaced by the core-to-plc plugin during compilation: " <> message
+mustBeReplaced placeholder =
+  error $
+    "The " <> show placeholder <> " placeholder must have been replaced by the \
+      \core-to-plc plugin during compilation. \
+      \The most likely reason the replacement didn't happen is that a PlutusTx \
+      \function was evaluated by off-chain code."


### PR DESCRIPTION
Before:
```
ghci> PlutusTx.List.head []
*** Exception: This must be replaced by the core-to-plc plugin during compilation: error
CallStack (from HasCallStack):
  error, called at src/PlutusTx/Utils.hs:8:26 in plutus-tx-1.25.0.0-inplace:PlutusTx.Utils
```

After:
```
PlutusTx.List.head []
*** Exception: The "error" placeholder must have been replaced by the core-to-plc plugin 
during compilation. The most likely reason the replacement didn't happen is that a PlutusTx 
function was evaluated by off-chain code.
CallStack (from HasCallStack):
  error, called at src/PlutusTx/Utils.hs:8:3 in plutus-tx-1.25.0.0-inplace:PlutusTx.Utils
```