### PR TITLE
Run nightly tests on plutus-benchmark

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,7 @@ jobs:
           whoami 
           nix profile install nixpkgs#diffutils 
           nix profile install nixpkgs#which
+          which which
           echo Installed 
 
       - name: plutus-core-nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,8 @@ jobs:
         run: | 
           whoami 
           nix profile install nixpkgs#diffutils 
+          nix profile install nixpkgs#which
+          echo Installed 
 
       - name: plutus-core-nightly
         run: | 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,12 +24,18 @@ jobs:
 
       - name: plutus-core-nightly
         run: |
+          env 
+          which which
+          which diff 
           pushd plutus-core
           nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly
         run: |
+          env 
+          which which
+          which diff 
           pushd plutus-core
           nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,13 +24,11 @@ jobs:
       - name: plutus-core-nightly
         run: | 
           pushd plutus-core
-          nix shell nixpkgs#diffutils --command \
-            nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix run --no-warn-dirty --accept-flake-config .#checks.x86_64-linux.plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly
         run: |
           pushd plutus-core
-          nix shell nixpkgs#diffutils --command \
-            nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix run --no-warn-dirty --accept-flake-config .#checks.x86_64-linux.plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,20 +22,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # This is a runtime dependency of the tests
+      - name: Install diffutils in Nix Profile 
+        run: | 
+          whoami 
+          nix profile install nixpkgs#diffutils 
+
       - name: plutus-core-nightly
-        run: |
-          env 
-          which which
-          which diff 
+        run: | 
+          echo ******************************* Running which diff 
+          which diff
           pushd plutus-core
           nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly
         run: |
-          env 
-          which which
-          which diff 
           pushd plutus-core
           nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,15 +9,15 @@ on:
       hedgehog-tests:
         description: Numer of tests to run (--hedgehog-tests XXXXX)
         required: false
-        default: "50000"
+        default: "100000"
 
 env: 
-  HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 50000 }}
+  HEDGEHOG_TESTS: ${{ github.event.inputs.hedgehog-tests || 100000 }}
 
 jobs:
   nightly-test-suite:
     timeout-minutes: 14400
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, plutus-benchmark]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,12 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-      
       - name: plutus-core-nightly
         if: always()
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,11 +24,11 @@ jobs:
       - name: plutus-core-nightly
         run: | 
           pushd plutus-core
-          nix run --no-warn-dirty --accept-flake-config .#checks.x86_64-linux.plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly
         run: |
           pushd plutus-core
-          nix run --no-warn-dirty --accept-flake-config .#checks.x86_64-linux.plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,6 @@ env:
 
 jobs:
   nightly-test-suite:
-    timeout-minutes: 14400
     runs-on: [self-hosted, plutus-benchmark]
     steps:
       - name: Checkout
@@ -25,9 +24,7 @@ jobs:
       - name: plutus-core-nightly
         run: | 
           pushd plutus-core
-          nix develop --no-warn-dirty --accept-flake-config --command \
-            cabal run plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
-          # nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,21 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # This is a runtime dependency of the tests
-      - name: Install diffutils in Nix Profile 
-        run: | 
-          whoami 
-          nix profile install nixpkgs#diffutils 
-          nix profile install nixpkgs#which
-          which which
-          echo Installed 
-
       - name: plutus-core-nightly
         run: | 
-          echo ******************************* Running which diff 
-          which diff
           pushd plutus-core
-          nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix develop --no-warn-dirty --accept-flake-config --command \
+            cabal run plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          # nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,11 +24,13 @@ jobs:
       - name: plutus-core-nightly
         run: | 
           pushd plutus-core
-          nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix shell nixpkgs#diffutils --command \
+            nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly
         run: |
           pushd plutus-core
-          nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
+          nix shell nixpkgs#diffutils --command \
+            nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,14 +23,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: plutus-core-nightly
-        if: always()
         run: |
           pushd plutus-core
           nix run --no-warn-dirty --accept-flake-config .#plutus-core-test -- --hedgehog-tests $HEDGEHOG_TESTS
           popd
 
       - name: plutus-ir-nightly
-        if: always()
         run: |
           pushd plutus-core
           nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -141,14 +141,6 @@ let
                 ssreflect
                 equations
               ];
-
-            plutus-core.components.tests.plutus-core-test.preCheck = ''
-              PATH=${lib.makeBinPath [ pkgs.diffutils ]}:$PATH
-            '';
-
-            plutus-core.components.tests.plutus-ir-test.preCheck = ''
-              PATH=${lib.makeBinPath [ pkgs.diffutils ]}:$PATH
-            '';
           };
         }
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -142,12 +142,12 @@ let
                 equations
               ];
 
-            plutus-core.components.tests.plutus-core-test.preCheck = ''
-              PATH=${lib.makeBinPath [ pkgs.diffutils ]}:$PATH
+            plutus-core.components.tests.plutus-core-test.postInstall = ''
+              wrapProgram $out/bin/plutus-core-test --set PATH ${lib.makeBinPath [ pkgs.diffutils ]}
             '';
 
-            plutus-core.components.tests.plutus-ir-test.preCheck = ''
-              PATH=${lib.makeBinPath [ pkgs.diffutils ]}:$PATH
+            plutus-core.components.tests.plutus-ir-test.postInstall = ''
+              wrapProgram $out/bin/plutus-ir-test --set PATH ${lib.makeBinPath [ pkgs.diffutils ]}
             '';
           };
         }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -141,6 +141,14 @@ let
                 ssreflect
                 equations
               ];
+
+            plutus-core.components.tests.plutus-core-test.preCheck = ''
+              PATH=${lib.makeBinPath [ pkgs.diffutils ]}:$PATH
+            '';
+
+            plutus-core.components.tests.plutus-ir-test.preCheck = ''
+              PATH=${lib.makeBinPath [ pkgs.diffutils ]}:$PATH
+            '';
           };
         }
 


### PR DESCRIPTION
The nightly tests now run 100k test cases by default and will run on the self-hosted plutus-benchmark instance.