### PR TITLE
More error checking for update-vesion.sh

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -19,6 +19,12 @@ VERSION=$2
 
 IFS='.' read -r -a components <<< "$VERSION"
 
+if [[ ${#components[@]} < 2 ]]; then
+    echo "Too few components in version number" $VERSION "(need at least two)"
+    usage
+    exit 1
+fi
+
 major_version="${components[0]}.${components[1]}"
 
 echo "Updating version of $PACKAGE to $VERSION"


### PR DESCRIPTION
`update-version.sh` gave a cryptic error if you gave it a version number without any dots.  This is just a small fix to make it say something more sensible if that happens.  I don't think this needs to be reviewed.