### PR TITLE
Remove reference to benching.csv in plutus-core.cabal

### DIFF
--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -1,19 +1,18 @@
-cabal-version:      3.0
-name:               plutus-conformance
-version:            1.0.0.0
-license:            Apache-2.0
+cabal-version:   3.0
+name:            plutus-conformance
+version:         1.0.0.0
+license:         Apache-2.0
 license-files:
   LICENSE
   NOTICE
 
-maintainer:         marty.stumpf@iohk.io
-author:             Plutus Core Team
-synopsis:           Conformance Test Suite for Plutus Core
-description:        Comprehensive Conformance Test Suite for Plutus Core.
-category:           Language, Plutus, Conformance
-build-type:         Simple
-extra-doc-files:    README.md
-extra-source-files:
+maintainer:      marty.stumpf@iohk.io
+author:          Plutus Core Team
+synopsis:        Conformance Test Suite for Plutus Core
+description:     Comprehensive Conformance Test Suite for Plutus Core.
+category:        Language, Plutus, Conformance
+build-type:      Simple
+extra-doc-files: README.md
 
 source-repository head
   type:     git

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,22 +1,22 @@
-cabal-version:      3.0
-name:               plutus-core
-version:            1.28.0.0
-license:            Apache-2.0
+cabal-version:   3.0
+name:            plutus-core
+version:         1.28.0.0
+license:         Apache-2.0
 license-files:
   LICENSE
   NOTICE
 
-maintainer:         michael.peyton-jones@iohk.io
-author:             Plutus Core Team
-synopsis:           Language library for Plutus Core
-description:        Pretty-printer, parser, and typechecker for Plutus Core.
-category:           Language, Plutus
-build-type:         Simple
+maintainer:      michael.peyton-jones@iohk.io
+author:          Plutus Core Team
+synopsis:        Language library for Plutus Core
+description:     Pretty-printer, parser, and typechecker for Plutus Core.
+category:        Language, Plutus
+build-type:      Simple
 extra-doc-files:
   CHANGELOG.md
   README.md
 
-extra-source-files:
+data-files:
   cost-model/data/*.R
   cost-model/data/builtinCostModelA.json
   cost-model/data/builtinCostModelB.json

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -18,7 +18,6 @@ extra-doc-files:
 
 extra-source-files:
   cost-model/data/*.R
-  cost-model/data/benching.csv
   cost-model/data/builtinCostModelA.json
   cost-model/data/builtinCostModelB.json
   cost-model/data/builtinCostModelC.json


### PR DESCRIPTION
There was a reference to `benching.csv` in `plutus-core.cabal`.  That file has now been replaced by `benching-vasil.csv` and `benching-conway.csv`, but I don't think either of these is needed in a distribution so I've just removed the entry for the original file.

I'll set this to auto-merge since it's not a big change.