### PR TITLE
nothunks ^>= 0.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -92,9 +92,4 @@ constraints:
   -- The API has changed for version 2.2, ledger depends on the old version and ledger will not
   -- be updated until after the Conway release.
   , cardano-crypto-class ^>= 2.1
-  -- Later versions have API changes.
-  , nothunks ^>= 0.1.5
-
-allow-newer:
-  , nothunks:containers
 

--- a/plutus-core/changelog.d/20240726_165736_Yuriy.Lazaryev_nothunks_0_2.md
+++ b/plutus-core/changelog.d/20240726_165736_Yuriy.Lazaryev_nothunks_0_2.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Updated version boundaries for the `nothunks` dependency (^>=0.2)

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -318,7 +318,7 @@ library
     , monoidal-containers
     , mtl
     , multiset
-    , nothunks                    ^>=0.1.5
+    , nothunks                    ^>=0.2
     , parser-combinators          >=0.4.0
     , prettyprinter               >=1.1.0.1
     , prettyprinter-configurable  ^>=1.31

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
@@ -38,7 +38,7 @@ instance NoThunks (BuiltinRuntime val) where
     wNoThunks ctx = \case
         -- Unreachable, because we don't allow nullary builtins and the 'BuiltinArrow' case only
         -- checks for WHNF without recursing. Hence we can throw if we reach this clause somehow.
-        BuiltinCostedResult _ _    -> pure . Just $ ThunkInfo ctx
+        BuiltinCostedResult _ _    -> pure . Just . ThunkInfo $ Left ctx
         -- This one doesn't do much. It only checks that the function stored in the 'BuiltinArrow'
         -- is in WHNF. The function may contain thunks inside of it. Not sure if it's possible to do
         -- better, since the final 'BuiltinCostedResult' contains a thunk for the result of the

--- a/plutus-ledger-api/test/Spec/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Eval.hs
@@ -114,8 +114,8 @@ evaluationContextCacheIsComplete =
 
 failIfThunk :: Show a => Maybe a -> IO ()
 failIfThunk mbThunkInfo =
-    whenJust mbThunkInfo $ \thunkInfo ->
-        assertFailure $ "Unexpected thunk: " <> show thunkInfo
+    whenJust mbThunkInfo $ \thunk ->
+        assertFailure $ "Unexpected thunk: " <> show thunk
 
 -- | Ensure that no 'EvaluationContext' has thunks in it for all language versions.
 evaluationContextNoThunks :: TestTree


### PR DESCRIPTION

Update `nothunks` version removing `cabal.project` workarounds.