### PR TITLE
Kwxm/costing/reduce CEK CPU step costs B

### DIFF
--- a/plutus-core/changelog.d/20240530_123928_kenneth.mackenzie_reduce_cek_cpu_step_costs_B.md
+++ b/plutus-core/changelog.d/20240530_123928_kenneth.mackenzie_reduce_cek_cpu_step_costs_B.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/plutus-core/changelog.d/20240530_123928_kenneth.mackenzie_reduce_cek_cpu_step_costs_B.md
+++ b/plutus-core/changelog.d/20240530_123928_kenneth.mackenzie_reduce_cek_cpu_step_costs_B.md
@@ -1,42 +1,4 @@
-<!--
-A new scriv changelog fragment.
-
-Uncomment the section that is right (remove the HTML comment wrapper).
--->
-
-<!--
-### Removed
-
-- A bullet item for the Removed category.
-
--->
-<!--
-### Added
-
-- A bullet item for the Added category.
-
--->
-<!--
 ### Changed
 
-- A bullet item for the Changed category.
+- CPU charges reduced for PlutusV1 and PlutusV2 scripts in the Conway era.
 
--->
-<!--
-### Deprecated
-
-- A bullet item for the Deprecated category.
-
--->
-<!--
-### Fixed
-
-- A bullet item for the Fixed category.
-
--->
-<!--
-### Security
-
-- A bullet item for the Security category.
-
--->

--- a/plutus-core/cost-model/data/cekMachineCostsB.json
+++ b/plutus-core/cost-model/data/cekMachineCostsB.json
@@ -1,13 +1,13 @@
 {
     "cekStartupCost" : {"exBudgetCPU":     100, "exBudgetMemory": 100},
-    "cekVarCost"     : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekConstCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekLamCost"     : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekDelayCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekForceCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekApplyCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekBuiltinCost" : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekConstrCost"  : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekCaseCost"    : {"exBudgetCPU":   23000, "exBudgetMemory": 100}
+    "cekVarCost"     : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekConstCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekLamCost"     : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekDelayCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekForceCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekApplyCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekBuiltinCost" : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekConstrCost"  : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
+    "cekCaseCost"    : {"exBudgetCPU":   16000, "exBudgetMemory": 100}
 }
 


### PR DESCRIPTION
This adjusts the CPU costs for machine steps in `cekMachineCostsB.json` to match those in `cekMachineCostsC.json`.  This means that after the Chang HF script costs should be approximately the same for PlutusV1, PlutusV2, and PlutusV3, and all should be cheaper than at present.