### PR TITLE
[Refactoring] Use 'KnownBuiltinTypeIn' instead of 'HasConstant' consistently

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -369,12 +369,12 @@ instance KnownTypeAst tyname DefaultUni (AsInteger a) where
     type ToBinds _ acc _ = acc
     typeAst = toTypeAst $ Proxy @Integer
 
-instance (HasConstantIn DefaultUni term, Integral a) =>
+instance (KnownBuiltinTypeIn DefaultUni term Integer, Integral a) =>
         MakeKnownIn DefaultUni term (AsInteger a) where
     makeKnown = makeKnown . toInteger . unAsInteger
     {-# INLINE makeKnown #-}
 
-instance (HasConstantIn DefaultUni term, Integral a, Bounded a, Typeable a) =>
+instance (KnownBuiltinTypeIn DefaultUni term Integer, Integral a, Bounded a, Typeable a) =>
         ReadKnownIn DefaultUni term (AsInteger a) where
     readKnown term =
         -- See Note [Performance of ReadKnownIn and MakeKnownIn instances].
@@ -397,89 +397,89 @@ instance (HasConstantIn DefaultUni term, Integral a, Bounded a, Typeable a) =>
 -- See Note [Integral types as Integer].
 deriving via AsInteger Int instance
     KnownTypeAst tyname DefaultUni Int
-deriving via AsInteger Int instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Int
-instance HasConstantIn DefaultUni term => ReadKnownIn DefaultUni term Int where
+instance KnownBuiltinTypeIn DefaultUni term Integer => ReadKnownIn DefaultUni term Int where
     readKnown term = fromIntegral @Int64 @Int <$> readKnown term
     {-# INLINE readKnown #-}
 
 deriving via AsInteger Word instance
     KnownTypeAst tyname DefaultUni Word
-deriving via AsInteger Word instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Word
-instance HasConstantIn DefaultUni term => ReadKnownIn DefaultUni term Word where
+instance KnownBuiltinTypeIn DefaultUni term Integer => ReadKnownIn DefaultUni term Word where
     readKnown term = fromIntegral @Word64 @Word <$> readKnown term
     {-# INLINE readKnown #-}
 #endif
 
 deriving via AsInteger Int8 instance
     KnownTypeAst tyname DefaultUni Int8
-deriving via AsInteger Int8 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int8 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Int8
-deriving via AsInteger Int8 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int8 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Int8
 
 deriving via AsInteger Int16 instance
     KnownTypeAst tyname DefaultUni Int16
-deriving via AsInteger Int16 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int16 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Int16
-deriving via AsInteger Int16 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int16 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Int16
 
 deriving via AsInteger Int32 instance
     KnownTypeAst tyname DefaultUni Int32
-deriving via AsInteger Int32 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int32 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Int32
-deriving via AsInteger Int32 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int32 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Int32
 
 deriving via AsInteger Int64 instance
     KnownTypeAst tyname DefaultUni Int64
-deriving via AsInteger Int64 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int64 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Int64
-deriving via AsInteger Int64 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Int64 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Int64
 
 deriving via AsInteger Word8 instance
     KnownTypeAst tyname DefaultUni Word8
-deriving via AsInteger Word8 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word8 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Word8
-deriving via AsInteger Word8 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word8 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Word8
 
 deriving via AsInteger Word16 instance
     KnownTypeAst tyname DefaultUni Word16
-deriving via AsInteger Word16 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word16 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Word16
-deriving via AsInteger Word16 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word16 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Word16
 
 deriving via AsInteger Word32 instance
     KnownTypeAst tyname DefaultUni Word32
-deriving via AsInteger Word32 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word32 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Word32
-deriving via AsInteger Word32 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word32 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Word32
 
 deriving via AsInteger Word64 instance
     KnownTypeAst tyname DefaultUni Word64
-deriving via AsInteger Word64 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word64 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Word64
-deriving via AsInteger Word64 instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Word64 instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term Word64
 
 deriving newtype instance
     KnownTypeAst tyname DefaultUni NumBytesCostedAsNumWords
-deriving newtype instance HasConstantIn DefaultUni term =>
+deriving newtype instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term NumBytesCostedAsNumWords
-deriving newtype instance HasConstantIn DefaultUni term =>
+deriving newtype instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term NumBytesCostedAsNumWords
 
 deriving newtype instance
     KnownTypeAst tyname DefaultUni IntegerCostedLiterally
-deriving newtype instance HasConstantIn DefaultUni term =>
+deriving newtype instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term IntegerCostedLiterally
-deriving newtype instance HasConstantIn DefaultUni term =>
+deriving newtype instance KnownBuiltinTypeIn DefaultUni term Integer =>
     ReadKnownIn DefaultUni term IntegerCostedLiterally
 
 deriving newtype instance KnownTypeAst tyname DefaultUni a =>
@@ -491,9 +491,9 @@ deriving newtype instance KnownBuiltinTypeIn DefaultUni term [a] =>
 
 deriving via AsInteger Natural instance
     KnownTypeAst tyname DefaultUni Natural
-deriving via AsInteger Natural instance HasConstantIn DefaultUni term =>
+deriving via AsInteger Natural instance KnownBuiltinTypeIn DefaultUni term Integer =>
     MakeKnownIn DefaultUni term Natural
-instance HasConstantIn DefaultUni term => ReadKnownIn DefaultUni term Natural where
+instance KnownBuiltinTypeIn DefaultUni term Integer => ReadKnownIn DefaultUni term Natural where
     readKnown term =
         -- See Note [Performance of ReadKnownIn and MakeKnownIn instances].
         -- Funnily, we don't need 'inline' here, unlike in the default implementation of 'readKnown'

--- a/plutus-core/plutus-ir/test/PlutusCore/Generators/QuickCheck/TypesTests.hs
+++ b/plutus-core/plutus-ir/test/PlutusCore/Generators/QuickCheck/TypesTests.hs
@@ -72,7 +72,7 @@ prop_fixKind = withMaxSuccess 10000 $
 
 -- | Check that 'normalizeType' returns a normal type.
 prop_normalizedTypeIsNormal :: Property
-prop_normalizedTypeIsNormal = withMaxSuccess 10000 $
+prop_normalizedTypeIsNormal = withMaxSuccess 1000 $
   forAllDoc "k,ty" genKindAndType (shrinkKindAndType Map.empty) $ \ (_, ty) ->
     unless (isNormalType . unNormalized . runQuote $ normalizeType ty) $
       Left "'normalizeType' returned a non-normal type"

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -941,7 +941,7 @@ test_Conversion =
             , -- integerToByteString True 0 (multiplyInteger p 256) = appendByteString
               -- (integerToByteString True 0 p) (singleton 0)
               testPropertyNamed "property 5" "i2b_prop5"
-              . mapTestLimitAtLeast 99 (`div` 10) $ property Conversion.i2bProperty5
+              . mapTestLimitAtLeast 50 (`div` 20) $ property Conversion.i2bProperty5
             , -- integerToByteString False 0 (plusInteger (multiplyInteger q 256) r) =
               -- appendByteString (integerToByteString False 0 r) (integerToByteString False 0 q)
               testPropertyNamed "property 6" "i2b_prop6"
@@ -990,7 +990,7 @@ test_Bitwise =
             , testPropertyNamed "rotations move bits but don't change them" "rotate_move" $
                 mapTestLimitAtLeast 50 (`div` 20) Bitwise.rotateMoveBits
             , testPropertyNamed "rotations do not break when given minBound" "rotate_min_bound" $
-                mapTestLimitAtLeast 99 (`div` 10) Bitwise.rotateMinBound
+                mapTestLimitAtLeast 50 (`div` 20) Bitwise.rotateMinBound
             ]
         , testGroup "countSetBits"
             [ testGroup "homomorphism" Bitwise.csbHomomorphism


### PR DESCRIPTION
This replaces `HasConstantIn` constraints with `KnownBuiltinTypeIn` ones as we use the latter everywhere else. Just a quick refactoring for consistency. I've also downscaled a few slow tests.