### PR TITLE
Adding link to Haddock documentation to index.md

### DIFF
--- a/docusaurus/docs/index.md
+++ b/docusaurus/docs/index.md
@@ -42,7 +42,7 @@ See, for example:
 ## The Plutus repository
 
 The [Plutus repository](https://github.com/IntersectMBO/plutus) contains the implementation, specification, and mechanized metatheory of Plutus Core. 
-It also contains the Plutus Tx compiler and the libraries, such as `PlutusTx.List`, for writing Haskell code that can be compiled to Plutus Core.
+It also contains the Plutus Tx compiler and the [combined documentation for all the public Plutus code libraries](https://intersectmbo.github.io/plutus/master/), such as `PlutusTx.List`, for writing Haskell code that can be compiled to Plutus Core.
 
 ## Educational resources
 


### PR DESCRIPTION
This change adds a link to the combined documentation for all the public Plutus code libraries under the heading for "The Plutus repository."
