### PR TITLE
 [PlutusLedgerApi] [Refactoring] Polish imports and exports

### DIFF
--- a/plutus-ledger-api/changelog.d/20240606_160839_effectfully_polish_imports_and_exports.md
+++ b/plutus-ledger-api/changelog.d/20240606_160839_effectfully_polish_imports_and_exports.md
@@ -1,0 +1,18 @@
+### Added
+
+- Exported the following from `PlutusLedgerApi.Common` in #6178:
+  + `ExCPU (..)`
+  + `ExMemory (..)`
+  + `SatInt (unSatInt)`
+  + `fromSatInt`
+  + `toOpaque,
+  + `fromOpaque`
+  + `BuiltinData (..)`
+  + `ToData (..)`
+  + `FromData (..)`
+  + `UnsafeFromData (..)`
+  + `toData`
+  + `fromData`
+  + `unsafeFromData`
+  + `dataToBuiltinData`
+  + `builtinDataToData`

--- a/plutus-ledger-api/exe/analyse-script-events/Main.hs
+++ b/plutus-ledger-api/exe/analyse-script-events/Main.hs
@@ -34,7 +34,6 @@ import Control.Monad.Writer.Strict
 import Data.Int (Int64)
 import Data.List (find, intercalate)
 import Data.Primitive.PrimArray qualified as P
-import Data.SatInt (fromSatInt)
 import System.Directory.Extra (listFiles)
 import System.Environment (getArgs, getProgName)
 import System.FilePath (isExtensionOf, takeFileName)
@@ -308,8 +307,8 @@ data EvaluationResult =  OK ExBudget | Failed | DeserialisationError
 -- Convert to a string for use in an R frame
 toRString :: EvaluationResult -> String
 toRString = \case
-  OK _ -> "T"
-  Failed -> "F"
+  OK _                 -> "T"
+  Failed               -> "F"
   DeserialisationError -> "NA"
 
 -- Print out the actual and claimed CPU and memory cost of every script.
@@ -471,6 +470,6 @@ main =
               eventFiles -> analysis eventFiles
 
     in getArgs >>= \case
-      [name] -> go name "."
+      [name]      -> go name "."
       [name, dir] -> go name dir
-      _ -> usage
+      _           -> usage

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common.hs
@@ -1,73 +1,112 @@
+-- editorconfig-checker-disable-file
+
 -- | The types and functions that are common among all ledger Plutus versions.
-module PlutusLedgerApi.Common
-    ( -- * Script (de)serialization
-      SerialisedScript
-    , ScriptForEvaluation
-    , serialisedScript
-    , deserialisedScript
-    , serialiseCompiledCode
-    , serialiseUPLC
-    , deserialiseScript
-    , uncheckedDeserialiseUPLC
-    , ScriptDecodeError (..)
-    , ScriptNamedDeBruijn (..)
+module PlutusLedgerApi.Common (
+  -- * Script (de)serialization
+  SerialisedScript.SerialisedScript,
+  SerialisedScript.ScriptForEvaluation,
+  SerialisedScript.serialisedScript,
+  SerialisedScript.deserialisedScript,
+  SerialisedScript.serialiseCompiledCode,
+  SerialisedScript.serialiseUPLC,
+  SerialisedScript.deserialiseScript,
+  SerialisedScript.uncheckedDeserialiseUPLC,
+  SerialisedScript.ScriptDecodeError (..),
+  SerialisedScript.ScriptNamedDeBruijn (..),
 
-      -- * Script evaluation
-    , evaluateScriptCounting
-    , evaluateScriptRestricting
-    , evaluateTerm
-    , VerboseMode (..)
-    , LogOutput
-    , EvaluationError (..)
-    -- reexport Data & ExBudget for convenience to upstream users
-    , PlutusCore.Data (..)
-    , PlutusCore.ExBudget (..)
+  -- * Script evaluation
+  Eval.evaluateScriptCounting,
+  Eval.evaluateScriptRestricting,
+  Eval.evaluateTerm,
+  Eval.VerboseMode (..),
+  Eval.LogOutput,
+  Eval.EvaluationError (..),
 
-      -- * Network's versioning
-      {-| The network's behaviour (and plutus's by extension) can change via /hard forks/,
-      which directly correspond to major-number protocol version bumps.
-      -}
-    , MajorProtocolVersion (..)
-    , PlutusLedgerLanguage (..)
-    , Version (..)
-    , builtinsIntroducedIn
-    , builtinsAvailableIn
-    , ledgerLanguageIntroducedIn
-    , ledgerLanguagesAvailableIn
+  -- * Network's versioning
+  {-| The network's behaviour (and plutus's by extension) can change via /hard forks/,
+  which directly correspond to major-number protocol version bumps.
+  -}
+  Versions.MajorProtocolVersion (..),
+  Versions.PlutusLedgerLanguage (..),
+  Versions.Version (..),
+  Versions.builtinsIntroducedIn,
+  Versions.builtinsAvailableIn,
+  Versions.ledgerLanguageIntroducedIn,
+  Versions.ledgerLanguagesAvailableIn,
 
-      -- * Network's costing parameters
-      {-| A less drastic approach (that does not rely on a HF)
-      to affect the network's (and plutus's by extension) behaviour
-      is by tweaking the values of the cost model parameters.
+  -- * Costing-related types
+  PLC.ExBudget (..),
+  PLC.ExCPU (..),
+  PLC.ExMemory (..),
+  SatInt.SatInt (unSatInt),
+  SatInt.fromSatInt,
 
-      The network does not associate names to cost model parameters;
-      Plutus attaches names to the network's cost model parameters (values)
-      either in a raw textual form or typed by a specific plutus version.
+  -- * Network's costing parameters
+  {-| A less drastic approach (that does not rely on a HF)
+  to affect the network's (and plutus's by extension) behaviour
+  is by tweaking the values of the cost model parameters.
 
-      See Note [Cost model parameters]
-      -}
-    , CostModelParams
-    , toCostModelParams
-    , assertWellFormedCostModelParams
-    , IsParamName (showParamName, readParamName)
-    , GenericParamName
-    , CostModelApplyError (..)
-    , CostModelApplyWarn (..)
+  The network does not associate names to cost model parameters;
+  Plutus attaches names to the network's cost model parameters (values)
+  either in a raw textual form or typed by a specific plutus version.
 
-      -- ** Evaluation context
-    , EvaluationContext (..)
-    , mkDynEvaluationContext
-    , toMachineParameters
-    -- While not strictly used by the ledger, this is useful for people trying to
-    -- reconstruct the term evaluated by the ledger from the arguments, e.g.
-    -- for profiling purposes.
-    , mkTermToEvaluate
-    ) where
+  See Note [Cost model parameters]
+  -}
+  PLC.CostModelParams,
+  ParamName.toCostModelParams,
+  Eval.assertWellFormedCostModelParams,
+  ParamName.IsParamName (showParamName, readParamName),
+  ParamName.GenericParamName,
+  ParamName.CostModelApplyError (..),
+  ParamName.CostModelApplyWarn (..),
 
-import PlutusCore.Data as PlutusCore (Data (..))
-import PlutusCore.Evaluation.Machine.CostModelInterface (CostModelParams)
-import PlutusCore.Evaluation.Machine.ExBudget as PlutusCore (ExBudget (..))
-import PlutusLedgerApi.Common.Eval
-import PlutusLedgerApi.Common.ParamName
-import PlutusLedgerApi.Common.SerialisedScript
-import PlutusLedgerApi.Common.Versions
+  -- ** Evaluation context
+  Eval.EvaluationContext (..),
+  Eval.mkDynEvaluationContext,
+  Eval.toMachineParameters,
+  -- While not strictly used by the ledger, this is useful for people trying to
+  -- reconstruct the term evaluated by the ledger from the arguments, e.g.
+  -- for profiling purposes.
+  Eval.mkTermToEvaluate,
+
+  -- ** Supporting types used in the context types
+
+  -- *** Builtins
+  TxPrelude.BuiltinByteString,
+  TxPrelude.toBuiltin,
+  TxPrelude.fromBuiltin,
+  TxPrelude.toOpaque,
+  TxPrelude.fromOpaque,
+
+  -- * Data
+  PLC.Data (..),
+  Builtins.BuiltinData (..),
+  IsData.ToData (..),
+  IsData.FromData (..),
+  IsData.UnsafeFromData (..),
+  IsData.toData,
+  IsData.fromData,
+  IsData.unsafeFromData,
+  Builtins.dataToBuiltinData,
+  Builtins.builtinDataToData,
+
+  -- * Misc
+  MonadError,
+) where
+
+import PlutusLedgerApi.Common.Eval qualified as Eval
+import PlutusLedgerApi.Common.ParamName qualified as ParamName
+import PlutusLedgerApi.Common.SerialisedScript qualified as SerialisedScript
+import PlutusLedgerApi.Common.Versions qualified as Versions
+
+import PlutusTx.Builtins.Internal qualified as Builtins
+import PlutusTx.IsData.Class qualified as IsData
+import PlutusTx.Prelude qualified as TxPrelude
+
+import PlutusCore.Data qualified as PLC
+import PlutusCore.Evaluation.Machine.CostModelInterface qualified as PLC
+import PlutusCore.Evaluation.Machine.ExBudget qualified as PLC
+import PlutusCore.Evaluation.Machine.ExMemory qualified as PLC
+
+import Control.Monad.Except (MonadError)
+import Data.SatInt qualified as SatInt

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
@@ -3,99 +3,101 @@
 -- | The interface to Plutus V1 for the ledger.
 module PlutusLedgerApi.V1 (
   -- * Scripts
-  SerialisedScript,
-  ScriptForEvaluation,
-  serialisedScript,
-  deserialisedScript,
-  serialiseCompiledCode,
-  serialiseUPLC,
+  Common.SerialisedScript,
+  Common.ScriptForEvaluation,
+  Common.serialisedScript,
+  Common.deserialisedScript,
+  Common.serialiseCompiledCode,
+  Common.serialiseUPLC,
   deserialiseScript,
-  uncheckedDeserialiseUPLC,
+  Common.uncheckedDeserialiseUPLC,
 
   -- * Running scripts
   evaluateScriptRestricting,
   evaluateScriptCounting,
 
   -- ** Protocol version
-  MajorProtocolVersion (..),
+  Common.MajorProtocolVersion (..),
 
   -- ** Verbose mode and log output
-  VerboseMode (..),
-  LogOutput,
+  Common.VerboseMode (..),
+  Common.LogOutput,
 
   -- * Costing-related types
-  ExBudget (..),
-  ExCPU (..),
-  ExMemory (..),
-  SatInt (unSatInt),
-  fromSatInt,
+  Common.ExBudget (..),
+  Common.ExCPU (..),
+  Common.ExMemory (..),
+  Common.SatInt (unSatInt),
+  Common.fromSatInt,
 
   -- ** Cost model
-  EvaluationContext,
-  mkEvaluationContext,
-  ParamName (..),
-  CostModelApplyError (..),
-  CostModelParams,
-  assertWellFormedCostModelParams,
+  EvaluationContext.EvaluationContext,
+  EvaluationContext.mkEvaluationContext,
+  ParamName.ParamName (..),
+  EvaluationContext.CostModelApplyError (..),
+  EvaluationContext.CostModelParams,
+  EvaluationContext.assertWellFormedCostModelParams,
 
   -- * Context types
-  ScriptContext (..),
-  ScriptPurpose (..),
+  Contexts.ScriptContext (..),
+  Contexts.ScriptPurpose (..),
 
   -- ** Supporting types used in the context types
 
-  -- *** ByteStrings
-  BuiltinByteString,
-  toBuiltin,
-  fromBuiltin,
+  -- *** Builtins
+  Common.BuiltinByteString,
+  Common.toBuiltin,
+  Common.fromBuiltin,
+  Common.toOpaque,
+  Common.fromOpaque,
 
   -- *** Bytes
-  LedgerBytes (..),
-  fromBytes,
+  Bytes.LedgerBytes (..),
+  Bytes.fromBytes,
 
   -- *** Certificates
-  DCert (..),
+  DCert.DCert (..),
 
   -- *** Credentials
-  StakingCredential (..),
-  Credential (..),
+  Credential.StakingCredential (..),
+  Credential.Credential (..),
 
   -- *** Value
-  Value (..),
-  CurrencySymbol (..),
-  TokenName (..),
-  singleton,
-  unionWith,
-  adaSymbol,
-  adaToken,
-  Lovelace (..),
+  Value.Value (..),
+  Value.CurrencySymbol (..),
+  Value.TokenName (..),
+  Value.singleton,
+  Value.unionWith,
+  Value.adaSymbol,
+  Value.adaToken,
+  Value.Lovelace (..),
 
   -- *** Time
-  POSIXTime (..),
-  POSIXTimeRange,
+  Time.POSIXTime (..),
+  Time.POSIXTimeRange,
 
   -- *** Types for representing transactions
-  Address (..),
-  PubKeyHash (..),
-  TxId (..),
-  TxInfo (..),
-  TxOut (..),
-  TxOutRef (..),
-  TxInInfo (..),
+  Address.Address (..),
+  Crypto.PubKeyHash (..),
+  Contexts.TxId (..),
+  Contexts.TxInfo (..),
+  Contexts.TxOut (..),
+  Contexts.TxOutRef (..),
+  Contexts.TxInInfo (..),
 
   -- *** Intervals
-  Interval (..),
-  Extended (..),
-  Closure,
-  UpperBound (..),
-  LowerBound (..),
-  always,
-  from,
-  to,
-  lowerBound,
-  upperBound,
-  strictLowerBound,
-  strictUpperBound,
+  Interval.Interval (..),
+  Interval.Extended (..),
+  Interval.Closure,
+  Interval.UpperBound (..),
+  Interval.LowerBound (..),
+  Interval.always,
+  Interval.from,
+  Interval.to,
+  Interval.lowerBound,
+  Interval.upperBound,
+  Interval.strictLowerBound,
+  Interval.strictUpperBound,
 
   -- *** Newtypes and hash types
   ScriptHash (..),
@@ -105,52 +107,42 @@ module PlutusLedgerApi.V1 (
   DatumHash (..),
 
   -- * Data
-  PLC.Data (..),
-  BuiltinData (..),
-  ToData (..),
-  FromData (..),
-  UnsafeFromData (..),
-  toData,
-  fromData,
-  dataToBuiltinData,
-  builtinDataToData,
+  Common.Data (..),
+  Common.BuiltinData (..),
+  Common.ToData (..),
+  Common.FromData (..),
+  Common.UnsafeFromData (..),
+  Common.toData,
+  Common.fromData,
+  Common.unsafeFromData,
+  Common.dataToBuiltinData,
+  Common.builtinDataToData,
 
   -- * Errors
-  EvaluationError (..),
-  ScriptDecodeError (..),
+  Common.MonadError,
+  Common.EvaluationError (..),
+  Common.ScriptDecodeError (..),
 ) where
 
-import Data.SatInt
-import PlutusCore.Data qualified as PLC
-import PlutusCore.Evaluation.Machine.ExBudget as PLC
-import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
-import PlutusLedgerApi.Common as Common hiding (deserialiseScript, evaluateScriptCounting,
-                                         evaluateScriptRestricting)
-import PlutusLedgerApi.Common qualified as Common (deserialiseScript, evaluateScriptCounting,
-                                                   evaluateScriptRestricting)
-import PlutusLedgerApi.V1.Address
-import PlutusLedgerApi.V1.Bytes
-import PlutusLedgerApi.V1.Contexts
-import PlutusLedgerApi.V1.Credential
-import PlutusLedgerApi.V1.Crypto
-import PlutusLedgerApi.V1.DCert
-import PlutusLedgerApi.V1.EvaluationContext
-import PlutusLedgerApi.V1.Interval hiding (singleton)
-import PlutusLedgerApi.V1.ParamName
+import PlutusLedgerApi.Common qualified as Common
+import PlutusLedgerApi.V1.Address qualified as Address
+import PlutusLedgerApi.V1.Bytes qualified as Bytes
+import PlutusLedgerApi.V1.Contexts qualified as Contexts
+import PlutusLedgerApi.V1.Credential qualified as Credential
+import PlutusLedgerApi.V1.Crypto qualified as Crypto
+import PlutusLedgerApi.V1.DCert qualified as DCert
+import PlutusLedgerApi.V1.EvaluationContext qualified as EvaluationContext
+import PlutusLedgerApi.V1.Interval qualified as Interval
+import PlutusLedgerApi.V1.ParamName qualified as ParamName
 import PlutusLedgerApi.V1.Scripts as Scripts
-import PlutusLedgerApi.V1.Time
-import PlutusLedgerApi.V1.Value
-import PlutusTx (FromData (..), ToData (..), UnsafeFromData (..), fromData, toData)
-import PlutusTx.Builtins.Internal (BuiltinData (..), builtinDataToData, dataToBuiltinData)
-import PlutusTx.Prelude (BuiltinByteString, fromBuiltin, toBuiltin)
-
-import Control.Monad.Except (MonadError)
+import PlutusLedgerApi.V1.Time qualified as Time
+import PlutusLedgerApi.V1.Value qualified as Value
 
 {- | An alias to the Plutus ledger language this module exposes at runtime.
  MAYBE: Use CPP '__FILE__' + some TH to automate this.
 -}
-thisLedgerLanguage :: PlutusLedgerLanguage
-thisLedgerLanguage = PlutusV1
+thisLedgerLanguage :: Common.PlutusLedgerLanguage
+thisLedgerLanguage = Common.PlutusV1
 
 {- Note [Abstract types in the ledger API]
 We need to support old versions of the ledger API as we update the code that it depends on. You
@@ -174,12 +166,12 @@ Called inside phase-1 validation (i.e., deserialisation error is a phase-1 error
 -}
 deserialiseScript ::
   forall m.
-  (MonadError ScriptDecodeError m) =>
+  (Common.MonadError Common.ScriptDecodeError m) =>
   -- | which major protocol version the script was submitted in.
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | the script to deserialise.
-  SerialisedScript ->
-  m ScriptForEvaluation
+  Common.SerialisedScript ->
+  m Common.ScriptForEvaluation
 deserialiseScript = Common.deserialiseScript thisLedgerLanguage
 
 {- | Evaluates a script, returning the minimum budget that the script would need
@@ -189,16 +181,16 @@ also returns the used budget.
 -}
 evaluateScriptCounting ::
   -- | Which major protocol version to run the operation in
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | Whether to produce log output
-  VerboseMode ->
+  Common.VerboseMode ->
   -- | Includes the cost model to use for tallying up the execution costs
-  EvaluationContext ->
+  EvaluationContext.EvaluationContext ->
   -- | The script to evaluate
-  ScriptForEvaluation ->
+  Common.ScriptForEvaluation ->
   -- | The arguments to the script
-  [PLC.Data] ->
-  (LogOutput, Either EvaluationError ExBudget)
+  [Common.Data] ->
+  (Common.LogOutput, Either Common.EvaluationError Common.ExBudget)
 evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 
 {- | Evaluates a script, with a cost model and a budget that restricts how many
@@ -210,16 +202,16 @@ a limit to guard against scripts that run for a long time or loop.
 -}
 evaluateScriptRestricting ::
   -- | Which major protocol version to run the operation in
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | Whether to produce log output
-  VerboseMode ->
+  Common.VerboseMode ->
   -- | Includes the cost model to use for tallying up the execution costs
-  EvaluationContext ->
+  EvaluationContext.EvaluationContext ->
   -- | The resource budget which must not be exceeded during evaluation
-  ExBudget ->
+  Common.ExBudget ->
   -- | The script to evaluate
-  ScriptForEvaluation ->
+  Common.ScriptForEvaluation ->
   -- | The arguments to the script
-  [PLC.Data] ->
-  (LogOutput, Either EvaluationError ExBudget)
+  [Common.Data] ->
+  (Common.LogOutput, Either Common.EvaluationError Common.ExBudget)
 evaluateScriptRestricting = Common.evaluateScriptRestricting thisLedgerLanguage

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
@@ -16,7 +16,6 @@ import PlutusLedgerApi.V1.ParamName as V1
 import PlutusCore.Default (BuiltinSemanticsVariant (DefaultFunSemanticsVariantA, DefaultFunSemanticsVariantB))
 
 import Control.Monad
-import Control.Monad.Except
 import Control.Monad.Writer.Strict
 import Data.Int (Int64)
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
@@ -3,150 +3,146 @@
 -- | The interface to Plutus V2 for the ledger.
 module PlutusLedgerApi.V2 (
   -- * Scripts
-  SerialisedScript,
-  ScriptForEvaluation,
-  serialisedScript,
-  deserialisedScript,
-  serialiseCompiledCode,
-  serialiseUPLC,
+  Common.SerialisedScript,
+  Common.ScriptForEvaluation,
+  Common.serialisedScript,
+  Common.deserialisedScript,
+  Common.serialiseCompiledCode,
+  Common.serialiseUPLC,
   deserialiseScript,
-  uncheckedDeserialiseUPLC,
+  Common.uncheckedDeserialiseUPLC,
 
   -- * Running scripts
   evaluateScriptRestricting,
   evaluateScriptCounting,
 
   -- ** Protocol version
-  MajorProtocolVersion (..),
+  Common.MajorProtocolVersion (..),
 
   -- ** Verbose mode and log output
-  VerboseMode (..),
-  LogOutput,
+  Common.VerboseMode (..),
+  Common.LogOutput,
 
   -- * Costing-related types
-  ExBudget (..),
-  ExCPU (..),
-  ExMemory (..),
-  SatInt (unSatInt),
-  fromSatInt,
+  Common.ExBudget (..),
+  V1.ExCPU (..),
+  V1.ExMemory (..),
+  V1.SatInt (unSatInt),
+  V1.fromSatInt,
 
   -- ** Cost model
-  EvaluationContext,
-  mkEvaluationContext,
-  ParamName (..),
-  CostModelApplyError (..),
-  CostModelParams,
-  assertWellFormedCostModelParams,
+  Common.EvaluationContext,
+  EvaluationContext.mkEvaluationContext,
+  ParamName.ParamName (..),
+  Common.CostModelApplyError (..),
+  Common.CostModelParams,
+  Common.assertWellFormedCostModelParams,
 
   -- * Context types
-  ScriptContext (..),
-  ScriptPurpose (..),
+  Contexts.ScriptContext (..),
+  Contexts.ScriptPurpose (..),
 
   -- ** Supporting types used in the context types
 
-  -- *** ByteStrings
-  BuiltinByteString,
-  toBuiltin,
-  fromBuiltin,
+  -- *** Builtins
+  Common.BuiltinByteString,
+  Common.toBuiltin,
+  Common.fromBuiltin,
+  Common.toOpaque,
+  Common.fromOpaque,
 
   -- *** Bytes
-  LedgerBytes (..),
-  fromBytes,
+  V1.LedgerBytes (..),
+  V1.fromBytes,
 
   -- *** Certificates
-  DCert (..),
+  V1.DCert (..),
 
   -- *** Credentials
-  StakingCredential (..),
-  Credential (..),
+  V1.StakingCredential (..),
+  V1.Credential (..),
 
   -- *** Value
-  Value (..),
-  CurrencySymbol (..),
-  TokenName (..),
-  singleton,
-  unionWith,
-  adaSymbol,
-  adaToken,
-  Lovelace (..),
+  V1.Value (..),
+  V1.CurrencySymbol (..),
+  V1.TokenName (..),
+  V1.singleton,
+  V1.unionWith,
+  V1.adaSymbol,
+  V1.adaToken,
+  V1.Lovelace (..),
 
   -- *** Time
-  POSIXTime (..),
-  POSIXTimeRange,
+  V1.POSIXTime (..),
+  V1.POSIXTimeRange,
 
   -- *** Types for representing transactions
-  Address (..),
-  PubKeyHash (..),
-  TxId (..),
-  TxInfo (..),
-  TxOut (..),
-  TxOutRef (..),
-  TxInInfo (..),
-  OutputDatum (..),
+  V1.Address (..),
+  V1.PubKeyHash (..),
+  Tx.TxId (..),
+  Contexts.TxInfo (..),
+  Tx.TxOut (..),
+  Tx.TxOutRef (..),
+  Contexts.TxInInfo (..),
+  Tx.OutputDatum (..),
 
   -- *** Intervals
-  Interval (..),
-  Extended (..),
-  Closure,
-  UpperBound (..),
-  LowerBound (..),
-  always,
-  from,
-  to,
-  lowerBound,
-  upperBound,
-  strictLowerBound,
-  strictUpperBound,
+  V1.Interval (..),
+  V1.Extended (..),
+  V1.Closure,
+  V1.UpperBound (..),
+  V1.LowerBound (..),
+  V1.always,
+  V1.from,
+  V1.to,
+  V1.lowerBound,
+  V1.upperBound,
+  V1.strictLowerBound,
+  V1.strictUpperBound,
 
   -- *** Association maps
   Map,
   unsafeFromList,
 
   -- *** Newtypes and hash types
-  ScriptHash (..),
-  Redeemer (..),
-  RedeemerHash (..),
-  Datum (..),
-  DatumHash (..),
+  V1.ScriptHash (..),
+  V1.Redeemer (..),
+  V1.RedeemerHash (..),
+  V1.Datum (..),
+  V1.DatumHash (..),
 
   -- * Data
-  Data (..),
-  BuiltinData (..),
-  ToData (..),
-  FromData (..),
-  UnsafeFromData (..),
-  toData,
-  fromData,
-  dataToBuiltinData,
-  builtinDataToData,
+  Common.Data (..),
+  Common.BuiltinData (..),
+  Common.ToData (..),
+  Common.FromData (..),
+  Common.UnsafeFromData (..),
+  Common.toData,
+  Common.fromData,
+  Common.unsafeFromData,
+  Common.dataToBuiltinData,
+  Common.builtinDataToData,
 
   -- * Errors
-  EvaluationError (..),
-  ScriptDecodeError (..),
+  Common.MonadError,
+  Common.EvaluationError (..),
+  Common.ScriptDecodeError (..),
 ) where
 
-import PlutusLedgerApi.Common as Common hiding (deserialiseScript, evaluateScriptCounting,
-                                         evaluateScriptRestricting)
-import PlutusLedgerApi.Common qualified as Common (deserialiseScript, evaluateScriptCounting,
-                                                   evaluateScriptRestricting)
-import PlutusLedgerApi.V1 hiding (ParamName, ScriptContext (..), TxInInfo (..), TxInfo (..),
-                           TxOut (..), deserialiseScript, evaluateScriptCounting,
-                           evaluateScriptRestricting, mkEvaluationContext)
-import PlutusLedgerApi.V2.Contexts
-import PlutusLedgerApi.V2.EvaluationContext
-import PlutusLedgerApi.V2.ParamName
-import PlutusLedgerApi.V2.Tx (OutputDatum (..))
+import PlutusLedgerApi.Common qualified as Common
+import PlutusLedgerApi.V1 qualified as V1
+import PlutusLedgerApi.V2.Contexts qualified as Contexts
+import PlutusLedgerApi.V2.EvaluationContext qualified as EvaluationContext
+import PlutusLedgerApi.V2.ParamName qualified as ParamName
+import PlutusLedgerApi.V2.Tx qualified as Tx
 
-import PlutusCore.Data qualified as PLC
 import PlutusTx.AssocMap (Map, unsafeFromList)
-
-import Control.Monad.Except (MonadError)
 
 {- | An alias to the Plutus ledger language this module exposes at runtime.
  MAYBE: Use CPP '__FILE__' + some TH to automate this.
 -}
-thisLedgerLanguage :: PlutusLedgerLanguage
-thisLedgerLanguage = PlutusV2
+thisLedgerLanguage :: Common.PlutusLedgerLanguage
+thisLedgerLanguage = Common.PlutusV2
 
 {- | The deserialization from a serialised script into a `ScriptForEvaluation`,
 ready to be evaluated on-chain.
@@ -154,12 +150,12 @@ Called inside phase-1 validation (i.e., deserialisation error is a phase-1 error
 -}
 deserialiseScript ::
   forall m.
-  (MonadError ScriptDecodeError m) =>
+  (Common.MonadError Common.ScriptDecodeError m) =>
   -- | which major protocol version the script was submitted in.
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | the script to deserialise.
-  SerialisedScript ->
-  m ScriptForEvaluation
+  Common.SerialisedScript ->
+  m Common.ScriptForEvaluation
 deserialiseScript = Common.deserialiseScript thisLedgerLanguage
 
 {- | Evaluates a script, returning the minimum budget that the script would need
@@ -169,16 +165,16 @@ also returns the used budget.
 -}
 evaluateScriptCounting ::
   -- | Which major protocol version to run the operation in
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | Whether to produce log output
-  VerboseMode ->
+  Common.VerboseMode ->
   -- | Includes the cost model to use for tallying up the execution costs
-  EvaluationContext ->
+  Common.EvaluationContext ->
   -- | The script to evaluate
-  ScriptForEvaluation ->
+  Common.ScriptForEvaluation ->
   -- | The arguments to the script
-  [PLC.Data] ->
-  (LogOutput, Either EvaluationError ExBudget)
+  [Common.Data] ->
+  (Common.LogOutput, Either Common.EvaluationError Common.ExBudget)
 evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 
 {- | Evaluates a script, with a cost model and a budget that restricts how many
@@ -190,16 +186,16 @@ a limit to guard against scripts that run for a long time or loop.
 -}
 evaluateScriptRestricting ::
   -- | Which major protocol version to run the operation in
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | Whether to produce log output
-  VerboseMode ->
+  Common.VerboseMode ->
   -- | Includes the cost model to use for tallying up the execution costs
-  EvaluationContext ->
+  Common.EvaluationContext ->
   -- | The resource budget which must not be exceeded during evaluation
-  ExBudget ->
+  Common.ExBudget ->
   -- | The script to evaluate
-  ScriptForEvaluation ->
+  Common.ScriptForEvaluation ->
   -- | The arguments to the script
-  [PLC.Data] ->
-  (LogOutput, Either EvaluationError ExBudget)
+  [Common.Data] ->
+  (Common.LogOutput, Either Common.EvaluationError Common.ExBudget)
 evaluateScriptRestricting = Common.evaluateScriptRestricting thisLedgerLanguage

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
@@ -16,7 +16,6 @@ import PlutusLedgerApi.V2.ParamName as V2
 import PlutusCore.Default (BuiltinSemanticsVariant (DefaultFunSemanticsVariantA, DefaultFunSemanticsVariantB))
 
 import Control.Monad
-import Control.Monad.Except
 import Control.Monad.Writer.Strict
 import Data.Int (Int64)
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -1,69 +1,71 @@
 -- | The interface to Plutus V3 for the ledger.
 module PlutusLedgerApi.V3 (
   -- * Scripts
-  SerialisedScript,
-  ScriptForEvaluation,
-  serialisedScript,
-  deserialisedScript,
-  serialiseCompiledCode,
-  serialiseUPLC,
+  Common.SerialisedScript,
+  Common.ScriptForEvaluation,
+  Common.serialisedScript,
+  Common.deserialisedScript,
+  Common.serialiseCompiledCode,
+  Common.serialiseUPLC,
   deserialiseScript,
-  uncheckedDeserialiseUPLC,
+  Common.uncheckedDeserialiseUPLC,
 
   -- * Running scripts
   evaluateScriptRestricting,
   evaluateScriptCounting,
 
   -- ** CIP-1694
-  ColdCommitteeCredential (..),
-  HotCommitteeCredential (..),
-  DRepCredential (..),
-  DRep (..),
-  Delegatee (..),
-  TxCert (..),
-  Voter (..),
-  Vote (..),
-  GovernanceActionId (..),
-  Committee (..),
-  Constitution (..),
-  ProtocolVersion (..),
-  GovernanceAction (..),
-  ChangedParameters (..),
-  ProposalProcedure (..),
+  Contexts.ColdCommitteeCredential (..),
+  Contexts.HotCommitteeCredential (..),
+  Contexts.DRepCredential (..),
+  Contexts.DRep (..),
+  Contexts.Delegatee (..),
+  Contexts.TxCert (..),
+  Contexts.Voter (..),
+  Contexts.Vote (..),
+  Contexts.GovernanceActionId (..),
+  Contexts.Committee (..),
+  Contexts.Constitution (..),
+  Contexts.ProtocolVersion (..),
+  Contexts.GovernanceAction (..),
+  Contexts.ChangedParameters (..),
+  Contexts.ProposalProcedure (..),
 
   -- ** Protocol version
-  MajorProtocolVersion (..),
+  Common.MajorProtocolVersion (..),
 
   -- ** Verbose mode and log output
-  VerboseMode (..),
-  LogOutput,
+  Common.VerboseMode (..),
+  Common.LogOutput,
 
   -- * Costing-related types
-  ExBudget (..),
+  Common.ExBudget (..),
   V2.ExCPU (..),
   V2.ExMemory (..),
   V2.SatInt (V2.unSatInt),
   V2.fromSatInt,
 
   -- ** Cost model
-  EvaluationContext,
-  mkEvaluationContext,
-  ParamName (..),
-  CostModelApplyError (..),
-  CostModelParams,
-  assertWellFormedCostModelParams,
+  EvaluationContext.EvaluationContext,
+  EvaluationContext.mkEvaluationContext,
+  ParamName.ParamName (..),
+  EvaluationContext.CostModelApplyError (..),
+  EvaluationContext.CostModelParams,
+  EvaluationContext.assertWellFormedCostModelParams,
 
   -- * Context types
-  ScriptContext (..),
-  ScriptPurpose (..),
-  ScriptInfo (..),
+  Contexts.ScriptContext (..),
+  Contexts.ScriptPurpose (..),
+  Contexts.ScriptInfo (..),
 
   -- ** Supporting types used in the context types
 
-  -- *** ByteStrings
-  V2.BuiltinByteString,
-  V2.toBuiltin,
-  V2.fromBuiltin,
+  -- *** Builtins
+  Common.BuiltinByteString,
+  Common.toBuiltin,
+  Common.fromBuiltin,
+  Common.toOpaque,
+  Common.fromOpaque,
 
   -- *** Bytes
   V2.LedgerBytes (..),
@@ -90,11 +92,11 @@ module PlutusLedgerApi.V3 (
   -- *** Types for representing transactions
   V2.Address (..),
   V2.PubKeyHash (..),
-  TxId (..),
-  TxInfo (..),
+  Tx.TxId (..),
+  Contexts.TxInfo (..),
   V2.TxOut (..),
-  TxOutRef (..),
-  TxInInfo (..),
+  Tx.TxOutRef (..),
+  Contexts.TxInInfo (..),
   V2.OutputDatum (..),
 
   -- *** Intervals
@@ -136,34 +138,29 @@ module PlutusLedgerApi.V3 (
   V2.UnsafeFromData (..),
   V2.toData,
   V2.fromData,
+  V2.unsafeFromData,
   V2.dataToBuiltinData,
   V2.builtinDataToData,
 
   -- * Errors
+  Common.MonadError,
   V2.EvaluationError (..),
   V2.ScriptDecodeError (..),
 ) where
 
-import PlutusCore.Data qualified as PLC
-import PlutusLedgerApi.Common as Common hiding (deserialiseScript, evaluateScriptCounting,
-                                         evaluateScriptRestricting)
-import PlutusLedgerApi.Common qualified as Common (deserialiseScript, evaluateScriptCounting,
-                                                   evaluateScriptRestricting)
-import PlutusLedgerApi.V2 qualified as V2 hiding (ScriptContext (..), ScriptPurpose (..), TxId (..),
-                                           TxInfo (..), TxOutRef (..))
-import PlutusLedgerApi.V3.Contexts
-import PlutusLedgerApi.V3.EvaluationContext
-import PlutusLedgerApi.V3.ParamName
-import PlutusLedgerApi.V3.Tx
+import PlutusLedgerApi.Common qualified as Common
+import PlutusLedgerApi.V2 qualified as V2
+import PlutusLedgerApi.V3.Contexts qualified as Contexts
+import PlutusLedgerApi.V3.EvaluationContext qualified as EvaluationContext
+import PlutusLedgerApi.V3.ParamName qualified as ParamName
+import PlutusLedgerApi.V3.Tx qualified as Tx
 import PlutusTx.Ratio qualified as Ratio
-
-import Control.Monad.Except (MonadError)
 
 {- | An alias to the Plutus ledger language this module exposes at runtime.
  MAYBE: Use CPP '__FILE__' + some TH to automate this.
 -}
-thisLedgerLanguage :: PlutusLedgerLanguage
-thisLedgerLanguage = PlutusV3
+thisLedgerLanguage :: Common.PlutusLedgerLanguage
+thisLedgerLanguage = Common.PlutusV3
 
 {- | The deserialization from a serialised script into a `ScriptForEvaluation`,
 ready to be evaluated on-chain.
@@ -171,12 +168,12 @@ Called inside phase-1 validation (i.e., deserialisation error is a phase-1 error
 -}
 deserialiseScript ::
   forall m.
-  (MonadError ScriptDecodeError m) =>
+  (Common.MonadError Common.ScriptDecodeError m) =>
   -- | which major protocol version the script was submitted in.
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | the script to deserialise.
-  SerialisedScript ->
-  m ScriptForEvaluation
+  Common.SerialisedScript ->
+  m Common.ScriptForEvaluation
 deserialiseScript = Common.deserialiseScript thisLedgerLanguage
 
 {- | Evaluates a script, returning the minimum budget that the script would need
@@ -186,16 +183,16 @@ also returns the used budget.
 -}
 evaluateScriptCounting ::
   -- | Which protocol version to run the operation in
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | Whether to produce log output
-  VerboseMode ->
+  Common.VerboseMode ->
   -- | Includes the cost model to use for tallying up the execution costs
-  EvaluationContext ->
+  EvaluationContext.EvaluationContext ->
   -- | The script to evaluate
-  ScriptForEvaluation ->
+  Common.ScriptForEvaluation ->
   -- | The @ScriptContext@ argument to the script
-  PLC.Data ->
-  (LogOutput, Either EvaluationError ExBudget)
+  Common.Data ->
+  (Common.LogOutput, Either Common.EvaluationError Common.ExBudget)
 evaluateScriptCounting mpv verbose ec s arg =
   Common.evaluateScriptCounting thisLedgerLanguage mpv verbose ec s [arg]
 
@@ -208,17 +205,17 @@ a limit to guard against scripts that run for a long time or loop.
 -}
 evaluateScriptRestricting ::
   -- | Which protocol version to run the operation in
-  MajorProtocolVersion ->
+  Common.MajorProtocolVersion ->
   -- | Whether to produce log output
-  VerboseMode ->
+  Common.VerboseMode ->
   -- | Includes the cost model to use for tallying up the execution costs
-  EvaluationContext ->
+  EvaluationContext.EvaluationContext ->
   -- | The resource budget which must not be exceeded during evaluation
-  ExBudget ->
+  Common.ExBudget ->
   -- | The script to evaluate
-  ScriptForEvaluation ->
+  Common.ScriptForEvaluation ->
   -- | The @ScriptContext@ argument to the script
-  PLC.Data ->
-  (LogOutput, Either EvaluationError ExBudget)
+  Common.Data ->
+  (Common.LogOutput, Either Common.EvaluationError Common.ExBudget)
 evaluateScriptRestricting mpv verbose ec budget s arg =
   Common.evaluateScriptRestricting thisLedgerLanguage mpv verbose ec budget s [arg]

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
@@ -14,7 +14,6 @@ import PlutusLedgerApi.V3.ParamName as V3
 import PlutusCore.Default (BuiltinSemanticsVariant (DefaultFunSemanticsVariantC))
 
 import Control.Monad
-import Control.Monad.Except
 import Control.Monad.Writer.Strict
 import Data.Int (Int64)
 

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
@@ -8,7 +8,6 @@ module PlutusLedgerApi.Test.Scripts
 
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1.Scripts
-import PlutusTx
 import UntypedPlutusCore qualified as UPLC
 
 uplcToScriptForEvaluation ::

--- a/plutus-tx/src/PlutusTx/IsData/Class.hs
+++ b/plutus-tx/src/PlutusTx/IsData/Class.hs
@@ -205,3 +205,7 @@ toData a = builtinDataToData (toBuiltinData a)
 -- | Convert a value from 'PLC.Data', returning 'Nothing' if this fails.
 fromData :: (FromData a) => PLC.Data -> Maybe a
 fromData d = fromBuiltinData (BuiltinData d)
+
+-- | Convert a value from 'PLC.Data', throwing if this fails.
+unsafeFromData :: (UnsafeFromData a) => PLC.Data -> a
+unsafeFromData d = unsafeFromBuiltinData (BuiltinData d)


### PR DESCRIPTION
This

- resolves #6098
- moves a bunch of stuff shared among `V1`/`V2`/`V3` into `Common` (see the PR review)
- makes all imports in the `Common`/`V1`/`V2`/`V3` modules qualified so that it's clear where definitions come from and whether they are inherited from `Common` or an earlier ledger language
- fixes some formatting, adds a definition for consistency etc