### PR TITLE
[Test] [Builtins] Add golden tests with unlifting errors

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -45,12 +45,12 @@ class HasConstant term where
 type HasConstantIn uni term = (UniOf term ~ uni, HasConstant term)
 
 -- | Wrap a Haskell value (given its explicit type tag) as a @term@.
-fromValueOf :: HasConstant term => UniOf term (Esc a) -> a -> term
+fromValueOf :: forall a term. HasConstant term => UniOf term (Esc a) -> a -> term
 fromValueOf uni = fromConstant . someValueOf uni
 {-# INLINE fromValueOf #-}
 
 -- | Wrap a Haskell value (provided its type is in the universe) as a @term@.
-fromValue :: (HasConstant term, UniOf term `HasTermLevel` a) => a -> term
+fromValue :: forall a term. (HasConstant term, UniOf term `HasTermLevel` a) => a -> term
 fromValue = fromValueOf knownUni
 {-# INLINE fromValue #-}
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -56,11 +56,17 @@ import Data.Text (Text)
 import Hedgehog hiding (Opaque, Size, Var)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+import Prettyprinter (vsep)
 import Test.Tasty
+import Test.Tasty.Extras
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit
 
 type DefaultFunExt = Either DefaultFun ExtensionFun
+
+runTestNestedHere :: [TestNested] -> TestTree
+runTestNestedHere = runTestNested
+    ["untyped-plutus-core", "test", "Evaluation", "Builtins", "Golden"]
 
 defaultBuiltinCostModelExt :: CostingPart DefaultUni DefaultFunExt
 defaultBuiltinCostModelExt = (defaultBuiltinCostModelForTesting, ())
@@ -458,107 +464,161 @@ test_SerialiseDataImpossible =
         typecheckAnd def evalRestricting defaultBuiltinCostModelForTesting dataLoop @?=
             Right EvaluationFailure
 
+stripParensIfAny :: String -> String
+stripParensIfAny ('(' : str) = init str
+stripParensIfAny str         = str
+
+-- | Apply a built-in function to type then term arguments, evaluate that expression and expect
+-- evaluation to succeed and return the given @a@ value.
+evals
+    :: DefaultUni `HasTermLevel` a
+    => a
+    -> DefaultFun
+    -> [Type TyName DefaultUni ()]
+    -> [Term TyName Name DefaultUni DefaultFun ()]
+    -> TestNested
+evals expectedVal fun typeArgs termArgs =
+    let actualExpNoTermArgs = mkIterInstNoAnn (builtin () fun) typeArgs
+        actualExp = mkIterAppNoAnn actualExpNoTermArgs termArgs
+        prename = stripParensIfAny . render $ prettyPlcReadableDef actualExp
+        -- Shorten the name of the test in case it's too long to be displayed in CLI.
+        name = if length prename < 70 then prename else
+            stripParensIfAny (render $ prettyPlcReadableDef actualExpNoTermArgs) ++
+                concatMap (\_ -> " <...>") termArgs
+        expectedRes = Right . EvaluationSuccess $ cons expectedVal
+        actualRes = typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting actualExp
+    in testNestedM name . embed . testCase "type checks and evaluates as expected" $
+        expectedRes @=? actualRes
+
+-- | Apply a built-in function to type then term arguments, evaluate that expression and expect
+-- evaluation to fail. The logs along with the error are printed to a golden file.
+fails
+    :: String  -- ^ Name of the golden file.
+    -> DefaultFun
+    -> [Type TyName DefaultUni ()]
+    -> [Term TyName Name DefaultUni DefaultFun ()]
+    -> TestNested
+fails fileName fun typeArgs termArgs = do
+    let actualExpNoTermArgs = mkIterInstNoAnn (builtin () fun) typeArgs
+        actualExp = mkIterAppNoAnn actualExpNoTermArgs termArgs
+        expectedToDisplay = "type checks and fails evaluation as expected"
+    case typecheckAnd def (evaluateCek logEmitter) defaultBuiltinCostModelForTesting actualExp of
+        Left err ->
+            embed . testCase "type checks as expected" $
+                assertFailure $ displayPlcCondensedErrorClassic err
+        Right (actualRes, logs) -> case actualRes of
+            Right _ ->
+                embed . testCase expectedToDisplay $
+                    assertFailure "expected an evaluation failure, but got a success"
+            Left err ->
+                let prename = stripParensIfAny . render $ prettyPlcReadableDef actualExp
+                    -- Shorten the name of the test in case it's too long to be displayed in CLI.
+                    name = if length prename < 70 then prename else
+                        stripParensIfAny (render $ prettyPlcReadableDef actualExpNoTermArgs) ++
+                            concatMap (\_ -> " <...>") termArgs
+                in testNestedNamedM mempty name $
+                    testNestedNamedM mempty expectedToDisplay $
+                        nestedGoldenVsDoc fileName ".err" . vsep $
+                            map pretty logs ++ [prettyPlcReadableDef err]
+
 -- | Test all integer related builtins
-test_Integer :: TestTree
-test_Integer = testCase "Integer" $ do
-    evals @Integer 3 AddInteger [cons @Integer 2, cons @Integer 1]
-    evals @Integer 2 SubtractInteger [cons @Integer 100, cons @Integer 98]
-    evals @Integer (-2) SubtractInteger [cons @Integer 98, cons @Integer 100]
-    evals @Integer 9702 MultiplyInteger [cons @Integer 99, cons @Integer 98]
-    evals @Integer (-3) DivideInteger [cons @Integer 99, cons @Integer (-34)]
-    evals @Integer (-2) QuotientInteger [cons @Integer 99, cons @Integer (-34)]
-    evals @Integer 31 RemainderInteger [cons @Integer 99, cons @Integer (-34)]
-    evals @Integer (-3) ModInteger [cons @Integer 99, cons @Integer (-34)]
-    evals True LessThanInteger [cons @Integer 30, cons @Integer 4000]
-    evals False LessThanInteger [cons @Integer 40, cons @Integer 40]
-    evals True LessThanEqualsInteger [cons @Integer 30, cons @Integer 4000]
-    evals True LessThanEqualsInteger [cons @Integer 4000, cons @Integer 4000]
-    evals False LessThanEqualsInteger [cons @Integer 4001, cons @Integer 4000]
-    evals True EqualsInteger [cons @Integer (-101), cons @Integer (-101)]
-    evals False EqualsInteger [cons @Integer 0, cons @Integer 1]
+test_Integer :: TestNested
+test_Integer = testNestedM "Integer" $ do
+    evals @Integer 3 AddInteger [] [cons @Integer 2, cons @Integer 1]
+    evals @Integer 2 SubtractInteger [] [cons @Integer 100, cons @Integer 98]
+    evals @Integer (-2) SubtractInteger [] [cons @Integer 98, cons @Integer 100]
+    evals @Integer 9702 MultiplyInteger [] [cons @Integer 99, cons @Integer 98]
+    evals @Integer (-3) DivideInteger [] [cons @Integer 99, cons @Integer (-34)]
+    evals @Integer (-2) QuotientInteger [] [cons @Integer 99, cons @Integer (-34)]
+    evals @Integer 31 RemainderInteger [] [cons @Integer 99, cons @Integer (-34)]
+    evals @Integer (-3) ModInteger [] [cons @Integer 99, cons @Integer (-34)]
+    evals True LessThanInteger [] [cons @Integer 30, cons @Integer 4000]
+    evals False LessThanInteger [] [cons @Integer 40, cons @Integer 40]
+    evals True LessThanEqualsInteger [] [cons @Integer 30, cons @Integer 4000]
+    evals True LessThanEqualsInteger [] [cons @Integer 4000, cons @Integer 4000]
+    evals False LessThanEqualsInteger [] [cons @Integer 4001, cons @Integer 4000]
+    evals True EqualsInteger [] [cons @Integer (-101), cons @Integer (-101)]
+    evals False EqualsInteger [] [cons @Integer 0, cons @Integer 1]
 
 -- | Test all string-like builtins
-test_String :: TestTree
-test_String = testCase "String" $ do
+test_String :: TestNested
+test_String = testNestedM "String" $ do
     -- bytestrings
-    evals @ByteString "hello world" AppendByteString [cons @ByteString "hello", cons @ByteString " world"]
-    evals @ByteString "mpla" AppendByteString [cons @ByteString "", cons @ByteString "mpla"]
-    evals False EqualsByteString [cons @ByteString "" , cons @ByteString "mpla"]
-    evals True EqualsByteString [cons @ByteString "mpla" , cons @ByteString "mpla"]
-    evals True LessThanByteString  [cons @ByteString "" , cons @ByteString "mpla"]
+    evals @ByteString "hello world" AppendByteString [] [cons @ByteString "hello", cons @ByteString " world"]
+    evals @ByteString "mpla" AppendByteString [] [cons @ByteString "", cons @ByteString "mpla"]
+    evals False EqualsByteString [] [cons @ByteString "" , cons @ByteString "mpla"]
+    evals True EqualsByteString [] [cons @ByteString "mpla" , cons @ByteString "mpla"]
+    evals True LessThanByteString  [] [cons @ByteString "" , cons @ByteString "mpla"]
 
     -- strings
-    evals @Text "mpla" AppendString [cons @Text "", cons @Text "mpla"]
-    evals False EqualsString [cons @Text "" , cons @Text "mpla"]
-    evals True EqualsString [cons @Text "mpla" , cons @Text "mpla"]
-    evals @Text "hello world" AppendString [cons @Text "hello", cons @Text " world"]
+    evals @Text "mpla" AppendString [] [cons @Text "", cons @Text "mpla"]
+    evals False EqualsString [] [cons @Text "" , cons @Text "mpla"]
+    evals True EqualsString [] [cons @Text "mpla" , cons @Text "mpla"]
+    evals @Text "hello world" AppendString [] [cons @Text "hello", cons @Text " world"]
 
     -- id for subset char8 of utf8
-    evals @ByteString "hello world" EncodeUtf8 [cons @Text "hello world"]
-    evals @Text "hello world" DecodeUtf8 [cons @ByteString "hello world"]
+    evals @ByteString "hello world" EncodeUtf8 [] [cons @Text "hello world"]
+    evals @Text "hello world" DecodeUtf8 [] [cons @ByteString "hello world"]
 
     -- the 'o's replaced with greek o's, so they are kind of "invisible"
-    evals @ByteString "hell\206\191 w\206\191rld" EncodeUtf8 [cons @Text "hellο wοrld"]
+    evals @ByteString "hell\206\191 w\206\191rld" EncodeUtf8 [] [cons @Text "hellο wοrld"]
     -- cannot decode back, because bytestring only works on Char8 subset of utf8
-    evals @Text "hellο wοrld" DecodeUtf8 [cons @ByteString "hell\206\191 w\206\191rld"]
+    evals @Text "hellο wοrld" DecodeUtf8 [] [cons @ByteString "hell\206\191 w\206\191rld"]
 
-    evals @ByteString "\NULhello world" ConsByteString [cons @Integer 0, cons @ByteString "hello world"]
+    evals @ByteString "\NULhello world" ConsByteString [] [cons @Integer 0, cons @ByteString "hello world"]
     -- cannot overflow back to 0
-    fails ConsByteString [cons @Integer 256, cons @ByteString "hello world"]
-    evals @ByteString "\240hello world" ConsByteString [cons @Integer 240, cons @ByteString "hello world"]
+    fails "consByteString-out-of-range" ConsByteString []
+        [cons @Integer 256, cons @ByteString "hello world"]
+    evals @ByteString "\240hello world" ConsByteString [] [cons @Integer 240, cons @ByteString "hello world"]
     -- 65 is ASCII A
-    evals @ByteString "Ahello world" ConsByteString [cons @Integer 65, cons @ByteString "hello world"]
+    evals @ByteString "Ahello world" ConsByteString [] [cons @Integer 65, cons @ByteString "hello world"]
 
-    evals @ByteString "h" SliceByteString [cons @Integer 0, cons @Integer 1, cons @ByteString "hello world"]
-    evals @ByteString "he" SliceByteString [cons @Integer 0, cons @Integer 2, cons @ByteString "hello world"]
-    evals @ByteString "el" SliceByteString [cons @Integer 1, cons @Integer 2, cons @ByteString "hello world"]
-    evals @ByteString "world" SliceByteString [cons @Integer 6, cons @Integer 5, cons @ByteString "hello world"]
+    evals @ByteString "h" SliceByteString [] [cons @Integer 0, cons @Integer 1, cons @ByteString "hello world"]
+    evals @ByteString "he" SliceByteString [] [cons @Integer 0, cons @Integer 2, cons @ByteString "hello world"]
+    evals @ByteString "el" SliceByteString [] [cons @Integer 1, cons @Integer 2, cons @ByteString "hello world"]
+    evals @ByteString "world" SliceByteString [] [cons @Integer 6, cons @Integer 5, cons @ByteString "hello world"]
 
-    evals @Integer 11 LengthOfByteString [cons @ByteString "hello world"]
-    evals @Integer 0 LengthOfByteString [cons @ByteString ""]
-    evals @Integer 1 LengthOfByteString [cons @ByteString "\NUL"]
+    evals @Integer 11 LengthOfByteString [] [cons @ByteString "hello world"]
+    evals @Integer 0 LengthOfByteString [] [cons @ByteString ""]
+    evals @Integer 1 LengthOfByteString [] [cons @ByteString "\NUL"]
 
     -- 65 is ASCII A
-    evals @Integer 65 IndexByteString [cons @ByteString "Ahello world", cons @Integer 0]
-    fails IndexByteString [cons @ByteString "hello world", cons @Integer 12]
-    fails IndexByteString [cons @ByteString "", cons @Integer 0]
-    fails IndexByteString [cons @ByteString "hello world", cons @Integer 12]
+    evals @Integer 65 IndexByteString [] [cons @ByteString "Ahello world", cons @Integer 0]
+    fails "indexByteString-out-of-bounds-non-empty" IndexByteString []
+        [cons @ByteString "hello world", cons @Integer 12]
+    fails "indexByteString-out-of-bounds-empty" IndexByteString []
+        [cons @ByteString "", cons @Integer 0]
 
 -- | Test all list-related builtins
-test_List :: TestTree
-test_List = testCase "List" $ do
-    evalsL False NullList integer [cons @[Integer] [1,2]]
-    evalsL False NullList integer [cons @[Integer] [1]]
-    evalsL True NullList integer [cons @[Integer] []]
+test_List :: TestNested
+test_List = testNestedM "List" $ do
+    evals False NullList [integer] [cons @[Integer] [1,2]]
+    evals False NullList [integer] [cons @[Integer] [1]]
+    evals True NullList [integer] [cons @[Integer] []]
 
-    evalsL @Integer 1 HeadList integer [cons @[Integer] [1,3]]
-    evalsL @[Integer] [3,4,5] TailList integer [cons @[Integer] [1,3,4,5]]
+    evals @Integer 1 HeadList [integer] [cons @[Integer] [1,3]]
+    evals @[Integer] [3,4,5] TailList [integer] [cons @[Integer] [1,3,4,5]]
 
-    failsL HeadList integer [cons @[Integer] []]
-    failsL TailList integer [cons @[Integer] []]
+    fails "headList-empty" HeadList [integer] [cons @[Integer] []]
+    fails "tailList-empty" TailList [integer] [cons @[Integer] []]
 
-    evalsL @[Integer] [1] MkCons integer [cons @Integer 1, cons @[Integer] []]
-    evalsL @[Integer] [1,2] MkCons integer [cons @Integer 1, cons @[Integer] [2]]
+    evals @[Integer] [1] MkCons [integer] [cons @Integer 1, cons @[Integer] []]
+    evals @[Integer] [1,2] MkCons [integer] [cons @Integer 1, cons @[Integer] [2]]
 
-    Right (EvaluationSuccess true)  @=?  typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting (nullViaChooseList [])
-    Right (EvaluationSuccess false)  @=?  typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting (nullViaChooseList [1])
-    Right (EvaluationSuccess false)  @=?  typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting (nullViaChooseList [1..10])
+    embed . testCase "nullViaChooseList []" $
+        Right (EvaluationSuccess true) @=?
+            typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting
+                (nullViaChooseList [])
+    embed . testCase "nullViaChooseList [1]" $
+        Right (EvaluationSuccess false) @=?
+            typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting
+                (nullViaChooseList [1])
+    embed . testCase "nullViaChooseList [1..10]" $
+        Right (EvaluationSuccess false) @=?
+            typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting
+                (nullViaChooseList [1..10])
 
- where
-   evalsL :: DefaultUni `HasTermLevel` a => a -> DefaultFun -> Type TyName DefaultUni () -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
-   evalsL expectedVal b tyArg args =
-    let actualExp = mkIterAppNoAnn (tyInst () (builtin () b) tyArg) args
-    in  Right (EvaluationSuccess $ cons expectedVal)
-        @=?
-        typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting actualExp
-
-   failsL :: DefaultFun -> Type TyName DefaultUni () -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
-   failsL b tyArg args =
-    let actualExp = mkIterAppNoAnn (tyInst () (builtin () b) tyArg) args
-    in  Right EvaluationFailure
-        @=?
-        typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting actualExp
-
+  where
    -- the null function that utilizes the ChooseList builtin (through the caseList helper function)
    nullViaChooseList :: [Integer] -> Term TyName Name DefaultUni DefaultFun ()
    nullViaChooseList l = mkIterAppNoAnn
@@ -572,45 +632,44 @@ test_List = testCase "List" $ do
                               pure $ lamAbs () a1 integer $ lamAbs () a2 (TyApp () Builtin.list integer) false
                       ]
 
-
 -- | Test all PlutusData builtins
-test_Data :: TestTree
-test_Data = testCase "Data" $ do
+test_Data :: TestNested
+test_Data = testNestedM "Data" $ do
     -- construction
-    evals (Constr 2 [I 3]) ConstrData [cons @Integer 2, cons @[Data] [I 3]]
-    evals (Constr 2 [I 3, B ""]) ConstrData [cons @Integer 2, cons @[Data] [I 3, B ""]]
-    evals (List []) ListData [cons @[Data] []]
-    evals (List [I 3, B ""]) ListData [cons @[Data] [I 3, B ""]]
-    evals (Map []) MapData [cons @[(Data,Data)] []]
-    evals (Map [(I 3, B "")]) MapData [cons @[(Data,Data)] [(I 3, B "")]]
-    evals (B "hello world") BData [cons @ByteString "hello world"]
-    evals (I 3) IData [cons @Integer 3]
-    evals (B "hello world") BData [cons @ByteString "hello world"]
-    evals @[Data] [] MkNilData [cons ()]
-    evals @[(Data,Data)] [] MkNilPairData [cons ()]
+    evals (Constr 2 [I 3]) ConstrData [] [cons @Integer 2, cons @[Data] [I 3]]
+    evals (Constr 2 [I 3, B ""]) ConstrData [] [cons @Integer 2, cons @[Data] [I 3, B ""]]
+    evals (List []) ListData [] [cons @[Data] []]
+    evals (List [I 3, B ""]) ListData [] [cons @[Data] [I 3, B ""]]
+    evals (Map []) MapData [] [cons @[(Data,Data)] []]
+    evals (Map [(I 3, B "")]) MapData [] [cons @[(Data,Data)] [(I 3, B "")]]
+    evals (B "hello world") BData [] [cons @ByteString "hello world"]
+    evals (I 3) IData [] [cons @Integer 3]
+    evals (B "hello world") BData [] [cons @ByteString "hello world"]
+    evals @[Data] [] MkNilData [] [cons ()]
+    evals @[(Data,Data)] [] MkNilPairData [] [cons ()]
 
     -- equality
-    evals True EqualsData [cons $ B "hello world", cons $ B "hello world"]
-    evals True EqualsData [cons $ I 4, cons $ I 4]
-    evals False EqualsData [cons $ B "hello world", cons $ I 4]
-    evals True EqualsData [cons $ Constr 3 [I 4], cons $ Constr 3 [I 4]]
-    evals False EqualsData [cons $ Constr 3 [I 3, B ""], cons $ Constr 3 [I 3]]
-    evals False EqualsData [cons $ Constr 2 [I 4], cons $ Constr 3 [I 4]]
-    evals True EqualsData [cons $ Map [(I 3, B "")], cons $ Map [(I 3, B "")]]
-    evals False EqualsData [cons $ Map [(I 3, B "")], cons $ Map []]
-    evals False EqualsData [cons $ Map [(I 3, B "")], cons $ Map [(I 3, B ""), (I 4, I 4)]]
+    evals True EqualsData [] [cons $ B "hello world", cons $ B "hello world"]
+    evals True EqualsData [] [cons $ I 4, cons $ I 4]
+    evals False EqualsData [] [cons $ B "hello world", cons $ I 4]
+    evals True EqualsData [] [cons $ Constr 3 [I 4], cons $ Constr 3 [I 4]]
+    evals False EqualsData [] [cons $ Constr 3 [I 3, B ""], cons $ Constr 3 [I 3]]
+    evals False EqualsData [] [cons $ Constr 2 [I 4], cons $ Constr 3 [I 4]]
+    evals True EqualsData [] [cons $ Map [(I 3, B "")], cons $ Map [(I 3, B "")]]
+    evals False EqualsData [] [cons $ Map [(I 3, B "")], cons $ Map []]
+    evals False EqualsData [] [cons $ Map [(I 3, B "")], cons $ Map [(I 3, B ""), (I 4, I 4)]]
 
     -- destruction
-    evals @Integer 3 UnIData [cons $ I 3]
-    evals @ByteString "hello world" UnBData [cons $ B "hello world"]
-    evals @Integer 3 UnIData [cons $ I 3]
-    evals @(Integer, [Data]) (1, []) UnConstrData [cons $ Constr 1 []]
-    evals @(Integer, [Data]) (1, [I 3]) UnConstrData [cons $ Constr 1 [I 3]]
-    evals @[(Data, Data)] [] UnMapData [cons $ Map []]
-    evals @[(Data, Data)] [(B "", I 3)] UnMapData [cons $ Map [(B "", I 3)]]
-    evals @[Data] [] UnListData [cons $ List []]
-    evals @[Data] [I 3, I 4, B ""] UnListData [cons $ List [I 3, I 4, B ""]]
-    evals @ByteString "\162\ETX@Ehello8c" SerialiseData [cons $ Map [(I 3, B ""), (B "hello", I $ -100)]]
+    evals @Integer 3 UnIData [] [cons $ I 3]
+    evals @ByteString "hello world" UnBData [] [cons $ B "hello world"]
+    evals @Integer 3 UnIData [] [cons $ I 3]
+    evals @(Integer, [Data]) (1, []) UnConstrData [] [cons $ Constr 1 []]
+    evals @(Integer, [Data]) (1, [I 3]) UnConstrData [] [cons $ Constr 1 [I 3]]
+    evals @[(Data, Data)] [] UnMapData [] [cons $ Map []]
+    evals @[(Data, Data)] [(B "", I 3)] UnMapData [] [cons $ Map [(B "", I 3)]]
+    evals @[Data] [] UnListData [] [cons $ List []]
+    evals @[Data] [I 3, I 4, B ""] UnListData [] [cons $ List [I 3, I 4, B ""]]
+    evals @ByteString "\162\ETX@Ehello8c" SerialiseData [] [cons $ Map [(I 3, B ""), (B "hello", I $ -100)]]
 
     -- ChooseData
     let actualExp = mkIterAppNoAnn
@@ -638,12 +697,15 @@ test_Data = testCase "Data" $ do
                               pure $ lamAbs () a1 (mkTyBuiltin @_ @ByteString ()) false
                       ]
 
-    Right (EvaluationSuccess true)  @=?  typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting actualExp
+    embed . testCase "chooseData" $
+        Right (EvaluationSuccess true) @=?
+            typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting
+                actualExp
 
 -- | Test all cryptography-related builtins
-test_Crypto :: TestTree
-test_Crypto = testCase "Crypto" $ do
-    evals True VerifyEd25519Signature
+test_Crypto :: TestNested
+test_Crypto = testNestedM "Crypto" $ do
+    evals True VerifyEd25519Signature []
         [ -- pubkey
           cons @ByteString "Y\218\215\204>\STX\233\152\251\243\158'm\130\&0\197\DEL\STXd\214`\147\243y(\234\167=kTj\164"
           -- message
@@ -652,7 +714,7 @@ test_Crypto = testCase "Crypto" $ do
         , cons @ByteString "\a'\198\r\226\SYN;\bX\254\228\129n\131\177\193\DC3-k\249RriY\221wIL\240\144\r\145\195\191\196]\227\169U(\ETX\171\SI\199\163\138\160\128R\DC4\246n\142[g\SI\169\SUB\178\245\166\&0\243\b"
         ]
 
-    evals False VerifyEd25519Signature
+    evals False VerifyEd25519Signature []
         [ -- pubkey
           cons @ByteString "Y\218\215\204>\STX\233\152\251\243\158'm\130\&0\197\DEL\STXd\214`\147\243y(\234\167=kTj\164"
           -- message
@@ -663,31 +725,31 @@ test_Crypto = testCase "Crypto" $ do
     -- independently verified by `/usr/bin/sha256sum` with the hex output converted to ascii text
     -- sha256sum hex output: b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
     evals @ByteString "\185M'\185\147M>\b\165.R\215\218}\171\250\196\132\239\227zS\128\238\144\136\247\172\226\239\205\233"
-        Sha2_256 [cons @ByteString "hello world"]
+        Sha2_256 [] [cons @ByteString "hello world"]
     -- independently verified by `/usr/bin/sha3-256sum` with the hex output converted to ascii text
     -- sha3-256sum hex output: 644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938
     evals @ByteString "dK\204~VCs\EOT\t\153\170\200\158v\"\243\202q\251\161\217r\253\148\163\FS;\251\242N98"
-        Sha3_256 [cons @ByteString "hello world"]
+        Sha3_256 [] [cons @ByteString "hello world"]
     -- independently verified by `/usr/bin/b2sum -l 256` with the hex output converted to ascii text
     -- b2sum -l 256 hex output: 256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610
     evals @ByteString "%l\131\178\151\DC1M \ESC0\ETB\159?\SO\240\202\206\151\131b-\165\151C&\180\&6\ETB\138\238\246\DLE"
-        Blake2b_256 [cons @ByteString "hello world"]
+        Blake2b_256 [] [cons @ByteString "hello world"]
     -- independently verified by `/usr/bin/b2sum -l 224` with the hex output converted to ascii text
     -- b2sum -l 224 hex output: 42d1854b7d69e3b57c64fcc7b4f64171b47dff43fba6ac0499ff437f
     evals @ByteString "B\209\133K}i\227\181|d\252\199\180\246Aq\180}\255C\251\166\172\EOT\153\255C\DEL"
-        Blake2b_224 [cons @ByteString "hello world"]
+        Blake2b_224 [] [cons @ByteString "hello world"]
     -- independently verified by the calculator at `https://emn178.github.io/online-tools/keccak_256.html`
     -- with the hex output converted to ascii text
     -- hex output: 47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad
     evals @ByteString "G\ETB2\133\168\215\&4\RS^\151/\198w(c\132\248\STX\248\239B\165\236_\ETX\187\250%L\176\US\173"
-        Keccak_256 [cons @ByteString "hello world"]
+        Keccak_256 [] [cons @ByteString "hello world"]
     -- Tests for blake2b_224: output obtained using the b2sum program from https://github.com/BLAKE2/BLAKE2
     evals (pack [ 0x83, 0x6c, 0xc6, 0x89, 0x31, 0xc2, 0xe4, 0xe3, 0xe8, 0x38, 0x60, 0x2e, 0xca, 0x19
                 , 0x02, 0x59, 0x1d, 0x21, 0x68, 0x37, 0xba, 0xfd, 0xdf, 0xe6, 0xf0, 0xc8, 0xcb, 0x07 ])
-        Blake2b_224 [cons $ pack []]
+        Blake2b_224 [] [cons $ pack []]
     evals (pack [ 0xfe, 0x57, 0xe0, 0x22, 0x87, 0x66, 0x2c, 0xe6, 0xe2, 0x9c, 0xba, 0x02, 0xca, 0x2f
                 , 0x23, 0xc4, 0x1f, 0x20, 0x84, 0xc7, 0x95, 0x9f, 0x1c, 0xa3, 0xa5, 0x7e, 0xaf, 0x9e ])
-        Blake2b_224 [cons $ pack [ 0xfc, 0x56, 0xca, 0x9a, 0x93, 0x98, 0x2a, 0x46, 0x69, 0xcc
+        Blake2b_224 [] [cons $ pack [ 0xfc, 0x56, 0xca, 0x9a, 0x93, 0x98, 0x2a, 0x46, 0x69, 0xcc
                                  , 0xab, 0xa6, 0xe3, 0xd1, 0x84, 0xa1, 0x9d, 0xe4, 0xce, 0x80
                                  , 0x0b, 0xb6, 0x43, 0xa3, 0x60, 0xc1, 0x45, 0x72, 0xae, 0xdb
                                  , 0x22, 0x97, 0x4f, 0x0c, 0x96, 0x6b, 0x85, 0x9d, 0x91, 0xad
@@ -695,10 +757,10 @@ test_Crypto = testCase "Crypto" $ do
     -- Tests for blake2b_256: output obtained using the b2sum program from https://github.com/BLAKE2/BLAKE2
     evals (pack [ 0x0e, 0x57, 0x51, 0xc0, 0x26, 0xe5, 0x43, 0xb2, 0xe8, 0xab, 0x2e, 0xb0, 0x60, 0x99, 0xda, 0xa1
                 , 0xd1, 0xe5, 0xdf, 0x47, 0x77, 0x8f, 0x77, 0x87, 0xfa, 0xab, 0x45, 0xcd, 0xf1, 0x2f, 0xe3, 0xa8 ])
-        Blake2b_256 [cons $ pack []]
+        Blake2b_256 [] [cons $ pack []]
     evals (pack [ 0xfc, 0x63, 0xa3, 0xcd, 0xf1, 0xc9, 0xbe, 0xb0, 0x9e, 0x18, 0x98, 0x8a, 0x95, 0x7c, 0x58, 0x31
                 , 0x98, 0xc7, 0xe3, 0x0f, 0xe4, 0x8b, 0x9e, 0x80, 0x41, 0xbb, 0x90, 0x4a, 0xf8, 0x78, 0x3b, 0x5c ])
-        Blake2b_256 [cons $ pack [ 0xfc, 0x56, 0xca, 0x9a, 0x93, 0x98, 0x2a, 0x46, 0x69, 0xcc
+        Blake2b_256 [] [cons $ pack [ 0xfc, 0x56, 0xca, 0x9a, 0x93, 0x98, 0x2a, 0x46, 0x69, 0xcc
                                  , 0xab, 0xa6, 0xe3, 0xd1, 0x84, 0xa1, 0x9d, 0xe4, 0xce, 0x80
                                  , 0x0b, 0xb6, 0x43, 0xa3, 0x60, 0xc1, 0x45, 0x72, 0xae, 0xdb
                                  , 0x22, 0x97, 0x4f, 0x0c, 0x96, 0x6b, 0x85, 0x9d, 0x91, 0xad
@@ -706,10 +768,10 @@ test_Crypto = testCase "Crypto" $ do
     -- Test vectors from ShortMsgKAT_256.txt in https://keccak.team/obsolete/KeccakKAT-3.zip.
     evals (pack [ 0xC5, 0xD2, 0x46, 0x01, 0x86, 0xF7, 0x23, 0x3C, 0x92, 0x7E, 0x7D, 0xB2, 0xDC, 0xC7, 0x03, 0xC0
                 , 0xE5, 0x00, 0xB6, 0x53, 0xCA, 0x82, 0x27, 0x3B, 0x7B, 0xFA, 0xD8, 0x04, 0x5D, 0x85, 0xA4, 0x70 ])
-        Keccak_256 [cons $ pack []]
+        Keccak_256 [] [cons $ pack []]
     evals (pack [ 0xFA, 0x46, 0x0C, 0xD5, 0x1B, 0xC6, 0x11, 0x78, 0x6D, 0x36, 0x4F, 0xCA, 0xBE, 0x39, 0x05, 0x2B
                 , 0xCD, 0x5F, 0x00, 0x9E, 0xDF, 0xA8, 0x1F, 0x47, 0x01, 0xC5, 0xB2, 0x2B, 0x72, 0x9B, 0x00, 0x16 ])
-        Keccak_256 [cons $ pack [ 0x7E, 0x15, 0xD2, 0xB9, 0xEA, 0x74, 0xCA, 0x60, 0xF6, 0x6C
+        Keccak_256 [] [cons $ pack [ 0x7E, 0x15, 0xD2, 0xB9, 0xEA, 0x74, 0xCA, 0x60, 0xF6, 0x6C
                                 , 0x8D, 0xFA, 0xB3, 0x77, 0xD9, 0x19, 0x8B, 0x7B, 0x16, 0xDE
                                 , 0xB6, 0xA1, 0xBA, 0x0E, 0xA3, 0xC7, 0xEE, 0x20, 0x42, 0xF8
                                 , 0x9D, 0x37, 0x86, 0xE7, 0x79, 0xCF, 0x05, 0x3C, 0x77, 0x78
@@ -718,10 +780,10 @@ test_Crypto = testCase "Crypto" $ do
     -- https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip
     evals (pack [ 0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24
                 , 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55 ])
-        Sha2_256 [cons $ pack []]
+        Sha2_256 [] [cons $ pack []]
     evals (pack [ 0x99, 0xdc, 0x77, 0x2e, 0x91, 0xea, 0x02, 0xd9, 0xe4, 0x21, 0xd5, 0x52, 0xd6, 0x19, 0x01, 0x01
                 , 0x6b, 0x9f, 0xd4, 0xad, 0x2d, 0xf4, 0xa8, 0x21, 0x2c, 0x1e, 0xc5, 0xba, 0x13, 0x89, 0x3a, 0xb2 ])
-        Sha2_256 [cons $ pack [ 0x3d, 0x83, 0xdf, 0x37, 0x17, 0x2c, 0x81, 0xaf, 0xd0, 0xde
+        Sha2_256 [] [cons $ pack [ 0x3d, 0x83, 0xdf, 0x37, 0x17, 0x2c, 0x81, 0xaf, 0xd0, 0xde
                               , 0x11, 0x51, 0x39, 0xfb, 0xf4, 0x39, 0x0c, 0x22, 0xe0, 0x98
                               , 0xc5, 0xaf, 0x4c, 0x5a, 0xb4, 0x85, 0x24, 0x06, 0x51, 0x0b
                               , 0xc0, 0xe6, 0xcf, 0x74, 0x17, 0x69, 0xf4, 0x44, 0x30, 0xc5
@@ -730,10 +792,10 @@ test_Crypto = testCase "Crypto" $ do
     -- https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/sha-3bytetestvectors.zip
     evals (pack [ 0xa7, 0xff, 0xc6, 0xf8, 0xbf, 0x1e, 0xd7, 0x66, 0x51, 0xc1, 0x47, 0x56, 0xa0, 0x61, 0xd6, 0x62
                 , 0xf5, 0x80, 0xff, 0x4d, 0xe4, 0x3b, 0x49, 0xfa, 0x82, 0xd8, 0x0a, 0x4b, 0x80, 0xf8, 0x43, 0x4a ])
-        Sha3_256 [cons $ pack []]
+        Sha3_256 [] [cons $ pack []]
     evals (pack [ 0xe2, 0x18, 0x06, 0xce, 0x76, 0x6b, 0xbc, 0xe8, 0xb8, 0xd1, 0xb9, 0x9b, 0xcf, 0x16, 0x2f, 0xd1
                 , 0x54, 0xf5, 0x46, 0x92, 0x35, 0x1a, 0xec, 0x8e, 0x69, 0x14, 0xe1, 0xa6, 0x94, 0xbd, 0xa9, 0xee ])
-        Sha3_256 [cons $ pack [ 0xfc, 0x56, 0xca, 0x9a, 0x93, 0x98, 0x2a, 0x46, 0x69, 0xcc
+        Sha3_256 [] [cons $ pack [ 0xfc, 0x56, 0xca, 0x9a, 0x93, 0x98, 0x2a, 0x46, 0x69, 0xcc
                               , 0xab, 0xa6, 0xe3, 0xd1, 0x84, 0xa1, 0x9d, 0xe4, 0xce, 0x80
                               , 0x0b, 0xb6, 0x43, 0xa3, 0x60, 0xc1, 0x45, 0x72, 0xae, 0xdb
                               , 0x22, 0x97, 0x4f, 0x0c, 0x96, 0x6b, 0x85, 0x9d, 0x91, 0xad
@@ -812,22 +874,6 @@ test_ConsByteString =
 -- shorthand
 cons :: (DefaultUni `HasTermLevel` a, TermLike term tyname name DefaultUni fun) => a -> term ()
 cons = mkConstant ()
-
--- shorthand
-evals :: DefaultUni `HasTermLevel` a => a -> DefaultFun -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
-evals expectedVal b args =
-    let actualExp = mkIterAppNoAnn (builtin () b) args
-    in  Right (EvaluationSuccess $ cons expectedVal)
-        @=?
-        typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting actualExp
-
--- shorthand
-fails :: DefaultFun -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
-fails b args =
-    let actualExp = mkIterAppNoAnn (builtin () b) args
-    in  Right EvaluationFailure
-        @=?
-        typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting actualExp
 
 -- Test that the SECP256k1 builtins are behaving correctly
 test_SignatureVerification :: TestTree
@@ -926,11 +972,13 @@ test_definition =
         , test_TrackCostsRestricting
         , test_TrackCostsRetaining
         , test_SerialiseDataImpossible
-        , test_Integer
-        , test_String
-        , test_List
-        , test_Data
-        , test_Crypto
+        , runTestNestedHere
+            [ test_Integer
+            , test_String
+            , test_List
+            , test_Data
+            , test_Crypto
+            ]
         , test_HashSizes
         , test_SignatureVerification
         , test_BLS12_381

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/List/headList-empty.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/List/headList-empty.err.golden
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: (force headList [])

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/List/tailList-empty.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/List/tailList-empty.err.golden
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: (force tailList [])

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/String/consByteString-out-of-range.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/String/consByteString-out-of-range.err.golden
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: (consByteString 256 #68656c6c6f20776f726c64)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/String/indexByteString-out-of-bounds-empty.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/String/indexByteString-out-of-bounds-empty.err.golden
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: (indexByteString # 0)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/String/indexByteString-out-of-bounds-non-empty.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/String/indexByteString-out-of-bounds-non-empty.err.golden
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: (indexByteString #68656c6c6f20776f726c64 12)


### PR DESCRIPTION
This refactors a file with tests so that unit tests that are supposed to result in evaluation failure also become golden tests with the error message printed to a golden file. Need it to demonstrate that #6181 does indeed allow us to preserve operational unlifting errors.