### PR TITLE
Add integerToByteString and byteStringToInteger to PlutusV2 at PV10

### DIFF
--- a/plutus-core/changelog.d/20240517_094957_unsafeFixIO_v2_new_prims.md
+++ b/plutus-core/changelog.d/20240517_094957_unsafeFixIO_v2_new_prims.md
@@ -1,0 +1,5 @@
+
+### Added
+
+- Primitives `integerToByteString` and `byteStringToInteger` are added to PlutusV2,
+  enabled at protocol version 10.

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
@@ -11,6 +11,7 @@ module PlutusLedgerApi.Common.ProtocolVersions
     , vasilPV
     , valentinePV
     , conwayPV
+    , conwayPlus1PV
     , knownPVs
     , futurePV
     ) where
@@ -68,10 +69,25 @@ valentinePV = MajorProtocolVersion 8
 conwayPV :: MajorProtocolVersion
 conwayPV = MajorProtocolVersion 9
 
+-- | The next HF after Conway. It doesn't yet have a name, and it's not
+-- yet known whether it will be an intra-era HF or introduce a new era.
+conwayPlus1PV :: MajorProtocolVersion
+conwayPlus1PV = MajorProtocolVersion 10
+
 -- | The set of protocol versions that are "known", i.e. that have been released
 -- and have actual differences associated with them.
 knownPVs :: Set.Set MajorProtocolVersion
-knownPVs = Set.fromList [ shelleyPV, allegraPV, maryPV, alonzoPV, vasilPV, valentinePV, conwayPV ]
+knownPVs =
+  Set.fromList
+    [ shelleyPV
+    , allegraPV
+    , maryPV
+    , alonzoPV
+    , vasilPV
+    , valentinePV
+    , conwayPV
+    , conwayPlus1PV
+    ]
 
 -- | This is a placeholder for when we don't yet know what protocol version will
 -- be used for something. It's a very high protocol version that should never

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
@@ -81,7 +81,6 @@ instance Pretty PlutusLedgerLanguage where
     pretty = viaShow
 
 {-| A map indicating which builtin functions were introduced in which 'MajorProtocolVersion'.
-Each builtin function should appear at most once.
 
 This __must__ be updated when new builtins are added.
 See Note [New builtins/language versions and protocol versions]
@@ -106,6 +105,9 @@ builtinsIntroducedIn = Map.fromList [
           ]),
   ((PlutusV2, valentinePV), Set.fromList [
           VerifyEcdsaSecp256k1Signature, VerifySchnorrSecp256k1Signature
+          ]),
+  ((PlutusV2, conwayPlus1PV), Set.fromList [
+          IntegerToByteString, ByteStringToInteger
           ]),
   ((PlutusV3, conwayPV), Set.fromList [
           Bls12_381_G1_add, Bls12_381_G1_neg, Bls12_381_G1_scalarMul,
@@ -173,10 +175,10 @@ and 'MajorProtocolVersion'?
 See Note [New builtins/language versions and protocol versions]
 -}
 builtinsAvailableIn :: PlutusLedgerLanguage -> MajorProtocolVersion -> Set.Set DefaultFun
-builtinsAvailableIn thisLv thisPv = fold $ Map.elems $
-    Map.takeWhileAntitone builtinAvailableIn builtinsIntroducedIn
+builtinsAvailableIn thisLv thisPv = fold $
+    Map.filterWithKey (const . alreadyIntroduced) builtinsIntroducedIn
     where
-      builtinAvailableIn :: (PlutusLedgerLanguage, MajorProtocolVersion) -> Bool
-      builtinAvailableIn (introducedInLv,introducedInPv) =
+      alreadyIntroduced :: (PlutusLedgerLanguage, MajorProtocolVersion) -> Bool
+      alreadyIntroduced (introducedInLv,introducedInPv) =
           -- both should be satisfied
           introducedInLv <= thisLv && introducedInPv <= thisPv


### PR DESCRIPTION
This can be used by e2e testing to verify that adding new builtins to existing ledger languages actually works. Only adding these two for now to make the change minimal; more primitives can be added to V1 and V2 later.