### PR TITLE
Changed update CC thresholds to 51%

### DIFF
--- a/cardano-constitution/data/defaultConstitution.json
+++ b/cardano-constitution/data/defaultConstitution.json
@@ -311,12 +311,12 @@
         "$comment": "All thresholds must be in the range 50%-100%"
       },
       {
-        "minValue": { "numerator": 65, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "minValue": { "numerator": 51, "denominator": 100 },
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       },
       {
         "maxValue": { "numerator": 90, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       }
     ],
     "$comment": "poolVotingThresholds[committeeNormal]"
@@ -334,12 +334,12 @@
         "$comment": "All thresholds must be in the range 50%-100%"
       },
       {
-        "minValue": { "numerator": 65, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "minValue": { "numerator": 51, "denominator": 100 },
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       },
       {
         "maxValue": { "numerator": 90, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       }
     ],
     "$comment": "poolVotingThresholds[committeeNoConfidence]"
@@ -418,12 +418,12 @@
         "$comment": "All thresholds must be in the range 50%-100%"
       },
       {
-        "minValue": { "numerator": 65, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "minValue": { "numerator": 51, "denominator": 100 },
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       },
       {
         "maxValue": { "numerator": 90, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       }
     ],
     "$comment": "dRepVotingThresholds[committeeNormal]"
@@ -441,12 +441,12 @@
         "$comment": "All thresholds must be in the range 50%-100%"
       },
       {
-        "minValue": { "numerator": 65, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "minValue": { "numerator": 51, "denominator": 100 },
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       },
       {
         "maxValue": { "numerator": 90, "denominator": 100 },
-        "$comment": "Update Constitutional committee action thresholds must be in the range 65%-90%"
+        "$comment": "Update Constitutional committee action thresholds must be in the range 51%-90%"
       }
     ],
     "$comment": "dRepVotingThresholds[committeeNoConfidence]"


### PR DESCRIPTION
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [N/A] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [N/A] Changelog fragments have been written (if appropriate)
    - [N/A] Relevant tickets are mentioned in commit messages
    - [N/A] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

This PR updates the thresholds and comments for the "Update constitutional committee action" in `defaultConstitution.json` to reflect a late guardrail change from 65% to 51%.

The original high-level guardrail was:

`"Update Constitutional committee action thresholds must be in the range 65%-90%"
`
The new guardrail is:

`"Update Constitutional committee action thresholds must be in the range 51%-90%"
`

Four guardrails are affected: for DReps or for SPOs in both Confidence and No Confidence states
