### PR TITLE
Kwxm/mainnet script budgets 2

### DIFF
--- a/plutus-ledger-api/exe/analyse-script-events/Main.hs
+++ b/plutus-ledger-api/exe/analyse-script-events/Main.hs
@@ -358,11 +358,11 @@ analyseCosts ctx _ ev =
           in case result of
                OK cost ->
                  let (actualCPU, actualMem) = costAsInts cost
-                 in printf "%15d   %15d   %15d   %15d       T\n" actualCPU claimedCPU actualMem claimedMem
+                 in printf "%15d   %15d   %15d   %15d      %2s\n" actualCPU claimedCPU actualMem claimedMem (toRString result)
                -- Something went wrong; print the cost as "NA" ("Not Available" in R) so that R can
                -- still process it.
                _ ->
-                 printf "%15s   %15d   %15s   %15d   F\n" "NA       %s\n" claimedCPU "NA" claimedMem (toRString result)
+                 printf "%15s   %15d   %15s   %15d      %2s\n" "NA" claimedCPU "NA" claimedMem (toRString result)
         costAsInts :: ExBudget -> (Int, Int)
         costAsInts (ExBudget (V2.ExCPU cpu) (V2.ExMemory mem)) = (fromSatInt cpu, fromSatInt mem)
 

--- a/plutus-ledger-api/exe/analyse-script-events/Main.hs
+++ b/plutus-ledger-api/exe/analyse-script-events/Main.hs
@@ -363,7 +363,6 @@ analyseCosts :: EventAnalyser
 analyseCosts ctx _ ev =
   case ev of
     PlutusV1Event ScriptEvaluationData{..} _ ->
-      --
       let actualCost =
             case deserialiseScript PlutusV1 dataProtocolVersion dataScript of
               Left _ -> Nothing

--- a/plutus-ledger-api/exe/analyse-script-events/Main.hs
+++ b/plutus-ledger-api/exe/analyse-script-events/Main.hs
@@ -455,7 +455,7 @@ main =
             Nothing       -> printf "Unknown analysis: %s\n" name >> usage
             Just (_,_,analysis) ->
               filter ("event" `isExtensionOf`) <$> listFiles dir >>= \case
-              []         -> printf "No event files in %s\n" dir
+              []         -> printf "No .event files in %s\n" dir
               eventFiles -> analysis eventFiles
 
     in getArgs >>= \case


### PR DESCRIPTION
This extends #5973 to print out the actual CPU and memory costs of every script in a mainnet dump, as well as the claimed costs.  It will take many hours to run on a complete dump.