### PR TITLE
[plc] Support for `Natural` numbers in the universe, backed by Integer

### DIFF
--- a/plutus-core/changelog.d/20240726_102834_bezirg_ratinteger.md
+++ b/plutus-core/changelog.d/20240726_102834_bezirg_ratinteger.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support for `Natural` numbers in the default universe, backed by `Integer`.


### PR DESCRIPTION
Prerequisite for introducing #6333 

One argument and the result type is going to be `Natural`
See https://hackage.haskell.org/package/ghc-bignum-1.3/docs/GHC-Num-Integer.html#v:integerPowMod-35-

This is not optimised and left as TODO.

Should work on GHC8.10 onwards. However, Idk yet if the actual builtin will work for GHC8.10.


Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
