### PR TITLE
Moved the Getting Started page for higher visibility

### DIFF
--- a/docusaurus/docs/getting-started-plutus-tx.md
+++ b/docusaurus/docs/getting-started-plutus-tx.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 2
 ---
 
 # Getting started with Plutus Tx


### PR DESCRIPTION
For higher visibility, moved the Getting Started page to immediately follow the Introduction page. 

