### PR TITLE
Kwxm/mainnet script budgets

### DIFF
--- a/plutus-ledger-api/exe/analyse-script-events/Main.hs
+++ b/plutus-ledger-api/exe/analyse-script-events/Main.hs
@@ -360,6 +360,8 @@ max_tx_ex_steps = 10_000_000_000
 max_tx_ex_mem :: Double
 max_tx_ex_mem = 14_000_000
 
+-- Print out the CPU and memory budgets of each script event.  These are the costs
+-- paid for by the submitters, not the actual costs consumed during execution.
 getBudgets :: EventAnalyser
 getBudgets _ctx _params ev =
   let printFractions d =

--- a/plutus-ledger-api/exe/analyse-script-events/Main.hs
+++ b/plutus-ledger-api/exe/analyse-script-events/Main.hs
@@ -362,6 +362,7 @@ max_tx_ex_mem = 14_000_000
 
 -- Print out the CPU and memory budgets of each script event.  These are the costs
 -- paid for by the submitters, not the actual costs consumed during execution.
+-- TODO: add a version that tells us the actual execution costs.
 getBudgets :: EventAnalyser
 getBudgets _ctx _params ev =
   let printFractions d =


### PR DESCRIPTION
This is just a small PR to add an option to `analyse-script-events` to print out the CPU and memory costs of each script event.