### PR TITLE
Let nightly.yml accept hedgehog-tests input

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: 0 0 * * * # daily at midnight
 
+
   workflow_dispatch: # or manually dispatch the job
     inputs:
       hedgehog-tests:
@@ -13,9 +14,11 @@ on:
 
 env: 
   HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 10000 }}
-          
+
+  
 jobs:
   nightly-test-suite:
+    timeout-minutes: 14400
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,18 +4,16 @@ on:
   schedule:
     - cron: 0 0 * * * # daily at midnight
 
-
   workflow_dispatch: # or manually dispatch the job
     inputs:
       hedgehog-tests:
         description: Numer of tests to run (--hedgehog-tests XXXXX)
         required: false
-        default: "10000"
+        default: "100000"
 
 env: 
-  HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 10000 }}
+  HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 100000 }}
 
-  
 jobs:
   nightly-test-suite:
     timeout-minutes: 14400

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,8 +3,17 @@ name: Nightly Test Suite
 on:
   schedule:
     - cron: 0 0 * * * # daily at midnight
-  workflow_dispatch: # or manually dispatch the job
 
+  workflow_dispatch: # or manually dispatch the job
+    inputs:
+      hedgehog-tests:
+        description: Numer of tests to run (--hedgehog-tests XXXXX)
+        required: false
+        default: "10000"
+
+env: 
+  HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 10000 }}
+          
 jobs:
   nightly-test-suite:
     runs-on: ubuntu-latest
@@ -12,23 +21,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Quick Install Nix
-        uses: cachix/install-nix-action@V27
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
 
+      - name: Use Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      
       - name: plutus-core-nightly
         if: always()
         run: |
           pushd plutus-core
-          nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests 10000
+          nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly
         if: always()
         run: |
           pushd plutus-core
-          nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests 10000
+          nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,10 +9,10 @@ on:
       hedgehog-tests:
         description: Numer of tests to run (--hedgehog-tests XXXXX)
         required: false
-        default: "100000"
+        default: "50000"
 
 env: 
-  HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 100000 }}
+  HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 50000 }}
 
 jobs:
   nightly-test-suite:


### PR DESCRIPTION
The nightly.yml workflow will now run 50k test cases by default instead of 10k.
In addition, the nightly.yml workflow will now accept the number of test cases as a workflow_dispatch input.