### PR TITLE
Update update-version.sh to match package names less greedily

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -43,8 +43,8 @@ sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 # The second sed command is to match the case where the package name is at the end of the line:
 # we need this because the first case requires at least one character after the package name.
 #
-# Note that this all requires a comma (maybe preceded and followed by whitespace) at the start
-# of the line: it won't work with commas at the end.
+# Note that this all requires a comma (maybe preceded and/or followed by whitespace) at the
+# start of the line: it won't work with commas at the end.
 
 echo "Updating version bounds on $PACKAGE to '^>=$major_version'"
 find . -name "?*.cabal" -exec sed -i "s/\(^[ \t]*,[ \t]*$PACKAGE[^-A-Za-z0-1][^^]*\).*/\1^>=$major_version/" {} \; \

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -37,14 +37,17 @@ sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 #
 # The ?* pattern prevents 'find' from attempting to modify ".cabal" (no basename).
 #
-# The pattern $PACKAGE[^-A-Za-z0-1][^^] matches exactly the package name followed by anything
-# up to ^. We need [^-A-Za-z0-1] to prevent eg `plutus-tx` from matching `plutus-tx-plugin`.
+# The pattern $PACKAGE[^-A-Za-z0-1][^^] matches the package name followed by the rest of the
+# line up to but not including the first ^ (if any); anything after that is replaced with the
+# new bound. We need [^-A-Za-z0-1] to exactly match the name of the package whose bounds we
+# want to update and make sure that we don't get a situation like `plutus-tx` matching
+# `plutus-tx-plugin`.
 #
 # The second sed command is to match the case where the package name is at the end of the line:
 # we need this because the first case requires at least one character after the package name.
 #
 # Note that this all requires a comma (maybe preceded and/or followed by whitespace) at the
-# start of the line: it won't work with commas at the end.
+# start of the line: it won't work with a comma at the end.
 
 echo "Updating version bounds on $PACKAGE to '^>=$major_version'"
 find . -name "?*.cabal" -exec sed -i "s/\(^[ \t]*,[ \t]*$PACKAGE[^-A-Za-z0-1][^^]*\).*/\1^>=$major_version/" {} \; \

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -43,9 +43,9 @@ sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 # The second sed command is to match the case where the package name is at the end of the line:
 # we need this because the first case requires at least one character after the package name.
 #
-# Note that this all requires a comma (maybe preceded by whitespace) at the start of the line:
-# it won't work with commas at the end.
+# Note that this all requires a comma (maybe preceded and followed by whitespace) at the start
+# of the line: it won't work with commas at the end.
 
 echo "Updating version bounds on $PACKAGE to '^>=$major_version'"
-find . -name "?*.cabal" -exec sed -i "s/\(^[ \t]*, $PACKAGE[^-A-Za-z0-1][^^]*\).*/\1^>=$major_version/" {} \; \
-                        -exec sed -i "s/\(^[ \t]*, $PACKAGE$\)/\1 ^>=$major_version/" {} \;
+find . -name "?*.cabal" -exec sed -i "s/\(^[ \t]*,[ \t]*$PACKAGE[^-A-Za-z0-1][^^]*\).*/\1^>=$major_version/" {} \; \
+                        -exec sed -i "s/\(^[ \t]*,[ \t]*$PACKAGE$\)/\1 ^>=$major_version/" {} \;

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
 usage () {
-  echo "$(basename $0) PACKAGE VERSION
+  echo "usage: $(basename $0) PACKAGE VERSION
   Updates the version for PACKAGE to VERSION, and updates bounds
   on that package in other cabal files."
 }
 
-if [ "$#" == "0" ]; then
+if [[ $# != 2 ]]; then
+  echo "Wrong number of arguments"
   usage
   exit 1
 fi
@@ -24,7 +25,7 @@ echo "Updating version of $PACKAGE to $VERSION"
 # update package version in cabal file for package
 sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 
-# update version bounds in all cabal files
+# Update version bounds in all cabal files
 # It looks for patterns like the following:
 #
 # - ", plutus-core"
@@ -33,6 +34,18 @@ sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 # - ", plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.0"
 #
 # and updates the version bounds to "^>={major version}"
+#
 # The ?* pattern prevents 'find' from attempting to modify ".cabal" (no basename).
+#
+# The pattern $PACKAGE[^-A-Za-z0-1][^^] matches exactly the package name followed by anything
+# up to ^. We need [^-A-Za-z0-1] to prevent eg `plutus-tx` from matching `plutus-tx-plugin`.
+#
+# The second sed command is to match the case where the package name is at the end of the line:
+# we need this because the first case requires at least one character after the package name.
+#
+# Note that this all requires a comma (maybe preceded by whitespace) at the start of the line:
+# it won't work with commas at the end.
+
 echo "Updating version bounds on $PACKAGE to '^>=$major_version'"
-find . -name "?*.cabal" -exec sed -i "s/\(, $PACKAGE[^^]*\).*/\1 ^>=$major_version/" {} \;
+find . -name "?*.cabal" -exec sed -i "s/\(^[ \t]*, $PACKAGE[^-A-Za-z0-1][^^]*\).*/\1^>=$major_version/" {} \; \
+                        -exec sed -i "s/\(^[ \t]*, $PACKAGE$\)/\1 ^>=$major_version/" {} \;


### PR DESCRIPTION
I had a problem in #6170 because `update-versions.sh` was adding a version bound for the recently-added `plutus-tx-test-utils` package, and this was causing problems for our nix setup  This was because there was a `sed` command which was matching `plutus-tx-test-util` when updating the bounds for `plutus-tx`.  This PR should make the `sed` command match the package name exactly, so it won't matter if one package name is a prefix of another.  In fact the previous version would modify entries for `plutus-tx-plugin` twice, once for `plutus-tx` and once for `plutus-tx-plugin`.  This didn't actually matter because both of those packages are versioned, but `plutus-tx-test-utils` introduced an unversioned package whose name contained the name of a versioned package as a prefix.