### PR TITLE
Add some more complex test cases for the remove-trace plugin option

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -151,6 +151,7 @@ test-suite plutus-tx-plugin-tests
     Plugin.Functions.Spec
     Plugin.Laziness.Spec
     Plugin.Lib
+    Plugin.NoTrace.Lib
     Plugin.NoTrace.Spec
     Plugin.NoTrace.WithoutTraces
     Plugin.NoTrace.WithTraces

--- a/plutus-tx-plugin/test/Plugin/NoTrace/Lib.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/Lib.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unused-foralls #-}
+
+module Plugin.NoTrace.Lib where
+
+import Control.Lens (universeOf, (^.))
+import Data.Int (Int)
+import Data.List (length)
+import GHC.Exts (noinline)
+import PlutusCore.Builtin.Debug qualified as Builtin
+import PlutusTx.Bool (Bool)
+import PlutusTx.Builtins (BuiltinString, Integer, appendString)
+import PlutusTx.Code (CompiledCode, getPlcNoAnn)
+import PlutusTx.Numeric ((+))
+import PlutusTx.Show.TH (Show (show))
+import PlutusTx.Trace (trace, traceError)
+import UntypedPlutusCore qualified as UPLC
+
+data Arg = MkArg
+
+instance Show Arg where
+  show MkArg = "MkArg"
+
+countTraces :: CompiledCode a -> Int
+countTraces code =
+  length
+    [ subterm
+    | let term = getPlcNoAnn code ^. UPLC.progTerm
+    , subterm@(UPLC.Builtin _ Builtin.Trace) <- universeOf UPLC.termSubterms term
+    ]
+
+----------------------------------------------------------------------------------------------------
+-- Functions that contain traces -------------------------------------------------------------------
+
+traceArgument :: BuiltinString -> ()
+traceArgument x = trace x ()
+
+traceShow :: ()
+traceShow =
+  let f :: (Show s) => s -> ()
+      f s = trace (show s) ()
+   in noinline f MkArg
+
+traceDirect :: ()
+traceDirect = trace "test" ()
+
+traceNonConstant :: (BuiltinString -> BuiltinString)
+traceNonConstant x = trace "!!!" (x `appendString` "7")
+
+traceComplex :: (Bool -> ())
+traceComplex b =
+  if b
+    then trace "yes" ()
+    else traceError "no" ()
+
+traceRepeatedly :: Integer
+traceRepeatedly =
+  let i1 = trace "Making my first int" (1 :: Integer)
+      i2 = trace "Making my second int" (2 :: Integer)
+      i3 = trace "Adding them up" (i1 + i2)
+   in i3

--- a/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
@@ -8,15 +8,12 @@ module Plugin.NoTrace.Spec where
 
 import Prelude
 
-import Control.Lens (universeOf, (^.))
+import Plugin.NoTrace.Lib (countTraces)
 import Plugin.NoTrace.WithoutTraces qualified as WithoutTraces
 import Plugin.NoTrace.WithTraces qualified as WithTraces
-import PlutusCore.Default.Builtins qualified as Builtin
-import PlutusTx.Code (CompiledCode, getPlcNoAnn)
 import Test.Tasty (testGroup)
 import Test.Tasty.Extras (TestNested)
 import Test.Tasty.HUnit (testCase, (@=?))
-import UntypedPlutusCore.Core qualified as UPLC
 
 noTrace :: TestNested
 noTrace = pure do
@@ -24,36 +21,32 @@ noTrace = pure do
     "remove-trace"
     [ testGroup
         "Trace calls are present"
-        [ testCase "trace" $
-            1 @=? countTraces WithTraces.trace
+        [ testCase "trace-argument" $
+            1 @=? countTraces WithTraces.traceArgument
+        , testCase "trace-show" $
+            1 @=? countTraces WithTraces.traceShow
         , testCase "trace-complex" $
             2 @=? countTraces WithTraces.traceComplex
         , testCase "trace-direct" $
             1 @=? countTraces WithTraces.traceDirect
-        , testCase "trace-prelude" $
-            1 @=? countTraces WithTraces.tracePrelude
+        , testCase "trace-non-constant" $
+            1 @=? countTraces WithTraces.traceNonConstant
         , testCase "trace-repeatedly" $
             3 @=? countTraces WithTraces.traceRepeatedly
         ]
     , testGroup
         "Trace calls are absent"
-        [ testCase "trace" $
-            0 @=? countTraces WithoutTraces.trace
+        [ testCase "trace-argument" $
+            0 @=? countTraces WithoutTraces.traceArgument
+        , testCase "trace-show" $
+            0 @=? countTraces WithoutTraces.traceShow
         , testCase "trace-complex" $
             0 @=? countTraces WithoutTraces.traceComplex
         , testCase "trace-direct" $
             0 @=? countTraces WithoutTraces.traceDirect
-        , testCase "trace-prelude" $
-            0 @=? countTraces WithoutTraces.tracePrelude
+        , testCase "trace-non-constant" $
+            0 @=? countTraces WithoutTraces.traceNonConstant
         , testCase "trace-repeatedly" $
             0 @=? countTraces WithoutTraces.traceRepeatedly
         ]
-    ]
-
-countTraces :: CompiledCode a -> Int
-countTraces code =
-  length
-    [ subterm
-    | subterm@(UPLC.Builtin _ Builtin.Trace) <-
-        universeOf UPLC.termSubterms (getPlcNoAnn code ^. UPLC.progTerm)
     ]

--- a/plutus-tx-plugin/test/Plugin/NoTrace/WithTraces.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/WithTraces.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE BlockArguments    #-}
 {-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 -- The plugin uses non-conservative optimizations by default and they remove some traces.
@@ -11,30 +9,27 @@
 
 module Plugin.NoTrace.WithTraces where
 
-import PlutusTx (CompiledCode, compile)
-import PlutusTx.Builtins qualified as B
-import PlutusTx.Prelude qualified as P
+import Data.Proxy (Proxy (..))
+import Plugin.NoTrace.Lib qualified as Lib
+import PlutusTx.Bool (Bool)
+import PlutusTx.Builtins (BuiltinString, Integer)
+import PlutusTx.Code (CompiledCode)
+import PlutusTx.Plugin (plc)
 
-trace :: CompiledCode (B.BuiltinString -> ())
-trace = $$(compile [||\(x :: B.BuiltinString) -> B.trace x ()||])
+traceArgument :: CompiledCode (BuiltinString -> ())
+traceArgument = plc (Proxy @"traceArgument") Lib.traceArgument
+
+traceShow :: CompiledCode ()
+traceShow = plc (Proxy @"traceShow") Lib.traceShow
 
 traceDirect :: CompiledCode ()
-traceDirect = $$(compile [||B.trace "test" ()||])
+traceDirect = plc (Proxy @"traceDirect") Lib.traceDirect
 
-tracePrelude :: CompiledCode Integer
-tracePrelude = $$(compile [||P.trace "test" (1 :: Integer)||])
+traceNonConstant :: CompiledCode (BuiltinString -> BuiltinString)
+traceNonConstant = plc (Proxy @"traceNonConstant") Lib.traceNonConstant
 
 traceComplex :: CompiledCode (Bool -> ())
-traceComplex =
-  $$(compile [||\(b :: Bool) -> if b then P.trace "yes" () else P.traceError "no" ()||])
+traceComplex = plc (Proxy @"traceComplex") Lib.traceComplex
 
-traceRepeatedly :: CompiledCode P.Integer
-traceRepeatedly =
-  $$( compile
-        [||
-        let i1 = P.trace "Making my first int" (1 :: P.Integer)
-            i2 = P.trace "Making my second int" (2 :: P.Integer)
-            i3 = P.trace "Adding them up" (i1 P.+ i2)
-         in i3
-        ||]
-    )
+traceRepeatedly :: CompiledCode Integer
+traceRepeatedly = plc (Proxy @"traceRepeatedly") Lib.traceRepeatedly

--- a/plutus-tx-plugin/test/Plugin/NoTrace/WithoutTraces.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/WithoutTraces.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE BlockArguments    #-}
 {-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 -- The plugin uses non-conservative optimizations by default and they remove some traces.
@@ -11,30 +9,27 @@
 
 module Plugin.NoTrace.WithoutTraces where
 
-import PlutusTx (CompiledCode, compile)
-import PlutusTx.Builtins qualified as B
-import PlutusTx.Prelude qualified as P
+import Data.Proxy (Proxy (..))
+import Plugin.NoTrace.Lib qualified as Lib
+import PlutusTx.Bool (Bool)
+import PlutusTx.Builtins (BuiltinString, Integer)
+import PlutusTx.Code (CompiledCode)
+import PlutusTx.Plugin (plc)
 
-trace :: CompiledCode (B.BuiltinString -> ())
-trace = $$(compile [||\(x :: B.BuiltinString) -> B.trace x ()||])
+traceArgument :: CompiledCode (BuiltinString -> ())
+traceArgument = plc (Proxy @"traceArgument") Lib.traceArgument
+
+traceShow :: CompiledCode ()
+traceShow = plc (Proxy @"traceShow") Lib.traceShow
 
 traceDirect :: CompiledCode ()
-traceDirect = $$(compile [||B.trace "test" ()||])
+traceDirect = plc (Proxy @"traceDirect") Lib.traceDirect
 
-tracePrelude :: CompiledCode Integer
-tracePrelude = $$(compile [||P.trace "test" (1 :: Integer)||])
+traceNonConstant :: CompiledCode (BuiltinString -> BuiltinString)
+traceNonConstant = plc (Proxy @"traceNonConstant") Lib.traceNonConstant
 
 traceComplex :: CompiledCode (Bool -> ())
-traceComplex =
-  $$(compile [||\(b :: Bool) -> if b then P.trace "yes" () else P.traceError "no" ()||])
+traceComplex = plc (Proxy @"traceComplex") Lib.traceComplex
 
-traceRepeatedly :: CompiledCode P.Integer
-traceRepeatedly =
-  $$( compile
-        [||
-        let i1 = P.trace "Making my first int" (1 :: P.Integer)
-            i2 = P.trace "Making my second int" (2 :: P.Integer)
-            i3 = P.trace "Adding them up" (i1 P.+ i2)
-         in i3
-        ||]
-    )
+traceRepeatedly :: CompiledCode Integer
+traceRepeatedly = plc (Proxy @"traceRepeatedly") Lib.traceRepeatedly


### PR DESCRIPTION
- [x] Extract common code into a `Lib` module;
- [x] Test case for a non-constant trace.