### PR TITLE
Update baseUrl in docusaurus.config.ts

### DIFF
--- a/doc/docusaurus/docusaurus.config.ts
+++ b/doc/docusaurus/docusaurus.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   url: "https://intersectmbo.github.io",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/plutus/docs/",
+  baseUrl: "/docs/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
This reflects the recent addition of the custom `plutus.cardano.intersectmbo.org` CNAME to GitHub Pages