### PR TITLE
Cabal project to compile docusaurus examples.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,6 +28,7 @@ packages: plutus-benchmark
           plutus-tx-test-util
           prettyprinter-configurable
           stubs/plutus-ghc-stub
+          doc/docusaurus/docusaurus-examples.cabal
 
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/doc/docusaurus/LICENSE
+++ b/doc/docusaurus/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/doc/docusaurus/docs/using-plutus-tx/producing-a-blueprint.md
+++ b/doc/docusaurus/docs/using-plutus-tx/producing-a-blueprint.md
@@ -23,15 +23,15 @@ writeBlueprint
 
 In order to demonstrate the usage of the `writeBlueprint` function, let's consider the following example validator function and its interface:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="interface types" start="-- BEGIN interface types" end="-- END interface types" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="interface types" start="-- BEGIN interface types" end="-- END interface types" />
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="validator" start="-- BEGIN validator" end="-- END validator" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="validator" start="-- BEGIN validator" end="-- END validator" />
 
 ## Importing required functionality
 
 First of all, we need to import required functionality:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="imports" start="-- BEGIN imports" end="-- END imports" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="imports" start="-- BEGIN imports" end="-- END imports" />
 
 ## Defining a contract blueprint value
 
@@ -75,7 +75,7 @@ data ContractBlueprint where
 
 We can construct a value of this type in the following way:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="contract blueprint declaration" start="-- BEGIN contract blueprint declaration" end="-- END contract blueprint declaration" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="contract blueprint declaration" start="-- BEGIN contract blueprint declaration" end="-- END contract blueprint declaration" />
 
 The `contractId` field is optional and can be used to give a unique identifier to the contract.
 
@@ -102,7 +102,7 @@ data Preamble = MkPreamble
 
 Here is an example construction:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="preamble declaration" start="-- BEGIN preamble declaration" end="-- END preamble declaration" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="preamble declaration" start="-- BEGIN preamble declaration" end="-- END preamble declaration" />
 
 The `contractDefinitions` field is a registry of schema definitions used across the blueprint. 
 It can be constructed using the `deriveDefinitions` function which automatically constructs schema definitions for all the types it is applied to including the types nested within them.
@@ -111,15 +111,15 @@ Since every type in the `referencedTypes` list is going to have its derived JSON
 
 - An instance of the `GHC.Generics.Generic` type class:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="generic instances" start="-- BEGIN generic instances" end="-- END generic instances" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="generic instances" start="-- BEGIN generic instances" end="-- END generic instances" />
 
 - An instance of the `AsDefinitionId` type class. Most of the time it could be derived generically with the `anyclass` strategy; for example:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="AsDefinitionId instances" start="-- BEGIN AsDefinitionId instances" end="-- END AsDefinitionId instances" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="AsDefinitionId instances" start="-- BEGIN AsDefinitionId instances" end="-- END AsDefinitionId instances" />
 
 - An instance of the `HasSchema` type class. If your validator exposes standard supported types like `Integer` or `Bool`, you don't need to define this instance. If your validator uses custom types, then you should be deriving it using the `makeIsDataSchemaIndexed` Template Haskell function, which derives it alongside with the corresponding [ToBuiltinData]/[FromBuiltinData] instances; for example:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="makeIsDataSchemaIndexed" start="-- BEGIN makeIsDataSchemaIndexed" end="-- END makeIsDataSchemaIndexed" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="makeIsDataSchemaIndexed" start="-- BEGIN makeIsDataSchemaIndexed" end="-- END makeIsDataSchemaIndexed" />
 
 ## Defining a validator blueprint
 
@@ -146,7 +146,7 @@ Our contract can contain one or more validators. For each one we need to provide
 
 In our example, this would be:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="validator blueprint declaration" start="-- BEGIN validator blueprint declaration" end="-- END validator blueprint declaration" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="validator blueprint declaration" start="-- BEGIN validator blueprint declaration" end="-- END validator blueprint declaration" />
 
 The `definitionRef` function is used to reference a schema definition of a given type. 
 It is smart enough to discover the schema definition from the `referencedType` list and fails to compile if the referenced type is not included.
@@ -155,7 +155,7 @@ It is smart enough to discover the schema definition from the `referencedType` l
 
 With all the pieces in place, we can now write the blueprint to a file:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="write blueprint to file" start="-- BEGIN write blueprint to file" end="-- END write blueprint to file" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="write blueprint to file" start="-- BEGIN write blueprint to file" end="-- END write blueprint to file" />
 
 ## Annotations
 
@@ -173,7 +173,7 @@ It's possible to add these keywords to a Blueprint type definition by annotating
 
 For example, to add a title and description to the `MyParams` type, we can use the `SchemaTitle` and `SchemaDescription` annotations:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="MyParams annotations" start="-- BEGIN MyParams annotations" end="-- END MyParams annotations" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="MyParams annotations" start="-- BEGIN MyParams annotations" end="-- END MyParams annotations" />
 
 These annotations result in the following JSON schema definition:
 
@@ -192,7 +192,7 @@ These annotations result in the following JSON schema definition:
 
 For sum-types, it's possible to annotate constructors:
 
-<LiteralInclude file="Cip57Blueprint.hs" language="haskell" title="MyRedeemer annotations" start="-- BEGIN MyRedeemer annotations" end="-- END MyRedeemer annotations" />
+<LiteralInclude file="Example/Cip57/Blueprint/Main.hs" language="haskell" title="MyRedeemer annotations" start="-- BEGIN MyRedeemer annotations" end="-- END MyRedeemer annotations" />
 
 These annotations result in the following JSON schema definition:
 

--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -1,0 +1,37 @@
+cabal-version: 3.0
+name:          docusaurus-examples
+version:       0.1.0.0
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Yura Lazaryev
+maintainer:    Yuriy.Lazaryev@iohk.io
+category:      Language
+build-type:    Simple
+
+source-repository head
+  type:     git
+  location: https://github.com/IntersectMBO/plutus
+
+common lang
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    -Wunused-packages -Wmissing-deriving-strategies
+
+common ghc-version-support
+  -- See the section on GHC versions in CONTRIBUTING
+  if (impl(ghc <9.6) || impl(ghc >=9.7))
+    buildable: False
+
+executable example-cip57
+  import:           lang, ghc-version-support
+  main-is:          Example/Cip57/Blueprint/Main.hs
+  hs-source-dirs:   static/code
+  default-language: Haskell2010
+  other-modules:    Paths_docusaurus_examples
+  build-depends:
+    , base               ^>=4.18
+    , containers
+    , plutus-ledger-api
+    , plutus-tx

--- a/doc/docusaurus/plutus.json
+++ b/doc/docusaurus/plutus.json
@@ -1,0 +1,92 @@
+{
+  "$id": "my-contract",
+  "$schema": "https://cips.cardano.org/cips/cip57/schemas/plutus-blueprint.json",
+  "$vocabulary": {
+    "https://cips.cardano.org/cips/cip57": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true
+  },
+  "preamble": {
+    "title": "My Contract",
+    "description": "A simple contract",
+    "version": "1.0.0",
+    "plutusVersion": "v2",
+    "license": "MIT"
+  },
+  "validators": [
+    {
+      "title": "My Validator",
+      "description": "An example validator",
+      "redeemer": {
+        "title": "My Redeemer",
+        "description": "A redeemer that does something awesome",
+        "purpose": {
+          "oneOf": [
+            "spend",
+            "mint"
+          ]
+        },
+        "schema": {
+          "$ref": "#/definitions/MyRedeemer"
+        }
+      },
+      "datum": {
+        "title": "My Datum",
+        "description": "A datum that contains something awesome",
+        "purpose": "spend",
+        "schema": {
+          "$ref": "#/definitions/Integer"
+        }
+      },
+      "parameters": [
+        {
+          "title": "My Validator Parameters",
+          "description": "Compile-time validator parameters",
+          "purpose": "spend",
+          "schema": {
+            "$ref": "#/definitions/MyParams"
+          }
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "Bool": {
+      "dataType": "#boolean"
+    },
+    "Integer": {
+      "dataType": "integer"
+    },
+    "MyParams": {
+      "title": "Title for the MyParams definition",
+      "description": "Description for the MyParams definition",
+      "dataType": "constructor",
+      "fields": [
+        {
+          "$ref": "#/definitions/Bool"
+        },
+        {
+          "$ref": "#/definitions/Integer"
+        }
+      ],
+      "index": 0
+    },
+    "MyRedeemer": {
+      "oneOf": [
+        {
+          "$comment": "Left redeemer",
+          "dataType": "constructor",
+          "fields": [],
+          "index": 0
+        },
+        {
+          "$comment": "Right redeemer",
+          "dataType": "constructor",
+          "fields": [],
+          "index": 1
+        }
+      ]
+    }
+  }
+}

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -62,6 +62,7 @@ let
         (lib.mkIf isCrossCompiling {
           packages = {
             # Things that need plutus-tx-plugin
+            docusaurus-examples.package.buildable = false;
             plutus-benchmark.package.buildable = false;
             plutus-tx-plugin.package.buildable = false;
             plutus-ledger-api.components.tests.plutus-ledger-api-plugin-test.buildable = lib.mkForce false;


### PR DESCRIPTION
**Before this PR:**

- docusaurus project contains Haskell source files that aren't typechecked and might contain compilation errors.
- A change in the Plutus plug-in or API might break examples without any CI failure.
-  CIP-57 Example validator script isn't compatible with the CIP-69 and CIP-117.

**After this PR:**

- Cabal package `docusaurus-examples` exists to build a single executable `example-cip57` (for now) which compiles a corresponding CIP-57 Blueprint example.
- A change in the Plutus plug-in or API that breaks examples will cause the whole project build to fail CI.
-  CIP-57 Example validator script is compatible with the CIP-69 and CIP-117.
