### PR TITLE
Do not build the plutus executable if GHC <9.6

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -675,7 +675,7 @@ executable plutus
   hs-source-dirs:     executables/plutus
 
   -- singletons-th does not support GHC<=8.10
-  if impl(ghc <9.0)
+  if impl(ghc <9.6)
     buildable: False
 
   -- Hydra complains that this is not buildable on mingw32 because of brick.

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -319,7 +319,7 @@ data ModelConstantOrLinear = ModelConstantOrLinear
     } deriving stock (Show, Eq, Generic, Lift)
     deriving anyclass (NFData)
 
-  -- | if p then f(x) else c; p depends on usage
+-- | if p then f(x) else c; p depends on usage
 data ModelConstantOrOneArgument = ModelConstantOrOneArgument
     { modelConstantOrOneArgumentConstant :: CostingInteger
     , modelConstantOrOneArgumentModel    :: ModelOneArgument


### PR DESCRIPTION
It doesn't build with 9.2: https://github.com/IntersectMBO/cardano-haskell-packages/actions/runs/8902018953/job/24447188265