### PR TITLE
Fix overflow bug in shiftByteString, rotateByteString, add tests to ensure it stays fixed

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
@@ -736,8 +736,11 @@ rotateByteString bs bitMove
       -- functions, like for shifts), and also simplify rotations larger than
       -- the bit length to the equivalent value modulo the bit length, as
       -- they're equivalent.
-      let !magnitude = abs bitMove
-          !reducedMagnitude = magnitude `rem` bitLen
+      --
+      -- We have to be a little careful here, as abs minBound == minBound for Int.
+      let !reducedMagnitude = if bitMove == minBound
+                              then fromIntegral $ abs (fromIntegral bitMove) `rem` bitLenInteger
+                              else abs bitMove `rem` bitLen
        in if reducedMagnitude == 0
             then bs
             else unsafeDupablePerformIO . BS.useAsCString bs $ \srcPtr ->
@@ -751,6 +754,8 @@ rotateByteString bs bitMove
     !len = BS.length bs
     bitLen :: Int
     !bitLen = len * 8
+    bitLenInteger :: Integer
+    bitLenInteger = fromIntegral bitLen
     negativeRotate :: Ptr Word8 -> Ptr Word8 -> Int -> Int -> IO ()
     negativeRotate srcPtr dstPtr bigRotate smallRotate = do
       -- Two partial copies are needed here, unlike with shifts, because

--- a/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
@@ -613,6 +613,9 @@ shiftByteStringWrapper bs bitMove
                     bitLen = fromIntegral $ 8 * len
                   in if abs bitMove >= bitLen
                      then BS.replicate len 0x00
+                     -- fromIntegral is safe to use here, as the only way this
+                     -- could overflow (or underflow) an Int is if we had a
+                     -- ByteString onchain that was over 30 petabytes in size.
                      else shiftByteString bs (fromIntegral bitMove)
 
 -- | Wrapper for calling 'rotateByteString' safely. Specifically, we avoid various edge cases:
@@ -621,7 +624,7 @@ shiftByteStringWrapper bs bitMove
 -- * Bit moves whose absolute value is larger than the bit length gets modulo reduced
 --
 -- Furthermore, we can convert all rotations into positive rotations, by noting that a rotation by @b@
--- is the same as a rotation by @b `mod` bitLen@, where @bitLen` is the length of the 'ByteString'
+-- is the same as a rotation by @b `mod` bitLen@, where @bitLen@ is the length of the 'ByteString'
 -- argument in bits. This value is always non-negative, and if we get 0, we have nothing to do. This
 -- reduction also helps us avoid integer overflow issues.
 rotateByteStringWrapper :: ByteString -> Integer -> ByteString
@@ -632,6 +635,9 @@ rotateByteStringWrapper bs bitMove
                     reducedBitMove = bitMove `mod` bitLen
                   in if reducedBitMove == 0
                      then bs
+                     -- fromIntegral is safe to use here, as the only way this
+                     -- could overflow (or underflow) an Int is if we had a
+                     -- ByteString onchain that was over 30 petabytes in size.
                      else rotateByteString bs (fromIntegral reducedBitMove)
 
 {- Note [Shift and rotation implementation]

--- a/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
@@ -656,6 +656,9 @@ shiftByteString :: ByteString -> Int -> ByteString
 shiftByteString bs bitMove
   | BS.null bs = bs
   | bitMove == 0 = bs
+  -- Needed to guard against overflow when given minBound for Int as a bit move
+  | abs (fromIntegral bitMove) >= (fromIntegral bitLen :: Integer) =
+      BS.replicate len 0x00
   | otherwise = unsafeDupablePerformIO . BS.useAsCString bs $ \srcPtr ->
       BSI.create len $ \dstPtr -> do
         -- To simplify our calculations, we work only with absolute values,

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1940,8 +1940,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     -- Bitwise
 
     toBuiltinMeaning _semvar ShiftByteString =
-        let shiftByteStringDenotation :: BS.ByteString -> Int -> BS.ByteString
-            shiftByteStringDenotation = Bitwise.shiftByteString
+        let shiftByteStringDenotation :: BS.ByteString -> Integer -> BS.ByteString
+            shiftByteStringDenotation = Bitwise.shiftByteStringWrapper
             {-# INLINE shiftByteStringDenotation #-}
         in makeBuiltinMeaning
             shiftByteStringDenotation

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1948,8 +1948,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             (runCostingFunTwoArguments . unimplementedCostingFun)
 
     toBuiltinMeaning _semvar RotateByteString =
-        let rotateByteStringDenotation :: BS.ByteString -> Int -> BS.ByteString
-            rotateByteStringDenotation = Bitwise.rotateByteString
+        let rotateByteStringDenotation :: BS.ByteString -> Integer -> BS.ByteString
+            rotateByteStringDenotation = Bitwise.rotateByteStringWrapper
             {-# INLINE rotateByteStringDenotation #-}
         in makeBuiltinMeaning
             rotateByteStringDenotation

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Bitwise.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Bitwise.hs
@@ -21,7 +21,8 @@ module Evaluation.Builtins.Bitwise (
   ffsXor,
   ffsIndex,
   ffsZero,
-  shiftMinBound
+  shiftMinBound,
+  rotateMinBound
   ) where
 
 import Control.Monad (unless)
@@ -37,6 +38,27 @@ import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.HUnit (testCase)
+
+-- | If given 'Int' 'minBound' as an argument, rotations behave sensibly.
+rotateMinBound :: Property
+rotateMinBound = property $ do
+  bs <- forAllByteString 1 512
+  let bitLen = fromIntegral $ BS.length bs * 8
+  -- By the laws of rotations, we know that we can perform a modular reduction on
+  -- the argument and not change the result we get. Thus, we (via Integer) do
+  -- this exact reduction on minBound, then compare the result of running a
+  -- rotation using this reduced argument versus the actual argument.
+  let minBoundInt = fromIntegral (minBound :: Int)
+  let minBoundIntReduced = negate (abs minBoundInt `rem` bitLen)
+  let lhs = mkIterAppNoAnn (builtin () PLC.RotateByteString) [
+        mkConstant @ByteString () bs,
+        mkConstant @Integer () minBoundInt
+        ]
+  let rhs = mkIterAppNoAnn (builtin () PLC.RotateByteString) [
+        mkConstant @ByteString () bs,
+        mkConstant @Integer () minBoundIntReduced
+        ]
+  evaluateTheSame lhs rhs
 
 -- | If given 'Int' 'minBound' as an argument, shifts behave sensibly.
 shiftMinBound :: Property

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Bitwise.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Bitwise.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
--- | Tests for [this
--- CIP](https://github.com/mlabs-haskell/CIPs/blob/koz/bitwise/CIP-XXXX/CIP-XXXX.md)
+-- | Tests for [CIP-123](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0123)
 module Evaluation.Builtins.Bitwise (
   shiftHomomorphism,
   rotateHomomorphism,
@@ -21,7 +20,8 @@ module Evaluation.Builtins.Bitwise (
   ffsReplicate,
   ffsXor,
   ffsIndex,
-  ffsZero
+  ffsZero,
+  shiftMinBound
   ) where
 
 import Control.Monad (unless)
@@ -37,6 +37,17 @@ import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.HUnit (testCase)
+
+-- | If given 'Int' 'minBound' as an argument, shifts behave sensibly.
+shiftMinBound :: Property
+shiftMinBound = property $ do
+  bs <- forAllByteString 0 512
+  let len = BS.length bs
+  let shiftExp = mkIterAppNoAnn (builtin () PLC.ShiftByteString) [
+        mkConstant @ByteString () bs,
+        mkConstant @Integer () . fromIntegral $ (minBound :: Int)
+        ]
+  evaluatesToConstant @ByteString (BS.replicate len 0x00) shiftExp
 
 -- | Finding the first set bit in a bytestring with only zero bytes should always give -1.
 ffsZero :: Property

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -972,7 +972,9 @@ test_Bitwise =
       testPropertyNamed "positive shifts clear low indexes" "shift_pos_low"
                         Bitwise.shiftPosClearLow,
       testPropertyNamed "negative shifts clear high indexes" "shift_neg_high"
-                        Bitwise.shiftNegClearHigh
+                        Bitwise.shiftNegClearHigh,
+      testPropertyNamed "shifts do not break when given minBound as a shift" "shift_min_bound"
+                        Bitwise.shiftMinBound
     ],
   testGroup "rotateByteString" [
       testGroup "homomorphism" Bitwise.rotateHomomorphism,

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -981,7 +981,9 @@ test_Bitwise =
       testPropertyNamed "rotations over bit length roll over" "rotate_too_much"
                         Bitwise.rotateRollover,
       testPropertyNamed "rotations move bits but don't change them" "rotate_move"
-                        Bitwise.rotateMoveBits
+                        Bitwise.rotateMoveBits,
+      testPropertyNamed "rotations do not break when given minBound as a rotation" "rotate_min_bound"
+                        Bitwise.rotateMinBound
     ],
   testGroup "countSetBits" [
       testGroup "homomorphism" Bitwise.csbHomomorphism,

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -717,7 +717,7 @@ shiftByteString ::
   BuiltinInteger ->
   BuiltinByteString
 shiftByteString (BuiltinByteString bs) =
-  BuiltinByteString . Bitwise.shiftByteString bs . fromIntegral
+  BuiltinByteString . Bitwise.shiftByteStringWrapper bs
 
 {-# NOINLINE rotateByteString #-}
 rotateByteString ::
@@ -725,7 +725,7 @@ rotateByteString ::
   BuiltinInteger ->
   BuiltinByteString
 rotateByteString (BuiltinByteString bs) =
-  BuiltinByteString . Bitwise.rotateByteString bs . fromIntegral
+  BuiltinByteString . Bitwise.rotateByteStringWrapper bs
 
 {-# NOINLINE countSetBits #-}
 countSetBits ::


### PR DESCRIPTION
This repairs an issue spotted by @effectfully and @kwxm in both `shiftByteString` and `rotateByteString`. Specifically, this happened due to `abs minBound = minBound` for `Int`, which would lead to incorrect behaviour if `shiftByteString` or `rotateByteString` was given that value as a shift or rotation argument. More specifically, we added the following:

1. An additional check in `shiftByteString`, via `Integer`, to ensure that this case gets properly trapped;
2. An additional check in `rotateByteString`, via `Integer`, to do the same thing;
3. Test that verifies that any such shift or rotation does not crash, instead giving a sensible result.