### PR TITLE
Reduce benchmarking time limits

### DIFF
--- a/plutus-benchmark/nofib/bench/Shared.hs
+++ b/plutus-benchmark/nofib/bench/Shared.hs
@@ -103,5 +103,5 @@ benchWith benchmarker = do
   let runners = ( benchClausifyWith benchmarker, benchKnightsWith benchmarker
                 , benchPrimeWith benchmarker, benchQueensWith benchmarker)
   -- Run each benchmark for at least one minute.  Change this with -L or --timeout.
-  config <- getConfig 60.0
+  config <- getConfig 30.0
   defaultMainWith config $ mkBenchMarks runners


### PR DESCRIPTION
This is a followup to #6328.  Criterion runs each individual benchmark up to some time limit then analyses the times of the different runs.  Our benchmark suites currently get run with different time limits: 60s for `nofib`, 20 for `validation`, and 15 for `lists`.  There  should be scope for reducing these limits without reducing the accuracy of the results too much.  I'm going to do some experiments in this PR to see what happens.  Using `/benchmark`, the benchmarks will be run in the base branch with the old time limits and in this branch with the new ones, so we should be able to get a decent comparison.