### PR TITLE
Release 1.31.0.0

### DIFF
--- a/cardano-constitution/cardano-constitution.cabal
+++ b/cardano-constitution/cardano-constitution.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-constitution
-version:            1.30.0.0
+version:            1.31.0.0
 license:            Apache-2.0
 license-files:
   LICENSE
@@ -77,10 +77,10 @@ library
     , base               >=4.9   && <5
     , containers
     , filepath
-    , plutus-core        ^>=1.30
-    , plutus-ledger-api  ^>=1.30
-    , plutus-tx          ^>=1.30
-    , plutus-tx-plugin   ^>=1.30
+    , plutus-core        ^>=1.31
+    , plutus-ledger-api  ^>=1.31
+    , plutus-tx          ^>=1.31
+    , plutus-tx-plugin   ^>=1.31
     , regex-tdfa
     , safe
     , template-haskell
@@ -112,13 +112,13 @@ test-suite cardano-constitution-test
     , aeson
     , base                                            >=4.9   && <5
     , bytestring
-    , cardano-constitution                            ^>=1.30
+    , cardano-constitution                            ^>=1.31
     , containers
     , directory
     , filepath
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-ledger-api                               ^>=1.30
-    , plutus-tx                                       ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-ledger-api                               ^>=1.31
+    , plutus-tx                                       ^>=1.31
     , QuickCheck
     , serialise
     , tasty
@@ -129,6 +129,9 @@ test-suite cardano-constitution-test
     , tasty-quickcheck
 
 executable create-json-envelope
+  -- This is a temporary workaround to solve the plutus-ledger-api dependency conflict
+  -- caused by the `cardano-api` dependency.
+  buildable:      False
   import:         lang, ghc-version-support, os-support
   hs-source-dirs: create-json-envelope
   main-is:        Main.hs

--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -33,5 +33,5 @@ executable example-cip57
   build-depends:
     , base               ^>=4.18
     , containers
-    , plutus-ledger-api
-    , plutus-tx
+    , plutus-ledger-api  ^>=1.31
+    , plutus-tx          ^>=1.31

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -90,8 +90,8 @@ library plutus-benchmark-common
     , directory
     , filepath
     , flat                 ^>=0.6
-    , plutus-core          ^>=1.30
-    , plutus-ledger-api    ^>=1.30
+    , plutus-core          ^>=1.31
+    , plutus-ledger-api    ^>=1.31
     , plutus-tx-test-util
     , tasty
     , tasty-golden
@@ -118,9 +118,9 @@ library nofib-internal
     , base                     >=4.9   && <5
     , deepseq
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-tx                ^>=1.30
-    , plutus-tx-plugin         ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-tx                ^>=1.31
+    , plutus-tx-plugin         ^>=1.31
 
 executable nofib-exe
   import:         lang, ghc-version-support
@@ -134,8 +134,8 @@ executable nofib-exe
     , nofib-internal
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-tx                ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-tx                ^>=1.31
     , prettyprinter
     , transformers
 
@@ -173,8 +173,8 @@ test-suite plutus-benchmark-nofib-tests
     , base                                            >=4.9   && <5
     , nofib-internal
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.31
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -200,9 +200,9 @@ library lists-internal
     , base                     >=4.9   && <5
     , mtl
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-tx                ^>=1.30
-    , plutus-tx-plugin         ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-tx                ^>=1.31
+    , plutus-tx-plugin         ^>=1.31
 
 executable list-sort-exe
   import:         lang, ghc-version-support
@@ -213,7 +213,7 @@ executable list-sort-exe
     , lists-internal
     , monoidal-containers
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
+    , plutus-core              ^>=1.31
 
 benchmark lists
   import:         lang, ghc-version-support
@@ -225,7 +225,7 @@ benchmark lists
     , criterion                >=1.5.9.0
     , lists-internal
     , plutus-benchmark-common
-    , plutus-ledger-api        ^>=1.30
+    , plutus-ledger-api        ^>=1.31
 
 test-suite plutus-benchmark-lists-tests
   import:         lang, ghc-version-support
@@ -242,8 +242,8 @@ test-suite plutus-benchmark-lists-tests
     , base                             >=4.9   && <5
     , lists-internal
     , plutus-benchmark-common
-    , plutus-core:plutus-core-testlib  ^>=1.30
-    , plutus-tx:plutus-tx-testlib      ^>=1.30
+    , plutus-core:plutus-core-testlib  ^>=1.31
+    , plutus-tx:plutus-tx-testlib      ^>=1.31
     , tasty
     , tasty-quickcheck
 
@@ -264,8 +264,8 @@ benchmark validation
     , flat                     ^>=0.6
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-ledger-api        ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-ledger-api        ^>=1.31
 
 ---------------- validation-decode ----------------
 
@@ -285,8 +285,8 @@ benchmark validation-decode
     , flat                     ^>=0.6
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-ledger-api        ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-ledger-api        ^>=1.31
 
 ---------------- validation-full ----------------
 
@@ -306,8 +306,8 @@ benchmark validation-full
     , flat                     ^>=0.6
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-ledger-api        ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-ledger-api        ^>=1.31
 
 ---------------- Cek cost model calibration ----------------
 
@@ -323,10 +323,10 @@ benchmark cek-calibration
     , lens
     , mtl
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-ledger-api        ^>=1.30
-    , plutus-tx                ^>=1.30
-    , plutus-tx-plugin         ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-ledger-api        ^>=1.31
+    , plutus-tx                ^>=1.31
+    , plutus-tx-plugin         ^>=1.31
 
 ---------------- Signature verification throughput ----------------
 
@@ -342,9 +342,9 @@ executable ed25519-costs
     , cardano-crypto-class
     , hedgehog
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-tx                ^>=1.30
-    , plutus-tx-plugin         ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-tx                ^>=1.31
+    , plutus-tx-plugin         ^>=1.31
 
 -- Calculate the predicted costs of sequences of ed25519 signature verification
 -- operations and compare them with a golden file.
@@ -361,9 +361,9 @@ test-suite ed25519-costs-test
     , cardano-crypto-class
     , hedgehog
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-tx                                       ^>=1.30
-    , plutus-tx-plugin                                ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-tx                                       ^>=1.31
+    , plutus-tx-plugin                                ^>=1.31
 
 ---------------- BLS12-381 experiments ----------------
 
@@ -381,10 +381,10 @@ library bls12-381lib-internal
     , bytestring
     , hedgehog
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
-    , plutus-ledger-api        ^>=1.30
-    , plutus-tx                ^>=1.30
-    , plutus-tx-plugin         ^>=1.30
+    , plutus-core              ^>=1.31
+    , plutus-ledger-api        ^>=1.31
+    , plutus-tx                ^>=1.31
+    , plutus-tx-plugin         ^>=1.31
 
 -- Print out predicted costs of various scripts involving BLS12-381 operations
 executable bls12-381-costs
@@ -408,7 +408,7 @@ test-suite bls12-381-costs-test
     , base                             >=4.9   && <5
     , bls12-381lib-internal
     , plutus-benchmark-common
-    , plutus-core:plutus-core-testlib  ^>=1.30
+    , plutus-core:plutus-core-testlib  ^>=1.31
 
 -- Run benchmarks for various scripts involving BLS12-381 operations
 benchmark bls12-381-benchmarks
@@ -422,8 +422,8 @@ benchmark bls12-381-benchmarks
     , bytestring
     , criterion                >=1.5.9.0
     , plutus-benchmark-common
-    , plutus-ledger-api        ^>=1.30
-    , plutus-tx                ^>=1.30
+    , plutus-ledger-api        ^>=1.31
+    , plutus-tx                ^>=1.31
 
 ---------------- script contexts ----------------
 
@@ -433,9 +433,9 @@ library script-contexts-internal
   exposed-modules: PlutusBenchmark.ScriptContexts
   build-depends:
     , base               >=4.9   && <5
-    , plutus-ledger-api  ^>=1.30
-    , plutus-tx          ^>=1.30
-    , plutus-tx-plugin   ^>=1.30
+    , plutus-ledger-api  ^>=1.31
+    , plutus-tx          ^>=1.31
+    , plutus-tx-plugin   ^>=1.31
 
 test-suite plutus-benchmark-script-contexts-tests
   import:         lang, ghc-version-support
@@ -447,8 +447,8 @@ test-suite plutus-benchmark-script-contexts-tests
   build-depends:
     , base                                            >=4.9   && <5
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-tx:plutus-tx-testlib                     ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-tx:plutus-tx-testlib                     ^>=1.31
     , script-contexts-internal
     , tasty
     , tasty-hunit
@@ -477,10 +477,10 @@ library marlowe-internal
     , mtl
     , newtype-generics
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.30
-    , plutus-ledger-api                               ^>=1.30
-    , plutus-tx                                       ^>=1.30
-    , plutus-tx-plugin                                ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.31
+    , plutus-ledger-api                               ^>=1.31
+    , plutus-tx                                       ^>=1.31
+    , plutus-tx-plugin                                ^>=1.31
     , serialise
 
 executable marlowe-validators
@@ -500,8 +500,8 @@ executable marlowe-validators
     , cardano-binary
     , marlowe-internal
     , plutus-benchmark-common
-    , plutus-ledger-api        ^>=1.30
-    , plutus-tx                ^>=1.30
+    , plutus-ledger-api        ^>=1.31
+    , plutus-tx                ^>=1.31
     , serialise
 
 benchmark marlowe
@@ -515,8 +515,8 @@ benchmark marlowe
     , criterion
     , marlowe-internal
     , plutus-benchmark-common
-    , plutus-ledger-api        ^>=1.30
-    , plutus-tx                ^>=1.30
+    , plutus-ledger-api        ^>=1.31
+    , plutus-tx                ^>=1.31
 
 test-suite plutus-benchmark-marlowe-tests
   import:         lang, ghc-version-support
@@ -528,9 +528,9 @@ test-suite plutus-benchmark-marlowe-tests
   build-depends:
     , base                                            >=4.9   && <5
     , marlowe-internal
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-ledger-api                               ^>=1.30
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-ledger-api                               ^>=1.31
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.31
     , tasty
 
 ---------------- agda evaluators ----------------
@@ -544,7 +544,7 @@ library agda-internal
   build-depends:
     , base               >=4.9   && <5
     , criterion
-    , plutus-core        ^>=1.30
+    , plutus-core        ^>=1.31
     , plutus-metatheory
 
 benchmark validation-agda-cek
@@ -564,7 +564,7 @@ benchmark validation-agda-cek
     , flat                     ^>=0.6
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.30
+    , plutus-core              ^>=1.31
 
 benchmark nofib-agda-cek
   import:         lang, ghc-version-support
@@ -591,5 +591,5 @@ benchmark marlowe-agda-cek
     , criterion
     , marlowe-internal
     , plutus-benchmark-common
-    , plutus-ledger-api        ^>=1.30
-    , plutus-tx                ^>=1.30
+    , plutus-ledger-api        ^>=1.31
+    , plutus-tx                ^>=1.31

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -48,7 +48,7 @@ library
     , base
     , directory
     , filepath
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
     , tasty
     , tasty-expected-failure
     , tasty-golden
@@ -71,7 +71,7 @@ test-suite haskell-conformance
   build-depends:
     , base                >=4.9   && <5
     , plutus-conformance
-    , plutus-core         ^>=1.30
+    , plutus-core         ^>=1.31
 
 test-suite haskell-steppable-conformance
   import:         lang
@@ -84,7 +84,7 @@ test-suite haskell-steppable-conformance
     , base                >=4.9   && <5
     , lens
     , plutus-conformance
-    , plutus-core         ^>=1.30
+    , plutus-core         ^>=1.31
 
 test-suite agda-conformance
   import:         lang
@@ -97,6 +97,6 @@ test-suite agda-conformance
     , aeson
     , base                >=4.9   && <5
     , plutus-conformance
-    , plutus-core         ^>=1.30
+    , plutus-core         ^>=1.31
     , plutus-metatheory
     , transformers

--- a/plutus-core/CHANGELOG.md
+++ b/plutus-core/CHANGELOG.md
@@ -1,4 +1,25 @@
 
+<a id='changelog-1.31.0.0'></a>
+# 1.31.0.0 — 2024-07-17
+
+## Removed
+
+- Removed `Emitter` and `MonadEmitter` in #6224.
+
+- In #6248 the case-of-case optimization was removed from the compiler due to it causing OOMs.
+
+## Changed
+
+-  All names are printed with their unique suffixes by default.
+
+- Forbade using `EvaluationResult` in the builtins code in favor of `BuiltinResult` in #5926, so that builtins throw errors with more helpful messages.
+
+- Changed the type of `emit` to `Text -> BuiltinResult ()` in #6224.
+
+## Fixed
+
+- In #6272 fixed a bug in `isNormalType`.
+
 <a id='changelog-1.30.0.0'></a>
 # 1.30.0.0 — 2024-06-17
 

--- a/plutus-core/changelog.d/20240510_200705_Yuriy.Lazaryev_4808_unique_names_roundtrip_tests.md
+++ b/plutus-core/changelog.d/20240510_200705_Yuriy.Lazaryev_4808_unique_names_roundtrip_tests.md
@@ -1,3 +1,0 @@
-### Changed
-
--  All names are printed with their unique suffixes by default.

--- a/plutus-core/changelog.d/20240618_023306_effectfully_replace_EvaluationResult_with_BuiltinResult.md
+++ b/plutus-core/changelog.d/20240618_023306_effectfully_replace_EvaluationResult_with_BuiltinResult.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Forbade using `EvaluationResult` in the builtins code in favor of `BuiltinResult` in #5926, so that builtins throw errors with more helpful messages.

--- a/plutus-core/changelog.d/20240620_025344_effectfully_remove_Emitter_and_MonadEmitter.md
+++ b/plutus-core/changelog.d/20240620_025344_effectfully_remove_Emitter_and_MonadEmitter.md
@@ -1,7 +1,0 @@
-### Removed
-
-- Removed `Emitter` and `MonadEmitter` in #6224.
-
-### Changed
-
-- Changed the type of `emit` to `Text -> BuiltinResult ()` in #6224.

--- a/plutus-core/changelog.d/20240626_184002_effectfully_remove_case_of_case.md
+++ b/plutus-core/changelog.d/20240626_184002_effectfully_remove_case_of_case.md
@@ -1,3 +1,0 @@
-### Removed
-
-- In #6248 the case-of-case optimization was removed from the compiler due to it causing OOMs.

--- a/plutus-core/changelog.d/20240701_104059_effectfully_fix_isNormalType.md
+++ b/plutus-core/changelog.d/20240701_104059_effectfully_fix_isNormalType.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- In #6272 fixed a bug in `isNormalType`.

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-core
-version:         1.30.0.0
+version:         1.31.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -321,7 +321,7 @@ library
     , nothunks                    ^>=0.1.5
     , parser-combinators          >=0.4.0
     , prettyprinter               >=1.1.0.1
-    , prettyprinter-configurable  ^>=1.30
+    , prettyprinter-configurable  ^>=1.31
     , primitive
     , profunctors
     , recursion-schemes
@@ -384,7 +384,7 @@ test-suite plutus-core-test
     , hex-text
     , mmorph
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
     , prettyprinter
     , serialise
     , tasty
@@ -447,7 +447,7 @@ test-suite untyped-plutus-core-test
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
     , pretty-show
     , prettyprinter
     , QuickCheck
@@ -470,8 +470,8 @@ executable plc
     , bytestring
     , flat                  ^>=0.6
     , optparse-applicative
-    , plutus-core           ^>=1.30
-    , plutus-core-execlib   ^>=1.30
+    , plutus-core           ^>=1.31
+    , plutus-core-execlib   ^>=1.31
     , text
 
 executable uplc
@@ -487,8 +487,8 @@ executable uplc
     , haskeline
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.30
-    , plutus-core-execlib   ^>=1.30
+    , plutus-core           ^>=1.31
+    , plutus-core-execlib   ^>=1.31
     , prettyprinter
     , split
     , text
@@ -584,7 +584,7 @@ library plutus-ir
     , mtl
     , multiset
     , parser-combinators   >=0.4.0
-    , plutus-core          ^>=1.30
+    , plutus-core          ^>=1.31
     , prettyprinter        >=1.1.0.1
     , profunctors
     , semigroupoids
@@ -653,7 +653,7 @@ test-suite plutus-ir-test
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.31
     , QuickCheck
     , serialise
     , tasty
@@ -676,8 +676,8 @@ executable pir
     , lens
     , megaparsec
     , optparse-applicative
-    , plutus-core-execlib                   ^>=1.30
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.30
+    , plutus-core-execlib                   ^>=1.31
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.31
     , text
     , transformers
 
@@ -733,7 +733,7 @@ executable plutus
     , microlens-th                          ^>=0.4
     , mono-traversable
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.31
     , prettyprinter
     , primitive
     , serialise
@@ -773,7 +773,7 @@ library plutus-core-execlib
     , monoidal-containers
     , mtl
     , optparse-applicative
-    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.31
     , prettyprinter
     , text
 
@@ -836,9 +836,9 @@ library plutus-core-testlib
     , mmorph
     , mtl
     , multiset
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.31
     , prettyprinter                         >=1.1.0.1
-    , prettyprinter-configurable            ^>=1.30
+    , prettyprinter-configurable            ^>=1.31
     , QuickCheck
     , quickcheck-instances
     , quickcheck-transformer
@@ -870,7 +870,7 @@ library plutus-ir-cert
   exposed-modules:  PlutusIR.Certifier
   build-depends:
     , base
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.31
 
 ----------------------------------------------
 -- profiling
@@ -948,7 +948,7 @@ executable cost-model-budgeting-bench
     , hedgehog
     , mtl
     , optparse-applicative
-    , plutus-core            ^>=1.30
+    , plutus-core            ^>=1.31
     , QuickCheck
     , quickcheck-instances
     , random
@@ -982,7 +982,7 @@ executable generate-cost-model
     , directory
     , inline-r              >=1.0.1
     , optparse-applicative
-    , plutus-core           ^>=1.30
+    , plutus-core           ^>=1.31
     , text
 
   --    , exceptions
@@ -1022,7 +1022,7 @@ benchmark cost-model-test
     , hedgehog
     , inline-r          >=1.0.1
     , mmorph
-    , plutus-core       ^>=1.30
+    , plutus-core       ^>=1.31
     , template-haskell
     , text
 
@@ -1039,7 +1039,7 @@ executable print-cost-model
     , aeson
     , base         >=4.9   && <5
     , bytestring
-    , plutus-core  ^>=1.30
+    , plutus-core  ^>=1.31
 
 ----------------------------------------------
 -- satint

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-ledger-api
-version:         1.30.0.0
+version:         1.31.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -101,8 +101,8 @@ library
     , lens
     , mtl
     , nothunks
-    , plutus-core        ^>=1.30
-    , plutus-tx          ^>=1.30
+    , plutus-core        ^>=1.31
+    , plutus-tx          ^>=1.31
     , prettyprinter
     , serialise
     , tagged
@@ -130,9 +130,9 @@ library plutus-ledger-api-testlib
     , base64-bytestring
     , bytestring
     , containers
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-ledger-api                               ^>=1.30
-    , plutus-tx                                       ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-ledger-api                               ^>=1.31
+    , plutus-tx                                       ^>=1.31
     , prettyprinter
     , QuickCheck
     , serialise
@@ -165,9 +165,9 @@ test-suite plutus-ledger-api-test
     , lens
     , mtl
     , nothunks
-    , plutus-core:{plutus-core, plutus-core-testlib}                    ^>=1.30
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.30
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}                          ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}                    ^>=1.31
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.31
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}                          ^>=1.31
     , prettyprinter
     , serialise
     , tasty
@@ -201,10 +201,10 @@ test-suite plutus-ledger-api-plugin-test
     , containers
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}                    ^>=1.30
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.30
-    , plutus-tx-plugin                                                  ^>=1.30
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}                          ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}                    ^>=1.31
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.31
+    , plutus-tx-plugin                                                  ^>=1.31
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}                          ^>=1.31
     , prettyprinter
     , tasty
     , tasty-hunit
@@ -223,8 +223,8 @@ executable test-onchain-evaluation
     , extra
     , filepath
     , mtl
-    , plutus-core                                                       ^>=1.30
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.30
+    , plutus-core                                                       ^>=1.31
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.31
     , serialise
     , tasty
     , tasty-hunit
@@ -243,9 +243,9 @@ executable analyse-script-events
     , filepath
     , lens
     , mtl
-    , plutus-core                                                       ^>=1.30
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.30
-    , plutus-tx                                                         ^>=1.30
+    , plutus-core                                                       ^>=1.31
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.31
+    , plutus-tx                                                         ^>=1.31
     , primitive
     , serialise
 

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -63,7 +63,7 @@ library
     , megaparsec
     , memory
     , optparse-applicative
-    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.31
     , process
     , text
     , transformers
@@ -548,8 +548,8 @@ executable plc-agda
 test-suite test1
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.30
-    , plutus-core:uplc  ^>=1.30
+    , plutus-core:plc   ^>=1.31
+    , plutus-core:uplc  ^>=1.31
 
   hs-source-dirs:     test
   build-depends:
@@ -564,8 +564,8 @@ test-suite test1
 test-suite test2
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.30
-    , plutus-core:uplc  ^>=1.30
+    , plutus-core:plc   ^>=1.31
+    , plutus-core:uplc  ^>=1.31
 
   hs-source-dirs:     test
   type:               detailed-0.9
@@ -590,7 +590,7 @@ test-suite test3
     , base
     , lazy-search
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
     , plutus-metatheory
     , size-based
     , Stream

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx-plugin
-version:         1.30.0.0
+version:         1.31.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -83,8 +83,8 @@ library
     , flat                                  ^>=0.6
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.30
-    , plutus-tx                             ^>=1.30
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.31
+    , plutus-tx                             ^>=1.31
     , prettyprinter
     , PyF                                   >=0.11.1.0
     , template-haskell
@@ -109,7 +109,7 @@ executable gen-plugin-opts-doc
     , containers
     , lens
     , optparse-applicative
-    , plutus-tx-plugin      ^>=1.30
+    , plutus-tx-plugin      ^>=1.31
     , prettyprinter
     , PyF                   >=0.11.1.0
     , text
@@ -184,10 +184,10 @@ test-suite plutus-tx-plugin-tests
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-tx-plugin                                ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-tx-plugin                                ^>=1.31
     , plutus-tx-test-util
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.30
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.31
     , serialise
     , tasty
     , tasty-golden
@@ -216,9 +216,9 @@ test-suite size
   hs-source-dirs:     test/size
   build-depends:
     , base                                            >=4.9   && <5.0
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-tx-plugin                                ^>=1.30
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-tx-plugin                                ^>=1.31
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.31
     , tagged
     , tasty
 

--- a/plutus-tx-test-util/plutus-tx-test-util.cabal
+++ b/plutus-tx-test-util/plutus-tx-test-util.cabal
@@ -71,8 +71,8 @@ library
   -- other-extensions:
   build-depends:
     , base         >=4.9   && <5
-    , plutus-core  ^>=1.30
-    , plutus-tx    ^>=1.30
+    , plutus-core  ^>=1.31
+    , plutus-tx    ^>=1.31
     , text
 
   hs-source-dirs:   testlib

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx
-version:         1.30.0.0
+version:         1.31.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -131,7 +131,7 @@ library
     , lens
     , memory
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.30
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.31
     , prettyprinter
     , serialise
     , template-haskell                      >=2.13.0.0
@@ -164,8 +164,8 @@ library plutus-tx-testlib
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.30
-    , plutus-tx                                                  ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.31
+    , plutus-tx                                                  ^>=1.31
     , prettyprinter
     , tagged
     , tasty
@@ -213,8 +213,8 @@ test-suite plutus-tx-test
     , hedgehog-fn
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.30
-    , plutus-tx                                       ^>=1.30
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.31
+    , plutus-tx                                       ^>=1.31
     , pretty-show
     , serialise
     , tasty

--- a/prettyprinter-configurable/prettyprinter-configurable.cabal
+++ b/prettyprinter-configurable/prettyprinter-configurable.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               prettyprinter-configurable
-version:            1.30.0.0
+version:            1.31.0.0
 synopsis:           Configurable pretty-printing
 homepage:
   https://github.com/input-output-hk/plutus/tree/master/prettyprinter-configurable/
@@ -76,7 +76,7 @@ test-suite prettyprinter-configurable-test
     , base                        >=4.9   && <5
     , megaparsec
     , parser-combinators
-    , prettyprinter-configurable  ^>=1.30
+    , prettyprinter-configurable  ^>=1.31
     , QuickCheck
     , quickcheck-text
     , tasty


### PR DESCRIPTION
Result of `./scripts/prepare-release.sh "1.31.0.0"`

* I had to remove the `create-json-envelope` executable as it depends on the `cardano-api` which in turn depends on the `plutus` making it a circular dependency hindering the plutus version upgrade.