### PR TITLE
Fix some Notes so they pass the check

### DIFF
--- a/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
@@ -36,7 +36,7 @@ noTrace = pure do
             3 @=? countTraces WithTraces.traceRepeatedly
         , testCase "trace-impure" $
             1 @=? countTraces WithTraces.traceImpure
-        , testCase "trace-impure with effect" $ -- See note [Impure trace messages]
+        , testCase "trace-impure with effect" $ -- See Note [Impure trace messages]
             assertBool "Effect is missing" (Lib.evaluatesToError WithTraces.traceImpure)
         ]
     , testGroup
@@ -55,7 +55,7 @@ noTrace = pure do
             0 @=? countTraces WithoutTraces.traceRepeatedly
         , testCase "trace-impure" $
             0 @=? countTraces WithoutTraces.traceImpure
-        , testCase "trace-impure without effect" $ -- See note [Impure trace messages]
+        , testCase "trace-impure without effect" $ -- See Note [Impure trace messages]
             assertBool "Effect wasn't erased" (Lib.evaluatesWithoutError WithoutTraces.traceImpure)
         ]
     ]

--- a/plutus-tx/src/PlutusTx/Blueprint/Contract.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Contract.hs
@@ -26,7 +26,7 @@ import PlutusTx.Blueprint.Validator (ValidatorBlueprint)
 
 The 'referencedTypes' type variable is used to track the types used in the contract
 making sure their schemas are included in the blueprint and that they are referenced
-in a type-safe way. See the note ["Unrolling" types] for more details.
+in a type-safe way. See Note ["Unrolling" types] for more details.
 -}
 data ContractBlueprint where
   MkContractBlueprint ::

--- a/plutus-tx/src/PlutusTx/Blueprint/Definition/Unroll.hs
+++ b/plutus-tx/src/PlutusTx/Blueprint/Definition/Unroll.hs
@@ -30,7 +30,7 @@ import PlutusTx.Builtins.Internal (BuiltinByteString, BuiltinData, BuiltinList, 
                                    BuiltinUnit)
 
 ----------------------------------------------------------------------------------------------------
--- Functionality to "unroll" types. -- For more context see the note ["Unrolling" types] -----------
+-- Functionality to "unroll" types. -- For more context see Note ["Unrolling" types] -----------
 
 {- Note ["Unrolling" types]
 

--- a/scripts/check-Notes.awk
+++ b/scripts/check-Notes.awk
@@ -120,41 +120,41 @@ maybeSplitReference && /^[- \t-]*\[/ {
 # Check for plural references
 /(NOTES|Notes|notes) *\[/ {
     printf ("Invalid note format (no plurals allowed) at %s:%d\n ", FILENAME, FNR)
-    printf ("> %s\n", $0)
+    printf ("> %s\n\n", $0)
     exitCode = 1
 }
 
 # Check that we have at least one space after "Note"
 /Note\[/ {
     printf ("Invalid note format (space expected after \"Note\") at %s:%d\n", FILENAME, FNR)
-    printf ("> %s\n", $0)
+    printf ("> %s\n\n", $0)
     exitCode = 1
 }
 # Check for invalid characters
 /Note *[^ ] *\[/ { # There is a non-space (eg ":") between "Note" and "["
     printf ("Invalid note format at %s:%d\n", FILENAME, FNR)
-    printf ("> %s\n", $0)
+    printf ("> %s\n\n", $0)
     exitCode = 1
 }
 
 # Check for Haddock
 /(--|{-) *\| *Note *\[/  {
     printf ("Invalid note format (no Haddock allowed) at %s:%d ", FILENAME, FNR)
-    printf ("> %s\n", $0)
+    printf ("> %s\n\n", $0)
     exitCode = 1
 }
 
 # Check for improper capitalisation
 /(NOTE|note) *\[/ {  # We require all references to be of the form `Note [...]`
     printf ("Invalid note format (must say \"Note [...]\") at %s:%d\n", FILENAME, FNR)
-    printf ("> %s\n", $0)
+    printf ("> %s\n\n", $0)
     exitCode = 1
 }
 
 # Make sure there's at least one space before "Note" in a definition
 /(--|{-)Note *\[/ {
     printf ("Invalid note format (space expected before \"Note\") at %s:%d\n", FILENAME, FNR)
-    printf ("> %s\n", $0)
+    printf ("> %s\n\n", $0)
     exitCode = 1
 }
 
@@ -164,7 +164,7 @@ maybeSplitReference && /^[- \t-]*\[/ {
     if (defined[noteName]) {
         if (longOutput) {
             printf ("Duplicate Note [%s] at %s:%d and %s", noteName, FILENAME, FNR, defined[noteName])
-            printf ("> %s\n", $0)
+            printf ("> %s\n\n", $0)
         }
         else printf ("Duplicate Note [%s]\n", noteName)
     }
@@ -198,13 +198,13 @@ END {  # Report references which refer to missing Notes.
                 w = max(w,length(x))
         for (x in referenced)
             if (!(x in defined)) {
-                printf ("Missing Note %-*s%s\n", w+3, "["x"]", referenced[x])
+                printf ("Missing Note %-*s%s\n\n", w+3, "["x"]", referenced[x])
                 exitCode = 1
             }
     }
     else for (x in referenced)
              if (!(x in defined)) {
-                 printf ("Missing Note [%s]\n", x)
+                 printf ("Missing Note [%s]\n\n", x)
                  exitCode = 1
              }
     exit exitCode


### PR DESCRIPTION
I ran the `scripts/check-Notes.sh` script and found a few references that said "note" instead of "Note" (see the rules [here](https://github.com/IntersectMBO/plutus/blob/0567ef7fc1efb4ec415fe882df9b313d8c3dd0df/scripts/check-Notes.awk#L3), which are supposed to make it easier to find Notes and references to them).  This fixes that.

(Also, see `find-Notes.sh` for a script to list/search the Notes.)