### PR TITLE
Remove annoying error message

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
@@ -147,11 +147,9 @@ benchTwoTextStrings name =
         s2 = makeSizedTextStrings seedB twoArgumentSizes
     in createTwoTermBuiltinBench name [] s1 s2
 
-
 -- Benchmark times for a function applied to equal arguments.  This is used for
--- benchmarking EqualsString on the diagonal.
--- Copy the bytestring here, because otherwise it'll be exactly the same and
--- the equality will short-circuit.
+-- benchmarking EqualsString on the diagonal.  Copy the string here, because
+-- otherwise it'll be exactly the same and the equality will short-circuit.
 benchSameTwoTextStrings :: DefaultFun -> Benchmark
 benchSameTwoTextStrings name =
     createTwoTermBuiltinBenchElementwise name [] inputs (fmap T.copy inputs)

--- a/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
+++ b/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
@@ -2,7 +2,6 @@
 
 module CriterionExtensions (criterionMainWith, BenchmarkingPhase(..)) where
 
-import Control.Monad (unless)
 import Control.Monad.Trans (liftIO)
 import Criterion.Internal (runAndAnalyse, runFixedIters)
 import Criterion.IO.Printf (printError, writeCsv)
@@ -83,12 +82,12 @@ criterionMainWith phase defCfg bs =
       RunIters cfg iters matchType benches ->
           withConfig cfg $ do
             () <- initCsvFile phase cfg
-            shouldRun <- liftIO $ selectBenches matchType benches bsgroup
+            shouldRun <- liftIO $ selectBenches matchType benches
             runFixedIters iters shouldRun bsgroup
       Run cfg matchType benches ->
           withConfig cfg $ do
             () <- initCsvFile phase cfg
-            shouldRun <- liftIO $ selectBenches matchType benches bsgroup
+            shouldRun <- liftIO $ selectBenches matchType benches
             liftIO initializeTime
             runAndAnalyse shouldRun bsgroup
       where bsgroup = BenchGroup "" bs
@@ -97,8 +96,8 @@ criterionMainWith phase defCfg bs =
 -- line then only the matching benchmarks will be run.  If there are no matching
 -- benchmarks then the command will stil succeed (with no error or warning), but
 -- nothing will be benchmarked.
-selectBenches :: MatchType -> [String] -> Benchmark -> IO (String -> Bool)
-selectBenches matchType benches bsgroup = do
+selectBenches :: MatchType -> [String] -> IO (String -> Bool)
+selectBenches matchType benches = do
   toRun <- either parseError return . makeMatcher matchType $ benches
   return toRun
 

--- a/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
+++ b/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
@@ -93,11 +93,13 @@ criterionMainWith phase defCfg bs =
             runAndAnalyse shouldRun bsgroup
       where bsgroup = BenchGroup "" bs
 
+-- Select the benchmarks to be run.  If a pattern is specified on the command
+-- line then only the matching benchmarks will be run.  If there are no matching
+-- benchmarks then the command will stil succeed (with no error or warning), but
+-- nothing will be benchmarked.
 selectBenches :: MatchType -> [String] -> Benchmark -> IO (String -> Bool)
 selectBenches matchType benches bsgroup = do
   toRun <- either parseError return . makeMatcher matchType $ benches
-  unless (null benches || any toRun (benchNames bsgroup)) $
-    parseError "none of the specified names matches a benchmark"
   return toRun
 
 parseError :: String -> IO a

--- a/plutus-core/cost-model/budgeting-bench/Main.hs
+++ b/plutus-core/cost-model/budgeting-bench/Main.hs
@@ -61,11 +61,6 @@ main = do
 
   {- Run the nop benchmarks with a large time limit (30 seconds) in an attempt to
      get accurate results. -}
-  -- FIXME: this doesn't quite work.  If you specify a benchmark name on the
-  -- command line and it's in the first group then it'll run but you'll get an
-  -- error when the argument gets passed to the nop benchmarks below (but the
-  -- data will still be generated and saved in benching.csv).
-
   criterionMainWith
        Continue
        (defaultConfig { C.timeLimit = 30 }) $


### PR DESCRIPTION
The `cost-model-budgeting-bench` executable runs benchmarks for the builtins but also runs some no-op benchmarks to give us an idea of the overhead involved in calling a builtin.  To get accurate results for the no-op benchmarks we run them with a bigger time limit, which involves calling Criterion twice.  If you asked it to benchmark some subset of the builtins (eg, by passing `EqualsString` on the command line) then there would be an error with the message  "none of the specified names matches a benchmark" when it ran the no-op benchmarks (because none of them do match).   This was annoying and also meant that you couldn't run a subset of the benchmarks on the benchmarking machine and get the results back.  This PR removes the error mesage.  Now it's less annoying, but if you ask it to benchmark something that doesn't exist (maybe because you mistype a name) then it'll complete silently and leave you with a CSV file containing only a header.  This might be a bit mystifying, but it's better than a spurious error message.  We could maybe do better if we were to bypass the Criterion command-line processing code altogether, but that might be quite a lot of work for a small gain.

I don't think this needs to be reviewed, so I'll set it to auto-merge.