### PR TITLE
Compile unicode strings

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -167,6 +167,7 @@ test-suite plutus-tx-plugin-tests
     Strictness.Spec
     TH.Spec
     TH.TestTH
+    Unicode.Spec
 
   build-depends:
     , base                                            >=4.9   && <5

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -136,8 +136,11 @@ compileLiteral = \case
 stringExprContent :: GHC.CoreExpr -> Maybe BS.ByteString
 stringExprContent = \case
   GHC.Lit (GHC.LitString bs) -> Just bs
-  -- unpackCString# is just a wrapper around a literal
-  GHC.Var n `GHC.App` expr | GHC.getName n == GHC.unpackCStringName -> stringExprContent expr
+  -- unpackCString# / unpackCStringUtf8# are just wrappers around a literal
+  GHC.Var n `GHC.App` expr
+    | let name = GHC.getName n
+    , name == GHC.unpackCStringName || name == GHC.unpackCStringUtf8Name ->
+      stringExprContent expr
   -- See Note [unpackFoldrCString#]
   GHC.Var build `GHC.App` _ `GHC.App` GHC.Lam _ (GHC.Var unpack `GHC.App` _ `GHC.App` expr)
     | GHC.getName build == GHC.buildName && GHC.getName unpack == GHC.unpackCStringFoldrName -> stringExprContent expr

--- a/plutus-tx-plugin/test/Spec.hs
+++ b/plutus-tx-plugin/test/Spec.hs
@@ -1,13 +1,12 @@
--- editorconfig-checker-disable-file
 module Main (main) where
 
 import AsData.Budget.Spec qualified as AsData.Budget
 import Blueprint.Tests qualified
 import Budget.Spec qualified as Budget
-import IntegerLiterals.NoStrict.NegativeLiterals.Spec qualified as IntegerLiterals.NoStrict.NegativeLiterals
-import IntegerLiterals.NoStrict.NoNegativeLiterals.Spec qualified as IntegerLiterals.NoStrict.NoNegativeLiterals
-import IntegerLiterals.Strict.NegativeLiterals.Spec qualified as IntegerLiterals.Strict.NegativeLiterals
-import IntegerLiterals.Strict.NoNegativeLiterals.Spec qualified as IntegerLiterals.Strict.NoNegativeLiterals
+import IntegerLiterals.NoStrict.NegativeLiterals.Spec qualified
+import IntegerLiterals.NoStrict.NoNegativeLiterals.Spec qualified
+import IntegerLiterals.Strict.NegativeLiterals.Spec qualified
+import IntegerLiterals.Strict.NoNegativeLiterals.Spec qualified
 import IsData.Spec qualified as IsData
 import Lift.Spec qualified as Lift
 import Optimization.Spec qualified as Optimization
@@ -15,10 +14,10 @@ import Plugin.Spec qualified as Plugin
 import ShortCircuit.Spec qualified as ShortCircuit
 import StdLib.Spec qualified as Lib
 import Strictness.Spec qualified as Strictness
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.Extras (TestNested, runTestNestedIn)
 import TH.Spec qualified as TH
-
-import Test.Tasty
-import Test.Tasty.Extras
+import Unicode.Spec qualified as Unicode
 
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests
@@ -28,10 +27,10 @@ tests =
   testGroup "tests"
     <$> sequence
       [ Plugin.tests
-      , IntegerLiterals.NoStrict.NegativeLiterals.tests
-      , IntegerLiterals.NoStrict.NoNegativeLiterals.tests
-      , IntegerLiterals.Strict.NegativeLiterals.tests
-      , IntegerLiterals.Strict.NoNegativeLiterals.tests
+      , IntegerLiterals.NoStrict.NegativeLiterals.Spec.tests
+      , IntegerLiterals.NoStrict.NoNegativeLiterals.Spec.tests
+      , IntegerLiterals.Strict.NegativeLiterals.Spec.tests
+      , IntegerLiterals.Strict.NoNegativeLiterals.Spec.tests
       , IsData.tests
       , Lift.tests
       , TH.tests
@@ -42,4 +41,5 @@ tests =
       , pure ShortCircuit.tests
       , Strictness.tests
       , Blueprint.Tests.goldenTests
+      , pure Unicode.tests
       ]

--- a/plutus-tx-plugin/test/Unicode/Spec.hs
+++ b/plutus-tx-plugin/test/Unicode/Spec.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE BlockArguments    #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Unicode.Spec where
+
+import Control.Lens (view)
+import Data.Text (Text)
+import PlutusCore.MkPlc (mkConstant)
+import PlutusTx (CompiledCode, compile, getPlcNoAnn, liftCodeDef)
+import PlutusTx.Builtins (BuiltinString)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import UntypedPlutusCore (progTerm)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Unicode"
+    [ testCase "Unicode characters are supported" do
+        let
+          code :: CompiledCode BuiltinString
+          code = $$(compile [||"λ"||])
+
+          lifted :: CompiledCode BuiltinString
+          lifted = liftCodeDef "λ"
+
+          term = view progTerm . getPlcNoAnn
+
+        term code @?= term lifted
+        term code @?= mkConstant () ("λ" :: Text)
+    ]


### PR DESCRIPTION
Fix compilation of "BuiltinString"s containing unicode chars:
```
GHC Core to PLC plugin: Error: Unexpected error during compilation, 
please report this to the Plutus team: 
Use of fromString with inscrutable content: unpackCStringUtf8#
```