### PR TITLE
Move  cross-compiling logic from project.nix to cabal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -58,6 +58,17 @@ if impl(ghc < 9.0) || os(windows)
   -- won't actually build it.
   allow-older: plutus-cert:base
 
+if os(windows)
+   -- When cross compiling we don't have a `ghc` package, so use
+  -- the `plutus-ghc-stub` package instead.
+  package plutus-tx-plugin
+    flags: +use-ghc-stub
+
+  -- Exclude tests that use `doctest`.  They will not work for
+  -- cross compilation and `cabal` will not be able to make a plan.
+  package prettyprinter-configurable
+    tests: False
+
 -- Recently introduced flag to be clever and use SIMD instructions.
 -- We don't need this and it causes problems in a few settings including
 -- cross-compilation.

--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -24,12 +24,13 @@ common ghc-version-support
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
 
-library docusaurus-code
-  import:         lang, ghc-version-support
-  hs-source-dirs: static/code
-
+common os-support
   if (impl(ghcjs) || os(windows))
     buildable: False
+
+library docusaurus-code
+  import:         lang, ghc-version-support, os-support
+  hs-source-dirs: static/code
 
   other-modules:
     AuctionValidator
@@ -46,8 +47,9 @@ library docusaurus-code
   if !(impl(ghcjs) || os(ghcjs))
     build-depends: plutus-tx-plugin
 
+
 executable example-cip57
-  import:           lang, ghc-version-support
+  import:           lang, ghc-version-support, os-support
   main-is:          Example/Cip57/Blueprint/Main.hs
   hs-source-dirs:   static/code
   default-language: Haskell2010

--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -31,7 +31,6 @@ common os-support
 library docusaurus-code
   import:         lang, ghc-version-support, os-support
   hs-source-dirs: static/code
-
   other-modules:
     AuctionValidator
     BasicPlutusTx
@@ -46,7 +45,6 @@ library docusaurus-code
 
   if !(impl(ghcjs) || os(ghcjs))
     build-depends: plutus-tx-plugin
-
 
 executable example-cip57
   import:           lang, ghc-version-support, os-support

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -40,46 +40,8 @@ let
         "https://github.com/jaccokrijnen/plutus-cert"."e814b9171398cbdfecdc6823067156a7e9fc76a3" = "0srqvx0b819b5crrbsa9hz2fnr50ahqizvvm0wdmyq2bbpk2rka7";
       };
 
-      # TODO: move this into the cabalib.project using the new conditional support?
-      # Configuration settings needed for cabal configure to work when cross compiling.
-      # We can't use `modules` for these as `modules` are only applied
-      # after cabal has been configured.
-      cabalProjectLocal = lib.optionalString isCrossCompiling
-        ''
-          -- When cross compiling we don't have a `ghc` package, so use
-          -- the `plutus-ghc-stub` package instead.
-          package plutus-tx-plugin
-            flags: +use-ghc-stub
-
-          -- Exclude tests that use `doctest`.  They will not work for
-          -- cross compilation and `cabal` will not be able to make a plan.
-          package prettyprinter-configurable
-            tests: False
-        '';
-
       modules = [
-
-        # Cross Compiling
-        (lib.mkIf isCrossCompiling {
-          packages = {
-            # Things that need plutus-tx-plugin
-            docusaurus-examples.package.buildable = false;
-            plutus-benchmark.package.buildable = false;
-            plutus-tx-plugin.package.buildable = false;
-            plutus-ledger-api.components.tests.plutus-ledger-api-plugin-test.buildable = lib.mkForce false;
-            # Needs agda
-            plutus-metatheory.package.buildable = false;
-            # These need R
-            plutus-core.components.benchmarks.cost-model-test.buildable = lib.mkForce false;
-            plutus-core.components.exes.generate-cost-model.buildable = lib.mkForce false;
-            # This contains support for doing testing, so we're not interested in cross-compiling it
-            plutus-conformance.package.buildable = false;
-          };
-          # can't rebuild lib:ghc when cross-compiling
-          reinstallableLibGhc = false;
-        })
-
-        # Common
+        # Common 
         {
           packages = {
             # In this case we can just propagate the native dependencies for the build of

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -41,6 +41,10 @@ common ghc-version-support
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
 
+common os-support
+  if (impl(ghcjs) || os(windows))
+    buildable: False
+
 common lang
   default-language:   Haskell2010
   default-extensions:
@@ -74,7 +78,7 @@ common lang
 ---------------- Common code for benchmarking ----------------
 
 library plutus-benchmark-common
-  import:          lang
+  import:          lang, os-support
   hs-source-dirs:  common
   exposed-modules:
     PlutusBenchmark.Common
@@ -100,7 +104,7 @@ library plutus-benchmark-common
 ---------------- nofib ----------------
 
 library nofib-internal
-  import:          lang, ghc-version-support
+  import:          lang, ghc-version-support, os-support
   hs-source-dirs:  nofib/src
   exposed-modules:
     PlutusBenchmark.NoFib.Clausify
@@ -123,7 +127,7 @@ library nofib-internal
     , plutus-tx-plugin         ^>=1.32
 
 executable nofib-exe
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   main-is:        Main.hs
   hs-source-dirs: nofib/exe
   build-depends:
@@ -140,7 +144,7 @@ executable nofib-exe
     , transformers
 
 benchmark nofib
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchCek.hs
   hs-source-dirs: nofib/bench
@@ -152,7 +156,7 @@ benchmark nofib
     , plutus-benchmark-common
 
 benchmark nofib-hs
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchHaskell.hs
   hs-source-dirs: nofib/bench
@@ -164,7 +168,7 @@ benchmark nofib-hs
     , plutus-benchmark-common
 
 test-suite plutus-benchmark-nofib-tests
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   hs-source-dirs: nofib/test
@@ -182,7 +186,7 @@ test-suite plutus-benchmark-nofib-tests
 ---------------- lists ----------------
 
 library lists-internal
-  import:          lang, ghc-version-support
+  import:          lang, ghc-version-support, os-support
   hs-source-dirs:  lists/src
   exposed-modules:
     PlutusBenchmark.Lists.Lookup.Compiled
@@ -205,7 +209,7 @@ library lists-internal
     , plutus-tx-plugin         ^>=1.32
 
 executable list-sort-exe
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   main-is:        Main.hs
   hs-source-dirs: lists/exe
   build-depends:
@@ -216,7 +220,7 @@ executable list-sort-exe
     , plutus-core              ^>=1.32
 
 benchmark lists
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Bench.hs
   hs-source-dirs: lists/bench
@@ -228,7 +232,7 @@ benchmark lists
     , plutus-ledger-api        ^>=1.32
 
 test-suite plutus-benchmark-lists-tests
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
@@ -250,7 +254,7 @@ test-suite plutus-benchmark-lists-tests
 ---------------- validation ----------------
 
 benchmark validation
-  import:         lang
+  import:         lang, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchCek.hs
   hs-source-dirs: validation/bench
@@ -270,7 +274,7 @@ benchmark validation
 ---------------- validation-decode ----------------
 
 benchmark validation-decode
-  import:         lang
+  import:         lang, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchDec.hs
   hs-source-dirs: validation/bench
@@ -291,7 +295,7 @@ benchmark validation-decode
 ---------------- validation-full ----------------
 
 benchmark validation-full
-  import:         lang
+  import:         lang, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchFull.hs
   hs-source-dirs: validation/bench
@@ -312,7 +316,7 @@ benchmark validation-full
 ---------------- Cek cost model calibration ----------------
 
 benchmark cek-calibration
-  import:           lang, ghc-version-support
+  import:           lang, ghc-version-support, os-support
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:          Main.hs
@@ -331,7 +335,7 @@ benchmark cek-calibration
 ---------------- Signature verification throughput ----------------
 
 executable ed25519-costs
-  import:           lang, ghc-version-support
+  import:           lang, ghc-version-support, os-support
   default-language: Haskell2010
   hs-source-dirs:   ed25519-costs/exe ed25519-costs/src
   main-is:          Main.hs
@@ -349,7 +353,7 @@ executable ed25519-costs
 -- Calculate the predicted costs of sequences of ed25519 signature verification
 -- operations and compare them with a golden file.
 test-suite ed25519-costs-test
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: ed25519-costs/test ed25519-costs/src
@@ -370,7 +374,7 @@ test-suite ed25519-costs-test
 library bls12-381lib-internal
   -- bls12-381-internal isn't allowed: you must have at least one letter in each
   -- component.
-  import:          lang, ghc-version-support
+  import:          lang, ghc-version-support, os-support
   hs-source-dirs:  bls12-381-costs/src
   exposed-modules:
     PlutusBenchmark.BLS12_381.RunTests
@@ -388,7 +392,7 @@ library bls12-381lib-internal
 
 -- Print out predicted costs of various scripts involving BLS12-381 operations
 executable bls12-381-costs
-  import:           lang, ghc-version-support
+  import:           lang, ghc-version-support, os-support
   default-language: Haskell2010
   main-is:          Main.hs
   hs-source-dirs:   bls12-381-costs/exe
@@ -399,7 +403,7 @@ executable bls12-381-costs
 -- Calculate predicted costs of various scripts involving BLS12-381 operations
 -- and compare them with a golden file.
 test-suite bls12-381-costs-test
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
@@ -412,7 +416,7 @@ test-suite bls12-381-costs-test
 
 -- Run benchmarks for various scripts involving BLS12-381 operations
 benchmark bls12-381-benchmarks
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Bench.hs
   hs-source-dirs: bls12-381-costs/bench
@@ -428,7 +432,7 @@ benchmark bls12-381-benchmarks
 ---------------- script contexts ----------------
 
 library script-contexts-internal
-  import:          lang, ghc-version-support
+  import:          lang, ghc-version-support, os-support
   hs-source-dirs:  script-contexts/src
   exposed-modules:
     PlutusBenchmark.Data.ScriptContexts
@@ -441,7 +445,7 @@ library script-contexts-internal
     , plutus-tx-plugin   ^>=1.32
 
 test-suite plutus-benchmark-script-contexts-tests
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
@@ -460,7 +464,7 @@ test-suite plutus-benchmark-script-contexts-tests
 ---------------- Marlowe scripts ----------------
 
 library marlowe-internal
-  import:          lang, ghc-version-support
+  import:          lang, ghc-version-support, os-support
   hs-source-dirs:  marlowe/src
   exposed-modules:
     PlutusBenchmark.Marlowe.BenchUtil
@@ -487,7 +491,7 @@ library marlowe-internal
     , serialise
 
 executable marlowe-validators
-  import:           lang, ghc-version-support
+  import:           lang, ghc-version-support, os-support
   default-language: Haskell2010
   hs-source-dirs:   marlowe/exe
   main-is:          Main.hs
@@ -508,7 +512,7 @@ executable marlowe-validators
     , serialise
 
 benchmark marlowe
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchCek.hs
   other-modules:  Shared
@@ -522,7 +526,7 @@ benchmark marlowe
     , plutus-tx                ^>=1.32
 
 test-suite plutus-benchmark-marlowe-tests
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
@@ -541,7 +545,7 @@ test-suite plutus-benchmark-marlowe-tests
 -- TODO: Add benchmarks for the executable semantics when we have a UPLC version
 
 library agda-internal
-  import:          lang
+  import:          lang, os-support
   hs-source-dirs:  agda-common
   exposed-modules: PlutusBenchmark.Agda.Common
   build-depends:
@@ -551,7 +555,7 @@ library agda-internal
     , plutus-metatheory
 
 benchmark validation-agda-cek
-  import:         lang
+  import:         lang, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   hs-source-dirs: validation/bench
@@ -570,7 +574,7 @@ benchmark validation-agda-cek
     , plutus-core              ^>=1.32
 
 benchmark nofib-agda-cek
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   hs-source-dirs: nofib/bench
@@ -583,7 +587,7 @@ benchmark nofib-agda-cek
     , plutus-benchmark-common
 
 benchmark marlowe-agda-cek
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   other-modules:  Shared
@@ -600,7 +604,7 @@ benchmark marlowe-agda-cek
 -------------------- bitwise-----------------------
 
 library bitwise-internal
-  import:          lang, ghc-version-support
+  import:          lang, ghc-version-support, os-support
   hs-source-dirs:  bitwise/src
   exposed-modules:
     PlutusBenchmark.Ed25519
@@ -615,7 +619,7 @@ library bitwise-internal
     , plutus-tx-plugin
 
 test-suite bitwise-test
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   hs-source-dirs: bitwise/test
@@ -630,7 +634,7 @@ test-suite bitwise-test
     , tasty-hunit
 
 benchmark bitwise-bench
-  import:         lang, ghc-version-support
+  import:         lang, ghc-version-support, os-support
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   hs-source-dirs: bitwise/bench

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -40,8 +40,12 @@ common lang
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -Wunused-packages -Wmissing-deriving-strategies
 
+common os-support
+  if (impl(ghcjs) || os(windows))
+    buildable: False
+
 library
-  import:          lang
+  import:          lang, os-support
   hs-source-dirs:  src
   exposed-modules: PlutusConformance.Common
   build-depends:
@@ -62,7 +66,7 @@ library
 -- where you started.  To avoid this, only use `--accept` with
 -- haskell-conformance.
 test-suite haskell-conformance
-  import:         lang
+  import:         lang, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
@@ -74,7 +78,7 @@ test-suite haskell-conformance
     , plutus-core         ^>=1.32
 
 test-suite haskell-steppable-conformance
-  import:         lang
+  import:         lang, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
@@ -87,7 +91,7 @@ test-suite haskell-steppable-conformance
     , plutus-core         ^>=1.32
 
 test-suite agda-conformance
-  import:         lang
+  import:         lang, os-support
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -974,6 +974,10 @@ executable generate-cost-model
   if os(osx)
     buildable: False
 
+  -- Can't build on windows as it depends on R.
+  if os(windows)
+    buildable: False
+
   build-depends:
     , aeson-pretty
     , barbies
@@ -993,7 +997,7 @@ executable generate-cost-model
 -- The cost models for builtins are generated using R and converted into a JSON
 -- form that can later be used to construct Haskell functions.  This tests that
 -- the predictions of the Haskell version are (approximately) identical to the R
--- ones.  This test is problematic in CI: pretending that it's a benchmark will
+-- ones. This test is problematic in CI: pretending that it's a benchmark will
 -- prevent it from being run automatically but will still allow us to run it
 -- manually; `cabal bench` also sets the working directory to the root of the
 -- relevant package, which makes it easier to find the cost model data files
@@ -1013,6 +1017,10 @@ benchmark cost-model-test
   -- > Error: C stack usage  17556409549320 is too close to the limit
   -- > Fatal error: unable to initialize the JI
   if os(osx)
+    buildable: False
+
+  -- Can't build on windows as it depends on R.
+  if os(windows)
     buildable: False
 
   build-depends:

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -210,6 +210,9 @@ test-suite plutus-ledger-api-plugin-test
     Spec.ScriptSize
     Spec.Value
 
+  if os(windows)
+    buildable: false 
+
   build-depends:
     , base                                                              >=4.9   && <5
     , bytestring

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -47,8 +47,12 @@ common lang
   ghc-options:
     -fwarn-incomplete-patterns -fno-warn-overlapping-patterns
 
+common os-support
+  if (impl(ghcjs) || os(windows))
+    buildable: False
+
 library
-  import:          lang
+  import:          lang, os-support
   hs-source-dirs:  src
   build-depends:
     , aeson
@@ -538,7 +542,7 @@ library
     MAlonzo.RTE.Float
 
 executable plc-agda
-  import:         lang
+  import:         lang, os-support
   hs-source-dirs: exe
   main-is:        Main.hs
   build-depends:
@@ -546,7 +550,7 @@ executable plc-agda
     , plutus-metatheory
 
 test-suite test1
-  import:             lang
+  import:             lang, os-support
   build-tool-depends:
     , plutus-core:plc   ^>=1.32
     , plutus-core:uplc  ^>=1.32
@@ -562,7 +566,7 @@ test-suite test1
   main-is:            TestSimple.hs
 
 test-suite test2
-  import:             lang
+  import:             lang, os-support
   build-tool-depends:
     , plutus-core:plc   ^>=1.32
     , plutus-core:uplc  ^>=1.32
@@ -581,7 +585,7 @@ test-suite test2
     , text
 
 test-suite test3
-  import:         lang
+  import:         lang, os-support
   hs-source-dirs: test
   type:           exitcode-stdio-1.0
   main-is:        TestNEAT.hs

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -101,7 +101,7 @@ library
       -Wno-unused-packages -Wno-unused-imports -Wno-overlapping-patterns
 
   else
-    build-depends: ghc >=9.2
+    build-depends: ghc
 
 executable gen-plugin-opts-doc
   import:           lang, ghc-version-support, os-support

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -46,13 +46,17 @@ common ghc-version-support
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
 
+common os-support
+  if (impl(ghcjs) || os(windows))
+    buildable: False
+
 flag use-ghc-stub
   description: Use the `plutus-ghc-stub` package instead of `ghc`.
   default:     False
   manual:      True
 
 library
-  import:          lang, ghc-version-support
+  import:          lang, ghc-version-support, os-support
   hs-source-dirs:  src
   exposed-modules:
     PlutusTx.Compiler.Error
@@ -100,7 +104,7 @@ library
     build-depends: ghc >=9.2
 
 executable gen-plugin-opts-doc
-  import:           lang, ghc-version-support
+  import:           lang, ghc-version-support, os-support
   main-is:          GeneratePluginOptionsDoc.hs
   hs-source-dirs:   app
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N
@@ -117,7 +121,7 @@ executable gen-plugin-opts-doc
   default-language: Haskell2010
 
 test-suite plutus-tx-plugin-tests
-  import:             lang, ghc-version-support
+  import:             lang, ghc-version-support, os-support
 
   if flag(use-ghc-stub)
     buildable: False
@@ -207,7 +211,7 @@ test-suite plutus-tx-plugin-tests
     -fno-unbox-small-strict-fields -fno-full-laziness
 
 test-suite size
-  import:             lang, ghc-version-support
+  import:             lang, ghc-version-support, os-support
 
   -- needs plutus-tx-plugin but it looks unused
   ghc-options:        -Wno-unused-packages


### PR DESCRIPTION
In Plutus, several packages cannot be built on Windows (e.g., plutus-benchmark, plutus-tx-plugin, plutus-conformance). Currently, we mark these packages as not buildable in nix/project.nix using haskell.nix. However, this creates two inconsistent sources of truth: cabal.project and nix/project.nix. This PR addresses the issue by moving the relevant logic from nix/project.nix to the corresponding .cabal files.