### PR TITLE
Remove PyF as it depends on GHC and causes depenecy conflicts downstream

### DIFF
--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -125,7 +125,7 @@ library plutus-ledger-api-testlib
 
   build-depends:
     , barbies
-    , base                                            >=4.9      && <5
+    , base                                            >=4.9   && <5
     , base16-bytestring
     , base64-bytestring
     , bytestring
@@ -134,7 +134,6 @@ library plutus-ledger-api-testlib
     , plutus-ledger-api                               ^>=1.29
     , plutus-tx                                       ^>=1.29
     , prettyprinter
-    , PyF                                             >=0.11.1.0
     , QuickCheck
     , serialise
     , text

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE RecordWildCards   #-}
 
 module PlutusLedgerApi.Test.EvaluationEvent (
@@ -30,7 +29,6 @@ import Data.List.NonEmpty (NonEmpty, toList)
 import Data.Text.Encoding qualified as Text
 import GHC.Generics (Generic)
 import Prettyprinter
-import PyF (fmt)
 
 
 data ScriptEvaluationResult = ScriptEvaluationSuccess | ScriptEvaluationFailure
@@ -152,16 +150,14 @@ data TestFailure
 renderTestFailure :: TestFailure -> String
 renderTestFailure = \case
     InvalidResult err -> display err
-    MissingCostParametersFor lang -> [fmt|
-        Missing cost parameters for {show lang}.
-        Report this as a bug against the script dumper in plutus-apps.
-    |]
+    MissingCostParametersFor lang ->
+        "Missing cost parameters for " ++ show lang ++ ".\n"
+        ++ "Report this as a bug against the script dumper in plutus-apps."
 
 renderTestFailures :: NonEmpty TestFailure -> String
-renderTestFailures xs = [fmt|
-    Number of failed test cases: {length xs}
-    {unlines . fmap renderTestFailure $ toList xs}
-|]
+renderTestFailures testFailures =
+    "Number of failed test cases: " ++ show (length testFailures) ++ ".\n"
+    ++ unwords (map renderTestFailure (toList testFailures))
 
 -- | Re-evaluate an on-chain script evaluation event.
 checkEvaluationEvent ::


### PR DESCRIPTION

Example of the dependency conflict caused by the `PyF`:
```
       last 25 log lines:
       > [__6] trying: base-4.18.2.0/installed-4.18.2.0 (dependency of
       > byron-spec-chain)
       > [__7] trying: cardano-api-8.47.0.0 (user goal)
       > [__8] trying: plutus-ledger-api-1.29.0.0 (dependency of cardano-api)
       > [__9] trying: PyF-0.11.3.0 (dependency of plutus-ledger-api)
       > [_10] trying: ghc-9.6.4/installed-9.6.4 (dependency of PyF)
       > [_11] trying: ouroboros-network-framework-0.13.2.0 (dependency of cardano-api)
       > [_12] trying: io-classes-1.5.0.0 (dependency of ouroboros-network-framework)
       > [_13] next goal: Win32-network (dependency of ouroboros-network-framework)
       > [_13] rejecting: Win32-network-0.2.0.0 (conflict: time =>
       > Win32==2.13.3.0/installed-2.13.3.0, Win32-network => Win32^>=2.14)
       > [_13] rejecting: Win32-network-0.1.1.1 (conflict: ouroboros-network-framework
       > => Win32-network^>=0.2)
       > [_13] skipping: Win32-network-0.1.1.0, Win32-network-0.1.0.0 (has the same
       > characteristics that caused the previous version to fail: excluded by
       > constraint '^>=0.2' from 'ouroboros-network-framework')
       > [_13] fail (backjumping, conflict set: Win32-network,
       > ouroboros-network-framework, time)
       > After searching the rest of the dependency tree exhaustively, these were the
       > goals I've had most trouble fulfilling: ghc, PyF, plutus-ledger-api, time,
       > cardano-api, io-classes, ouroboros-network-api, base,
       > ouroboros-network-framework, pretty, template-haskell, Win32-network,
       > hedgehog, byron-spec-chain, microlens-th
       > Try running with --minimize-conflict-set to improve the error message.
       > )
 ```
 
 I have removed the `PyF` dependency as it was only used in 2 places. 
 (It is ok to concatenate a few strings without using a QuasiQuoter).