### PR TITLE
Experiment: print Agda-readable ASTs from UPLC simplifier

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -261,6 +261,7 @@ library
     UntypedPlutusCore.Simplify.Opts
     UntypedPlutusCore.Size
     UntypedPlutusCore.Subst
+    UntypedPlutusCore.TempUntyped
     UntypedPlutusCore.Transform.CaseOfCase
     UntypedPlutusCore.Transform.CaseReduce
     UntypedPlutusCore.Transform.Cse

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
@@ -67,17 +67,25 @@ simplifyTerm opts builtinSemanticsVariant =
         >=> inline (_soInlineConstants opts) (_soInlineHints opts) builtinSemanticsVariant
 
     caseOfCase' :: Term name uni fun a -> Term name uni fun a
-    caseOfCase' t = case eqT @fun @DefaultFun of
+    caseOfCase' t =
+      case eqT @fun @DefaultFun of
+        Just Refl ->
+          let result = caseOfCase (printAgdaAST t)
+           in printAgdaAST result
+        Nothing   -> t
+
+    printAgdaAST :: Term name uni fun a -> Term name uni fun a
+    printAgdaAST t = case eqT @fun @DefaultFun of
       Just Refl ->
         case eqT @uni @PLC.DefaultUni of
           Just Refl ->
             case eqT @name @Name of
               Just Refl ->
                 case deBruijnTerm t of
-                  Right res                       -> trace (show . conv $ res) $ caseOfCase t
+                  Right res                       -> trace (show . conv $ res) t
                   Left (err :: FreeVariableError) -> error $ show err
-              Nothing -> caseOfCase t
-          Nothing -> caseOfCase t
+              Nothing -> t
+          Nothing -> t
       Nothing   -> t
 
     cseStep :: Int -> Term name uni fun a -> m (Term name uni fun a)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
@@ -13,7 +13,9 @@ import PlutusCore.Default qualified as PLC
 import PlutusCore.Default.Builtins
 import PlutusCore.Name.Unique
 import UntypedPlutusCore.Core.Type
+import UntypedPlutusCore.DeBruijn (FreeVariableError, deBruijnTerm)
 import UntypedPlutusCore.Simplify.Opts as Opts
+import UntypedPlutusCore.TempUntyped (UTerm, conv)
 import UntypedPlutusCore.Transform.CaseOfCase
 import UntypedPlutusCore.Transform.CaseReduce
 import UntypedPlutusCore.Transform.Cse
@@ -24,6 +26,7 @@ import UntypedPlutusCore.Transform.Inline (InlineHints (..), inline)
 import Control.Monad
 import Data.List
 import Data.Typeable
+import Debug.Trace (trace)
 
 simplifyProgram ::
     forall name uni fun m a.
@@ -64,9 +67,18 @@ simplifyTerm opts builtinSemanticsVariant =
         >=> inline (_soInlineConstants opts) (_soInlineHints opts) builtinSemanticsVariant
 
     caseOfCase' :: Term name uni fun a -> Term name uni fun a
-    caseOfCase' = case eqT @fun @DefaultFun of
-      Just Refl -> caseOfCase
-      Nothing   -> id
+    caseOfCase' t = case eqT @fun @DefaultFun of
+      Just Refl ->
+        case eqT @uni @PLC.DefaultUni of
+          Just Refl ->
+            case eqT @name @Name of
+              Just Refl ->
+                case deBruijnTerm t of
+                  Right res                       -> trace (show . conv $ res) $ caseOfCase t
+                  Left (err :: FreeVariableError) -> error $ show err
+              Nothing -> caseOfCase t
+          Nothing -> caseOfCase t
+      Nothing   -> t
 
     cseStep :: Int -> Term name uni fun a -> m (Term name uni fun a)
     cseStep _ =

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/TempUntyped.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/TempUntyped.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE GADTs          #-}
+{-# LANGUAGE KindSignatures #-}
+
+module UntypedPlutusCore.TempUntyped where
+
+import PlutusCore.Data hiding (Constr)
+import PlutusCore.DeBruijn (Index (..), NamedDeBruijn (..), deBruijnInitIndex)
+import PlutusCore.Default
+import UntypedPlutusCore.Core.Type
+
+import Data.ByteString as BS hiding (map)
+import Data.Text as T hiding (map)
+import Data.Word (Word64)
+import GHC.Exts (IsList (..))
+import Universe
+
+-- TODO: this is a copy of the Untyped module from plutus-metatheory;
+-- we can't import it directly because it depends on the plutus-core package,
+-- so it forms a cyclic package dependency;
+-- if possible, we should move common modules to a separate package to avoid this;
+
+-- Untyped (Raw) syntax
+
+data UTerm = UVar Integer
+           | ULambda UTerm
+           | UApp UTerm UTerm
+           | UCon (Some (ValueOf DefaultUni))
+           | UError
+           | UBuiltin DefaultFun
+           | UDelay UTerm
+           | UForce UTerm
+           | UConstr Integer [UTerm]
+           | UCase UTerm [UTerm]
+           deriving Show
+
+unIndex :: Index -> Integer
+unIndex (Index n) = toInteger n
+
+convP :: Program NamedDeBruijn DefaultUni DefaultFun a -> UTerm
+convP (Program _ _ t) = conv t
+
+conv :: Term NamedDeBruijn DefaultUni DefaultFun a -> UTerm
+conv (Var _ x)       = UVar (unIndex (ndbnIndex x) - 1)
+conv (LamAbs _ _ t)  = ULambda (conv t)
+conv (Apply _ t u)   = UApp (conv t) (conv u)
+conv (Builtin _ b)   = UBuiltin b
+conv (Constant _ c)  = UCon c
+conv (Error _)       = UError
+conv (Delay _ t)     = UDelay (conv t)
+conv (Force _ t)     = UForce (conv t)
+conv (Constr _ i es) = UConstr (toInteger i) (toList (fmap conv es))
+conv (Case _ arg cs) = UCase (conv arg) (toList (fmap conv cs))
+
+tmnames = ['a' .. 'z']
+
+uconv ::  Int -> UTerm -> Term NamedDeBruijn DefaultUni DefaultFun ()
+uconv i (UVar x)     = Var
+  ()
+  (NamedDeBruijn (T.pack [tmnames !! (i - 1 - fromInteger x)])
+                -- PLC's debruijn starts counting from 1, while in the metatheory it starts from 0.
+                 (Index (fromInteger x + 1)))
+uconv i (ULambda t)  = LamAbs
+  ()
+  (NamedDeBruijn (T.pack [tmnames !! i]) deBruijnInitIndex)
+  (uconv (i+1) t)
+uconv i (UApp t u)     = Apply () (uconv i t) (uconv i u)
+uconv i (UCon c)       = Constant () c
+uconv i UError         = Error ()
+uconv i (UBuiltin b)   = Builtin () b
+uconv i (UDelay t)     = Delay () (uconv i t)
+uconv i (UForce t)     = Force () (uconv i t)
+uconv i (UConstr j xs) = Constr () (fromInteger j) (fmap (uconv i) xs)
+uconv i (UCase t xs)   = Case () (uconv i t) (fromList (fmap (uconv i) xs))
+

--- a/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
@@ -43,7 +43,7 @@ caseOfCase1 = runQuote $ do
       true = Constr () 0 []
       false = Constr () 1 []
       alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+  pure $ LamAbs () b $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 {- | This should not simplify, because one of the branches of `ifThenElse` is not a `Constr`.
 Unless both branches are known constructors, the case-of-case transformation
@@ -57,7 +57,7 @@ caseOfCase2 = runQuote $ do
       true = Var () t
       false = Constr () 1 []
       alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+  pure $ LamAbs () b $ LamAbs () t $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 {- | Similar to `caseOfCase1`, but the type of the @true@ and @false@ branches is
 @[Integer]@ rather than Bool (note that @Constr 0@ has two parameters, @x@ and @xs@).
@@ -74,7 +74,7 @@ caseOfCase3 = runQuote $ do
       altTrue = Var () f
       altFalse = mkConstant @Integer () 2
       alts = V.fromList [altTrue, altFalse]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+  pure $ LamAbs () b $ LamAbs () x $ LamAbs () xs $ LamAbs () f $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 -- | The `Delay` should be floated into the lambda.
 floatDelay1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()

--- a/plutus-core/untyped-plutus-core/test/Transform/caseOfCase1.uplc.golden
+++ b/plutus-core/untyped-plutus-core/test/Transform/caseOfCase1.uplc.golden
@@ -1,1 +1,1 @@
-(force ifThenElse b_0 1 2)
+(\b_1 -> force ifThenElse b_1 1 2)

--- a/plutus-core/untyped-plutus-core/test/Transform/caseOfCase2.uplc.golden
+++ b/plutus-core/untyped-plutus-core/test/Transform/caseOfCase2.uplc.golden
@@ -1,1 +1,1 @@
-(case (force ifThenElse b_0 t_1 (constr 1 [])) [1, 2])
+(\b_2 t_3 -> case (force ifThenElse b_2 t_3 (constr 1 [])) [1, 2])

--- a/plutus-core/untyped-plutus-core/test/Transform/caseOfCase3.uplc.golden
+++ b/plutus-core/untyped-plutus-core/test/Transform/caseOfCase3.uplc.golden
@@ -1,1 +1,1 @@
-(force ifThenElse b_0 (f_3 x_1 xs_2) 2)
+(\b_4 x_5 xs_6 f_7 -> force ifThenElse b_4 (f_7 x_5 xs_6) 2)

--- a/plutus-metatheory/src/Untyped.lagda.md
+++ b/plutus-metatheory/src/Untyped.lagda.md
@@ -170,6 +170,16 @@ scopeCheckUList g (x ∷ xs) = do
 
 scopeCheckU0 : Untyped → Either ScopeError (⊥ ⊢)
 scopeCheckU0 t = scopeCheckU (λ _ → inj₁ deBError) t
+
+f : {X : Set} → ℕ → Either ScopeError (Maybe X)
+f x = extG' (λ _ → inj₁ deBError) x
+
+toWellScoped : {X : Set} → Untyped → Either ScopeError (Maybe X ⊢)
+toWellScoped = scopeCheckU f
+
+example1 : Untyped 
+example1 = ULambda (UCase (UApp (UApp (UApp (UForce (UBuiltin ifThenElse)) (UVar 0)) (UConstr 0 [])) (UConstr 1 [])) ((UCon (RawU.tagCon RawU.integer (ℤ.pos 1))) List.∷ (UCon (RawU.tagCon RawU.integer (ℤ.pos 2))) List.∷ List.[]))
+
 ```
 
 ## Equality checking for raw terms


### PR DESCRIPTION
This is WIP.

To generate ASTs for testing the Agda decision procedure by hand, run `cabal test untyped-plutus-core-test --test-options="-p caseOfCase1"` where `caseOfCase1` is the name of the Haskell test you want to get ASTs from. They will be printed to the console, and you can use them as examples to run the decision procedure on. There are currently some extra manual steps required for converting the ASTs, see my Agda examples.

Work needed to be done:
  - fix Haskell term to Agda term translation
  - reorganise `plutus-metatheory` to avoid cyclic dependences
  - the UPLC compiler should print the ASTs to a file in some structured format, so that a future Agda executable can parse the list of ASTs and run the decision procedures (or there might be a better way to do this?)


Issue: many of our Haskell tests have free variables; this doesn't play well with the Agda representation; real-life examples shouldn't have this problem, but we won't be able to easily run the Agda program on all our unit tests without making changes to the unit tests.


<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
