### PR TITLE
Kwxm/plc spec/bitwise conversions

### DIFF
--- a/doc/plutus-core-spec/builtins.tex
+++ b/doc/plutus-core-spec/builtins.tex
@@ -55,7 +55,7 @@ would be considerably less compact.}
 The universe $\Uni$ consists entirely of \textit{names}, and the semantics of
 these names are given by \textit{denotations}. Each built-in type $\tn \in \Uni$
 is associated with some mathematical set $\denote{\tn}$, the \textit{denotation}
-of $\tn$. For example, we might have $\denote{\texttt{boolean}}=
+of $\tn$. For example, we might have $\denote{\texttt{bool}}=
 \{\mathsf{true}, \mathsf{false}\}$ and $\denote{\texttt{integer}} = \mathbb{Z}$
 and $\denote{\pairOf{a}{b}} = \denote{a} \times \denote{b}$.
 
@@ -326,7 +326,7 @@ $$[\iota_1, \ldots, \iota_n] \rightarrow \tau$$ with
 \noindent For example, in our default set of built-in functions we have the
 functions \texttt{mkCons} with signature $[\forall a_\#, a_\#,$  %% Allow line break
   $\listOf{a_\#}] \rightarrow \listOf{a_\#}$ and \texttt{ifThenElse} with signature
-$[\forall a_*, \mathtt{boolean}, a_*, a_*] \rightarrow a_*$.  When we use
+$[\forall a_*, \mathtt{bool}, a_*, a_*] \rightarrow a_*$.  When we use
 \texttt{mkCons} its arguments must be of built-in types, but the two final
 arguments of \texttt{ifThenElse} can be any Plutus Core values.
 

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -69,8 +69,8 @@ The \texttt{integerToByteString} function converts non-negative integers to byte
 It takes three arguments:
 \begin{itemize}
 \item An endianness flag $e$.
-\item A width argument $w$.
-\item The integer $n$ to be converted.
+\item A width argument $w$ with $0 \leq w < 8192$.
+\item The integer $n$ to be converted: it is required that $0 \leq n < 256^{8192} = 2^{65536}$.
 \end{itemize}
 
 \noindent If $e$ is \texttt{True} then the conversion is big-endian, otherwise it is
@@ -84,8 +84,21 @@ make it the correct length.  In all cases it is an error if $n<0$.
 \newpage
 \noindent The precise semantics of \texttt{integerToByteString} are given
 by the functions $\itobsBE: \Z \times \Z \rightarrow \B^*$ and $\itobsLE
-: \Z \times \Z \rightarrow \B^*$.  Writing $n = \sum_{i=0}^{N-1}a_i256^i$ with
-$a_{N-1} \ne 0$, we have
+: \Z \times \Z \rightarrow \B^*$.  Firstly we deal with out-of-range cases and
+the case $n=0$:
+
+$$
+\itobsLE (w,n) = \itobsBE (w,n) = 
+\begin{cases}
+  \errorX & \text{if $n<0$ or $n \geq 2^{65536}$}\\
+  \errorX & \text{if $w<0$ or $w > 8192$}\\
+  [] & \text{if $n=0$ and $0 \leq w \leq 8192$}\\
+\end{cases}
+$$
+
+\noindent  Now assume that none of the conditions above hold, so $0 < n < 2^{65536}$ and
+$0 \leq w \leq 8192$.  Since $n>0$ we can write
+$n = \sum_{i=0}^{N-1}a_i256^i$ with $a_{N-1} \ne 0$ and $N \geq 1$.   We then  have
 
 $$
 \itobsLE (w,n) =
@@ -106,7 +119,7 @@ $$
 \noindent
 \itobsBE (w,n) =
 \begin{cases}
-  [b_0, \ldots, b_{N-1}] & \text{if $w=0$, where $b_i = a_{N-1-i}$} \\
+  [a_{N-1}, \ldots, a_0] & \text{if $w=0$} \\
   [b_0, \ldots, b_{w-1}] &  \text{if $w > 0$ and $N\leq w$, where }
       b_i = \begin{cases}
                 a_{w-1-i} & \text{if $i \geq w-N$} \\
@@ -115,8 +128,6 @@ $$
   \errorX & \text{if $w > 0$ and $N > w$.}
 \end{cases}
 $$
-
-\noindent In the vacuous case $N=0$ we have $\itobsLE(0,0) = \itobsBE(0,0) = []$, the empty bytestring.
 
 \note{Bytestring to integer conversion.}
 \label{note:bstoi}
@@ -128,7 +139,8 @@ integers.  It takes two arguments:
 \end{itemize}
 \noindent  
 If $e$ is \texttt{True} then the conversion is big-endian, otherwise it is
-little-endian.  In both cases the empty bytestring is converted to the integer 0.
+little-endian.  In both cases the empty bytestring is converted to the integer
+0. There is no limitation on the size of $s$.
 
 \subsubsection{BLS12-381 built-in types}
 \label{sec:bls-types-4}

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -46,7 +46,7 @@ The fourth batch of builtins adds support for
     \TT{keccak\_256}  & $[\ty{bytestring}] \to \ty{bytestring}$  & \text{Hash a $\ty{bytestring}$ using}
                                                                    \TT{Keccak-256}~\cite{KeccakRef3}. &  & \\
     \hline
-    \TT{integerToByteString} & $[\ty{boolean}, \ty{boolean}, \ty{integer}]$  \text{\: $\to \ty{bytestring}$}
+    \TT{integerToByteString} & $[\ty{boolean}, \ty{integer}, \ty{integer}]$  \text{\: $\to \ty{bytestring}$}
                                         & \itobs & Yes & \ref{note:itobs}\\
     \TT{byteStringToInteger} & $[\ty{boolean}, \ty{bytestring}] $ \text{\: $ \to \ty{bytestring}$}
                                         & \bstoi & & \ref{note:bstoi} \\

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -8,8 +8,10 @@
   \noindent\textbf{Note \thenotenumberD. #1}
 }
 
-\newcommand{\itobs}{\textsf{itobs}}
-\newcommand{\bstoi}{\textsf{bstoi}}
+\newcommand{\itobsBE}{\mathsf{itobs_{LE}}}
+\newcommand{\itobsLE}{\mathsf{itobs_{BE}}}
+\newcommand{\bstoiBE}{\mathsf{bstoi_{LE}}}
+\newcommand{\bstoiLE}{\mathsf{bstoi_{BE}}}
 
 \subsection{Batch 4}
 \label{sec:default-builtins-4}
@@ -26,7 +28,7 @@ The fourth batch of builtins adds support for
 \label{sec:misc-builtins-4}
 
 \setlength{\LTleft}{-10mm} % Shift the table left a bit to centre it on the page
-\begin{longtable}[H]{|l|p{45mm}|p{4cm}|c|c|}
+\begin{longtable}[H]{|l|p{45mm}|p{60mm}|c|c|}
     \hline \text{Function} & \text{Signature} & \text{Denotation} & \text{Can}
     & \text{Note} \\ & & & fail?
     & \\ \hline \endfirsthead \hline \text{Function} & \text{Type}
@@ -45,22 +47,87 @@ The fourth batch of builtins adds support for
                                                                    \TT{Blake2b-224}~\cite{IETF-Blake2}. &  & \\
     \TT{keccak\_256}  & $[\ty{bytestring}] \to \ty{bytestring}$  & \text{Hash a $\ty{bytestring}$ using}
                                                                    \TT{Keccak-256}~\cite{KeccakRef3}. &  & \\
-    \hline
-    \TT{integerToByteString} & $[\ty{boolean}, \ty{integer}, \ty{integer}]$  \text{\: $\to \ty{bytestring}$}
-                                        & \itobs & Yes & \ref{note:itobs}\\
-    \TT{byteStringToInteger} & $[\ty{boolean}, \ty{bytestring}] $ \text{\: $ \to \ty{bytestring}$}
-                                        & \bstoi & & \ref{note:bstoi} \\
+    \hline\strut
+    \TT{integerToByteString} & $[\ty{bool}, \ty{integer}, \ty{integer}]$  \text{\: $\to \ty{bytestring}$}
+                                        & $(e, w, n) $ \text{$\mapsto \begin{cases}
+                                        \itobsLE(w,n) & \text{if $e=\mathtt{false}$}\\
+                                        \bstoiBE(w,n) & \text{if $e=\mathtt{true}$}\\
+                                        \end{cases}$}
+                                        & Yes & \ref{note:itobs}\strut\\ \strut
+    \TT{byteStringToInteger} & $[\ty{bool}, \ty{bytestring}] $ \text{\: $ \to \ty{bytestring}$}
+                                        & $(e, [c_0, \ldots, c_{N-1}]) $ \text{\; $\mapsto \begin{cases}
+                                        \sum_{i=0}^{N-1}c_i256^i & \text{if $e=\mathtt{false}$}\\
+                                        \sum_{i=0}^{N-1}c_{N-1-i}256^i & \text{if $e=\mathtt{true}$}\\
+                                        \end{cases}$}
+                                        &  & \ref{note:bstoi} \\
 
     \hline
 \end{longtable}
 
 \note{Integer to bytestring conversion.}
 \label{note:itobs}
-Blah blah blah.
+The \texttt{integerToByteString} function converts non-negative integers to bytestrings.
+It takes three arguments:
+\begin{itemize}
+\item An endianness flag $e$.
+\item A width argument $w$.
+\item The integer $n$ to be converted.
+\end{itemize}
+
+\noindent If $e$ is \texttt{True} then the conversion is big-endian, otherwise it is
+little-endian. If the width $w$ is zero then the output is a bytestring which is
+just large enough to hold the converted integer.  If $w>0$ then the output is
+exactly $w$ bytes long, and it is an error if $n$ does not fit into a bytestring
+of that size; if necessary, the output is padded with 0x00 bytes (on the left if
+$e = \mathtt{True}$ and on the right if $e = \mathtt{False}$) to make it the
+correct length.  In all cases it is an error if $n<0$.
+
+The precise semantics are given by the functions $\itobsBE
+: \Z \times \Z \rightarrow \B^*$ and $\itobsLE : \Z \times \Z \rightarrow \B^*$.
+Writing $n = \sum_{i=0}^Na_i256^i$ with $a_N \ne 0$, we have 
+
+$$
+\itobsLE (w,n) =
+\begin{cases}
+  [a_0, \ldots, a_N] & \text{if $w=0$} \\
+  [b_0, \ldots, b_w] &  \text{if $w > 0$ and $N\le w$, where }
+      b_i = \begin{cases}
+                a_i & \text{if $i \leq N$} \\
+                0   & \text{if $i > N$}\\
+            \end{cases}\\
+  \errorX & \text{otherwise}
+\end{cases}
+$$
+
+\noindent and
+
+$$
+\noindent
+\itobsBE (w,n) =
+\begin{cases}
+  [a_N, \ldots, a_0] & \text{if $w=0$} \\
+  [b_w, \ldots, b_0] &  \text{if $w > 0$ and $N\le w$, where }
+      b_i = \begin{cases}
+                a_i & \text{if $i \leq N$} \\
+                0   & \text{if $i > N$}\\
+            \end{cases}\\
+  \errorX & \text{otherwise}
+\end{cases}
+$$
+
+\noindent We have $\itobsLE(0,0) = \itobsBE(0,0) = 0$.
 
 \note{Bytestring to integer conversion.}
 \label{note:bstoi}
-Blah blah blah.
+The \texttt{byteStringToInteger} function converts bytestrings to non-negative
+integers.  It takes two arguments:
+\begin{itemize}
+\item An endianness flag $e$.
+\item The bytestring $s$ to be converted.
+\end{itemize}
+\noindent  
+If $e$ is \texttt{True} then the conversion is big-endian, otherwise it is
+little-endian.  In both cases the empty bytestring is converted to the integer 0.
 
 \subsubsection{BLS12-381 built-in types}
 \label{sec:bls-types-4}

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -18,7 +18,7 @@
 The fourth batch of builtins adds support for
 \begin{itemize}
 \item The \texttt{Blake2b-224} and \texttt{Keccak-256} hash functions.
-\item Conversions functions from integers to bytestrings and vice-versa.
+\item Conversion functions from integers to bytestrings and vice-versa.
 \item BLS12-381 elliptic curve pairing operations
 (see~\cite{CIP-0381}, \cite{BLS12-381}, \cite[4.2.1]{IETF-pairing-friendly-curves}, \cite{BLST-library}).
  For clarity these are described separately in Sections~\ref{sec:bls-types-4} and \ref{sec:bls-builtins-4}.
@@ -68,8 +68,8 @@ The fourth batch of builtins adds support for
 The \texttt{integerToByteString} function converts non-negative integers to bytestrings.
 It takes three arguments:
 \begin{itemize}
-\item An endianness flag $e$.
-\item A width argument $w$ with $0 \leq w < 8192$.
+\item A boolean endianness flag $e$.
+\item An integer width argument $w$ with $0 \leq w < 8192$.
 \item The integer $n$ to be converted: it is required that $0 \leq n < 256^{8192} = 2^{65536}$.
 \end{itemize}
 
@@ -78,13 +78,13 @@ little-endian. If the width $w$ is zero then the output is a bytestring which is
 just large enough to hold the converted integer.  If $w>0$ then the output is
 exactly $w$ bytes long, and it is an error if $n$ does not fit into a bytestring
 of that size; if necessary, the output is padded with \texttt{0x00} bytes (on
-the left if $e = \mathtt{True}$ and on the right if $e = \mathtt{False}$) to
+the right if $e = \mathtt{False}$ and on the left if $e = \mathtt{True}$ ) to
 make it the correct length.  In all cases it is an error if $n<0$.
 
 \newpage
 \noindent The precise semantics of \texttt{integerToByteString} are given
-by the functions $\itobsBE: \Z \times \Z \rightarrow \B^*$ and $\itobsLE
-: \Z \times \Z \rightarrow \B^*$.  Firstly we deal with out-of-range cases and
+by the functions $\itobsLE: \Z \times \Z \rightarrow \withError{\B^*}$ and $\itobsBE
+: \Z \times \Z \rightarrow \withError{\B^*}$.  Firstly we deal with out-of-range cases and
 the case $n=0$:
 
 $$
@@ -134,7 +134,7 @@ $$
 The \texttt{byteStringToInteger} function converts bytestrings to non-negative
 integers.  It takes two arguments:
 \begin{itemize}
-\item An endianness flag $e$.
+\item A boolean endianness flag $e$.
 \item The bytestring $s$ to be converted.
 \end{itemize}
 \noindent  

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -122,8 +122,8 @@ $$
   [a_{N-1}, \ldots, a_0] & \text{if $w=0$} \\
   [b_0, \ldots, b_{w-1}] &  \text{if $w > 0$ and $N\leq w$, where }
       b_i = \begin{cases}
-                a_{w-1-i} & \text{if $i \geq w-N$} \\
                 0   & \text{if $i \leq w-1-N$}\\
+                a_{w-1-i} & \text{if $i \geq w-N$} \\
             \end{cases}\\
   \errorX & \text{if $w > 0$ and $N > w$.}
 \end{cases}

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -73,13 +73,18 @@ It takes three arguments:
 \item The integer $n$ to be converted: it is required that $0 \leq n < 256^{8192} = 2^{65536}$.
 \end{itemize}
 
-\noindent If $e$ is \texttt{True} then the conversion is big-endian, otherwise it is
-little-endian. If the width $w$ is zero then the output is a bytestring which is
-just large enough to hold the converted integer.  If $w>0$ then the output is
-exactly $w$ bytes long, and it is an error if $n$ does not fit into a bytestring
-of that size; if necessary, the output is padded with \texttt{0x00} bytes (on
-the right if $e = \mathtt{False}$ and on the left if $e = \mathtt{True}$ ) to
-make it the correct length.  In all cases it is an error if $n<0$.
+\noindent The conversion is little-endian if $e$ is \texttt{(con bool False)} and
+big-endian if $e$ is \texttt{(con bool True)}. If the width $w$ is zero then the
+output is a bytestring which is just large enough to hold the converted integer.
+If $w>0$ then the output is exactly $w$ bytes long, and it is an error if $n$
+does not fit into a bytestring of that size; if necessary, the output is padded
+with \texttt{0x00} bytes (on the right in the little-endian case and the left in
+the big-endian case) to make it the correct length.  For example, the five-byte
+little-endian representation of the integer \texttt{0x123456} is the
+bytestring \texttt{[0x56, 0x34, 0x12, 0x00, 0x00]} and the five-byte big-endian
+representation is \texttt{[0x00, 0x00, 0x12, 0x34, 0x56]}.  In all cases an
+error occurs error if $w$ or $n$ lies outside the expected range, and in
+particular if $n$ is negative.
 
 \newpage
 \noindent The precise semantics of \texttt{integerToByteString} are given
@@ -138,9 +143,10 @@ integers.  It takes two arguments:
 \item The bytestring $s$ to be converted.
 \end{itemize}
 \noindent  
-If $e$ is \texttt{True} then the conversion is big-endian, otherwise it is
-little-endian.  In both cases the empty bytestring is converted to the integer
-0. There is no limitation on the size of $s$.
+The conversion is little-endian if $e$ is \texttt{(con bool False)} and
+big-endian if $e$ is \texttt{(con bool True)}. In both cases the empty bytestring is
+converted to the integer 0. All bytestrings are legal inputs and there is no
+limitation on the size of $s$.
 
 \subsubsection{BLS12-381 built-in types}
 \label{sec:bls-types-4}

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -27,8 +27,8 @@ The fourth batch of builtins adds support for
 \subsubsection{Miscellaneous built-in functions}
 \label{sec:misc-builtins-4}
 
-\setlength{\LTleft}{-10mm} % Shift the table left a bit to centre it on the page
-\begin{longtable}[H]{|l|p{45mm}|p{60mm}|c|c|}
+\setlength{\LTleft}{-17mm} % Shift the table left a bit to centre it on the page
+\begin{longtable}[H]{|l|p{45mm}|p{65mm}|c|c|}
     \hline \text{Function} & \text{Signature} & \text{Denotation} & \text{Can}
     & \text{Note} \\ & & & fail?
     & \\ \hline \endfirsthead \hline \text{Function} & \text{Type}
@@ -43,10 +43,10 @@ The fourth batch of builtins adds support for
     \endlastfoot
 %% G1
     \hline
-    \TT{blake2b\_224} & $[\ty{bytestring}] \to \ty{bytestring}$  & \text{Hash a $\ty{bytestring}$ using}
-                                                                   \TT{Blake2b-224}~\cite{IETF-Blake2}. &  & \\
-    \TT{keccak\_256}  & $[\ty{bytestring}] \to \ty{bytestring}$  & \text{Hash a $\ty{bytestring}$ using}
-                                                                   \TT{Keccak-256}~\cite{KeccakRef3}. &  & \\
+    \TT{blake2b\_224} & $[\ty{bytestring}] \to \ty{bytestring}$  & \text{Hash a $\ty{bytestring}$ using
+                                                                   \TT{Blake2b-224}~\cite{IETF-Blake2}.} & & \\
+    \TT{keccak\_256}  & $[\ty{bytestring}] \to \ty{bytestring}$  & \text{Hash a $\ty{bytestring}$ using
+                                                                   \TT{Keccak-256}~\cite{KeccakRef3}.} & & \\
     \hline\strut
     \TT{integerToByteString} & $[\ty{bool}, \ty{integer}, \ty{integer}]$  \text{\: $\to \ty{bytestring}$}
                                         & $(e, w, n) $ \text{$\mapsto \begin{cases}
@@ -56,8 +56,8 @@ The fourth batch of builtins adds support for
                                         & Yes & \ref{note:itobs}\strut\\ \strut
     \TT{byteStringToInteger} & $[\ty{bool}, \ty{bytestring}] $ \text{\: $ \to \ty{bytestring}$}
                                         & $(e, [c_0, \ldots, c_{N-1}]) $ \text{\; $\mapsto \begin{cases}
-                                        \sum_{i=0}^{N-1}c_i256^i & \text{if $e=\mathtt{false}$}\\
-                                        \sum_{i=0}^{N-1}c_i256^{N-1-i} & \text{if $e=\mathtt{true}$}\\
+                                        \sum_{i=0}^{N-1}c_{i}256^i & \text{if $e=\mathtt{false}$}\\
+                                        \sum_{i=0}^{N-1}c_{i}256^{N-1-i} & \text{if $e=\mathtt{true}$}\\
                                         \end{cases}$}
                                         &  & \ref{note:bstoi}\\
     \hline
@@ -98,7 +98,7 @@ $$
 
 \noindent  Now assume that none of the conditions above hold, so $0 < n < 2^{65536}$ and
 $0 \leq w \leq 8192$.  Since $n>0$ we can write
-$n = \sum_{i=0}^{N-1}a_i256^i$ with $a_{N-1} \ne 0$ and $N \geq 1$.   We then  have
+$n = \sum_{i=0}^{N-1}a_{i}256^i$ with $N \geq 1$ and $a_{N-1} \ne 0$.   We then  have
 
 $$
 \itobsLE (w,n) =

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -8,10 +8,10 @@
   \noindent\textbf{Note \thenotenumberD. #1}
 }
 
-\newcommand{\itobsBE}{\mathsf{itobs_{LE}}}
-\newcommand{\itobsLE}{\mathsf{itobs_{BE}}}
-\newcommand{\bstoiBE}{\mathsf{bstoi_{LE}}}
-\newcommand{\bstoiLE}{\mathsf{bstoi_{BE}}}
+\newcommand{\itobsBE}{\mathsf{itobs_{BE}}}
+\newcommand{\itobsLE}{\mathsf{itobs_{LE}}}
+\newcommand{\bstoiBE}{\mathsf{bstoi_{BE}}}
+\newcommand{\bstoiLE}{\mathsf{bstoi_{LE}}}
 
 \subsection{Batch 4}
 \label{sec:default-builtins-4}
@@ -51,16 +51,15 @@ The fourth batch of builtins adds support for
     \TT{integerToByteString} & $[\ty{bool}, \ty{integer}, \ty{integer}]$  \text{\: $\to \ty{bytestring}$}
                                         & $(e, w, n) $ \text{$\mapsto \begin{cases}
                                         \itobsLE(w,n) & \text{if $e=\mathtt{false}$}\\
-                                        \bstoiBE(w,n) & \text{if $e=\mathtt{true}$}\\
+                                        \itobsBE(w,n) & \text{if $e=\mathtt{true}$}\\
                                         \end{cases}$}
                                         & Yes & \ref{note:itobs}\strut\\ \strut
     \TT{byteStringToInteger} & $[\ty{bool}, \ty{bytestring}] $ \text{\: $ \to \ty{bytestring}$}
                                         & $(e, [c_0, \ldots, c_{N-1}]) $ \text{\; $\mapsto \begin{cases}
                                         \sum_{i=0}^{N-1}c_i256^i & \text{if $e=\mathtt{false}$}\\
-                                        \sum_{i=0}^{N-1}c_{N-1-i}256^i & \text{if $e=\mathtt{true}$}\\
+                                        \sum_{i=0}^{N-1}c_i256^{N-1-i} & \text{if $e=\mathtt{true}$}\\
                                         \end{cases}$}
-                                        &  & \ref{note:bstoi} \\
-
+                                        &  & \ref{note:bstoi}\\
     \hline
 \end{longtable}
 
@@ -78,22 +77,22 @@ It takes three arguments:
 little-endian. If the width $w$ is zero then the output is a bytestring which is
 just large enough to hold the converted integer.  If $w>0$ then the output is
 exactly $w$ bytes long, and it is an error if $n$ does not fit into a bytestring
-of that size; if necessary, the output is padded with 0x00 bytes (on the left if
-$e = \mathtt{True}$ and on the right if $e = \mathtt{False}$) to make it the
-correct length.  In all cases it is an error if $n<0$.
+of that size; if necessary, the output is padded with \texttt{0x00} bytes (on
+the left if $e = \mathtt{True}$ and on the right if $e = \mathtt{False}$) to
+make it the correct length.  In all cases it is an error if $n<0$.
 
 The precise semantics are given by the functions $\itobsBE
 : \Z \times \Z \rightarrow \B^*$ and $\itobsLE : \Z \times \Z \rightarrow \B^*$.
-Writing $n = \sum_{i=0}^Na_i256^i$ with $a_N \ne 0$, we have 
+Writing $n = \sum_{i=0}^{N-1}a_i256^i$ with $a_{N-1} \ne 0$, we have 
 
 $$
 \itobsLE (w,n) =
 \begin{cases}
-  [a_0, \ldots, a_N] & \text{if $w=0$} \\
-  [b_0, \ldots, b_w] &  \text{if $w > 0$ and $N\le w$, where }
+  [a_0, \ldots, a_{N-1}] & \text{if $w=0$} \\
+  [b_0, \ldots, b_{w-1}] &  \text{if $w > 0$ and $N\leq w$, where }
       b_i = \begin{cases}
-                a_i & \text{if $i \leq N$} \\
-                0   & \text{if $i > N$}\\
+                a_i & \text{if $i \leq N-1$} \\
+                0   & \text{if $i \geq N$}\\
             \end{cases}\\
   \errorX & \text{otherwise}
 \end{cases}
@@ -105,17 +104,17 @@ $$
 \noindent
 \itobsBE (w,n) =
 \begin{cases}
-  [a_N, \ldots, a_0] & \text{if $w=0$} \\
-  [b_w, \ldots, b_0] &  \text{if $w > 0$ and $N\le w$, where }
+  [b_0, \ldots, b_{N-1}] & \text{if $w=0$, where $b_i = a_{N-1-i}$} \\
+  [b_0, \ldots, b_{w-1}] &  \text{if $w > 0$ and $N\leq w$, where }
       b_i = \begin{cases}
-                a_i & \text{if $i \leq N$} \\
-                0   & \text{if $i > N$}\\
+                a_{w-1-i} & \text{if $i \geq w-N$} \\
+                0   & \text{if $i \leq w-1-N$}\\
             \end{cases}\\
-  \errorX & \text{otherwise}
+  \errorX & \text{otherwise.}
 \end{cases}
 $$
 
-\noindent We have $\itobsLE(0,0) = \itobsBE(0,0) = 0$.
+\noindent In the vacuous case $N=0$ we have $\itobsLE(0,0) = \itobsBE(0,0) = []$, the empty bytestring.
 
 \note{Bytestring to integer conversion.}
 \label{note:bstoi}

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -8,11 +8,15 @@
   \noindent\textbf{Note \thenotenumberD. #1}
 }
 
+\newcommand{\itobs}{\textsf{itobs}}
+\newcommand{\bstoi}{\textsf{bstoi}}
+
 \subsection{Batch 4}
 \label{sec:default-builtins-4}
 The fourth batch of builtins adds support for
 \begin{itemize}
-\item The \texttt{Blake2b-224} and \texttt{Keccak-256} hash functions (Section \ref{sec:misc-builtins-4})
+\item The \texttt{Blake2b-224} and \texttt{Keccak-256} hash functions.
+\item Conversions functions from integers to bytestrings and vice-versa.
 \item BLS12-381 elliptic curve pairing operations
 (see~\cite{CIP-0381}, \cite{BLS12-381}, \cite[4.2.1]{IETF-pairing-friendly-curves}, \cite{BLST-library}).
  For clarity these are described separately in Sections~\ref{sec:bls-types-4} and \ref{sec:bls-builtins-4}.
@@ -22,7 +26,7 @@ The fourth batch of builtins adds support for
 \label{sec:misc-builtins-4}
 
 \setlength{\LTleft}{-10mm} % Shift the table left a bit to centre it on the page
-\begin{longtable}[H]{|l|p{5cm}|p{55mm}|c|c|}
+\begin{longtable}[H]{|l|p{45mm}|p{4cm}|c|c|}
     \hline \text{Function} & \text{Signature} & \text{Denotation} & \text{Can}
     & \text{Note} \\ & & & fail?
     & \\ \hline \endfirsthead \hline \text{Function} & \text{Type}
@@ -42,7 +46,21 @@ The fourth batch of builtins adds support for
     \TT{keccak\_256}  & $[\ty{bytestring}] \to \ty{bytestring}$  & \text{Hash a $\ty{bytestring}$ using}
                                                                    \TT{Keccak-256}~\cite{KeccakRef3}. &  & \\
     \hline
+    \TT{integerToByteString} & $[\ty{boolean}, \ty{boolean}, \ty{integer}]$  \text{\: $\to \ty{bytestring}$}
+                                        & \itobs & Yes & \ref{note:itobs}\\
+    \TT{byteStringToInteger} & $[\ty{boolean}, \ty{bytestring}] $ \text{\: $ \to \ty{bytestring}$}
+                                        & \bstoi & & \ref{note:bstoi} \\
+
+    \hline
 \end{longtable}
+
+\note{Integer to bytestring conversion.}
+\label{note:itobs}
+Blah blah blah.
+
+\note{Bytestring to integer conversion.}
+\label{note:bstoi}
+Blah blah blah.
 
 \subsubsection{BLS12-381 built-in types}
 \label{sec:bls-types-4}

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -81,9 +81,11 @@ of that size; if necessary, the output is padded with \texttt{0x00} bytes (on
 the left if $e = \mathtt{True}$ and on the right if $e = \mathtt{False}$) to
 make it the correct length.  In all cases it is an error if $n<0$.
 
-The precise semantics are given by the functions $\itobsBE
-: \Z \times \Z \rightarrow \B^*$ and $\itobsLE : \Z \times \Z \rightarrow \B^*$.
-Writing $n = \sum_{i=0}^{N-1}a_i256^i$ with $a_{N-1} \ne 0$, we have 
+\newpage
+\noindent The precise semantics of \texttt{integerToByteString} are given
+by the functions $\itobsBE: \Z \times \Z \rightarrow \B^*$ and $\itobsLE
+: \Z \times \Z \rightarrow \B^*$.  Writing $n = \sum_{i=0}^{N-1}a_i256^i$ with
+$a_{N-1} \ne 0$, we have
 
 $$
 \itobsLE (w,n) =
@@ -94,7 +96,7 @@ $$
                 a_i & \text{if $i \leq N-1$} \\
                 0   & \text{if $i \geq N$}\\
             \end{cases}\\
-  \errorX & \text{otherwise}
+  \errorX & \text{if $w > 0$ and $N > w$}
 \end{cases}
 $$
 
@@ -110,7 +112,7 @@ $$
                 a_{w-1-i} & \text{if $i \geq w-N$} \\
                 0   & \text{if $i \leq w-1-N$}\\
             \end{cases}\\
-  \errorX & \text{otherwise.}
+  \errorX & \text{if $w > 0$ and $N > w$.}
 \end{cases}
 $$
 

--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -73,18 +73,19 @@ It takes three arguments:
 \item The integer $n$ to be converted: it is required that $0 \leq n < 256^{8192} = 2^{65536}$.
 \end{itemize}
 
-\noindent The conversion is little-endian if $e$ is \texttt{(con bool False)} and
-big-endian if $e$ is \texttt{(con bool True)}. If the width $w$ is zero then the
-output is a bytestring which is just large enough to hold the converted integer.
-If $w>0$ then the output is exactly $w$ bytes long, and it is an error if $n$
-does not fit into a bytestring of that size; if necessary, the output is padded
-with \texttt{0x00} bytes (on the right in the little-endian case and the left in
-the big-endian case) to make it the correct length.  For example, the five-byte
-little-endian representation of the integer \texttt{0x123456} is the
-bytestring \texttt{[0x56, 0x34, 0x12, 0x00, 0x00]} and the five-byte big-endian
-representation is \texttt{[0x00, 0x00, 0x12, 0x34, 0x56]}.  In all cases an
-error occurs error if $w$ or $n$ lies outside the expected range, and in
-particular if $n$ is negative.
+\noindent The conversion is little-endian ($\mathsf{LE}$) if $e$ is
+\texttt{(con bool False)} and big-endian ($\mathsf{BE}$) if $e$ is
+\texttt{(con bool True)}. If the width $w$
+is zero then the output is a bytestring which is just large enough to hold the
+converted integer.  If $w>0$ then the output is exactly $w$ bytes long, and it
+is an error if $n$ does not fit into a bytestring of that size; if necessary,
+the output is padded with \texttt{0x00} bytes (on the right in the little-endian
+case and the left in the big-endian case) to make it the correct length.  For
+example, the five-byte little-endian representation of the
+integer \texttt{0x123456} is the bytestring \texttt{[0x56, 0x34, 0x12, 0x00,
+0x00]} and the five-byte big-endian representation is \texttt{[0x00, 0x00, 0x12,
+0x34, 0x56]}.  In all cases an error occurs error if $w$ or $n$ lies outside the
+expected range, and in particular if $n$ is negative.
 
 \newpage
 \noindent The precise semantics of \texttt{integerToByteString} are given
@@ -102,8 +103,9 @@ $$
 $$
 
 \noindent  Now assume that none of the conditions above hold, so $0 < n < 2^{65536}$ and
-$0 \leq w \leq 8192$.  Since $n>0$ we can write
-$n = \sum_{i=0}^{N-1}a_{i}256^i$ with $N \geq 1$ and $a_{N-1} \ne 0$.   We then  have
+$0 \leq w \leq 8192$.  Since $n>0$ it has a unique base-256 expansion of the
+form $n = \sum_{i=0}^{N-1}a_{i}256^i$ with $N \geq 1$, $a_i \in \B$ for $0 \leq
+i \leq N-1$ and $a_{N-1} \ne 0$.  We then have
 
 $$
 \itobsLE (w,n) =

--- a/doc/plutus-core-spec/plutus-core-specification.tex
+++ b/doc/plutus-core-spec/plutus-core-specification.tex
@@ -6,7 +6,7 @@
   \LARGE{\red{\textsf{DRAFT}}}
 }
 
-\date{21st December 2023}
+\date{18th April 2024}
 \author{Plutus Core Team}
 
 \input{header.tex}


### PR DESCRIPTION
[PLT-8189]  This adds the two new integer/bytestring conversions to the specification. See p35-36 of the attached PDF for a readable version.
 
[plutus-core-specification.pdf](https://github.com/IntersectMBO/plutus/files/15024318/plutus-core-specification.pdf)
