### PR TITLE
CaseOfCase kind mismatch error fix

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -608,6 +608,7 @@ test-suite plutus-ir-test
     PlutusIR.Compiler.Error.Tests
     PlutusIR.Compiler.Let.Tests
     PlutusIR.Compiler.Recursion.Tests
+    PlutusIR.Contexts.Tests
     PlutusIR.Core.Tests
     PlutusIR.Generators.QuickCheck.Tests
     PlutusIR.Parser.Tests

--- a/plutus-core/plutus-ir/src/PlutusIR/Contexts.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Contexts.hs
@@ -133,10 +133,12 @@ data SplitMatchContext tyname name uni fun a = SplitMatchContext
   }
 
 extractTyArgs :: AppContext tyname name uni fun a -> Maybe [Type tyname uni a]
-extractTyArgs = go []
-  where go acc (TypeAppContext ty _ ctx) = go (ty:acc) ctx
-        go _ (TermAppContext{})          = Nothing
-        go acc AppContextEnd             = Just acc
+extractTyArgs = go id
+  where
+    go acc = \case
+      TypeAppContext ty _ ctx -> go (acc . (ty :)) ctx
+      TermAppContext{}        -> Nothing
+      AppContextEnd           -> Just (acc [])
 
 -- | Split a normal datatype 'match'.
 splitNormalDatatypeMatch

--- a/plutus-core/plutus-ir/test/PlutusIR/Contexts/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Contexts/Tests.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE BlockArguments    #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module PlutusIR.Contexts.Tests where
+
+import PlutusIR
+import PlutusIR.Contexts
+
+import PlutusCore.Default (DefaultFun, DefaultUni)
+import PlutusCore.Name.Unique (Unique (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+test_extractTyArgs :: TestTree
+test_extractTyArgs =
+  testGroup
+    "Applying extractTyArgs to an"
+    [ testCase "empty AppContext evaluates to an empty list of ty args" do
+        extractTyArgs AppContextEnd @?= Just ([] :: [Type TyName DefaultUni ()])
+    , testCase "AppContext without type applications evaluates to Nothing" do
+        extractTyArgs (TermAppContext term () AppContextEnd) @?= Nothing
+    , testCase "AppContext with a mix of term and type applications evaluates to Nothing" do
+        extractTyArgs (TypeAppContext ty1 () (TermAppContext term () AppContextEnd)) @?= Nothing
+        extractTyArgs (TermAppContext term () (TypeAppContext ty1 () AppContextEnd)) @?= Nothing
+    , testCase "AppContext with type applications only evaluates to Just (list of ty vars)" do
+        extractTyArgs (TypeAppContext ty1 () (TypeAppContext ty2 () AppContextEnd))
+          @?= Just [ty1, ty2]
+    ]
+
+----------------------------------------------------------------------------------------------------
+-- Test values -------------------------------------------------------------------------------------
+
+term :: Term TyName Name DefaultUni DefaultFun ()
+term = Var () (Name "x" (Unique 0))
+
+ty1 :: Type TyName DefaultUni ()
+ty1 = TyVar () (TyName (Name "t" (Unique 0)))
+
+ty2 :: Type TyName DefaultUni ()
+ty2 = TyVar () (TyName (Name "t" (Unique 1)))

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/CaseOfCase/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/CaseOfCase/Tests.hs
@@ -21,6 +21,7 @@ test_caseOfCase = runTestNestedIn ["plutus-ir", "test", "PlutusIR", "Transform"]
             , "builtinBool"
             , "largeExpr"
             , "exponential"
+            , "twoTyArgs"
             ]
 
 prop_caseOfCase :: Property

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/CaseOfCase/twoTyArgs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/CaseOfCase/twoTyArgs
@@ -1,0 +1,30 @@
+(let
+  (nonrec)
+  (datatypebind
+    (datatype
+      (tyvardecl d12 (fun (fun (type) (type)) (fun (type) (type))))
+      (tyvardecl a3 (fun (type) (type))) (tyvardecl a10 (type))
+      m11
+      (vardecl c6 (fun (con unit) [ [ d12 a3 ] a10 ]))
+    )
+  )
+  [
+    {
+      [
+        { { m11 (con list) } (con unit) }
+        [
+          {
+            [
+              { { m11 (con list) } (con unit) }
+              (error [ [ d12 (con list) ] (con unit) ])
+            ]
+            [ [ d12 (con list) ] (con unit) ]
+          }
+          (lam x23 (con unit) (error [ [ d12 (con list) ] (con unit) ]))
+        ]
+      ]
+      (con unit)
+    }
+    (error (fun (con unit) (con unit)))
+  ]
+)

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/CaseOfCase/twoTyArgs.golden
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/CaseOfCase/twoTyArgs.golden
@@ -1,0 +1,40 @@
+(let
+  (nonrec)
+  (datatypebind
+    (datatype
+      (tyvardecl d12 (fun (fun (type) (type)) (fun (type) (type))))
+      (tyvardecl a3 (fun (type) (type))) (tyvardecl a10 (type))
+      m11
+      (vardecl c6 (fun (con unit) [ [ d12 a3 ] a10 ]))
+    )
+  )
+  (let
+    (nonrec)
+    (termbind
+      (strict)
+      (vardecl k_caseOfCase (fun [ [ d12 (con list) ] (con unit) ] (con unit)))
+      (lam
+        scrutinee
+        [ [ d12 (con list) ] (con unit) ]
+        [
+          { [ { { m11 (con list) } (con unit) } scrutinee ] (con unit) }
+          (error (fun (con unit) (con unit)))
+        ]
+      )
+    )
+    [
+      {
+        [
+          { { m11 (con list) } (con unit) }
+          (error [ [ d12 (con list) ] (con unit) ])
+        ]
+        (con unit)
+      }
+      (lam
+        x23
+        (con unit)
+        [ k_caseOfCase (error [ [ d12 (con list) ] (con unit) ]) ]
+      )
+    ]
+  )
+)


### PR DESCRIPTION

Closes #5922 by fixing order of type arguments as they are extracted.