### PR TITLE
[Benchmark] Reduce the number of benchmarks

### DIFF
--- a/plutus-benchmark/lists/bench/Bench.hs
+++ b/plutus-benchmark/lists/bench/Bench.hs
@@ -44,11 +44,11 @@ benchmarks ctx =
       mkBMsForSort name f =
         bgroup name $ sizesForSort <&> \n ->
           bench (show n) $ benchTermCek ctx (f n)
-      sizesForSort = [10, 20..500]
+      sizesForSort = [50, 100..300]
       mkBMsForSum name f =
         bgroup name $ sizesForSum <&> \n ->
           bench (show n) $ benchTermCek ctx (f [1..n])
-      sizesForSum = [10, 50, 100, 500, 1000, 5000, 10000]
+      sizesForSum = [100, 500, 1000, 2500, 5000]
 
 main :: IO ()
 main = do

--- a/plutus-benchmark/nofib/bench/Shared.hs
+++ b/plutus-benchmark/nofib/bench/Shared.hs
@@ -38,11 +38,8 @@ mkBenchMarks (benchClausify, benchKnights, benchPrime, benchQueens) = [
                      , bench "8x8" $ benchKnights 100 8
                      ]
   , bgroup "primetest" [ bench "05digits" $ benchPrime Prime.P5
-                       , bench "08digits" $ benchPrime Prime.P8
                        , bench "10digits" $ benchPrime Prime.P10
-                       , bench "20digits" $ benchPrime Prime.P20
                        , bench "30digits" $ benchPrime Prime.P30
-                       , bench "40digits" $ benchPrime Prime.P40
                        , bench "50digits" $ benchPrime Prime.P50
                        -- Larger primes are available in Primes.hs, but may take a long time.
                        ]


### PR DESCRIPTION
Since we advise to run benchmarks multiple times anyway, there's no need in making them long-running, hence let's run less stuff. Plus, let's not run something that finishes way too quickly, since it's likely that those results are noise.