### PR TITLE
[Costing] Increase the cost of constructors of '[]'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1476,7 +1476,6 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             (runCostingFunThreeArguments . paramChooseList)
 
     toBuiltinMeaning _semvar MkCons =
-
         let mkConsDenotation
                 :: SomeConstant uni a -> SomeConstant uni [a] -> BuiltinResult (Opaque val [a])
             mkConsDenotation

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Costing.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Costing.hs
@@ -428,7 +428,7 @@ test_flattenCostRoseHandlesBottom =
 test_costsAreNeverNegative :: TestTree
 test_costsAreNeverNegative =
     testProperty "costs coming from 'memoryUsage' are never negative" $
-        withMaxSuccess 500 $ \(val :: Some (ValueOf DefaultUni)) ->
+        withMaxSuccess 1000 $ \(val :: Some (ValueOf DefaultUni)) ->
             all (>= 0) . toCostList . flattenCostRose $ memoryUsage val
 
 test_costing :: TestTree


### PR DESCRIPTION
This increases the cost for the `[]` and `(:)` constructors of the `[]` data type. It shouldn't really affect anything since all relevant builtins are constant-time anyway, but making individual pieces of the costing machinery more accurate is always good.