### PR TITLE
Conditionally add 'triage' label to new issues

### DIFF
--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -43,9 +43,15 @@ jobs:
               });
             }
 
-            if (!await issueHasInternalLabels()) {
-              async addNeedsTriageLabelToIssue();
-            }
+            try {
+              if (!await issueHasInternalLabels()) {
+                await addNeedsTriageLabelToIssue();
+              }
+            } catch (error) {
+              core.setFailed(`Error: ${error}`);
+            } 
+
+
 
 
             

--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -1,9 +1,13 @@
+# Whenever a new issue is opened, this workflow adds the "status: needs triage" 
+# label, unless the issue already has one of the "Internal" labels.
+
 name: Add Triage Label
 on:
   issues:
     types:
       - reopened
       - opened
+
 jobs:
   add-triage-label:
     runs-on: ubuntu-latest
@@ -13,10 +17,35 @@ jobs:
       - name: Run
         uses: actions/github-script@v7
         with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["status: needs triage"]
-            })
+          script: | 
+            const INTERNAL_LABELS = ["Internal"];
+
+            async function getIssueLabels() {
+              const { data: labels } = await github.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number
+              });
+              return labels.map(label => label.name);
+            }
+
+            async function issueHasInternalLabels() {
+              const labels = await getIssueLabels();
+              return INTERNAL_LABELS.some(item => labels.includes(item));
+            }
+
+            async function addNeedsTriageLabelToIssue() {
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ["status: needs triage"]
+              });
+            }
+
+            if (!await issueHasInternalLabels()) {
+              async addNeedsTriageLabelToIssue();
+            }
+
+
+            

--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: | 
-            const INTERNAL_LABELS = ["Internal"];
+            const INTERNAL_LABELS = ["Internal", "status: triaged"];
 
             async function getIssueLabels() {
               const { data: labels } = await github.issues.listLabelsOnIssue({


### PR DESCRIPTION
Add triage label only when the issue does not have any of the 'Internal' labels.