### PR TITLE
Add integerToByteString and byteStringToInteger to V2.ParamName

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/ParamName.hs
@@ -190,5 +190,15 @@ data ParamName =
   | VerifySchnorrSecp256k1Signature'cpu'arguments'intercept
   | VerifySchnorrSecp256k1Signature'cpu'arguments'slope
   | VerifySchnorrSecp256k1Signature'memory'arguments
+  | IntegerToByteString'cpu'arguments'c0
+  | IntegerToByteString'cpu'arguments'c1
+  | IntegerToByteString'cpu'arguments'c2
+  | IntegerToByteString'memory'arguments'intercept
+  | IntegerToByteString'memory'arguments'slope
+  | ByteStringToInteger'cpu'arguments'c0
+  | ByteStringToInteger'cpu'arguments'c1
+  | ByteStringToInteger'cpu'arguments'c2
+  | ByteStringToInteger'memory'arguments'intercept
+  | ByteStringToInteger'memory'arguments'slope
     deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)
     deriving IsParamName via (GenericParamName ParamName)

--- a/plutus-ledger-api/test/Spec/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/CostModelParams.hs
@@ -30,8 +30,8 @@ tests =
     [ testCase "length" $ do
             166 @=? length v1_ParamNames
             166 @=? length V1.costModelParamsForTesting
-            175 @=? length v2_ParamNames
-            175 @=? length V2.costModelParamsForTesting
+            185 @=? length v2_ParamNames
+            185 @=? length V2.costModelParamsForTesting
             233 @=? length v3_ParamNames
             233 @=? length V3.costModelParamsForTesting
     , testCase "tripping paramname" $ do

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V2/EvaluationContext.hs
@@ -52,4 +52,6 @@ clearBuiltinCostModel r = r
                { paramSerialiseData = mempty
                , paramVerifyEcdsaSecp256k1Signature = mempty
                , paramVerifySchnorrSecp256k1Signature = mempty
+               , paramIntegerToByteString = mempty
+               , paramByteStringToInteger = mempty
                }

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
@@ -67,6 +67,4 @@ clearBuiltinCostModel r = r
                , paramBls12_381_finalVerify = mempty
                , paramKeccak_256 = mempty
                , paramBlake2b_224 = mempty
-               , paramIntegerToByteString = mempty
-               , paramByteStringToInteger = mempty
                }


### PR DESCRIPTION
Should have been done in https://github.com/IntersectMBO/plutus/pull/6056 but I overlooked it.