### PR TITLE
Tests for the `preserve-logging` flag.

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -155,6 +155,7 @@ test-suite plutus-tx-plugin-tests
     Plugin.NoTrace.Lib
     Plugin.NoTrace.Spec
     Plugin.NoTrace.WithoutTraces
+    Plugin.NoTrace.WithPreservedLogging
     Plugin.NoTrace.WithTraces
     Plugin.Optimization.Spec
     Plugin.Patterns.Spec

--- a/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
@@ -11,15 +11,16 @@ import Prelude
 import Plugin.NoTrace.Lib (countTraces)
 import Plugin.NoTrace.Lib qualified as Lib
 import Plugin.NoTrace.WithoutTraces qualified as WithoutTraces
+import Plugin.NoTrace.WithPreservedLogging qualified as WithPreservedLogging
 import Plugin.NoTrace.WithTraces qualified as WithTraces
 import Test.Tasty (testGroup)
 import Test.Tasty.Extras (TestNested, embed)
 import Test.Tasty.HUnit (assertBool, testCase, (@=?))
 
 noTrace :: TestNested
-noTrace = embed $ do
+noTrace = embed do
   testGroup "remove-trace"
-    [ testGroup "Trace calls are preserved"
+    [ testGroup "Trace calls are preserved (no-remove-trace)"
         [ testCase "trace-argument" $
             1 @=? countTraces WithTraces.traceArgument
         , testCase "trace-show" $
@@ -37,8 +38,26 @@ noTrace = embed $ do
         , testCase "trace-impure with effect" $ -- See Note [Impure trace messages]
             assertBool "Effect is missing" (Lib.evaluatesToError WithTraces.traceImpure)
         ]
+    , testGroup "Trace calls are preserved (preserve-logging)"
+        [ testCase "trace-argument" $
+            1 @=? countTraces WithPreservedLogging.traceArgument
+        , testCase "trace-show" $
+            1 @=? countTraces WithPreservedLogging.traceShow
+        , testCase "trace-complex" $
+            2 @=? countTraces WithPreservedLogging.traceComplex
+        , testCase "trace-direct" $
+            1 @=? countTraces WithPreservedLogging.traceDirect
+        , testCase "trace-non-constant" $
+            1 @=? countTraces WithPreservedLogging.traceNonConstant
+        , testCase "trace-repeatedly" $
+            3 @=? countTraces WithPreservedLogging.traceRepeatedly
+        , testCase "trace-impure" $
+            1 @=? countTraces WithPreservedLogging.traceImpure
+        , testCase "trace-impure with effect" $ -- See Note [Impure trace messages]
+            assertBool "Effect is missing" (Lib.evaluatesToError WithPreservedLogging.traceImpure)
+        ]
     , testGroup
-        "Trace calls are removed"
+        "Trace calls are removed (remove-trace)"
         [ testCase "trace-argument" $
             0 @=? countTraces WithoutTraces.traceArgument
         , testCase "trace-show" $

--- a/plutus-tx-plugin/test/Plugin/NoTrace/WithPreservedLogging.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/WithPreservedLogging.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-conservative-optimisation #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:preserve-logging #-}
+
+module Plugin.NoTrace.WithPreservedLogging where
+
+import Data.Proxy (Proxy (..))
+import Plugin.NoTrace.Lib qualified as Lib
+import PlutusTx.Bool (Bool)
+import PlutusTx.Builtins (BuiltinString, Integer)
+import PlutusTx.Code (CompiledCode)
+import PlutusTx.Plugin (plc)
+
+traceArgument :: CompiledCode (BuiltinString -> ())
+traceArgument = plc (Proxy @"traceArgument") Lib.traceArgument
+
+traceShow :: CompiledCode ()
+traceShow = plc (Proxy @"traceShow") Lib.traceShow
+
+traceDirect :: CompiledCode ()
+traceDirect = plc (Proxy @"traceDirect") Lib.traceDirect
+
+traceNonConstant :: CompiledCode (BuiltinString -> BuiltinString)
+traceNonConstant = plc (Proxy @"traceNonConstant") Lib.traceNonConstant
+
+traceComplex :: CompiledCode (Bool -> ())
+traceComplex = plc (Proxy @"traceComplex") Lib.traceComplex
+
+traceRepeatedly :: CompiledCode Integer
+traceRepeatedly = plc (Proxy @"traceRepeatedly") Lib.traceRepeatedly
+
+traceImpure :: CompiledCode ()
+traceImpure = plc (Proxy @"traceImpure") Lib.traceImpure


### PR DESCRIPTION
A [user has reported](https://github.com/IntersectMBO/plutus/issues/5949#issuecomment-2141488071) that `preserve-logging` flag is not recognized, so I decided to verify it by adding it to the spec which verifies behavior of the `remove-trace` flag (very related).

(I wasn't able to reproduce the misbehaviour, tests show that in a presence of this flag logs are preserved.)
