### PR TITLE
Remove trailing whitespace in Agda code

### DIFF
--- a/plutus-metatheory/src/Algorithmic.lagda.md
+++ b/plutus-metatheory/src/Algorithmic.lagda.md
@@ -14,7 +14,7 @@ open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;trans;co
 open import Data.Empty using (⊥)
 open import Data.Fin using (Fin)
 open import Data.Product using (_×_)
-open import Data.Vec as Vec using (Vec;[];_∷_;lookup) 
+open import Data.Vec as Vec using (Vec;[];_∷_;lookup)
 open import Data.List.Properties using (foldr-++)
 
 open import Utils renaming (_×_ to _U×_; List to UList; map to umap)
@@ -101,7 +101,7 @@ data _∋_ : (Γ : Ctx Φ) → Φ ⊢Nf⋆ * → Set where
       -------------------
     → Γ ,⋆ K ∋ weakenNf A
 ```
-          
+
 ## Semantic of constant terms
 
 We define a predicate ♯Kinded for kinds that ultimately end in ♯.
@@ -112,7 +112,7 @@ data ♯Kinded : Kind → Set where
    K♯ : ∀{K J} → ♯Kinded J → ♯Kinded (K ⇒ J)
 ```
 
-There is no type of a ♯Kinded kind which takes more than two type arguments. 
+There is no type of a ♯Kinded kind which takes more than two type arguments.
 
 ```
 lemma♯Kinded : ∀ {K K₁ K₂ J} → ♯Kinded J → ∅ ⊢Ne⋆ (K₂ ⇒ (K₁ ⇒ (K ⇒ J))) → ⊥
@@ -123,7 +123,7 @@ Closed types can be mapped into the signature universe and viceversa.
 
 ```
 ty2sty : ∅ ⊢Nf⋆ ♯ → 0 ⊢♯
-ty2sty (ne (((f · _) · _) · _)) with lemma♯Kinded ♯ f 
+ty2sty (ne (((f · _) · _) · _)) with lemma♯Kinded ♯ f
 ... | ()
 ty2sty (ne ((^ pair · x) · y)) = pair (ty2sty x) (ty2sty y)
 ty2sty (ne (^ list · x)) = list (ty2sty x)
@@ -141,7 +141,7 @@ ty≅sty₁ : ∀ (A : ∅ ⊢Nf⋆ ♯) → A ≡ sty2ty (ty2sty A)
 ty≅sty₁ (ne (((f · _) · _) · _)) with  lemma♯Kinded ♯ f
 ... | ()
 ty≅sty₁ (ne ((^ pair · x) · y))  = cong ne (cong₂ _·_ (cong (^ pair ·_) (ty≅sty₁ x)) (ty≅sty₁ y))
-ty≅sty₁ (ne (^ list · x))        = cong ne (cong (^ list ·_) (ty≅sty₁ x)) 
+ty≅sty₁ (ne (^ list · x))        = cong ne (cong (^ list ·_) (ty≅sty₁ x))
 ty≅sty₁ (ne (^ (atomic x)))      = refl
 
 ty≅sty₂ : ∀ (A : 0 ⊢♯) →  A ≡ ty2sty (sty2ty A)
@@ -150,20 +150,20 @@ ty≅sty₂ (list A) = cong list (ty≅sty₂ A)
 ty≅sty₂ (pair A B) = cong₂ pair (ty≅sty₂ A) (ty≅sty₂ B)
 ```
 
-The semantics of closed types of kind ♯ is given by the following 
+The semantics of closed types of kind ♯ is given by the following
 interpretation function
 
 ```
 ⟦_⟧ : (ty : ∅ ⊢Nf⋆ ♯) → Set
-⟦ ne (((f · _) · _) · _) ⟧ with lemma♯Kinded ♯ f 
+⟦ ne (((f · _) · _) · _) ⟧ with lemma♯Kinded ♯ f
 ... | ()
 ⟦ ne ((^ pair · x) · y) ⟧ = ⟦ x ⟧ U× ⟦ y ⟧
 ⟦ ne (^ list · x) ⟧ = UList ⟦ x ⟧
 ⟦ ne (^ (atomic x)) ⟧ = ⟦ x ⟧at
 ```
 
-All these types need to be able to be interfaced with Haskell, as this 
-interpretation function is used everywhere of type or a type tag needs to be 
+All these types need to be able to be interfaced with Haskell, as this
+interpretation function is used everywhere of type or a type tag needs to be
 interpreted. It is precisely because they need to be interfaced with Haskell
 that we use the version of product and list from the Utils module.
 
@@ -171,14 +171,14 @@ that we use the version of product and list from the Utils module.
 
 A term is indexed over by its context and type.  A term is a variable,
 an abstraction, an application, a type abstraction, a type
-application, a wrapping or unwrapping of a recursive type, a constructor, 
+application, a wrapping or unwrapping of a recursive type, a constructor,
 a case expression, a constant, a builtin function, or an error.
 
 Constants of a builtin type A are given directly by its meaning ⟦ A ⟧, where
 A is restricted to kind ♯.
 
 The type of cases if a function consuming every type in a list.
-We construct it with the following function: 
+We construct it with the following function:
 ```
 mkCaseType : ∀{Φ} (A : Φ ⊢Nf⋆ *) → List (Φ ⊢Nf⋆ *) → Φ ⊢Nf⋆ *
 mkCaseType A = foldr _⇒_ A
@@ -189,7 +189,7 @@ for constructor arguments and cases.
 
 ```
 ConstrArgs : (Γ : Ctx Φ) → List (Φ ⊢Nf⋆ *) → Set
-data Cases (Γ : Ctx Φ) (B : Φ ⊢Nf⋆ *) : ∀{n} → Vec (List (Φ ⊢Nf⋆ *)) n → Set 
+data Cases (Γ : Ctx Φ) (B : Φ ⊢Nf⋆ *) : ∀{n} → Vec (List (Φ ⊢Nf⋆ *)) n → Set
 ```
 
 The actual type of terms
@@ -246,14 +246,14 @@ data _⊢_ (Γ : Ctx Φ) : Φ ⊢Nf⋆ * → Set where
   constr : ∀{n}
       → (i : Fin n)                     -- The tag
 
-      → (Tss : Vec (List (Φ ⊢Nf⋆ *)) n) -- The types of the sum of products. 
-                                        -- We make it a Vector of lists, so that 
+      → (Tss : Vec (List (Φ ⊢Nf⋆ *)) n) -- The types of the sum of products.
+                                        -- We make it a Vector of lists, so that
                                         -- the tag is statically correct.
-                                        -- We use the name `Tss` as it stands for a 
+                                        -- We use the name `Tss` as it stands for a
                                         -- a container of containers of types.
-      
+
       → ∀ {ts} → ts ≡ lookup Tss i      -- The reason to define it like this, rather than
-      → ConstrArgs Γ ts                 -- simply ConstrArgs Γ (lookup Tss i) is so that it 
+      → ConstrArgs Γ ts                 -- simply ConstrArgs Γ (lookup Tss i) is so that it
                                         -- is easier to construct terms (helps to avoid the use of subst)
                                         -- as often the result of a function will not match definitionally
                                         -- with (lookup Tss i) but only propositionally.
@@ -286,15 +286,15 @@ data _⊢_ (Γ : Ctx Φ) : Φ ⊢Nf⋆ * → Set where
 -- The type of arguments to a `constr` constructor
 ConstrArgs Γ = IList (Γ ⊢_)
 
--- Cases is indexed by a vector 
+-- Cases is indexed by a vector
 -- so it can't be an IList
-data Cases Γ B where 
+data Cases Γ B where
    []  : Cases Γ B []
    _∷_ : ∀{n}{Ts}{Tss : Vec _ n}(
-         c : Γ ⊢ (mkCaseType B Ts)) 
+         c : Γ ⊢ (mkCaseType B Ts))
        → (cs : Cases Γ B Tss)
-         --------------------- 
-       → Cases Γ B (Ts ∷ Tss) 
+         ---------------------
+       → Cases Γ B (Ts ∷ Tss)
 ```
 
 Utility functions
@@ -322,9 +322,9 @@ bwdMkCaseType : ∀{Φ} → Bwd (Φ ⊢Nf⋆ *) → (A : Φ ⊢Nf⋆ *) → Φ �
 bwdMkCaseType bs A = bwd-foldr _⇒_ A bs
 
 lemma-bwdfwdfunction' : ∀{Φ} {B : Φ ⊢Nf⋆ *} Ts → mkCaseType B Ts ≡ bwdMkCaseType ([] <>< Ts) B
-lemma-bwdfwdfunction' {B = B} Ts = trans (cong (mkCaseType B) (sym (lemma<>1 [] Ts))) (lemma-bwd-foldr _⇒_ B ([] <>< Ts))         
+lemma-bwdfwdfunction' {B = B} Ts = trans (cong (mkCaseType B) (sym (lemma<>1 [] Ts))) (lemma-bwd-foldr _⇒_ B ([] <>< Ts))
 
-constr-cong :  ∀{Γ : Ctx Φ}{n}{i : Fin n}{Tss : Vec (List (Φ ⊢Nf⋆ *)) n}{ts} 
+constr-cong :  ∀{Γ : Ctx Φ}{n}{i : Fin n}{Tss : Vec (List (Φ ⊢Nf⋆ *)) n}{ts}
             → (p : ts ≡ lookup Tss i)
             → {cs : ConstrArgs Γ ts}
             → {cs' : ConstrArgs Γ (lookup Tss i)}
@@ -332,7 +332,7 @@ constr-cong :  ∀{Γ : Ctx Φ}{n}{i : Fin n}{Tss : Vec (List (Φ ⊢Nf⋆ *)) n
             → constr i Tss refl cs' ≡ constr i Tss p cs
 constr-cong refl refl = refl
 
-constr-cong' :  ∀{Γ : Ctx Φ}{n}{i : Fin n}{A : Vec (List (Φ ⊢Nf⋆ *)) n}{ts}{ts'} 
+constr-cong' :  ∀{Γ : Ctx Φ}{n}{i : Fin n}{A : Vec (List (Φ ⊢Nf⋆ *)) n}{ts}{ts'}
             → (p : ts ≡ lookup A i)(p' : ts' ≡ lookup A i)
             → {cs : ConstrArgs Γ ts}
             → {cs' : ConstrArgs Γ ts'}

--- a/plutus-metatheory/src/Algorithmic/BehaviouralEquivalence/CCvsCK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/BehaviouralEquivalence/CCvsCK.lagda.md
@@ -45,7 +45,7 @@ open import Builtin.Constant.Type using (TyCon;aUnit)
 open TyCon
 
 open import Algorithmic.RenamingSubstitution using (_[_];_[_]⋆)
-open import Algorithmic.ReductionEC using (Frame;Value;deval;ival;BUILTIN';V-I;EC) 
+open import Algorithmic.ReductionEC using (Frame;Value;deval;ival;BUILTIN';V-I;EC)
                                     renaming (step to app;step⋆ to app⋆)
 open Frame
 open Value

--- a/plutus-metatheory/src/Algorithmic/BehaviouralEquivalence/CKvsCEK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/BehaviouralEquivalence/CKvsCEK.lagda.md
@@ -11,7 +11,7 @@ open import Data.Nat using (suc)
 open import Data.Empty using (⊥-elim)
 open import Data.Product using (∃)
 open import Data.List using ([];_∷_)
-open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;trans) 
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;trans)
                                                   renaming (subst to substEq)
 open import Data.Product using (_×_;Σ) renaming (_,_ to _,,_)
 open import Data.Sum using (_⊎_;inj₁;inj₂)
@@ -102,7 +102,7 @@ cek2ckFrame unwrap- = Red.unwrap-
 cek2ckStack : ∀{A B} → Stack A B → CK.Stack A B
 cek2ckStack ε = CK.ε
 cek2ckStack (s , f) = cek2ckStack s CK., cek2ckFrame f
- 
+
 cek2ckState : ∀{A} → State A → CK.State A
 cek2ckState (s ; ρ ▻ L) = cek2ckStack s CK.▻ cek2ckClos L ρ
 cek2ckState (s ◅ V) = cek2ckStack s CK.◅ cek2ckVal V
@@ -133,7 +133,7 @@ V-Ilem : ∀ {b}{A : ∅ ⊢Nf⋆ *}
        → (bt : Red.BApp b σA t)
        → (p : discharge (V-I b (ck2cekBApp bt)) ≡ t)
        → Red.V-I b bt ≡ subst (cek2ckVal (V-I b (ck2cekBApp bt)))
-V-Ilem bt = 
+V-Ilem bt =
 -}
 postulate ival-lem : ∀ b {A}{s : CK.Stack A _} → (s CK.◅ Red.ival b) ≡ (s CK.◅ cek2ckVal (ival b))
 --ival-lem b {s = s} = {! cong (λ z → s CK.◅ z)  !}
@@ -146,7 +146,7 @@ postulate dischargeBody-lem' : ∀{B}{Γ}{C}(M : Γ , C ⊢ B) ρ V → (dischar
 
 dischargeBody M ρ [ discharge (cek2ckVal V) ]
 = { def dischargeBody }
-sub (exts (env2sub ρ)) M [ discharge (cek2ckVal V) ] 
+sub (exts (env2sub ρ)) M [ discharge (cek2ckVal V) ]
 = { def of [_] }
 sub (sub-cons ` (discharge (cek2ckVal V)))
     (sub (exts (env2sub ρ)) (discharge (cek2ckVal V)))
@@ -177,31 +177,31 @@ postulate dischargeB-lem : ∀ {K}{A : ∅ ⊢Nf⋆ K}{B : ∅ ,⋆ K ⊢Nf⋆ *
                      {tn tm}{pt : tn ∔ suc tm ≣ fv (signature b)}
                      {an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
                      {σB : SigTy (bubble pt) pa B}
-                     {x : BApp b (Π B) (sucΠ σB)} 
-                  (s : CK.Stack C (B [ A ]Nf)) 
+                     {x : BApp b (Π B) (sucΠ σB)}
+                  (s : CK.Stack C (B [ A ]Nf))
                 → s CK.◅ Red.V-I b {σA = σB [ A ]SigTy} (Red.step⋆ (cek2ckBApp x) refl) ≡ (s CK.◅ cek2ckVal (V-I b {σA = σB [ A ]SigTy} (x $$ refl)))
 
 postulate dischargeB'-lem : ∀ {A}{C b}
                     {tn tm}{pt : tn ∔ tm ≣ fv (signature b)}
                      {an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
                      {σA : SigTy pt pa A}
-                     {x : BApp b A σA} 
-                     (s : CK.Stack C _) 
+                     {x : BApp b A σA}
+                     (s : CK.Stack C _)
                   → s CK.◅ Red.V-I b (cek2ckBApp x) ≡ (s CK.◅ cek2ckVal (V-I b x))
 
 postulate dischargeB-lem' : ∀ {A}{b}
                   {tn tm}{pt : tn ∔ tm ≣ fv (signature b)}
                     {an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
                     {σA : SigTy pt pa A}
-                    {x : BApp b A σA} 
+                    {x : BApp b A σA}
                   → dischargeB x ≡ discharge (V-I b x)
-                
+
 
 postulate dischargeB-lem'' :  ∀ {A}{b}
                   {tn tm}{pt : tn ∔ tm ≣ fv (signature b)}
                     {an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
                     {σA : SigTy pt pa A}
-                    {x : BApp b A σA} 
+                    {x : BApp b A σA}
                   → substEq Red.Value dischargeB-lem' (Red.V-I b (cek2ckBApp x)) ≡ cek2ckVal (V-I b x)
 
 
@@ -210,8 +210,8 @@ postulate dischargeB-lem'' :  ∀ {A}{b}
 postulate BUILTIN-lem : ∀ b {A}
                {tn}{pt : tn ∔ 0 ≣ fv (signature b)}
                 {an}{pa : an ∔ 0 ≣ args♯ (signature b)}
-                {σA : SigTy pt pa A}          
-              → (q : BApp b A σA) 
+                {σA : SigTy pt pa A}
+              → (q : BApp b A σA)
               → Red.BUILTIN' b (cek2ckBApp q) ≡ cek2ckClos (BUILTIN' b q) []
 
 
@@ -295,7 +295,7 @@ cek2ckFrame-·-lem (x ·-) .(cek2ckVal x) refl = _ ,, refl ,, refl ,, refl
 postulate cek2ckFrame--·lem : ∀{A B}(f : Frame B (A ⇒ B)){M : ∅ ⊢ A} → (Red.-· M) ≡ cek2ckFrame f → ∃ λ Γ → ∃ λ (M' : Γ ⊢ A) → ∃ λ (ρ : Env Γ) → f ≡ (-· M' ρ) × M ≡ cek2ckClos M' ρ
 
 postulate cek2ckFrame--·⋆lem : ∀{K A}{B : ∅ ,⋆ K ⊢Nf⋆ *}(f : Frame (B [ A ]Nf) (Π B)) → Red.-·⋆ A ≡ cek2ckFrame f → f ≡ -·⋆ A
-   
+
 postulate cek2ckFrame-unwrap-lem : ∀{K}{A}{B : ∅ ⊢Nf⋆ K}(f : Frame _ (μ A B)) → Red.unwrap- {A = A}{B = B} ≡ cek2ckFrame f → f ≡ unwrap-
 
 postulate cek2ckFrame-wrap-lem : ∀{K}{A}{B : ∅ ⊢Nf⋆ K}(f : Frame (μ A B) _) → Red.wrap- {A = A}{B = B} ≡ cek2ckFrame f → f ≡ wrap-

--- a/plutus-metatheory/src/Algorithmic/BehaviouralEquivalence/ReductionvsCC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/BehaviouralEquivalence/ReductionvsCC.lagda.md
@@ -12,10 +12,10 @@ module Algorithmic.BehaviouralEquivalence.ReductionvsCC where
 
 ```
 open import Data.Nat using (suc;zero)
-open import Relation.Binary.PropositionalEquality using (_≡_;refl;subst;inspect;cong;sym;trans) 
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;subst;inspect;cong;sym;trans)
                                                   renaming ([_] to I[_])
 open import Data.Sum using (_⊎_;inj₁;inj₂)
-open import Data.Product using (Σ;_×_;∃) 
+open import Data.Product using (Σ;_×_;∃)
                          renaming (_,_ to _,,_)
 open import Data.List using (_∷_;[])
 open import Data.Empty using (⊥;⊥-elim)
@@ -163,7 +163,7 @@ postulate lemV : ∀{A B}(M : ∅ ⊢ B)(V : Value M)(E : EC A B) → (E ▻ M) 
 {-
 lemV .(ƛ M) (V-ƛ M) E = step* refl base
 lemV .(Λ M) (V-Λ M) E = step* refl base
-lemV .(wrap _ _ _) (V-wrap V) E = step* refl (step** (lemV _ V (extEC E wrap-)) 
+lemV .(wrap _ _ _) (V-wrap V) E = step* refl (step** (lemV _ V (extEC E wrap-))
                                                      (step* (cong (stepV V) (dissect-lemma E wrap-)) base))
 lemV .(con cn) (V-con cn) E = step* refl base
 lemV M (V-I⇒ b {am = am} bt) E =  {! am  !}
@@ -214,30 +214,30 @@ unwindVE : ∀{A B C}(M : ∅ ⊢ A)(N : ∅ ⊢ B)(E : EC C B)(E' : EC B A)
       → (compEC' E E' ◅ VM) -→s (E ◅ VN)
 unwindVE A B E E' refl VM VN with dissect E' | inspect dissect E'
 ... | inj₁ refl | I[ eq ] rewrite dissect-inj₁ E' refl eq rewrite uniqueVal A VM VN = base
-... | inj₂ (_ ,, E'' ,, (V-ƛ M ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-ƛ M ·-) eq 
+... | inj₂ (_ ,, E'' ,, (V-ƛ M ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-ƛ M ·-) eq
     = ⊥-elim (lemVβ (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (V-ƛ M ·-) A) VN)))
-... | inj₂ (_ ,, E'' ,, (V-I⇒ b {am = zero} x ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-I⇒ b x ·-) eq 
+... | inj₂ (_ ,, E'' ,, (V-I⇒ b {am = zero} x ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-I⇒ b x ·-) eq
     = ⊥-elim (valred (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (V-I⇒ b x ·-) A) VN)) (β-builtin b (deval (V-I⇒ b x)) x A VM))
-... | inj₂ (_ ,, E'' ,, (V-I⇒ b {am = suc am} x ·-)) | I[ eq ]  rewrite dissect-inj₂ E' E'' (V-I⇒ b x ·-) eq  
-    = step* (trans (cong (λ E → stepV VM (dissect E)) (compEC'-extEC E E'' (V-I⇒ b x ·-))) (cong (stepV VM) (dissect-lemma (compEC' E E'') (V-I⇒ b x ·-)))) 
+... | inj₂ (_ ,, E'' ,, (V-I⇒ b {am = suc am} x ·-)) | I[ eq ]  rewrite dissect-inj₂ E' E'' (V-I⇒ b x ·-) eq
+    = step* (trans (cong (λ E → stepV VM (dissect E)) (compEC'-extEC E E'' (V-I⇒ b x ·-))) (cong (stepV VM) (dissect-lemma (compEC' E E'') (V-I⇒ b x ·-))))
             (unwindVE _ _ E E'' (extEC-[]ᴱ E'' (V-I⇒ b x ·-) A) (V-I b (step x VM)) VN)
-unwindVE .(Λ M) .(E' [ Λ M ]ᴱ) E E' refl (V-Λ M) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq 
+unwindVE .(Λ M) .(E' [ Λ M ]ᴱ) E E' refl (V-Λ M) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq
  = ⊥-elim (lemVβ⋆ (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (-·⋆ C) (Λ M)) VN)))
-unwindVE A .(E' [ A ]ᴱ) E E' refl (V-IΠ b x) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq  
- = step* (trans (cong (λ E → stepV _ (dissect E)) (compEC'-extEC E E'' (-·⋆ C))) (cong (stepV (V-IΠ b x)) (dissect-lemma (compEC' E E'') (-·⋆ C)))) (unwindVE _ _ E E'' (extEC-[]ᴱ E'' (-·⋆ C) A) (V-I b (step⋆ x refl)) VN) 
-... | inj₂ (_ ,, E'' ,, wrap-) | I[ eq ] rewrite dissect-inj₂ E' E'' wrap- eq 
+unwindVE A .(E' [ A ]ᴱ) E E' refl (V-IΠ b x) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq
+ = step* (trans (cong (λ E → stepV _ (dissect E)) (compEC'-extEC E E'' (-·⋆ C))) (cong (stepV (V-IΠ b x)) (dissect-lemma (compEC' E E'') (-·⋆ C)))) (unwindVE _ _ E E'' (extEC-[]ᴱ E'' (-·⋆ C) A) (V-I b (step⋆ x refl)) VN)
+... | inj₂ (_ ,, E'' ,, wrap-) | I[ eq ] rewrite dissect-inj₂ E' E'' wrap- eq
     = step* (trans (cong (λ E → stepV VM (dissect E)) (compEC'-extEC E E'' wrap-)) (cong (stepV VM) (dissect-lemma (compEC' E E'') wrap-))) (unwindVE _ _ E E'' (extEC-[]ᴱ E'' wrap- A) (V-wrap VM) VN)
-unwindVE _ _ E E' refl (V-wrap VM) VN | inj₂ (_ ,, E'' ,, unwrap-) | I[ eq ] rewrite dissect-inj₂ E' E'' unwrap- eq 
+unwindVE _ _ E E' refl (V-wrap VM) VN | inj₂ (_ ,, E'' ,, unwrap-) | I[ eq ] rewrite dissect-inj₂ E' E'' unwrap- eq
     = ⊥-elim (valred (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' unwrap- (deval (V-wrap VM))) VN)) (β-wrap VM refl))
 unwindVE .(ƛ M) .(E' [ ƛ M ]ᴱ) E E' refl (V-ƛ M) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq = ⊥-elim (lemVβ (lemVE (ƛ M · M') E'' (subst Value (extEC-[]ᴱ E'' (-· M') (ƛ M)) VN)))
-unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {am = zero} x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq 
+unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {am = zero} x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq
   = ⊥-elim (valred (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (-· M') A) VN)) (β-builtin b A x M' (lemVE _ (extEC E'' (V ·-)) (subst Value (trans (extEC-[]ᴱ E'' (-· M') A) (sym (extEC-[]ᴱ E'' (V ·-) M'))) VN))))
-unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {am = suc am} x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq 
-  = step* (trans (cong (λ E → stepV (V-I⇒ b x) (dissect E)) (compEC'-extEC E E'' (-· M'))) (cong (stepV (V-I⇒ b x)) (dissect-lemma (compEC' E E'') (-· M')))) 
-             (step** (lemV M' (lemVE M' (extEC E'' (V-I⇒ b x ·-)) (subst Value (trans (extEC-[]ᴱ E'' (-· M') A) (sym (extEC-[]ᴱ E'' (V-I⇒ b x ·-) M'))) VN)) (extEC (compEC' E E'') (V-I⇒ b x ·-))) 
-                     (step* (cong (stepV _) (dissect-lemma (compEC' E E'') (V-I⇒ b x ·-))) 
-                            ((unwindVE (A · M') _ E E'' (extEC-[]ᴱ E'' (-· M') A) (V-I b (step x (lemVE M' (extEC E'' (V-I⇒ b x ·-))  
-                              (subst Value (trans (extEC-[]ᴱ E'' (-· M') A)  (sym (extEC-[]ᴱ E'' (V-I⇒ b x ·-) M'))) VN)))) VN))))  
+unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {am = suc am} x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq
+  = step* (trans (cong (λ E → stepV (V-I⇒ b x) (dissect E)) (compEC'-extEC E E'' (-· M'))) (cong (stepV (V-I⇒ b x)) (dissect-lemma (compEC' E E'') (-· M'))))
+             (step** (lemV M' (lemVE M' (extEC E'' (V-I⇒ b x ·-)) (subst Value (trans (extEC-[]ᴱ E'' (-· M') A) (sym (extEC-[]ᴱ E'' (V-I⇒ b x ·-) M'))) VN)) (extEC (compEC' E E'') (V-I⇒ b x ·-)))
+                     (step* (cong (stepV _) (dissect-lemma (compEC' E E'') (V-I⇒ b x ·-)))
+                            ((unwindVE (A · M') _ E E'' (extEC-[]ᴱ E'' (-· M') A) (V-I b (step x (lemVE M' (extEC E'' (V-I⇒ b x ·-))
+                              (subst Value (trans (extEC-[]ᴱ E'' (-· M') A)  (sym (extEC-[]ᴱ E'' (V-I⇒ b x ·-) M'))) VN)))) VN))))
 
 unwindE : ∀{A B C}(M : ∅ ⊢ A)(N : ∅ ⊢ B)(E : EC C B)(E' : EC B A)
       → N ≡ E' [ M ]ᴱ
@@ -402,12 +402,12 @@ lem-→s⋆ E (β-wrap V refl) = step*
   (step** (lemV _ (V-wrap V) (extEC E unwrap-))
           (step* (cong (stepV (V-wrap V)) (dissect-lemma E unwrap-))
                  base))
-lem-→s⋆ E (β-builtin b t bt u vu) = step* 
-   refl 
+lem-→s⋆ E (β-builtin b t bt u vu) = step*
+   refl
    (step** (lemV t (V-I⇒ b bt) (extEC E (-· u)))
-           (step* (cong (stepV (V-I⇒ b bt)) (dissect-lemma E (-· u))) 
-                  (step** (lemV u vu (extEC E (V-I⇒ b bt ·-))) 
-                          (step* (cong (stepV vu) (dissect-lemma E (V-I⇒ b bt ·-))) base)))) 
+           (step* (cong (stepV (V-I⇒ b bt)) (dissect-lemma E (-· u)))
+                  (step** (lemV u vu (extEC E (V-I⇒ b bt ·-)))
+                          (step* (cong (stepV vu) (dissect-lemma E (V-I⇒ b bt ·-))) base))))
 
 {-
 lemmaF : ∀{A A' B B'}(M : ∅ ⊢ A)(F : Frame B A)(E : EC B' B)

--- a/plutus-metatheory/src/Algorithmic/CC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CC.lagda.md
@@ -12,9 +12,9 @@ module Algorithmic.CC where
 
 ```
 open import Data.Nat using (suc)
-open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;trans;cong) 
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;trans;cong)
 open import Data.Sum using (_⊎_;inj₁;inj₂)
-open import Data.Product using (Σ;_×_;∃) 
+open import Data.Product using (Σ;_×_;∃)
                          renaming (_,_ to _,,_)
 open import Data.List using (_∷_;[])
 open import Data.Vec as Vec using (_∷_;[];lookup)
@@ -51,10 +51,10 @@ dissect (wrap E) with dissect E
 dissect (unwrap E / refl) with dissect E
 ... | inj₁ refl           = inj₂ (_ ,, [] ,, unwrap-)
 ... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, unwrap E' / refl ,, F)
-dissect (constr i Tss p {tidx} vs ts E) with dissect E 
+dissect (constr i Tss p {tidx} vs ts E) with dissect E
 ... | inj₁ refl           = inj₂ (_ ,, ([] ,, (constr- i Tss p {tidx} vs ts)))
 ... | inj₂ (C ,, E' ,, F) = inj₂ (_ ,, ((constr i Tss p {tidx} vs ts E') ,, F))
-dissect (case cs E)  with dissect E 
+dissect (case cs E)  with dissect E
 ... | inj₁ refl           = inj₂ (_ ,, ([] ,, (case- cs)))
 ... | inj₂ (C ,, E' ,, F) = inj₂ (_ ,, ((case cs E') ,, F))
 
@@ -104,26 +104,26 @@ stepV : ∀{A B }{M : ∅ ⊢ A}(V : Value M)
        → (B ≡ A) ⊎ ∃ (λ C → EC B C × Frame C A)
        → State B
 stepV V (inj₁ refl) = □ V
-stepV V (inj₂ (_ ,, E ,, (-· N))) = extEC E (V ·-) ▻ N 
+stepV V (inj₂ (_ ,, E ,, (-· N))) = extEC E (V ·-) ▻ N
 stepV V (inj₂ (_ ,, E ,, -·v V')) = stepV V' (inj₂ (_ ,, E ,, (V ·-)))
 stepV V (inj₂ (_ ,, E ,, (V-ƛ M ·-))) = E ▻ (M [ deval V ])
-stepV V (inj₂ (_ ,, E ,, V-I⇒ b {am = 0} q ·-)) = 
+stepV V (inj₂ (_ ,, E ,, V-I⇒ b {am = 0} q ·-)) =
           E ▻ BUILTIN' b (step q V)
-stepV V (inj₂ (_ ,, E ,, V-I⇒ b {am = suc am} q ·-)) = 
+stepV V (inj₂ (_ ,, E ,, V-I⇒ b {am = suc am} q ·-)) =
           E ◅ V-I b (step q V)
 stepV (V-Λ M) (inj₂ (_ ,, E ,, -·⋆ A)) = E ▻ (M [ A ]⋆)
-stepV (V-IΠ b  {σA = σ} q) (inj₂ (_ ,, E ,, -·⋆ A)) = 
+stepV (V-IΠ b  {σA = σ} q) (inj₂ (_ ,, E ,, -·⋆ A)) =
           E ◅ V-I b (step⋆ q refl {σ [ A ]SigTy})
 stepV V (inj₂ (_ ,, E ,, wrap-)) = E ◅ V-wrap V
 stepV (V-wrap V) (inj₂ (_ ,, E ,, unwrap-)) = E ▻ deval V -- E ◅ V
-stepV V (inj₂ (_ ,, E ,, constr- i Tss p vs ts)) with Vec.lookup Tss i in eq  
-stepV V (inj₂ (_ ,, E ,, constr- i _ refl {tidx} vs ts)) | [] with no-empty-≣-<>> tidx 
+stepV V (inj₂ (_ ,, E ,, constr- i Tss p vs ts)) with Vec.lookup Tss i in eq
+stepV V (inj₂ (_ ,, E ,, constr- i _ refl {tidx} vs ts)) | [] with no-empty-≣-<>> tidx
 ... | ()
-stepV V (inj₂ (_ ,, E ,, constr- {Vs = Vs} {H} i _ refl {r}{tidx} vs [])) | _ ∷ _  = 
+stepV V (inj₂ (_ ,, E ,, constr- {Vs = Vs} {H} i _ refl {r}{tidx} vs [])) | _ ∷ _  =
      E ◅ V-constr i _ (sym eq) (sym (trans (cong ([] <><_) (lem-≣-<>> r)) (lemma<>2 Vs (H ∷ [])))) (vs :< V) refl
-stepV V (inj₂ (_ ,, E ,, constr- {Vs = Vs} i A refl {r} vs (t ∷ ts))) | _ ∷ _  
+stepV V (inj₂ (_ ,, E ,, constr- {Vs = Vs} i A refl {r} vs (t ∷ ts))) | _ ∷ _
     = extEC E (constr- i A (sym eq) {bubble r} (vs :< V) ts) ▻ t
-stepV (V-constr e Tss refl refl vs x) (inj₂ (_ ,, E ,, case- cs)) = 
+stepV (V-constr e Tss refl refl vs x) (inj₂ (_ ,, E ,, case- cs)) =
     extValueFrames E vs (lemma-bwdfwdfunction' (Vec.lookup Tss e)) ▻ lookupCase e cs
 
 stepT : ∀{A} → State A → State A
@@ -133,17 +133,17 @@ stepT (E ▻ Λ M) = E ◅ V-Λ M
 stepT (E ▻ (M ·⋆ A / refl)) = extEC E (-·⋆ A) ▻ M
 stepT (E ▻ wrap A B M) = extEC E wrap- ▻ M
 stepT (E ▻ unwrap M refl) = extEC E unwrap- ▻ M
-stepT (E ▻ constr e Tss refl z)  with Vec.lookup Tss e in eq  
+stepT (E ▻ constr e Tss refl z)  with Vec.lookup Tss e in eq
 stepT (E ▻ constr e Tss refl []) | [] = E ◅ V-constr e Tss (sym eq) refl [] refl
-stepT (E ▻ constr e Tss refl (x ∷ xs)) | a ∷ as = 
+stepT (E ▻ constr e Tss refl (x ∷ xs)) | a ∷ as =
         extEC E (constr- e Tss (sym eq) {start} [] xs) ▻  x
 stepT (E ▻ case M cases) = extEC E (case- cases) ▻ M
 stepT (E ▻ con c refl) = E ◅ V-con c
 stepT (E ▻ (builtin b / refl)) = E ◅ ival b
-stepT (E ▻ error A) = ◆ A 
+stepT (E ▻ error A) = ◆ A
 stepT (E ◅ V) = stepV V (dissect E)
 stepT (□ V) = □ V
-stepT (◆ A) = ◆ A 
+stepT (◆ A) = ◆ A
 ```
 
 ```

--- a/plutus-metatheory/src/Algorithmic/CEK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CEK.lagda.md
@@ -13,10 +13,10 @@ open import Agda.Builtin.String using (primStringFromList; primStringAppend; pri
 open import Data.Fin using (Fin;zero;suc)
 open import Data.Vec as Vec using (Vec;[];_∷_)
 open import Function using (_∘_)
-open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;trans) 
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;trans)
 open import Data.Unit using (⊤;tt)
 open import Data.Sum using (_⊎_;inj₁;inj₂)
-open import Data.Integer using (_<?_;_+_;_-_;∣_∣;_≤?_;_≟_;ℤ) 
+open import Data.Integer using (_<?_;_+_;_-_;∣_∣;_≤?_;_≟_;ℤ)
                          renaming (_*_ to _**_)
 open import Data.Bool using (true;false)
 open import Relation.Nullary using (no;yes)
@@ -45,7 +45,7 @@ open TyCon
 open import Builtin.Signature using (Sig;sig;Args;args♯;fv) renaming (_⊢♯ to _⊢b♯)
 open Sig
 
-open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π 
+open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π
     using (sig2type;⊢♯2TyNe♯;SigTy;sig2SigTy;saturatedSigTy;convSigTy)
 open SigTy
 ```
@@ -53,14 +53,14 @@ open SigTy
 ````
 data Env : Ctx ∅ → Set
 
-data BApp (b : Builtin) : 
+data BApp (b : Builtin) :
     ∀{tn tm tt} → {pt : tn ∔ tm ≣ tt}
   → ∀{an am at} → {pa : an ∔ am ≣ at}
   → (A : ∅ ⊢Nf⋆ *) → SigTy pt pa A → Set
 
 data Value : (A : ∅ ⊢Nf⋆ *) → Set
 
-VList : Bwd (∅ ⊢Nf⋆ *) → Set 
+VList : Bwd (∅ ⊢Nf⋆ *) → Set
 VList = IBwd Value
 
 data Value where
@@ -81,18 +81,18 @@ data Value where
    → Value (μ A B)
 
   V-con : ∀{A : ∅ ⊢Nf⋆ ♯}
-    → ⟦ A ⟧ 
+    → ⟦ A ⟧
     → Value (con A)
 
   V-I⇒ : ∀ b {A B}{tn}
-       → {pt : tn ∔ 0 ≣ fv (signature b)} 
+       → {pt : tn ∔ 0 ≣ fv (signature b)}
        → ∀{an am}{pa : an ∔ (suc am) ≣ args♯ (signature b)}
        → {σB : SigTy pt (bubble pa) B}
        → BApp b (A ⇒ B) (A B⇒ σB)
        → Value (A ⇒ B)
 
   V-IΠ : ∀ b {K}{B : ∅ ,⋆ K ⊢Nf⋆ *}
-       → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)} 
+       → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)}
        → ∀{an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
        → {σB : SigTy (bubble pt) pa B}
        → BApp b (Π B) (sucΠ σB)
@@ -102,14 +102,14 @@ data Value where
 data BApp b where
   base : BApp b (sig2type (signature b)) (sig2SigTy (signature b))
   _$_ : ∀{A B}{tn}
-    → {pt : tn ∔ 0 ≣ fv (signature b)} 
+    → {pt : tn ∔ 0 ≣ fv (signature b)}
     → ∀{an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
     → {σB : SigTy pt (bubble pa) B}
     → BApp b (A ⇒ B) (A B⇒ σB)
-    → Value A 
+    → Value A
     → BApp b B σB
   _$$_ : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ * }{C}
-    → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)} 
+    → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)}
     → ∀{an am}{pa : an ∔ (suc am) ≣ args♯ (signature b)}
     → {σB : SigTy (bubble pt) pa B}
     → BApp b (Π B) (sucΠ σB)
@@ -120,8 +120,8 @@ data BApp b where
 
 infixl 4 _$_
 infixl 4 _$$_
-pattern Λ̂ A = _$$_ base {A = A} refl 
-pattern _●_ bapp B = _$$_ bapp {A = B} refl 
+pattern Λ̂ A = _$$_ base {A = A} refl
+pattern _●_ bapp B = _$$_ bapp {A = B} refl
 ```
 
 ## Environments
@@ -166,7 +166,7 @@ dischargeBody⋆ {A = A} M ρ = conv⊢
 dischargeB : ∀{b : Builtin}
           → ∀{tn tm} → {pt : tn ∔ tm ≣ fv (signature b)}
           → ∀{an am} → {pa : an ∔ am ≣ args♯ (signature b)}
-          → ∀{C} → {Cb : SigTy pt pa C} → (bp : BApp b C Cb) 
+          → ∀{C} → {Cb : SigTy pt pa C} → (bp : BApp b C Cb)
           → ∅ ⊢ C
 dischargeB {b} base = builtin b / refl
 dischargeB (bt $ x) = dischargeB bt · discharge x
@@ -184,8 +184,8 @@ discharge (V-Λ M ρ)  = Λ (dischargeBody⋆ M ρ)
 discharge (V-wrap V) = wrap _ _ (discharge V)
 discharge (V-con c)  = con c refl
 discharge (V-I⇒ b bt) = dischargeB bt
-discharge (V-IΠ b bt) = dischargeB bt 
-discharge (V-constr i Tss s refl) = constr i Tss refl (dischargeStack s) 
+discharge (V-IΠ b bt) = dischargeB bt
+discharge (V-constr i Tss s refl) = constr i Tss refl (dischargeStack s)
 ```
 
 ## Builtin Semantics
@@ -242,7 +242,7 @@ BUILTIN appendString (base $ V-con s $ V-con s') = inj₂ (V-con (primStringAppe
 BUILTIN trace (Λ̂ A $ V-con s $  v) =  inj₂ (TRACE s v)
 BUILTIN iData (base $ V-con i) = inj₂ (V-con (iDATA i))
 BUILTIN bData (base $ V-con b) = inj₂ (V-con (bDATA b))
-BUILTIN consByteString (base $ V-con i $ V-con b) with cons i b 
+BUILTIN consByteString (base $ V-con i $ V-con b) with cons i b
 ... | just b' = inj₂ (V-con b')
 ... | nothing = inj₁ (con (ne (^ (atomic aBytestring))))
 BUILTIN sliceByteString (base $ V-con st $ V-con n $ V-con b) = inj₂ (V-con (slice st n b))
@@ -257,7 +257,7 @@ BUILTIN unIData (base $ V-con (iDATA i)) = inj₂ (V-con i)
 BUILTIN unIData (base $ V-con _) = inj₁ (con (ne (^ (atomic aData))))
 BUILTIN unBData (base $ V-con (bDATA b)) = inj₂ (V-con b)
 BUILTIN unBData (base $ V-con _) = inj₁ (con (ne (^ (atomic aData))))
-BUILTIN unConstrData (base $ V-con (ConstrDATA i xs)) = inj₂ (V-con (i ,, xs)) 
+BUILTIN unConstrData (base $ V-con (ConstrDATA i xs)) = inj₂ (V-con (i ,, xs))
 BUILTIN unConstrData (base $ V-con _) = inj₁ (con (ne (^ (atomic aData))))
 BUILTIN unMapData (base $ V-con (MapDATA x)) = inj₂ (V-con x)
 BUILTIN unMapData (base $ V-con _) =  inj₁ (con (ne (^ (atomic aData))))
@@ -269,7 +269,7 @@ BUILTIN mkNilPairData (base $ V-con _) = inj₂ (V-con [])
 BUILTIN chooseUnit (Λ̂ A $ x $ V-con _) = inj₂ x
 BUILTIN equalsData (base $ V-con d $ V-con d') = inj₂ (V-con (eqDATA d d'))
 BUILTIN mkPairData (base $ V-con x $ V-con y) = inj₂ (V-con (x ,, y))
-BUILTIN constrData (base $ V-con i $ V-con xs) = inj₂ (V-con (ConstrDATA i xs)) 
+BUILTIN constrData (base $ V-con i $ V-con xs) = inj₂ (V-con (ConstrDATA i xs))
 BUILTIN mapData (base $ V-con xs) = inj₂ (V-con (MapDATA xs))
 BUILTIN listData (base $ V-con xs) = inj₂ (V-con (ListDATA xs))
 BUILTIN fstPair (Λ̂ A ● B $ V-con (x ,, _)) = inj₂ (V-con x)
@@ -284,7 +284,7 @@ BUILTIN headList (Λ̂ A $ V-con (x ∷ _)) = inj₂ (V-con x)
 BUILTIN tailList (Λ̂ A $ V-con []) = inj₁ (con (ne ((^ list) · A)))
 BUILTIN tailList (Λ̂ A $ V-con (_ ∷ xs)) = inj₂ (V-con xs)
 BUILTIN nullList (Λ̂ B $ V-con []) = inj₂ (V-con true)
-BUILTIN nullList (Λ̂ B $ V-con (_ ∷ _)) = inj₂ (V-con false) 
+BUILTIN nullList (Λ̂ B $ V-con (_ ∷ _)) = inj₂ (V-con false)
 BUILTIN chooseData (Λ̂ A $ V-con (ConstrDATA _ _) $ c $ _ $ _ $ _ $ _) = inj₂ c
 BUILTIN chooseData (Λ̂ A $ V-con (MapDATA _)      $ _ $ m $ _ $ _ $ _) = inj₂ m
 BUILTIN chooseData (Λ̂ A $ V-con (ListDATA _)     $ _ $ _ $ l $ _ $ _) = inj₂ l
@@ -329,7 +329,7 @@ BUILTIN readBit (base $ V-con s $ V-con i) with readBIT s i
 BUILTIN writeBits (base $ V-con s $ V-con ps $ V-con us) with writeBITS s (toList ps) (toList us)
 ... | just r = inj₂ (V-con r)
 ... | nothing  = inj₁ (con (ne (^ (atomic aBytestring))))
-BUILTIN replicateByte (base  $ V-con l $ V-con w) with replicateBYTE l w 
+BUILTIN replicateByte (base  $ V-con l $ V-con w) with replicateBYTE l w
 ... | just r = inj₂ (V-con r)
 ... | nothing  = inj₁ (con (ne (^ (atomic aBytestring))))
 BUILTIN shiftByteString (base $ V-con s $ V-con i) = inj₂ (V-con (shiftBYTESTRING s i))
@@ -365,7 +365,7 @@ data Error : ∅ ⊢Nf⋆ * → Set where
   E-error : (A : ∅ ⊢Nf⋆ *) → Error A
 ```
 
-## Frames 
+## Frames
 
 ```
 data Frame : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
@@ -382,10 +382,10 @@ data Frame : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
   unwrap- : ∀{K}{A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}{B : ∅ ⊢Nf⋆ K}
     → Frame (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B))
             (μ A B)
-  constr- : ∀{Γ n Vs H Ts} 
-          → (i : Fin n) 
-          → (Tss : Vec _ n) 
-          → Env Γ 
+  constr- : ∀{Γ n Vs H Ts}
+          → (i : Fin n)
+          → (Tss : Vec _ n)
+          → Env Γ
           → ∀{Xs} → (Xs ≡ Vec.lookup Tss i)
           → {tidx : Xs ≣ Vs <>> (H ∷ Ts)} → VList Vs → ConstrArgs Γ Ts
           → Frame (SOP Tss) H
@@ -402,7 +402,7 @@ data State (T : ∅ ⊢Nf⋆ *) : Set where
   ◆     : ∅ ⊢Nf⋆ * → State T
 
 ival : ∀(b : Builtin) → Value (btype b)
-ival b = V-I b base 
+ival b = V-I b base
 
 pushValueFrames : ∀{T H Bs Xs} → Stack T H → VList Bs → Xs ≡ bwdMkCaseType Bs H → Stack T Xs
 pushValueFrames s [] refl = s
@@ -419,7 +419,7 @@ step (s ; ρ ▻ unwrap L refl) = (s , unwrap-) ; ρ ▻ L
 step (s ; ρ ▻ con c refl) = s ◅ V-con c
 step (s ; ρ ▻ (builtin b / refl)) = s ◅ ival b
 step (s ; ρ ▻ error A) = ◆ A
-step (s ; ρ ▻ constr e Tss refl as) with Vec.lookup Tss e in eq 
+step (s ; ρ ▻ constr e Tss refl as) with Vec.lookup Tss e in eq
 step (s ; ρ ▻ constr e Tss refl []) | []  = s ◅ V-constr e Tss [] (cong ([] <><_) (sym eq))
 step (_;_▻_ {Γ} s ρ (constr e Tss refl (_∷_ {xty} {xsty} x xs))) | _ ∷ _ = (s , constr- e Tss ρ (sym eq) {start} [] xs) ; ρ ▻ x
 step (s ; ρ ▻ case t ts) = (s , case- ρ ts) ; ρ ▻ t
@@ -433,14 +433,14 @@ step ((s , -·⋆ A) ◅ V-Λ M ρ) = s ; ρ ▻ (M [ A ]⋆)
 step ((s , -·⋆ A) ◅ V-IΠ b {σB = σ} bapp) = s ◅ V-I b (_$$_ bapp refl {σ [ A ]SigTy})
 step ((s , wrap-) ◅ V) = s ◅ V-wrap V
 step ((s , unwrap-) ◅ V-wrap V) = s ◅ V
-step ((s , constr- i Tss ρ refl {tidx} vs ts) ◅ v) 
+step ((s , constr- i Tss ρ refl {tidx} vs ts) ◅ v)
     with Vec.lookup Tss i in eq
 ... | [] with no-empty-≣-<>> tidx
 ... | ()
-step ((s , constr- i Tss ρ refl {r} vs []) ◅ v) | A ∷ As  = s ◅ V-constr i Tss (vs :< v) 
+step ((s , constr- i Tss ρ refl {r} vs []) ◅ v) | A ∷ As  = s ◅ V-constr i Tss (vs :< v)
                  (sym (trans (cong ([] <><_) (trans eq (lem-≣-<>> r))) (lemma<>2 _ (_ ∷ []))))
-step ((s , constr- i Tss ρ refl {r} vs (t ∷ ts)) ◅ v) | A ∷ As = (s , constr- i Tss ρ (sym eq) {bubble r} (vs :< v) ts) ; ρ ▻ t 
-step {t} ((s , case- ρ cases) ◅ V-constr e Tss vs refl) = pushValueFrames s vs (lemma-bwdfwdfunction' (Vec.lookup Tss e)) ; ρ ▻ (lookupCase e cases) 
+step ((s , constr- i Tss ρ refl {r} vs (t ∷ ts)) ◅ v) | A ∷ As = (s , constr- i Tss ρ (sym eq) {bubble r} (vs :< v) ts) ; ρ ▻ t
+step {t} ((s , case- ρ cases) ◅ V-constr e Tss vs refl) = pushValueFrames s vs (lemma-bwdfwdfunction' (Vec.lookup Tss e)) ; ρ ▻ (lookupCase e cases)
 step (□ V) = □ V
 step (◆ A) = ◆ A
 

--- a/plutus-metatheory/src/Algorithmic/CK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CK.lagda.md
@@ -35,7 +35,7 @@ open _⊢_
 
 open import Algorithmic.Signature using (_[_]SigTy)
 open import Algorithmic.RenamingSubstitution using (_[_];_[_]⋆)
-open import Algorithmic.ReductionEC using (Frame;Value;deval;ival;BUILTIN';V-I;VList;[];_[_]ᶠ) 
+open import Algorithmic.ReductionEC using (Frame;Value;deval;ival;BUILTIN';V-I;VList;[];_[_]ᶠ)
                                     renaming (step to app;step⋆ to app⋆)
 open Frame
 open Value
@@ -82,7 +82,7 @@ step (s ▻ (L ·⋆ A / refl))                    = (s , -·⋆ A) ▻ L
 step (s ▻ wrap A B L)                         = (s , wrap-) ▻ L
 step (s ▻ unwrap L refl)                      = (s , unwrap-) ▻ L
 step (s ▻ con cn refl)                        = s ◅ V-con cn
-step (s ▻ constr e Tss refl xs) with Vec.lookup Tss e in eq 
+step (s ▻ constr e Tss refl xs) with Vec.lookup Tss e in eq
 step (s ▻ constr e Tss refl []) | []          = s ◅ V-constr e Tss (sym eq) refl [] refl
 step (s ▻ constr e Tss refl (x ∷ xs)) | _ ∷ _ = (s , constr- e Tss (sym eq) {tidx = start} [] xs) ▻ x
 step (s ▻ case t ts)                          = (s , case- ts) ▻ t
@@ -94,17 +94,17 @@ step ((s , (V-ƛ t ·-)) ◅ V)                   = s ▻ (t [ discharge V ])
 step ((s , (-·⋆ A)) ◅ V-Λ t)                  = s ▻ (t [ A ]⋆)
 step ((s , wrap-) ◅ V)                        = s ◅ (V-wrap V)
 step ((s , unwrap-) ◅ V-wrap V)               = s ▻ deval V
-step ((s , constr- i Tss refl {tidx} vs ts) ◅ v) with Vec.lookup Tss i in eq 
-... | []   with no-empty-≣-<>> tidx 
-...      | () 
-step ((s , constr- {n} {Vs} {H} i Tss refl {tidx}{tvs} vs []) ◅ v) | _ ∷ _  = s ◅  
+step ((s , constr- i Tss refl {tidx} vs ts) ◅ v) with Vec.lookup Tss i in eq
+... | []   with no-empty-≣-<>> tidx
+...      | ()
+step ((s , constr- {n} {Vs} {H} i Tss refl {tidx}{tvs} vs []) ◅ v) | _ ∷ _  = s ◅
    V-constr i Tss
-            (sym eq) 
+            (sym eq)
             (trans (sym (lemma<>2 Vs (H ∷ []))) (sym (cong ([] <><_) (lem-≣-<>> tidx))))
-            {tvs :< deval v} 
+            {tvs :< deval v}
             (vs :< v)
             refl
-step ((s , constr- i Tss refl {r} vs (t ∷ ts)) ◅ v) | _ ∷ _ = 
+step ((s , constr- i Tss refl {r} vs (t ∷ ts)) ◅ v) | _ ∷ _ =
       (s , constr- i Tss (sym eq) {bubble r} (vs :< v) ts) ▻ t
 step ((s , case- cs) ◅ V-constr e Tss refl refl vs x) = pushValueFrames s vs (lemma-bwdfwdfunction' (Vec.lookup Tss e)) ▻ lookupCase e cs
 step (s ▻ (builtin b / refl))                 = s ◅ ival b
@@ -115,7 +115,7 @@ step (□ V)                                    = □ V
 step (◆ A)                                    = ◆ A
 
 
- 
+
 stepper : ℕ → ∀{T}
   → State T
   → Either RuntimeError (State T)

--- a/plutus-metatheory/src/Algorithmic/Completeness.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Completeness.lagda.md
@@ -9,8 +9,8 @@ open import Data.Nat using (zero;suc)
 open import Data.Fin using (Fin)
 open import Data.Vec using (Vec;[];_∷_;lookup) renaming (map to vmap)
 open import Data.List.NonEmpty using (_∷_;toList)
-open import Relation.Binary.PropositionalEquality using (_≡_;refl;cong;sym;trans;cong₂) 
-                                                  renaming (subst to substEq) 
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;cong;sym;trans;cong₂)
+                                                  renaming (subst to substEq)
 open Relation.Binary.PropositionalEquality.≡-Reasoning
 open import Function using (_∘_)
 open import Data.Product using (_×_) renaming (_,_ to _,,_)
@@ -112,13 +112,13 @@ lemσ σ C _ refl q = trans
 nfList : ∀{Δ} → List (Δ ⊢⋆ *) → List (Δ ⊢Nf⋆ *)
 nfList []       = []
 nfList (A ∷ As) = nf A ∷ nfList As
- 
+
 ```
 
 We need to prove that the type of a builtin `b` for the Algorithmic system is the same as normalising the type
 of the Declarative system
            Norm.btype b ≡ nf (Syn.btype b)
-           
+
 This involves doing an analogous proof for every function in the definition of btype
 
 ```
@@ -127,7 +127,7 @@ subNf-sub∅ {Φ} A = begin
           nf (sub∅ A)
         ≡⟨⟩
           nf (sub (λ ()) A)
-        ≡⟨ cong nf (sub-cong (λ ()) A) ⟩  
+        ≡⟨ cong nf (sub-cong (λ ()) A) ⟩
           nf (sub (embNf ∘ λ ()) A)
         ≡⟨ subNf-nf ((λ ())) A ⟩
           subNf (λ ()) (nf A)
@@ -160,22 +160,22 @@ sig2typeΠ-lem {zero} {zero} p = p
 sig2typeΠ-lem {zero} {suc n♯} {t} refl = sig2typeΠ-lem {_} {n♯} (cong Π (sym (reifyCR (idext exte-lem t))))
 sig2typeΠ-lem {suc n} {n♯} {t} refl = sig2typeΠ-lem {n} (cong Π (sym (reifyCR (idext exte-lem t))))
 
-sig2type-lem : ∀ s → Norm.sig2type s ≡ nf (Syn.sig2type s) 
+sig2type-lem : ∀ s → Norm.sig2type s ≡ nf (Syn.sig2type s)
 sig2type-lem (sig zero zero a r) = sig2type⇒-lem (toList a) (mkTy-lem r)
 
 sig2type-lem (sig zero (suc n) (head ∷ tail) r) = sig2typeΠ-lem {t = Π (Syn.sig2type⇒ tail (Syn.mkTy head ⇒ Syn.mkTy r))}
                   {Π (Norm.sig2type⇒ tail (Norm.mkTy head ⇒ Norm.mkTy r))}
-                  (cong Π (trans (sig2type⇒-lem {zero} {suc n} {Norm.mkTy r} {Syn.mkTy r} (head ∷ tail) (mkTy-lem r)) 
+                  (cong Π (trans (sig2type⇒-lem {zero} {suc n} {Norm.mkTy r} {Syn.mkTy r} (head ∷ tail) (mkTy-lem r))
                                  (sym (reifyCR (idext exte-lem (Syn.sig2type⇒ tail (Syn.mkTy head ⇒ Syn.mkTy r)))))
-                   )) 
+                   ))
 sig2type-lem (sig (suc n) n♯ (head ∷ tail) r) = sig2typeΠ-lem {t = Π (Syn.sig2type⇒ tail (Syn.mkTy head ⇒ Syn.mkTy r))}
                   {Π (Norm.sig2type⇒ tail (Norm.mkTy head ⇒ Norm.mkTy r))}
-                  (cong Π (trans (sig2type⇒-lem {suc n} {n♯} {Norm.mkTy r} {Syn.mkTy r} (head ∷ tail) (mkTy-lem r)) 
+                  (cong Π (trans (sig2type⇒-lem {suc n} {n♯} {Norm.mkTy r} {Syn.mkTy r} (head ∷ tail) (mkTy-lem r))
                                  (sym (reifyCR (idext exte-lem (Syn.sig2type⇒ tail (Syn.mkTy head ⇒ Syn.mkTy r)))))
-                   )) 
+                   ))
 
 btype-lem : ∀ {Φ} b → Norm.btype {Φ} b ≡ nf (Syn.btype b)
-btype-lem b = begin 
+btype-lem b = begin
         Norm.btype b
       ≡⟨⟩
         subNf∅ (Norm.sig2type (signature b))
@@ -192,26 +192,26 @@ btype-lem b = begin
 nfType : ∀{Φ Γ}
   → {A : Φ ⊢⋆ *}
   → Γ Syn.⊢ A
-  → nfCtx Γ Norm.⊢ nf A  
+  → nfCtx Γ Norm.⊢ nf A
 
-nfType-ConstrArgs : ∀ {Φ} {Γ : Syn.Ctx Φ} 
+nfType-ConstrArgs : ∀ {Φ} {Γ : Syn.Ctx Φ}
                   {Ts : List (Φ ⊢⋆ *)}
-                → (cs : Syn.ConstrArgs Γ Ts) 
+                → (cs : Syn.ConstrArgs Γ Ts)
                 → Norm.ConstrArgs (nfCtx Γ) (eval-List Ts (idEnv Φ))
 nfType-ConstrArgs [] = []
 nfType-ConstrArgs (c ∷ cs) = (nfType c) ∷ (nfType-ConstrArgs cs)
 
-lemma-mkCaseType : ∀{Φ}{B} As → 
+lemma-mkCaseType : ∀{Φ}{B} As →
    nf (Syn.mkCaseType B As) ≡ Norm.mkCaseType (nf B) (eval-List As (idEnv Φ))
 lemma-mkCaseType [] = refl
 lemma-mkCaseType (A ∷ As) = cong (eval A (idEnv _) ⇒_) (lemma-mkCaseType As)
 
 nfType-Cases : ∀ {Φ} {Γ : Syn.Ctx Φ} {A : Φ ⊢⋆ *} {n}
-                 {Tss : Vec (List (Φ ⊢⋆ *)) n} 
+                 {Tss : Vec (List (Φ ⊢⋆ *)) n}
                  (cases : Syn.Cases Γ A Tss) →
                Norm.Cases (nfCtx Γ) (nf A) (eval-VecList Tss (idEnv Φ))
 nfType-Cases Syn.[] = Norm.[]
-nfType-Cases (Syn._∷_ {Ts = Ts} c cases) = substEq (nfCtx _ Norm.⊢_) (lemma-mkCaseType Ts)  (nfType c) 
+nfType-Cases (Syn._∷_ {Ts = Ts} c cases) = substEq (nfCtx _ Norm.⊢_) (lemma-mkCaseType Ts)  (nfType c)
                                            Norm.∷ (nfType-Cases cases)
 
 nfType (Syn.` α) = Norm.` (nfTyVar α)

--- a/plutus-metatheory/src/Algorithmic/Erasure.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Erasure.lagda.md
@@ -36,7 +36,7 @@ open import Utils using (Kind;*;Maybe;nothing;just;fromList;map-cong)
 open import Utils.List using (List;IList;[];_∷_;map)
 open import RawU using (TmCon;tmCon;TyTag)
 open import Builtin.Signature using (_⊢♯)
-open _⊢♯ 
+open _⊢♯
 open import Builtin.Constant.Type
 
 open import Type using (Ctx⋆;∅;_,⋆_;_⊢⋆_;_∋⋆_;S;Z)
@@ -78,7 +78,7 @@ erase : ∀{Φ Γ}{A : Φ ⊢Nf⋆ *} → Γ ⊢ A → len Γ ⊢
 
 erase-ConstrArgs : ∀ {Φ} {Γ : Ctx Φ}
                {Ts : List (Φ ⊢Nf⋆ *)}
-               (cs : ConstrArgs Γ Ts) 
+               (cs : ConstrArgs Γ Ts)
           → List (len Γ ⊢)
 erase-ConstrArgs [] = []
 erase-ConstrArgs (c ∷ cs) = (erase c) ∷ (erase-ConstrArgs cs)
@@ -88,10 +88,10 @@ erase-Cases : ∀ {Φ} {Γ : Ctx Φ} {A : Φ ⊢Nf⋆ *} {n}
                 (cs : Cases Γ A Tss) →
               List (len Γ ⊢)
 erase-Cases [] = []
-erase-Cases (c ∷ cs) = (erase c) ∷ (erase-Cases cs) 
+erase-Cases (c ∷ cs) = (erase c) ∷ (erase-Cases cs)
 
 erase (` α)                  = ` (eraseVar α)
-erase (ƛ t)                  = ƛ (erase t) 
+erase (ƛ t)                  = ƛ (erase t)
 erase (t · u)                = erase t · erase u
 erase (Λ t)                  = delay (erase t)
 erase (t ·⋆ A / refl)        = force (erase t)
@@ -155,7 +155,7 @@ lemVar : ∀{X X'}(p : X ≡ X')(x : X) →  ` (subst id p x) ≡ subst _⊢ p (
 lemVar refl x = refl
 
 lemƛ : ∀{X X'}(p : X ≡ X')(q : Maybe X ≡ Maybe X')(t : Maybe X ⊢)
-  → ƛ (subst _⊢ q t) ≡ subst _⊢ p (ƛ t)  
+  → ƛ (subst _⊢ q t) ≡ subst _⊢ p (ƛ t)
 lemƛ refl refl t = refl
 
 lem· : ∀{X X'}(p : X ≡ X')(t u : X ⊢) → subst _⊢ p t · subst _⊢ p u ≡ subst _⊢ p (t · u)
@@ -183,7 +183,7 @@ lemConstr e (x ∷ xs) refl = cong (constr e) (cong (x ∷_) (sym (map-id xs)))
 
 lemCase : ∀ {X X'}(t : X ⊢) (cs : List (X ⊢))(p : X ≡ X')
         → subst _⊢ p (case t cs) ≡ case (subst _⊢ p t) (map (subst _⊢ p) cs)
-lemCase t cs refl = cong (case t) (sym (map-id cs)) 
+lemCase t cs refl = cong (case t) (sym (map-id cs))
 
 lem-erase : ∀{Φ Γ Γ'}{A A' : Φ ⊢Nf⋆ *}(p : Γ ≡ Γ')(q : A ≡ A')(t : Γ A.⊢ A)
   → subst _⊢ (lem≡Ctx p) (erase t)  ≡ erase (conv⊢ p q t)
@@ -200,25 +200,25 @@ lem-erase' {Γ = Γ} p t = trans
 
 lem-erase'' : ∀{Φ Γ}{A A' : Φ ⊢Nf⋆ *}(q : A ≡ A')(t : Γ A.⊢ A)
   → erase t  ≡ erase (subst (Γ A.⊢_) q t)
-lem-erase'' refl t = refl  
+lem-erase'' refl t = refl
 
 same : ∀{Φ Γ}{A : Φ ⊢⋆ *}(t : Γ D.⊢ A)
-  → D.erase t ≡ subst _⊢ (lenLemma Γ) (erase (nfType t)) 
+  → D.erase t ≡ subst _⊢ (lenLemma Γ) (erase (nfType t))
 
 +cancel : ∀{m m' n n'} → m + n ≡ m' + n' → m ≡ m' → n ≡ n'
 +cancel p refl = +-cancelˡ-≡ _ p
 
-same-ConstrArgs : ∀{Φ}{Γ : D.Ctx Φ}{Ts : List (Φ ⊢⋆ *)} 
-            
+same-ConstrArgs : ∀{Φ}{Γ : D.Ctx Φ}{Ts : List (Φ ⊢⋆ *)}
+
                    (xs : D.ConstrArgs Γ Ts)
    → D.erase-ConstrArgs xs ≡ map (subst _⊢ (lenLemma Γ)) (erase-ConstrArgs (nfType-ConstrArgs xs))
 same-ConstrArgs {Γ = Γ} [] = refl
-same-ConstrArgs {Γ = Γ} (x ∷ xs) = cong₂ _∷_ (same x) (same-ConstrArgs xs) 
+same-ConstrArgs {Γ = Γ} (x ∷ xs) = cong₂ _∷_ (same x) (same-ConstrArgs xs)
 
 same-mkCaseType : ∀ {Φ} {Γ : Ctx Φ} {A B : Φ ⊢Nf⋆ *}
                            (c : Γ ⊢ A)
                            (eq : A ≡ B)
-            → erase {Φ} {Γ} { A } c ≡ erase {Φ} {Γ} { B } (subst (Γ ⊢_) eq c)     
+            → erase {Φ} {Γ} { A } c ≡ erase {Φ} {Γ} { B } (subst (Γ ⊢_) eq c)
 same-mkCaseType c refl = refl
 
 same-Cases : ∀ {Φ} {Γ : D.Ctx Φ} {A : Φ ⊢⋆ *} {n}
@@ -227,7 +227,7 @@ same-Cases : ∀ {Φ} {Γ : D.Ctx Φ} {A : Φ ⊢⋆ *} {n}
              D.erase-Cases cases ≡
              map (subst _⊢ (lenLemma Γ)) (erase-Cases (nfType-Cases cases))
 same-Cases D.[] = refl
-same-Cases {Γ = Γ}(D._∷_ {Ts = As} c cs) = cong₂ _∷_ (trans (same c) 
+same-Cases {Γ = Γ}(D._∷_ {Ts = As} c cs) = cong₂ _∷_ (trans (same c)
                                                 (cong (subst _⊢ (lenLemma Γ)) (same-mkCaseType (nfType c) (lemma-mkCaseType As))))
                                          (same-Cases cs)
 
@@ -257,16 +257,16 @@ same {Γ = Γ} (D.unwrap {A = A}{B = B} t) = trans
   (same t)
   (cong
     (subst _⊢ (lenLemma Γ))
-    (lem-erase' (sym (stability-μ A B)) (unwrap (nfType t) refl))) 
+    (lem-erase' (sym (stability-μ A B)) (unwrap (nfType t) refl)))
 same {Γ = Γ} (D.conv p t) = trans
   (same t)
   (cong (subst _⊢ (lenLemma Γ)) (lem-erase' (completeness p) (nfType t)))
-same {Γ = Γ} (D.con {A = A} tcn p) = lemcon' (lenLemma Γ) (eraseTC (nf A) tcn) 
+same {Γ = Γ} (D.con {A = A} tcn p) = lemcon' (lenLemma Γ) (eraseTC (nf A) tcn)
 same {Γ = Γ} (D.builtin b) = trans
   (lembuiltin b (lenLemma Γ)) (cong (subst _⊢ (lenLemma Γ))
   (lem-erase refl (btype-lem b) (builtin b / refl)))
 same {Γ = Γ} (D.error A) = lemerror (lenLemma Γ)
-same {Γ = Γ} (D.constr e Tss refl xs) rewrite lemConstr (toℕ e) (erase-ConstrArgs (nfType-ConstrArgs xs)) (lenLemma Γ)  
+same {Γ = Γ} (D.constr e Tss refl xs) rewrite lemConstr (toℕ e) (erase-ConstrArgs (nfType-ConstrArgs xs)) (lenLemma Γ)
                 = cong (constr (toℕ e)) (same-ConstrArgs xs)
 same {Γ = Γ} (D.case t cases) rewrite lemCase (erase (nfType t)) (erase-Cases (Algorithmic.Completeness.nfType-Cases cases)) (lenLemma Γ)
      = cong₂ case (same t) (same-Cases cases)
@@ -294,19 +294,19 @@ same'Var {Γ = Γ ,⋆ _} (T {A = A} x) = trans
 same'TC : ∀ {Φ} {Γ : Ctx Φ} A (tcn : ⟦ A ⟧) →
          eraseTC A tcn ≡ D.eraseTC (embNf A) (subst ⟦_⟧ (sym (stability A)) tcn)
 same'TC A tcn rewrite stability A = refl
-  
+
 same' : ∀{Φ Γ}{A : Φ ⊢Nf⋆ *}(x : Γ A.⊢ A)
   →  erase x ≡ subst _⊢ (same'Len Γ) (D.erase (emb x))
 
-same'ConstrArgs : ∀ {Φ} {Γ : Ctx Φ} 
+same'ConstrArgs : ∀ {Φ} {Γ : Ctx Φ}
                     {Ts : List (Φ ⊢Nf⋆ *)}
                     (xs : ConstrArgs Γ Ts)
     → erase-ConstrArgs xs ≡  map (subst _⊢ (same'Len Γ))
                                  (D.erase-ConstrArgs (emb-ConstrArgs xs))
 same'ConstrArgs [] = refl
-same'ConstrArgs (x ∷ xs) = cong₂ _∷_ (same' x) (same'ConstrArgs xs)                                 
+same'ConstrArgs (x ∷ xs) = cong₂ _∷_ (same' x) (same'ConstrArgs xs)
 
-same-subst : ∀ {Φ} {Γ : D.Ctx Φ} {A B : Φ ⊢⋆ *} 
+same-subst : ∀ {Φ} {Γ : D.Ctx Φ} {A B : Φ ⊢⋆ *}
                (c : Γ D.⊢ A)
                (eq : A ≡ B)
              → D.erase c ≡ D.erase (subst (D._⊢_ Γ) eq c)
@@ -314,13 +314,13 @@ same-subst c refl = refl
 
 same'Case : ∀ {Φ} {Γ : Ctx Φ} {A : Φ ⊢Nf⋆ *} {n}
               {Tss : Vec (List (Φ ⊢Nf⋆ *)) n}
-              (cases : Cases Γ A Tss) 
-      → erase-Cases cases ≡ map (subst _⊢ (same'Len Γ)) 
+              (cases : Cases Γ A Tss)
+      → erase-Cases cases ≡ map (subst _⊢ (same'Len Γ))
                                 (D.erase-Cases (Algorithmic.Soundness.emb-Cases cases))
 same'Case [] = refl
-same'Case {Γ = Γ} (_∷_ {Ts = As} c cases) = 
-    cong₂ _∷_ (trans (same' c) 
-                     (cong (subst _⊢ (same'Len Γ)) (same-subst (emb c) (lema-mkCaseType As)))) 
+same'Case {Γ = Γ} (_∷_ {Ts = As} c cases) =
+    cong₂ _∷_ (trans (same' c)
+                     (cong (subst _⊢ (same'Len Γ)) (same-subst (emb c) (lema-mkCaseType As))))
               (same'Case cases)
 same' {Γ = Γ} (` x) =
   trans (cong ` (same'Var x)) (lemVar (same'Len Γ) (D.eraseVar (embVar x)))
@@ -338,12 +338,12 @@ same' {Γ = Γ} (t ·⋆ A / refl)   = trans
   (lem-force (same'Len Γ) (D.erase (emb t)))
 same' (wrap A B t)   = same' t
 same' (unwrap t refl) = same' t
-same' {Γ = Γ} (con {A = A} tcn refl) = trans (cong con (same'TC {Γ = Γ} A tcn)) 
+same' {Γ = Γ} (con {A = A} tcn refl) = trans (cong con (same'TC {Γ = Γ} A tcn))
   (lemcon' (same'Len Γ) (D.eraseTC (embNf A) (subst ⟦_⟧ (sym (stability A)) tcn)))
 same' {Γ = Γ} (builtin b / refl) = lembuiltin b (same'Len Γ)
 same' {Γ = Γ} (error A) = lemerror (same'Len Γ)
 same' {Γ = Γ} (constr e Tss {ts} refl xs) rewrite lemConstr (toℕ e) (D.erase-ConstrArgs (Algorithmic.Soundness.emb-ConstrArgs xs)) (same'Len Γ)
-            = cong (constr (toℕ e)) (same'ConstrArgs xs) 
+            = cong (constr (toℕ e)) (same'ConstrArgs xs)
 same' {Γ = Γ}(case t cases) rewrite lemCase (D.erase (emb t)) (D.erase-Cases (Algorithmic.Soundness.emb-Cases cases)) (same'Len Γ)
      = cong₂ case (same' t) (same'Case cases)
 ```

--- a/plutus-metatheory/src/Algorithmic/Erasure/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Erasure/RenamingSubstitution.lagda.md
@@ -21,7 +21,7 @@ open _⊢Nf⋆_
 open _⊢Ne⋆_
 open import Type.BetaNBE using (lookup-eval-VecList;idEnv)
 open import Type.BetaNormal.Equality using (renNf-id;renNf-comp)
-open import Type.BetaNBE.RenamingSubstitution 
+open import Type.BetaNBE.RenamingSubstitution
                 using (ren[]Nf;ren-nf-μ;SubNf;subNf-id;subNf;weakenNf[];weakenNf-subNf)
                 using (sub-nf-Π;sub[]Nf';sub-nf-μ;subNf-cons;extsNf)
 open import Algorithmic as A using (Ctx;_∋_;conv∋;_⊢_;conv⊢;Cases;[];_∷_)
@@ -60,14 +60,14 @@ subst-S refl x = refl
 
 subst-T : ∀{Φ}{Γ : Ctx Φ}{A A' : Φ ⊢Nf⋆ *}{K} →
   (p : A ≡ A')(q : weakenNf {K = K} A ≡ weakenNf A') → (x : Γ ∋ A) →
-  conv∋ refl q (T x) ≡ T (conv∋ refl p x) -- 
+  conv∋ refl q (T x) ≡ T (conv∋ refl p x) --
 subst-T refl refl x = refl
 
 subst-T' : ∀{Φ}{Γ : Ctx Φ}{A A' : Φ ⊢Nf⋆ *}{K}{A'' : Φ ,⋆ K ⊢Nf⋆ *}
   → (p : A ≡ A')
   → (q : weakenNf {K = K} A ≡ A'')
   → (r : weakenNf  {K = K} A' ≡ A'')
-  → (x : Γ ∋ A) 
+  → (x : Γ ∋ A)
   → conv∋ refl q (T x) ≡ conv∋ refl r (T (conv∋ refl p x))
 subst-T' refl refl refl x = refl
 
@@ -94,7 +94,7 @@ eraseVar-backVar (Γ , A)  (just x) = cong just (eraseVar-backVar Γ x)
 --
 
 erase-Ren : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}(ρ⋆ : ⋆.Ren Φ Ψ)
-  → A.Ren ρ⋆ Γ Δ → U.Ren (len Γ) (len Δ) 
+  → A.Ren ρ⋆ Γ Δ → U.Ren (len Γ) (len Δ)
 erase-Ren ρ⋆ ρ i = eraseVar (ρ (backVar _ i))
 
 ext-erase : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}(ρ⋆ : ⋆.Ren Φ Ψ)
@@ -141,7 +141,7 @@ ren-erase-ConstrArgs : ∀ {Φ} {Ψ} {Γ : Ctx Φ} {Δ : Ctx Ψ}
                          (cs : A.ConstrArgs Γ (lookup Tss i)) →
                        erase-ConstrArgs (A.ren-ConstrArgs ρ⋆ ρ i Tss cs)
                        ≡ U.renList (erase-Ren ρ⋆ ρ)(erase-ConstrArgs cs)
-ren-erase-ConstrArgs ρ⋆ ρ i Tss cs rewrite lookup-renNf-VecList ρ⋆ i Tss = ren-erase-ConstrArgs-List ρ⋆ ρ cs                 
+ren-erase-ConstrArgs ρ⋆ ρ i Tss cs rewrite lookup-renNf-VecList ρ⋆ i Tss = ren-erase-ConstrArgs-List ρ⋆ ρ cs
 
 ren-erase-Cases : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}
   → (ρ⋆ : ⋆.Ren Φ Ψ)
@@ -150,9 +150,9 @@ ren-erase-Cases : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}
   → (cs : Cases Γ A Tss)
   →  erase-Cases (A.ren-Cases ρ⋆ ρ cs) ≡ U.renList (erase-Ren ρ⋆ ρ) (erase-Cases cs)
 ren-erase-Cases ρ⋆ ρ [] = refl
-ren-erase-Cases ρ⋆ ρ {Tss = As ∷ _}(c ∷ cs) = 
+ren-erase-Cases ρ⋆ ρ {Tss = As ∷ _}(c ∷ cs) =
       cong₂ _∷_ (trans (sym (lem-erase'' (A.ren-mkCaseType ρ⋆ As) (A.ren ρ⋆ ρ c)))
-                       (ren-erase ρ⋆ ρ c)) 
+                       (ren-erase ρ⋆ ρ c))
                 (ren-erase-Cases ρ⋆ ρ cs)
 
 ren-erase ρ⋆ ρ (` x) = cong
@@ -191,7 +191,7 @@ ren-erase ρ⋆ ρ (case t cases) = cong₂ case (ren-erase ρ⋆ ρ t) (ren-era
 ren-erase ρ⋆ ρ (error A)          = refl
 --
 erase-Sub : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}(σ⋆ : SubNf Φ Ψ)
-  → A.Sub σ⋆ Γ Δ → U.Sub (len Γ) (len Δ) 
+  → A.Sub σ⋆ Γ Δ → U.Sub (len Γ) (len Δ)
 erase-Sub σ⋆ σ i = erase (σ (backVar _ i))
 
 cong-erase-sub : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}(σ⋆ : SubNf Φ Ψ)
@@ -219,7 +219,7 @@ exts⋆-erase : ∀ {Φ Ψ}{Γ Δ}(σ⋆ : SubNf Φ Ψ)(σ : A.Sub σ⋆ Γ Δ)
   → {B : Φ ⊢Nf⋆ *}
   → ∀{K}
   → (α : len Γ)
-  →  erase-Sub (extsNf σ⋆ {K}) (A.exts⋆ σ⋆ σ) α ≡ erase-Sub σ⋆ σ α 
+  →  erase-Sub (extsNf σ⋆ {K}) (A.exts⋆ σ⋆ σ) α ≡ erase-Sub σ⋆ σ α
 exts⋆-erase {Γ = Γ}{Δ} σ⋆ σ {B} α = trans
   (conv⊢-erase
     (weakenNf-subNf σ⋆ (backVar⋆ Γ α))
@@ -236,24 +236,24 @@ sub-erase : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}(σ⋆ : SubNf Φ Ψ)
 
 
 sub-Erase-ConstrList : ∀ {Φ}{Ψ}{Γ : Ctx Φ} {Δ : Ctx Ψ}
-                         {As : List (Φ ⊢Nf⋆ *)}  
+                         {As : List (Φ ⊢Nf⋆ *)}
                          (σ⋆ : SubNf Φ Ψ) (σ : A.Sub σ⋆ Γ Δ)
-                         (cs : A.ConstrArgs Γ As) 
-       →   erase-ConstrArgs (A.sub-ConstrList σ⋆ σ cs) 
+                         (cs : A.ConstrArgs Γ As)
+       →   erase-ConstrArgs (A.sub-ConstrList σ⋆ σ cs)
          ≡ U.subList (λ i₁ → erase (σ (backVar Γ i₁))) (erase-ConstrArgs cs)
 sub-Erase-ConstrList σ⋆ σ [] = refl
-sub-Erase-ConstrList σ⋆ σ (x ∷ cs) = cong₂ _∷_ (sub-erase σ⋆ σ x) (sub-Erase-ConstrList σ⋆ σ cs) 
+sub-Erase-ConstrList σ⋆ σ (x ∷ cs) = cong₂ _∷_ (sub-erase σ⋆ σ x) (sub-Erase-ConstrList σ⋆ σ cs)
 
 sub-Erase-ConstrArgs : ∀ {Φ} {Ψ} {Γ : Ctx Φ} {Δ : Ctx Ψ}
                          (σ⋆ : SubNf Φ Ψ) (σ : A.Sub σ⋆ Γ Δ) {n} (i : Fin n)
                          (Tss : Vec (List (Φ ⊢Nf⋆ *)) n)
-                         (cs : A.ConstrArgs Γ (lookup Tss i)) 
+                         (cs : A.ConstrArgs Γ (lookup Tss i))
                 → erase-ConstrArgs (A.sub-VecList σ⋆ σ i Tss cs) ≡ U.subList (erase-Sub σ⋆ σ) (erase-ConstrArgs cs)
-sub-Erase-ConstrArgs σ⋆ σ i Tss cs 
-     rewrite lookup-eval-VecList i (⋆.sub-VecList (λ x₁ → embNf (σ⋆ x₁)) (embNf-VecList Tss)) 
-                                   (idEnv _) 
-            | ⋆.lookup-sub-VecList (λ x₁ → embNf (σ⋆ x₁)) i (embNf-VecList Tss)  
-            | lookup-embNf-VecList i Tss = sub-Erase-ConstrList σ⋆ σ cs 
+sub-Erase-ConstrArgs σ⋆ σ i Tss cs
+     rewrite lookup-eval-VecList i (⋆.sub-VecList (λ x₁ → embNf (σ⋆ x₁)) (embNf-VecList Tss))
+                                   (idEnv _)
+            | ⋆.lookup-sub-VecList (λ x₁ → embNf (σ⋆ x₁)) i (embNf-VecList Tss)
+            | lookup-embNf-VecList i Tss = sub-Erase-ConstrList σ⋆ σ cs
 
 sub-erase-Cases : ∀ {Φ} {Ψ} {Γ : Ctx Φ} {Δ : Ctx Ψ}
                     (σ⋆ : SubNf Φ Ψ) (σ : A.Sub σ⋆ Γ Δ) {A : Φ ⊢Nf⋆ *} {n}
@@ -262,7 +262,7 @@ sub-erase-Cases : ∀ {Φ} {Ψ} {Γ : Ctx Φ} {Δ : Ctx Ψ}
                   erase-Cases (A.sub-Cases σ⋆ σ cases) ≡
                   U.subList (erase-Sub σ⋆ σ) (erase-Cases cases)
 sub-erase-Cases σ⋆ σ [] = refl
-sub-erase-Cases {Δ = Δ} σ⋆ σ {Tss = As ∷ _} (c ∷ cases) = cong₂ _∷_ (trans (sym (lem-erase'' (A.sub-mkCaseType σ⋆ As) (A.sub σ⋆ σ c))) (sub-erase σ⋆ σ c)) 
+sub-erase-Cases {Δ = Δ} σ⋆ σ {Tss = As ∷ _} (c ∷ cases) = cong₂ _∷_ (trans (sym (lem-erase'' (A.sub-mkCaseType σ⋆ As) (A.sub σ⋆ σ c))) (sub-erase σ⋆ σ c))
                                              (sub-erase-Cases σ⋆ σ cases)
 
 sub-erase σ⋆ σ (` x) =   cong-erase-sub
@@ -281,8 +281,8 @@ sub-erase σ⋆ σ (Λ {B = B} t) = cong
   (trans (conv⊢-erase (sub-nf-Π σ⋆ B) (A.sub (extsNf σ⋆) (A.exts⋆ σ⋆ σ) t))
          (trans (sub-erase (extsNf σ⋆) (A.exts⋆ σ⋆ σ) t)
                 (U.sub-cong (exts⋆-erase σ⋆ σ {B = Π B}) (erase t))))
-sub-erase σ⋆ σ (_·⋆_/_ {B = B} t A refl) = 
-  trans (conv⊢-erase (sym (sub[]Nf' σ⋆ A B)) (A.sub σ⋆ σ t ·⋆ subNf σ⋆ A / refl)) 
+sub-erase σ⋆ σ (_·⋆_/_ {B = B} t A refl) =
+  trans (conv⊢-erase (sym (sub[]Nf' σ⋆ A B)) (A.sub σ⋆ σ t ·⋆ subNf σ⋆ A / refl))
         (cong force (sub-erase σ⋆ σ t))
 sub-erase σ⋆ σ (wrap A B t) = trans
   (conv⊢-erase (sub-nf-μ σ⋆ A B) (A.sub σ⋆ σ t))
@@ -307,7 +307,7 @@ lem[]⋆ {Γ = Γ} N A = trans
         (cong ` (sym (eraseVar-backVar Γ α)))
         (sym (conv⊢-erase (weakenNf[] _ _) (` (backVar Γ α)))))
       (erase N)))
-  (sym (sub-erase (subNf-cons (ne ∘ `) A) A.lem N)) 
+  (sym (sub-erase (subNf-cons (ne ∘ `) A) A.lem N))
 
 
 lem[] : ∀{Φ}{Γ : Ctx Φ}{A B : Φ ⊢Nf⋆ *}(N : Γ , A ⊢ B)(W : Γ ⊢ A)
@@ -331,4 +331,4 @@ lem[] {Γ = Γ}{A = A}{B} N W = trans
            (conv⊢ refl (sym (subNf-id A)) W))
          N)))
 ```
- 
+

--- a/plutus-metatheory/src/Algorithmic/Evaluation.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Evaluation.lagda.md
@@ -35,12 +35,12 @@ When our evaluator returns a term `N`, it will either give evidence that
 ```
 data Finished {A : ∅ ⊢Nf⋆ *} :  (N : ∅ ⊢ A) →  Set where
 
-   done : ∀ N → 
+   done : ∀ N →
        Value N
        ----------
      → Finished N
 
-   out-of-gas : ∀{N} → 
+   out-of-gas : ∀{N} →
        ----------
        Finished N
 
@@ -89,4 +89,4 @@ stepper {A} t n with eval (gas n) t
 ... | steps x (error _)   = return (error A)
 
 ```
- 
+

--- a/plutus-metatheory/src/Algorithmic/Examples.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Examples.lagda.md
@@ -10,7 +10,7 @@ module Algorithmic.Examples where
 
 ```
 open import Utils using (*;_⇒_)
-open import Relation.Binary.PropositionalEquality using (refl) 
+open import Relation.Binary.PropositionalEquality using (refl)
                                                   renaming (subst to substEq)
 open import Type using (_,⋆_;_⇒_;Z;S;_⊢⋆_)
 open _⊢⋆_
@@ -74,10 +74,10 @@ module Scott where
     → Γ ⊢ μ0 ·Nf A
     → Γ ⊢ A ·Nf (μ0 ·Nf A)
   unwrap0 A X rewrite stability A = unwrap X refl
-  
+
   G : ∀{Γ} → Γ ,⋆  * ⊢Nf⋆ *
   G = Π (ne (` Z) ⇒ (ne (` (S Z)) ⇒ ne (` Z)) ⇒ ne (` Z))
-  
+
   M : ∀{Γ} → Γ ⊢Nf⋆ *
   M = μ0 ·Nf ƛ G
 
@@ -93,7 +93,7 @@ module Scott where
 
   One :  ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ N
   One = Succ · Zero
-  
+
   Two :  ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ N
   Two = Succ · One
 
@@ -182,7 +182,7 @@ module Church where
 
   Succ : ∅ ⊢ N ⇒ N
   Succ = ƛ (Λ (ƛ (ƛ (` Z · (((` (S (S (T Z)))) ·⋆ (ne (` Z)) / refl) · (` (S Z)) · (` Z))))))
-  
+
   Iter : ∅ ⊢ Π (ne (` Z) ⇒ (ne (` Z) ⇒ ne (` Z)) ⇒ N ⇒ ne (` Z))
   Iter = Λ (ƛ (ƛ (ƛ (((` Z) ·⋆ ne (` Z) / refl) · (` (S (S Z))) · (` (S Z))))))
 

--- a/plutus-metatheory/src/Algorithmic/Reduction.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Reduction.lagda.md
@@ -22,7 +22,7 @@ open import Data.Maybe using (just;from-just)
 open import Data.String using (String)
 
 open import Utils using (Kind;*;_⇒_;_∔_≣_;bubble;K;≡-subst-removable)
-open import Utils.List 
+open import Utils.List
 open import Type using (Ctx⋆;∅;_,⋆_;Z;_⊢⋆_)
 open _⊢⋆_
 
@@ -46,7 +46,7 @@ open import Builtin using (Builtin;signature)
 open import Builtin.Signature using (Sig;sig;Args;_⊢♯;args♯;fv)
 open Sig
 
-open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π 
+open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π
     using (sig2type;SigTy;sig2SigTy;sigTy2type;saturatedSigTy;convSigTy)
 open SigTy
 
@@ -84,7 +84,7 @@ data _—→V_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set wh
     → {Tss : Vec (List (∅ ⊢Nf⋆ *)) n}
     → ∀ {Xs} → (q : Xs ≡ Vec.lookup Tss i)
     → (tidx : Xs ≣ Vs <>> (A ∷ Ts))
-    → {tvs : IBwd (∅ ⊢_) Vs} 
+    → {tvs : IBwd (∅ ⊢_) Vs}
     → (vs : VList tvs) → (cs : ConstrArgs ∅ Ts)
     → (p : Vs <>> (A ∷ Ts) ≡  Vec.lookup Tss i)
     → L —→V L'
@@ -92,12 +92,12 @@ data _—→V_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set wh
     → constr i Tss p (tvs <>>I (L ∷ cs)) —→V constr i Tss p (tvs <>>I (L' ∷ cs))
 
   ξ-case : ∀ {A : ∅ ⊢Nf⋆ *}{n}
-     → {Tss : Vec (List (∅ ⊢Nf⋆ *)) n} 
+     → {Tss : Vec (List (∅ ⊢Nf⋆ *)) n}
      → {L L' : ∅ ⊢ SOP Tss}
      → {cases : Cases ∅ A Tss}
      → L —→V L'
-       ----------------------- 
-     → case L cases —→V case L' cases  
+       -----------------------
+     → case L cases —→V case L' cases
 
   β-ƛ : {A B : ∅ ⊢Nf⋆ *}{N : ∅ , A ⊢ B} {V : ∅ ⊢ A}
     → Value V
@@ -121,7 +121,7 @@ data _—→V_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set wh
     → {M M' : ∅ ⊢ μ A B}
     → M —→V M'
     → unwrap M refl —→V unwrap M' refl
-    
+
   ξ-wrap : ∀{K}
     → {A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}
     → {B : ∅ ⊢Nf⋆ K}
@@ -132,7 +132,7 @@ data _—→V_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set wh
   β-builtin : ∀{A B}{tn}
       (b : Builtin)
     → (t : ∅ ⊢ A ⇒ B)
-    → {pt : tn ∔ 0 ≣ fv (signature b)} 
+    → {pt : tn ∔ 0 ≣ fv (signature b)}
     → ∀{an} → {pa : an ∔ 1 ≣  args♯ (signature b)}
     → {σB : SigTy pt (bubble pa) B}
     → (bt : BApp b (A B⇒ σB) t) -- one left
@@ -177,12 +177,12 @@ data _—→E_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set wh
     → {B : ∅ ⊢Nf⋆ K}
     → {M : _}
     → M —→E error _
-    → wrap A B M —→E error (μ A B) 
+    → wrap A B M —→E error (μ A B)
   E-top : {A : ∅ ⊢Nf⋆ *} → error A —→E error A
   E-constr : ∀ {A : ∅ ⊢Nf⋆ *}{L : ∅ ⊢ A}{n}
     → (e : Fin n)
     → (Tss : Vec (List (∅ ⊢Nf⋆ *)) n)
-    → {Bs : Bwd _} 
+    → {Bs : Bwd _}
     → {vs : IBwd (∅ ⊢_) Bs}
     → (Vs : VList vs)
     → {Ts : List _}
@@ -194,11 +194,11 @@ data _—→E_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set wh
     → constr e Tss p (vs <>>I (L ∷ cs)) —→E error _
 
   E-case : ∀ {A : ∅ ⊢Nf⋆ *}{n}
-     → {Tss : Vec (List (∅ ⊢Nf⋆ *)) n} 
+     → {Tss : Vec (List (∅ ⊢Nf⋆ *)) n}
      → {L : ∅ ⊢ SOP Tss}
      → {cases : Cases ∅ A Tss}
      → L —→E error _
-       ----------------------- 
+       -----------------------
      → case L cases —→E error _
 ```
 
@@ -266,7 +266,7 @@ lemCS—→ (ruleErr E refl) = err (lemCS—→E E)
 
 lemSC—→V : ∀{A}{M M' : ∅ ⊢ A}
   → M —→V M'
-  → ∃ λ B 
+  → ∃ λ B
   → ∃ λ (E : EC A B)
   → ∃ λ L
   → ∃ λ L'
@@ -282,10 +282,10 @@ lemSC—→V (ξ-·⋆ p) with lemSC—→V p
 ... | B ,, E ,, L ,, L' ,, refl ,, refl ,, q =
   B ,, E ·⋆ _ / refl ,, L ,, L' ,, refl ,, refl ,, q
 lemSC—→V (ξ-constr i {Tss} refl tidx vs cs q' p)  with lemSC—→V p
-... | B ,, E ,, L ,, L' ,, refl ,, refl ,, p' = B ,, constr i Tss refl { tidx } vs cs E ,, L ,, L' ,, 
-    constr-cong' (trans (sym (lem-≣-<>> tidx)) refl) q' (≡-subst-removable (IList ( ∅ ⊢_)) q' ((trans (sym (lem-≣-<>> tidx)) refl)) _) ,, 
+... | B ,, E ,, L ,, L' ,, refl ,, refl ,, p' = B ,, constr i Tss refl { tidx } vs cs E ,, L ,, L' ,,
+    constr-cong' (trans (sym (lem-≣-<>> tidx)) refl) q' (≡-subst-removable (IList ( ∅ ⊢_)) q' ((trans (sym (lem-≣-<>> tidx)) refl)) _) ,,
     constr-cong' (trans (sym (lem-≣-<>> tidx)) refl) q' (≡-subst-removable (IList ( ∅ ⊢_)) q' ((trans (sym (lem-≣-<>> tidx)) refl)) _) ,, p'
-lemSC—→V (ξ-case p) with lemSC—→V p  
+lemSC—→V (ξ-case p) with lemSC—→V p
 ... | B ,, E ,, L ,, L' ,, refl ,, refl ,, p' = B ,, case _ E ,, L ,, L' ,, refl ,, refl ,, p'
 lemSC—→V (β-ƛ v) = _ ,, [] ,, _ ,, _ ,, refl ,, refl ,, E.β-ƛ v
 lemSC—→V β-Λ = _ ,, [] ,, _ ,, _ ,, refl ,, refl ,, E.β-Λ refl
@@ -302,7 +302,7 @@ lemSC—→V (β-case e _ q vs x cases) = _ ,, [] ,, _ ,, _ ,, refl ,, refl ,, �
 
 lemSC—→E : ∀{A}{M : ∅ ⊢ A}
   → M —→E error A
-  → ∃ λ B 
+  → ∃ λ B
   → ∃ λ (E : EC A B)
   → (M ≡ E [ error B ]ᴱ)
 lemSC—→E (E-·₂ v p) with lemSC—→E p
@@ -316,18 +316,18 @@ lemSC—→E (E-unwrap p) with lemSC—→E p
 lemSC—→E (E-wrap p) with lemSC—→E p
 ... | B ,, E ,, refl = B ,, wrap E ,, refl
 lemSC—→E E-top = _ ,, [] ,, refl
-lemSC—→E (E-constr {A} i Tss {Bs} {vs} Vs {Ts} cs {tidx} q p) with lemSC—→E p 
-... | B ,, E ,, refl = B ,, constr i Tss q {tidx = lemma-≣-<>>-refl _ _} Vs cs E ,, 
-     constr-cong' (trans (sym (lem-≣-<>> (lemma-≣-<>>-refl Bs (A ∷ Ts)))) q) 
-                  q 
+lemSC—→E (E-constr {A} i Tss {Bs} {vs} Vs {Ts} cs {tidx} q p) with lemSC—→E p
+... | B ,, E ,, refl = B ,, constr i Tss q {tidx = lemma-≣-<>>-refl _ _} Vs cs E ,,
+     constr-cong' (trans (sym (lem-≣-<>> (lemma-≣-<>>-refl Bs (A ∷ Ts)))) q)
+                  q
                   (≡-subst-removable (IList (∅ ⊢_)) q (trans (sym (lem-≣-<>> (lemma-≣-<>>-refl Bs (A ∷ Ts)))) q) ((vs <>>I ((E [ error B ]ᴱ) ∷ cs))))
-lemSC—→E (E-case p) with lemSC—→E p 
+lemSC—→E (E-case p) with lemSC—→E p
 ... | B ,, E ,, refl = B ,, case _ E ,, refl
 
 lemSC—→ : ∀{A}{M M' : ∅ ⊢ A} → M —→ M' → M E.—→ M'
 lemSC—→ (red p) =
   let B ,, E ,, L ,, L' ,, r ,, r' ,, q = lemSC—→V p in ruleEC E q r r'
-lemSC—→ (err p) = let B ,, E ,, p = lemSC—→E p in ruleErr E p 
+lemSC—→ (err p) = let B ,, E ,, p = lemSC—→E p in ruleErr E p
 
 
 data Progress {A : ∅ ⊢Nf⋆ *} (M : ∅ ⊢ A) : Set where

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -23,11 +23,11 @@ open import Data.Sum using (_⊎_;inj₁;inj₂)
 open import Data.Unit using (tt)
 open import Function using (_∘_)
 open import Relation.Nullary using (¬_;yes;no)
-open import Relation.Binary.PropositionalEquality 
-                    using (_≡_;refl;sym;trans;cong)  
+open import Relation.Binary.PropositionalEquality
+                    using (_≡_;refl;sym;trans;cong)
                     renaming (subst to substEq)
-open import Relation.Binary.HeterogeneousEquality 
-        using (_≅_;refl;≅-to-≡) 
+open import Relation.Binary.HeterogeneousEquality
+        using (_≅_;refl;≅-to-≡)
 
 open import Utils hiding (List;length;map)
 open import Utils.List
@@ -45,13 +45,13 @@ open import Type.BetaNBE.RenamingSubstitution using (_[_]Nf)
 open import Type.BetaNormal using (_⊢Nf⋆_;_⊢Ne⋆_;embNf;weakenNf)
 open _⊢Nf⋆_
 open _⊢Ne⋆_
-open import Builtin 
+open import Builtin
 open import Builtin.Constant.Type using (TyCon)
 
 open import Builtin.Signature using (Sig;sig;Args;_⊢♯;args♯;fv)
 open Sig
 
-open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π 
+open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π
     using (sig2type;SigTy;sig2SigTy;sigTy2type;saturatedSigTy;convSigTy)
 open SigTy
 
@@ -64,12 +64,12 @@ import Algorithmic.CEK as CEK
 Values are indexed by terms
 List of values are indexed by list of terms.
 
-``` 
+```
 data Value : {A : ∅ ⊢Nf⋆ *} → ∅ ⊢ A → Set
 
 -- List of Values
 VList : ∀{ts} → IBwd (∅ ⊢_) ts → Set
-VList = IIBwd Value 
+VList = IIBwd Value
 
 deval : {A : ∅ ⊢Nf⋆ *}{u : ∅ ⊢ A} → Value u → ∅ ⊢ A
 deval {u = u} _ = u
@@ -78,19 +78,19 @@ deval-VecList : ∀{n} → (Vec (List (∃ (∅ ⊢_))) n) → Vec (List (∅ �
 deval-VecList [] = []
 deval-VecList (xs ∷ xss) = map proj₁ xs ∷ (deval-VecList xss)
 
-data BApp (b : Builtin) : 
+data BApp (b : Builtin) :
     ∀{tn tm tt} → {pt : tn ∔ tm ≣ tt}
   → ∀{an am at} → {pa : an ∔ am ≣ at}
   → ∀{A} → SigTy pt pa A → ∅ ⊢ A → Set where
   base : BApp b (sig2SigTy (signature b)) (builtin b / refl )
   step : ∀{A B}{tn}
-    → {pt : tn ∔ 0 ≣ fv (signature b)} 
+    → {pt : tn ∔ 0 ≣ fv (signature b)}
     → ∀{an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
     → {σB : SigTy pt (bubble pa) B}
     → {t : ∅ ⊢ A ⇒ B} → BApp b (A B⇒ σB) t
     → {u : ∅ ⊢ A} → Value u → BApp b σB (t · u)
   step⋆ : ∀{C}{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}
-    → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)} 
+    → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)}
     → ∀{an am}{pa : an ∔ (suc am) ≣ args♯ (signature b)}
     → {σB : SigTy (bubble pt) pa B}
     → {t : ∅ ⊢ Π B} → BApp b (sucΠ σB) t
@@ -118,24 +118,24 @@ data Value where
    → Value (wrap A B M)
 
   V-con :  ∀{A : ∅ ⊢Nf⋆ ♯}
-    → (x : ⟦ A ⟧) 
+    → (x : ⟦ A ⟧)
     → Value (con {A = A} x refl)
 
   V-I⇒ : ∀ b {A B}{tn}
-       → {pt : tn ∔ 0 ≣ fv (signature b)} 
+       → {pt : tn ∔ 0 ≣ fv (signature b)}
        → ∀{an am}{pa : an ∔ (suc am) ≣ args♯ (signature b)}
        → {σB : SigTy pt (bubble pa) B}
        → {t : ∅ ⊢ A ⇒ B}
        → BApp b (A B⇒ σB) t
        → Value t
   V-IΠ : ∀ b {K}{A : ∅ ,⋆ K ⊢Nf⋆ *}
-       → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)} 
+       → ∀{tn tm} {pt : tn ∔ (suc tm) ≣ fv (signature b)}
        → ∀{an am}{pa : an ∔ suc am ≣ args♯ (signature b)}
        → {σA : SigTy (bubble pt) pa A}
        → {t : ∅ ⊢ Π A}
        → BApp b (sucΠ σA) t
        → Value t
-  V-constr : ∀{n}(e : Fin n) 
+  V-constr : ∀{n}(e : Fin n)
           → (Tss : Vec (List ( ∅ ⊢Nf⋆ *)) n )
           → ∀{Xs} → (p : Xs ≡ Vec.lookup Tss e)
           → ∀{Ys} → (q : Ys ≡ [] <>< Xs)
@@ -174,7 +174,7 @@ BUILTIN' : ∀ b {A}{t : ∅ ⊢ A}
   → {σA : SigTy pt pa A}
   → BApp b σA t
   → ∅ ⊢ A
-BUILTIN' b bt = CEK.BUILTIN' b (red2cekBApp bt) 
+BUILTIN' b bt = CEK.BUILTIN' b (red2cekBApp bt)
 ```
 
 ```
@@ -200,13 +200,13 @@ data Frame : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
     → Frame (μ A B) (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B))
   unwrap- : ∀{K}{A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}{B : ∅ ⊢Nf⋆ K}
     → Frame (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) (μ A B)
-  constr- : ∀{n Vs H Ts} 
-          → (i : Fin n) 
-          → (Tss : Vec _ n)  
+  constr- : ∀{n Vs H Ts}
+          → (i : Fin n)
+          → (Tss : Vec _ n)
           → ∀ {Xs} → (Xs ≡ Vec.lookup Tss i)
           → {tidx : Xs ≣ Vs <>> (H ∷ Ts)} → {tvs : IBwd (∅ ⊢_) Vs} → VList tvs → ConstrArgs ∅ Ts
           → Frame (SOP Tss) H
-  case-   : ∀{A n}{Tss : Vec _ n} → Cases ∅ A Tss → Frame A (SOP Tss) 
+  case-   : ∀{A n}{Tss : Vec _ n} → Cases ∅ A Tss → Frame A (SOP Tss)
 
 _[_]ᶠ : ∀{A B : ∅ ⊢Nf⋆ *} → Frame B A → ∅ ⊢ A → ∅ ⊢ B
 (-· M')          [ L ]ᶠ = L · M'
@@ -233,13 +233,13 @@ data EC : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
     → EC (μ A B) C
   unwrap_/_ : ∀{K}{A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}{B : ∅ ⊢Nf⋆ K}{C}{X}
     → EC (μ A B) C
-    → X ≡ (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) 
+    → X ≡ (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B))
     → EC X C
-  constr : ∀{n Vs H Ts C} 
-          → (i : Fin n) 
-          → (Tss : Vec _ n)  
+  constr : ∀{n Vs H Ts C}
+          → (i : Fin n)
+          → (Tss : Vec _ n)
           → ∀ {Xs} → (Xs ≡ Vec.lookup Tss i)
-          → {tidx : Xs ≣ Vs <>> (H ∷ Ts)} 
+          → {tidx : Xs ≣ Vs <>> (H ∷ Ts)}
           → {tvs : IBwd (∅ ⊢_) Vs} → VList tvs → ConstrArgs ∅ Ts
           → EC H C
           → EC (SOP Tss) C
@@ -260,13 +260,13 @@ case cs E [ L ]ᴱ = case (E [ L ]ᴱ) cs
 ## Evaluation Relation
 
 ```
-applyCase : ∀ {A : ∅ ⊢Nf⋆ *} 
+applyCase : ∀ {A : ∅ ⊢Nf⋆ *}
               {ts : List (∅ ⊢Nf⋆ *)}
               (f : ∅ ⊢ mkCaseType A ts)
            →  (cs : ConstrArgs ∅ ts)
            → ∅ ⊢ A
 applyCase f [] = f
-applyCase f (x ∷ cs) = applyCase (f · x) cs            
+applyCase f (x ∷ cs) = applyCase (f · x) cs
 
 infix 2 _—→⋆_
 
@@ -293,7 +293,7 @@ data _—→⋆_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set 
   β-builtin : ∀{A B}{tn}
       (b : Builtin)
     → (t : ∅ ⊢ A ⇒ B)
-    → {pt : tn ∔ 0 ≣ fv (signature b)} 
+    → {pt : tn ∔ 0 ≣ fv (signature b)}
     → ∀{an} → {pa : an ∔ 1 ≣  args♯ (signature b)}
     → {σB : SigTy pt (bubble pa) B}
     → (bt : BApp b (A B⇒ σB) t) -- one left
@@ -375,4 +375,4 @@ ival : ∀ b → Value (builtin b / refl)
 ival b = V-I b base
 -- -}
 ```
- 
+

--- a/plutus-metatheory/src/Algorithmic/ReductionEC/Determinism.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC/Determinism.lagda.md
@@ -15,11 +15,11 @@ open import Data.Vec as Vec using (lookup)
 open import Data.Product using (Σ;_×_;∃) renaming (_,_ to _,,_)
 open import Data.List.Properties using (∷-injective)
 open import Relation.Nullary using (¬_;yes;no)
-open import Relation.Binary.PropositionalEquality 
-                    using (_≡_;refl;sym;trans;cong;cong₂;subst-subst;subst-injective)  
+open import Relation.Binary.PropositionalEquality
+                    using (_≡_;refl;sym;trans;cong;cong₂;subst-subst;subst-injective)
                     renaming (subst to substEq)
-open import Relation.Binary.HeterogeneousEquality 
-        using (_≅_;refl;≅-to-≡) 
+open import Relation.Binary.HeterogeneousEquality
+        using (_≅_;refl;≅-to-≡)
 
 open import Utils hiding (_×_;List)
 open import Utils.List
@@ -52,24 +52,24 @@ lemΛE'' : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}
 lemΛE'' [] refl = refl ,, refl ,, refl
 
 conv∔≣ : ∀{tt tt' tn tm tn' tm'}
-  → (tn'  ∔ tm'  ≣ tt') 
+  → (tn'  ∔ tm'  ≣ tt')
   → tt ≡ tt' → tn ≡ tn' → tm ≡ tm'
   → tn ∔ tm ≣ tt
 conv∔≣ p refl refl refl = p
 
 conv∔≣t : ∀{b b' tn tm tn' tm'}
   → b ≡ b'
-  → (tn'  ∔ tm'  ≣ fv (signature b')) 
+  → (tn'  ∔ tm'  ≣ fv (signature b'))
   → tn ≡ tn' → tm ≡ tm'
   → tn ∔ tm ≣ fv (signature b)
-conv∔≣t refl pt = conv∔≣ pt refl  
+conv∔≣t refl pt = conv∔≣ pt refl
 
 conv∔≣a : ∀{b b' an am an' am'}
   → b ≡ b'
-  → (an'  ∔ am'  ≣ args♯ (signature b')) 
+  → (an'  ∔ am'  ≣ args♯ (signature b'))
   → an ≡ an' → am ≡ am'
   → an ∔ am ≣ args♯ (signature b)
-conv∔≣a refl pa = conv∔≣ pa refl  
+conv∔≣a refl pa = conv∔≣ pa refl
 
 uniqueVal : ∀{A}(M : ∅ ⊢ A)(v v' : Value M) → v ≡ v'
 
@@ -86,24 +86,24 @@ uniqueBApp : ∀{A b}
 uniqueBApp .(builtin _ / refl) base base = refl
 uniqueBApp (M · M') (step v x) (step v' x') with uniqueBApp M v v' | uniqueVal M' x x'
 ... | refl | refl  = refl
-uniqueBApp (M ·⋆ A / refl) (step⋆ {σB = σA} v refl) (step⋆ {σB = σA'} v' refl) with uniqueSigTy σA σA' 
-... | refl with uniqueBApp M v v'  
+uniqueBApp (M ·⋆ A / refl) (step⋆ {σB = σA} v refl) (step⋆ {σB = σA'} v' refl) with uniqueSigTy σA σA'
+... | refl with uniqueBApp M v v'
 ... | refl = refl
 
 uniqueBApp' : ∀{A b b'}
   → (M : ∅ ⊢ A)
-  → ∀{tn tm}{pt : tn ∔ tm ≣ fv (signature b)} 
+  → ∀{tn tm}{pt : tn ∔ tm ≣ fv (signature b)}
   → ∀{an am}{pa : an ∔ am ≣ args♯ (signature b)}
   → {σA : SigTy pt pa A}
-  → ∀{tn' tm'}{pt' : tn' ∔ tm' ≣ fv (signature b')} 
+  → ∀{tn' tm'}{pt' : tn' ∔ tm' ≣ fv (signature b')}
   → ∀{an' am'}{pa' : an' ∔ am' ≣ args♯ (signature b')}
   → {σA' : SigTy pt' pa' A}
   → (v : BApp b σA M)(v' : BApp b' σA' M)
-  → ∃ λ (be : b ≡ b') → ∃ λ (tne : tn ≡ tn') → ∃ λ (tme : tm ≡ tm')  → ∃ λ (ane : an ≡ an') →  ∃ λ (ame : am ≡ am') 
+  → ∃ λ (be : b ≡ b') → ∃ λ (tne : tn ≡ tn') → ∃ λ (tme : tm ≡ tm')  → ∃ λ (ane : an ≡ an') →  ∃ λ (ame : am ≡ am')
   → (pt ≡ conv∔≣t be pt' tne tme) × (pa ≡ conv∔≣a be pa' ane ame)
 uniqueBApp' (M · _) (step v _) (step v' _) with uniqueBApp' M v v'
 ... | refl ,, refl ,, refl ,, refl ,, refl ,, refl ,, refl  = refl ,, refl ,, refl ,, refl ,, refl ,, refl ,, refl
-uniqueBApp' (M ·⋆ A / x) (step⋆ v .x) (step⋆ v' .x) with uniqueBApp' M v v' 
+uniqueBApp' (M ·⋆ A / x) (step⋆ v .x) (step⋆ v' .x) with uniqueBApp' M v v'
 ... | refl ,, refl ,, refl ,, refl ,, refl ,, refl ,, refl = refl ,, refl ,, refl ,, refl ,, refl ,, refl ,, refl
 uniqueBApp' (builtin b / x) base base = refl ,, refl ,, refl ,, refl ,, refl ,, refl ,, refl
 
@@ -117,8 +117,8 @@ uniqueVal M (V-I⇒ b {σB = s} x) (V-I⇒ b' {σB = s'} x') with uniqueBApp' M 
 uniqueVal M (V-IΠ b {σA = s} x) (V-IΠ b' {σA = s'} x') with uniqueBApp' M x x'
 ... | refl ,, refl ,, refl ,, refl ,, refl ,, refl ,, refl with uniqueSigTy s s'
 ... | refl = cong (V-IΠ b) (uniqueBApp M x x')
-uniqueVal _ (V-constr e Tss refl refl {ts} vs refl) (V-constr .e .Tss .refl refl {ts'} vs₁ q) 
-        with inj-IBwd2IList {ts = ts'}{ts} (lemma<>1 [] (lookup Tss e)) q 
+uniqueVal _ (V-constr e Tss refl refl {ts} vs refl) (V-constr .e .Tss .refl refl {ts'} vs₁ q)
+        with inj-IBwd2IList {ts = ts'}{ts} (lemma<>1 [] (lookup Tss e)) q
 uniqueVal _ (V-constr e Tss .refl refl {ts} vs refl) (V-constr _ _ .refl refl {.ts} vs₁ refl) | refl =
      cong (λ vs → V-constr e Tss refl refl vs refl) (uniqueVal-List vs vs₁)
 ```
@@ -173,7 +173,7 @@ VE-constr-lemma : ∀ {Vs} {H} {Ts}
                     (ts : Algorithmic.ConstrArgs ∅ Ts)
                     {ZS}
                     (p : ZS ≡ (Vs <>< (H ∷ Ts)))
-                    {zs : IBwd (∅ ⊢_) ZS} 
+                    {zs : IBwd (∅ ⊢_) ZS}
                     (q : substEq (IBwd (∅ ⊢_)) p zs ≡ (tvs <><I (M ∷ ts)))
                     (vs : VList zs)
                    → VList (tvs <><I (M ∷ ts))
@@ -188,12 +188,12 @@ lemVE M (EC₁ ·⋆ A / x) (V-IΠ b (step⋆ x₁ .x)) = lemVE _ EC₁ (V-I b x
 lemVE M (wrap EC₁) (V-wrap V) = lemVE _ EC₁ V
 lemVE M (unwrap EC₁ / x) (V-I⇒ b ())
 lemVE M (unwrap EC₁ / x) (V-IΠ b ())
-lemVE M (constr {Vs = Vs}{H}{Ts} i A refl {tidx} {tvs} vs ts E) (V-constr _ _ _ refl {zs} vs' x) = 
+lemVE M (constr {Vs = Vs}{H}{Ts} i A refl {tidx} {tvs} vs ts E) (V-constr _ _ _ refl {zs} vs' x) =
        lemVE M E (proj-IIBwd (E [ M ]ᴱ) tvs ts
-                             (VE-constr-lemma ts (lemma<>2 Vs (H ∷ Ts)) 
-                                         (trans (cong (substEq (IBwd (_⊢_ ∅)) (lemma<>2 Vs (H ∷ Ts))) 
-                                        (trans (IBwd<>IList (lemma<>1 [] (Vs <>> (H ∷ Ts))) x) 
-                                          ((≡-subst-removable (IBwd (_⊢_ ∅)) _ refl  ([] <><I (tvs <>>I ((E [ M ]ᴱ) ∷ ts))))))) 
+                             (VE-constr-lemma ts (lemma<>2 Vs (H ∷ Ts))
+                                         (trans (cong (substEq (IBwd (_⊢_ ∅)) (lemma<>2 Vs (H ∷ Ts)))
+                                        (trans (IBwd<>IList (lemma<>1 [] (Vs <>> (H ∷ Ts))) x)
+                                          ((≡-subst-removable (IBwd (_⊢_ ∅)) _ refl  ([] <><I (tvs <>>I ((E [ M ]ᴱ) ∷ ts)))))))
                                          (lemma<>I2 tvs ((E [ M ]ᴱ) ∷ ts))) vs'))
 lemVE M (EC.case cs E) (V-I⇒ b ())
 lemVE M (EC.case cs E) (V-IΠ b ())
@@ -254,10 +254,10 @@ substƛVal refl = V-ƛ _
 
 
 BUILTIN-eq : ∀{A b b'}(M : ∅ ⊢ A)
-  → ∀{tn}{pt : tn ∔ _ ≣ fv (signature b)} 
+  → ∀{tn}{pt : tn ∔ _ ≣ fv (signature b)}
   → ∀{an}{pa : an ∔ _ ≣ args♯ (signature b)}
   → {σA : SigTy pt pa A}
-  → ∀{tn'}{pt' : tn' ∔ _ ≣ fv (signature b')} 
+  → ∀{tn'}{pt' : tn' ∔ _ ≣ fv (signature b')}
   → ∀{an'}{pa' : an' ∔ _ ≣ args♯ (signature b')}
   → {σA' : SigTy pt' pa' A}
   → (bv : BApp b σA M)
@@ -266,9 +266,9 @@ BUILTIN-eq : ∀{A b b'}(M : ∅ ⊢ A)
 BUILTIN-eq M {σA = σA} {σA' = σA'} bv bv'
   with uniqueBApp' M bv bv'
 ... | refl ,, refl ,, refl ,, refl ,, refl ,, refl ,, refl
-  with uniqueSigTy σA σA' 
-... | refl  with uniqueBApp M bv bv' 
-... | refl = refl 
+  with uniqueSigTy σA σA'
+... | refl  with uniqueBApp M bv bv'
+... | refl = refl
 
 determinism⋆ : ∀{A}{L N N' : ∅ ⊢ A} → L —→⋆ N → L —→⋆ N' → N ≡ N'
 determinism⋆ (β-ƛ _) (β-ƛ _) = refl
@@ -276,9 +276,9 @@ determinism⋆ (β-Λ refl) (β-Λ refl) = refl
 determinism⋆ (β-wrap _ refl) (β-wrap _ refl) = refl
 determinism⋆ (β-builtin b t bt u vu) (β-builtin b' .t bt' .u vu') =
   BUILTIN-eq _  (step bt vu) (step bt' vu')
-determinism⋆ (β-case e Tss refl {ts} vs refl cases) (β-case e' Tss' refl {ts'} vs' q cases') 
-   with inj-IBwd2IList {ts = ts'}{ts} (lemma<>1 [] (lookup Tss e)) q 
-... | refl = refl 
+determinism⋆ (β-case e Tss refl {ts} vs refl cases) (β-case e' Tss' refl {ts'} vs' q cases')
+   with inj-IBwd2IList {ts = ts'}{ts} (lemma<>1 [] (lookup Tss e)) q
+... | refl = refl
 
 data Redex {A : ∅ ⊢Nf⋆ *} : ∅ ⊢ A → Set where
   β   : {L N : ∅ ⊢ A} → L —→⋆ N → Redex L
@@ -308,8 +308,8 @@ data RProgress {A : ∅ ⊢Nf⋆ *} (M : ∅ ⊢ A) : Set where
       -----------
     → RProgress M
 
-data FocusedRProgress : ∀{tot}(itot : IList (∅ ⊢_) tot) → Set 
-     where 
+data FocusedRProgress : ∀{tot}(itot : IList (∅ ⊢_) tot) → Set
+     where
      done  : ∀{bs}{ibs : IBwd (∅ ⊢_) bs}{tot}{itot : IList (∅ ⊢_) tot}
               {idx : tot ≣ bs <>> []}
              (x : (itot ≣I ibs <>> []) idx)
@@ -331,7 +331,7 @@ data FocusedRProgress : ∀{tot}(itot : IList (∅ ⊢_) tot) → Set
             → ∃ λ (p : B ≡ B')
             → substEq (EC A) p E ≡ E' × substEq (∅ ⊢_) p L ≡ L')
           ----
-           → ∀ {ls : List (∅ ⊢Nf⋆ *)}(cs : ConstrArgs ∅ ls) 
+           → ∀ {ls : List (∅ ⊢Nf⋆ *)}(cs : ConstrArgs ∅ ls)
            → {idx : tot ≣ bs <>> (A ∷ ls)}
            → (x : (itot ≣I ibs <>> (M ∷ cs)) idx)
            → FocusedRProgress itot
@@ -360,13 +360,13 @@ U·⋆1 p (constr i _ refl vs ts E') () y
 U·⋆2 : ∀{K}{C}{A : ∅ ⊢Nf⋆ K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{M : ∅ ⊢ Π B}{E : EC (Π B) C}{L : ∅ ⊢ C}{X}
  {B' : ∅ ⊢Nf⋆ *}
  → ¬ (Value M)
- → (p : X ≡ B [ A ]Nf) 
+ → (p : X ≡ B [ A ]Nf)
  → (E' : EC X B')
- → {L' : ∅ ⊢ B'} → M _⊢_.·⋆ A / p ≡ (E' [ L' ]ᴱ) 
- → Redex L' 
- → (U : {B' : ∅ ⊢Nf⋆ *} (E' : EC (Π B) B') {L' : ∅ ⊢ B'} 
-      → M ≡ (E' [ L' ]ᴱ) 
-      → Redex L' 
+ → {L' : ∅ ⊢ B'} → M _⊢_.·⋆ A / p ≡ (E' [ L' ]ᴱ)
+ → Redex L'
+ → (U : {B' : ∅ ⊢Nf⋆ *} (E' : EC (Π B) B') {L' : ∅ ⊢ B'}
+      → M ≡ (E' [ L' ]ᴱ)
+      → Redex L'
       → ∃ (λ (q : C ≡ B') → substEq (EC _) q E ≡ E' × substEq (_⊢_ ∅) q L ≡ L'))
  → ∃ (λ (p₁ : C ≡ B') →
      substEq (EC X) p₁ (E EC.·⋆ A / p) ≡ E'
@@ -428,71 +428,71 @@ Uunwrap2 : ∀{A}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (
   Redex L' →
   ∃ (λ (q : X ≡ B')
     → substEq (EC X) q [] ≡ E' × substEq (∅ ⊢_) q (unwrap (wrap A B M) p) ≡ L')
-Uunwrap2 VM eq [] refl q = refl ,, refl ,, refl 
+Uunwrap2 VM eq [] refl q = refl ,, refl ,, refl
 Uunwrap2 VM eq (unwrap E / x) p q with lem-unwrap p
 ... | refl ,, refl ,, refl ,, X4 = ⊥-elim (valredex (lemVE _ E (substEq Value (≅-to-≡ X4) (V-wrap VM))) q)
 
 Ucase2 : ∀ {n} {Tss : Vec.Vec (List (∅ ⊢Nf⋆ *)) n}
            {M  : (∅ ⊢ SOP Tss)} {A}
-           {cs : Algorithmic.Cases ∅ A Tss} 
+           {cs : Algorithmic.Cases ∅ A Tss}
            (VM : Value M)
            {B'} {n'}{Tss' : Vec.Vec (List (∅ ⊢Nf⋆ *)) n'} {L' : ∅ ⊢ B'}
-       → (cs' : Algorithmic.Cases ∅ A Tss') 
-       → (E' : EC (SOP Tss') B') 
-       → _⊢_.case M cs ≡ _⊢_.case (E' [ L' ]ᴱ) cs' 
-       → Redex L' 
+       → (cs' : Algorithmic.Cases ∅ A Tss')
+       → (E' : EC (SOP Tss') B')
+       → _⊢_.case M cs ≡ _⊢_.case (E' [ L' ]ᴱ) cs'
+       → Redex L'
        → Σ (A ≡ B') (λ p → Σ (substEq (EC A) p [] ≡ case cs' E') (λ x → substEq (_⊢_ ∅) p (case M cs) ≡ L'))
 Ucase2 VM cs' E' refl r = ⊥-elim (valredex (lemVE _ E' VM) r)
 
 constr-helper : ∀ {Bs : Bwd (∅ ⊢Nf⋆ *)}
                   {bs} (ibs : IBwd (_⊢_ ∅) bs)
-                  {A} (w : ∅ ⊢ A) 
+                  {A} (w : ∅ ⊢ A)
                   {ls} (ils : ConstrArgs ∅ ls)
-                  {ts : IBwd (_⊢_ ∅) Bs} 
+                  {ts : IBwd (_⊢_ ∅) Bs}
           → (vs : IIBwd Value ts)
-          → (p : Bs ≡ bs <>< (A ∷ ls)) 
+          → (p : Bs ≡ bs <>< (A ∷ ls))
           → (q : substEq (IBwd (_⊢_ ∅)) p ts ≡ ibs <><I (w ∷ ils))
           → Value w
 constr-helper ibs w ils vs refl refl = proj-IIBwd w ibs ils vs
 
-subst-helper : ∀{a p} {A : Set a}(P : A → Set p) 
-                  {a x y : A} (a≡x : a ≡ x) (a≡y : a ≡ y) {p : P x}{q : P y} 
-                → substEq P (sym a≡x) p ≡ substEq P (sym a≡y) q 
+subst-helper : ∀{a p} {A : Set a}(P : A → Set p)
+                  {a x y : A} (a≡x : a ≡ x) (a≡y : a ≡ y) {p : P x}{q : P y}
+                → substEq P (sym a≡x) p ≡ substEq P (sym a≡y) q
                  → Σ (x ≡ y) λ eq → substEq P eq p ≡ q
-subst-helper P refl refl refl = refl ,, refl 
+subst-helper P refl refl refl = refl ,, refl
 
 Uconstr : ∀ {n} {Tss : Vec.Vec (List (∅ ⊢Nf⋆ *)) n} →
           -- First
-          ∀ {i : Fin n} {tot : ConstrArgs ∅ (lookup Tss i)} 
-            {B}  {bs} {H} {ls} 
+          ∀ {i : Fin n} {tot : ConstrArgs ∅ (lookup Tss i)}
+            {B}  {bs} {H} {ls}
             {ibs : IBwd (_⊢_ ∅) bs}
-          → (vs : IIBwd Value ibs) 
+          → (vs : IIBwd Value ibs)
           → (cs : IList (_⊢_ ∅) ls)
-          → (idx : lookup Tss i ≣ bs <>> (H ∷ ls)) 
-          → (E : EC H B) (L : ∅ ⊢ B) 
+          → (idx : lookup Tss i ≣ bs <>> (H ∷ ls))
+          → (E : EC H B) (L : ∅ ⊢ B)
           → Redex L
-          → tot ≡ substEq (IList (_⊢_ ∅)) (sym (lem-≣-<>> idx)) (ibs <>>I ((E [ L ]ᴱ) ∷ cs)) 
+          → tot ≡ substEq (IList (_⊢_ ∅)) (sym (lem-≣-<>> idx)) (ibs <>>I ((E [ L ]ᴱ) ∷ cs))
           -- Second
        → ∀  {i' : Fin n}
-            {B'} {Vs} {H'} {Ts} 
+            {B'} {Vs} {H'} {Ts}
             {tvs : IBwd (_⊢_ ∅) Vs}
-          → (vs' : IIBwd Value tvs) 
+          → (vs' : IIBwd Value tvs)
           → (cs' : ConstrArgs ∅ Ts)
-          → (idx' :  lookup Tss i' ≣ Vs <>> (H' ∷ Ts))    
+          → (idx' :  lookup Tss i' ≣ Vs <>> (H' ∷ Ts))
           → (E' : EC H' B') (L' : ∅ ⊢ B')
         → _≡_ {_}{∅ ⊢ SOP Tss} (constr i Tss refl tot) (constr i' Tss refl (substEq (IList (_⊢_ ∅)) ((sym (lem-≣-<>> idx'))) (tvs <>>I ((E' [ L' ]ᴱ) ∷ cs'))))
         → Redex L'
         → (∀ {B''} (E'' : EC H B'') {L' = L'' : ∅ ⊢ B''} →
-            (E [ L ]ᴱ) ≡ (E'' [ L'' ]ᴱ) 
-             →   Redex L'' 
+            (E [ L ]ᴱ) ≡ (E'' [ L'' ]ᴱ)
+             →   Redex L''
              →  Σ (B ≡ B'') (λ p → substEq (EC H) p E ≡ E'' × substEq (_⊢_ ∅) p L ≡ L''))
         → Σ (B ≡ B') (λ p → substEq (EC (SOP Tss)) p (constr i Tss refl {idx} {_} vs cs E) ≡  (constr i' Tss refl {idx'} vs' cs' E') × (substEq _ p L ≡ L'))
 Uconstr {tot = tot} vs cs idx E L r p vs' cs' idx' E' L' refl r' U with subst-helper (IList (∅ ⊢_)) (lem-≣-<>> idx') (lem-≣-<>> idx) p
-... | x ,, y with equalbyPredicateI tot Value (lem-≣-<>> idx) (lem-≣-<>> idx') p refl vs vs' (λ V → valredex (lemVE _ E V) r) (λ V' → valredex (lemVE _ E' V') r') 
+... | x ,, y with equalbyPredicateI tot Value (lem-≣-<>> idx) (lem-≣-<>> idx') p refl vs vs' (λ V → valredex (lemVE _ E V) r) (λ V' → valredex (lemVE _ E' V') r')
 ... | refl ,, refl ,, refl ,, refl with uniqueVal-List vs vs' | unique-≣-<>> idx idx'
-Uconstr {ibs = ibs} vs cs idx E L r p .vs cs' idx' E' L' refl r' U 
+Uconstr {ibs = ibs} vs cs idx E L r p .vs cs' idx' E' L' refl r' U
   | refl ,, y | refl ,, refl ,, refl ,, refl | refl | refl with ∷-injectiveI refl (<>>I-cancelˡ ibs ((E' [ L' ]ᴱ) ∷ cs') ((E [ L ]ᴱ) ∷ cs) y)
-... | pel ,, refl with U E' (sym pel) r' 
+... | pel ,, refl with U E' (sym pel) r'
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
 
 ----------
@@ -501,13 +501,13 @@ Uconstr {ibs = ibs} vs cs idx E L r p .vs cs' idx' E' L' refl r' U
 rlemma51! : {A : ∅ ⊢Nf⋆ *} → (M : ∅ ⊢ A) → RProgress M
 
 rlemma51-List :  ∀{tot}{itot : IList (∅ ⊢_) tot}{bs}{ibs : IBwd (∅ ⊢_) bs}
-                  {ls}{idx : tot ≣ bs <>> ls} 
+                  {ls}{idx : tot ≣ bs <>> ls}
                → (cs : IList (∅ ⊢_) ls)
                → (iidx : (itot ≣I ibs <>> cs) idx)
                → VList ibs
                → FocusedRProgress itot
 rlemma51-List [] x Vs = done x Vs
-rlemma51-List (c ∷ cs) x Vs with rlemma51! c 
+rlemma51-List (c ∷ cs) x Vs with rlemma51! c
 ... | step  ¬VM E p q U = step Vs ¬VM E p q U cs x
 ... | done V = rlemma51-List cs (bubble x) (Vs :< V)
 
@@ -517,7 +517,7 @@ rlemma51! (M · N) with rlemma51! M
   (lemV· ¬VM)
   (E l· N)
   p
-  (cong (_· N) q) 
+  (cong (_· N) q)
         λ { [] refl (β (β-ƛ VN)) → ⊥-elim (¬VM (V-ƛ _))
           ; [] refl (β (β-builtin b .M bt .N vu)) → ⊥-elim (¬VM (V-I⇒ b bt))
           ; (E' l· N') refl r → let X ,, Y ,, Y' = U E' refl r in X ,,  trans ( subst-l· E N X)  (cong (_l· N) Y)  ,, Y'
@@ -527,7 +527,7 @@ rlemma51! (M · N) with rlemma51! M
   (lemV'· ¬VN)
   (VM ·r E)
   p
-  (cong (M ·_) q) 
+  (cong (M ·_) q)
         λ { [] refl (β (β-ƛ VN)) → ⊥-elim (¬VN VN)
           ; [] refl (β (β-builtin b .M bt .N VN)) → ⊥-elim (¬VN VN)
           ; (E' l· N') refl q → ⊥-elim (valredex (lemVE _ _ VM) q)
@@ -585,57 +585,57 @@ rlemma51! (unwrap M x) with rlemma51! M
   refl
   λ E p' q' → Uunwrap2 VM x E p' q'
 rlemma51! (con c refl) = done (V-con c)
-rlemma51! (constr i Tss refl tot) with rlemma51-List tot start [] 
-... | done {bs}{ibs}{idx = idx} x vs = done 
-          (V-constr i 
-                    Tss 
-                    refl 
+rlemma51! (constr i Tss refl tot) with rlemma51-List tot start []
+... | done {bs}{ibs}{idx = idx} x vs = done
+          (V-constr i
+                    Tss
+                    refl
                     (sym (lemma<>2' _ _ (sym (lem-≣-<>> idx))))
-                    vs 
-                    (trans (≡-subst-removable (IList (_⊢_ ∅)) _ _ (ibs <>>I [])) 
+                    vs
+                    (trans (≡-subst-removable (IList (_⊢_ ∅)) _ _ (ibs <>>I []))
                            (sym (lem-≣I-<>>1' x))))
-... | step {bs = bs}{ibs} vs ¬VM E {L} r refl U {ls} cs {idx} x = step 
-          (λ {(V-constr .i .Tss .refl refl {ts} vs' x') → 
-                ¬VM (constr-helper ibs 
-                                   (E [ L ]ᴱ) 
-                                   cs 
+... | step {bs = bs}{ibs} vs ¬VM E {L} r refl U {ls} cs {idx} x = step
+          (λ {(V-constr .i .Tss .refl refl {ts} vs' x') →
+                ¬VM (constr-helper ibs
+                                   (E [ L ]ᴱ)
+                                   cs
                                    (substEq VList (IBwd<>IList (lemma<>1 [] (lookup Tss i)) {ts} x') vs')
-                                  (trans (cong ([] <><_) (lem-≣-<>> idx)) (lemma<>2 bs (_ ∷ ls))) 
+                                  (trans (cong ([] <><_) (lem-≣-<>> idx)) (lemma<>2 bs (_ ∷ ls)))
                                   (trans (trans (trans
-                                     (trans (trans 
-                                         (subst-subst (lemma<>2' ([] <>< lookup Tss i) (lookup Tss i) (lemma<>1 [] (lookup Tss i))) 
-                                              {(trans (cong ([] <><_) (lem-≣-<>> idx)) (lemma<>2 bs (_ ∷ ls)))}) 
-                                         (≡-subst-removable (IBwd (∅ ⊢_)) _ _ ([] <><I tot))) 
-                                         (sym (subst-subst (cong (_<><_ []) (lem-≣-<>> idx)) {lemma<>2 bs (_ ∷ ls) }  ))) 
-                                         (cong (substEq (IBwd (_⊢_ ∅)) (lemma<>2 bs (_ ∷ ls))) (sym (lem-<><I-subst(lem-≣-<>> idx))))) 
-                                         (cong (substEq (IBwd (_⊢_ ∅)) (lemma<>2 bs (_ ∷ ls))) (cong ([] <><I_) (lem-≣I-<>>1 x)))) 
-                                         (lemma<>I2 ibs ((E [ L ]ᴱ) ∷ cs))))  }) 
-          (constr i Tss refl { idx } vs cs E) 
-          r 
+                                     (trans (trans
+                                         (subst-subst (lemma<>2' ([] <>< lookup Tss i) (lookup Tss i) (lemma<>1 [] (lookup Tss i)))
+                                              {(trans (cong ([] <><_) (lem-≣-<>> idx)) (lemma<>2 bs (_ ∷ ls)))})
+                                         (≡-subst-removable (IBwd (∅ ⊢_)) _ _ ([] <><I tot)))
+                                         (sym (subst-subst (cong (_<><_ []) (lem-≣-<>> idx)) {lemma<>2 bs (_ ∷ ls) }  )))
+                                         (cong (substEq (IBwd (_⊢_ ∅)) (lemma<>2 bs (_ ∷ ls))) (sym (lem-<><I-subst(lem-≣-<>> idx)))))
+                                         (cong (substEq (IBwd (_⊢_ ∅)) (lemma<>2 bs (_ ∷ ls))) (cong ([] <><I_) (lem-≣I-<>>1 x))))
+                                         (lemma<>I2 ibs ((E [ L ]ᴱ) ∷ cs))))  })
+          (constr i Tss refl { idx } vs cs E)
+          r
           (constr-cong (trans (sym (lem-≣-<>> idx)) refl) (trans (lem-≣I-<>>1' x) (≡-subst-removable (IList (_⊢_ ∅)) _ _ (ibs <>>I ((E [ _ ]ᴱ) ∷ cs)))))
           λ { [] refl (β ())
             ; (constr i' .Tss refl {idx'} {tvs} vs' cs' E') {L'} p' r' →
-                  Uconstr vs cs idx E L r (lem-≣I-<>>1' x) 
-                                  vs' cs' idx' E' L' (trans p' 
-                                                            (sym (constr-cong (trans (sym (lem-≣-<>> idx')) refl) 
-                                                            (≡-subst-removable (IList (_⊢_ ∅)) (sym (lem-≣-<>> idx')) (trans (sym (lem-≣-<>> idx')) refl) _)))) 
-                                  r' U 
+                  Uconstr vs cs idx E L r (lem-≣I-<>>1' x)
+                                  vs' cs' idx' E' L' (trans p'
+                                                            (sym (constr-cong (trans (sym (lem-≣-<>> idx')) refl)
+                                                            (≡-subst-removable (IList (_⊢_ ∅)) (sym (lem-≣-<>> idx')) (trans (sym (lem-≣-<>> idx')) refl) _))))
+                                  r' U
             }
-rlemma51! (case M cs) with rlemma51! M  
-... | step ¬VM E p q U = step (λ V → ¬VM (lemVE _ (EC.case cs []) V)) 
-                              (EC.case cs E) 
-                              p 
-                              (cong₂ case q refl) 
+rlemma51! (case M cs) with rlemma51! M
+... | step ¬VM E p q U = step (λ V → ¬VM (lemVE _ (EC.case cs []) V))
+                              (EC.case cs E)
+                              p
+                              (cong₂ case q refl)
                               λ { [] refl (β (β-case e _ q vs x .cs)) → ⊥-elim (¬VM (V-constr e _ refl q vs x))
-                                ; (case x E') refl q' → let X ,, Y ,, Y' = U E' refl q' 
+                                ; (case x E') refl q' → let X ,, Y ,, Y' = U E' refl q'
                                                         in X ,, (trans (subst-case cs E X) (cong (case cs) Y)) ,, Y'}
-... | done VM@(V-constr e Tss refl refl vs x) = 
-      step (λ V → valred V (β-case e Tss refl vs x cs)) 
-          [] 
-          (β (β-case e Tss refl vs x cs)) 
-          refl 
+... | done VM@(V-constr e Tss refl refl vs x) =
+      step (λ V → valred V (β-case e Tss refl vs x cs))
+          []
+          (β (β-case e Tss refl vs x cs))
+          refl
           λ { [] refl r → refl ,, refl ,, refl
-            ; (EC.case cs' E') p r → Ucase2 VM cs' E' p r} 
+            ; (EC.case cs' E') p r → Ucase2 VM cs' E' p r}
 rlemma51! (builtin b / refl) = done (ival b)
 rlemma51! (error _) = step
   (valerr E-error)
@@ -687,5 +687,5 @@ determinism {L = L} (ruleErr E' p) (ruleEC .E () q' q'') | step ¬VL E err r' U 
 determinism {L = L} (ruleErr E' p) (ruleErr E'' q) | step ¬VL E err r' U with U E' p err | U E'' q err
 ... | refl ,, refl ,, refl | refl ,, refl ,, refl = refl
 -- -}
-```  
-    
+```
+

--- a/plutus-metatheory/src/Algorithmic/ReductionEC/Progress.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC/Progress.lagda.md
@@ -12,10 +12,10 @@ open import Data.Nat using (zero;suc)
 open import Data.Fin using (Fin;zero;suc)
 open import Data.Vec as Vec using ([];_∷_;lookup)
 open import Data.Product using (Σ;_×_) renaming (_,_ to _,,_)
-open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;trans;cong;subst)  
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;trans;cong;subst)
 
 open import Utils using (*;bubble;≡-subst-removable)
-open import Utils.List 
+open import Utils.List
 open import Type using (Ctx⋆;∅)
 open import Algorithmic using (Ctx;_⊢_;ConstrArgs;constr-cong)
 open Ctx
@@ -48,17 +48,17 @@ data Progress {A : ∅ ⊢Nf⋆ *} (M : ∅ ⊢ A) : Set where
     → Progress M
 ```
 
-## Progress for lists 
+## Progress for lists
 
 When processing constructors, we need to know the progress of a list of terms.
 A ProgressList is a zipper consisting of:
   * a typed backwards list of constructors already evaluated (vs),
-  * Progress on the current term M of type H  
+  * Progress on the current term M of type H
   * a (typed) lists of terms to be evaluated (ts)
 
 ```
-data FocusedProgDissect : ∀{tot}(itot : IList (∅ ⊢_) tot) → Set 
-     where 
+data FocusedProgDissect : ∀{tot}(itot : IList (∅ ⊢_) tot) → Set
+     where
      done  : ∀{bs}{ibs : IBwd (∅ ⊢_) bs}{tot}{itot : IList (∅ ⊢_) tot}
               {idx : tot ≣ bs <>> []}
              (x : (itot ≣I ibs <>> []) idx)
@@ -67,7 +67,7 @@ data FocusedProgDissect : ∀{tot}(itot : IList (∅ ⊢_) tot) → Set
      step  :  ∀{tot}{itot : IList (∅ ⊢_) tot}
            → ∀{bs}{ibs : IBwd (∅ ⊢_) bs}(vs : VList ibs) --evaluated
            → ∀{A : ∅ ⊢Nf⋆ *} {M : ∅ ⊢ A}{N : ∅ ⊢ A} → (st : M —→ N)  --current step
-           → ∀ {ls : List (∅ ⊢Nf⋆ *)}(cs : ConstrArgs ∅ ls) 
+           → ∀ {ls : List (∅ ⊢Nf⋆ *)}(cs : ConstrArgs ∅ ls)
            → {idx : tot ≣ bs <>> (A ∷ ls)}
            → (x : (itot ≣I ibs <>> (M ∷ cs)) idx)
            → FocusedProgDissect itot
@@ -76,13 +76,13 @@ progress : {A : ∅ ⊢Nf⋆ *} → (M : ∅ ⊢ A) → Progress M
 
 -- Walk the list to look for the first term than can make progress or is an error.
 progress-focus : ∀{tot}{itot : IList (∅ ⊢_) tot}{bs}{ibs : IBwd (∅ ⊢_) bs}
-                  {ls}{idx : tot ≣ bs <>> ls} 
+                  {ls}{idx : tot ≣ bs <>> ls}
                → (cs : IList (∅ ⊢_) ls)
                → (iidx : (itot ≣I ibs <>> cs) idx)
                → VList ibs
                → FocusedProgDissect itot
 progress-focus [] x Vs = done x Vs
-progress-focus (c ∷ cs) x Vs with progress c 
+progress-focus (c ∷ cs) x Vs with progress c
 ... | step st = step Vs st cs x
 ... | done V = progress-focus cs (bubble x) (Vs :< V)
 
@@ -119,28 +119,28 @@ progress (con c refl)      = done (V-con c)
 progress (builtin b / refl ) = done (ival b)
 progress (error A)    = step (ruleErr [] refl)
 progress (constr i Tss refl cs)  with progress-focus cs start []
-... | done {bs}{ibs}{idx = idx} x Vs = done (V-constr i 
-                                                     Tss 
-                                                     refl 
-                                                     (trans (sym (lemma<>2 bs [])) (cong ([] <><_) (sym (lem-≣-<>> idx)))) 
-                                                     Vs 
+... | done {bs}{ibs}{idx = idx} x Vs = done (V-constr i
+                                                     Tss
+                                                     refl
+                                                     (trans (sym (lemma<>2 bs [])) (cong ([] <><_) (sym (lem-≣-<>> idx))))
+                                                     Vs
                                                      (trans (≡-subst-removable (IList (_⊢_ ∅)) _ _ (ibs <>>I [])) (sym (lem-≣I-<>>1' x))))
-... | step Vs (ruleEC E p refl refl) cs {idx} x = 
-                     step (ruleEC (constr i Tss refl {idx} Vs cs E) 
-                           p 
-                           (constr-cong (trans (sym (lem-≣-<>> idx)) refl) 
-                                         (trans (lem-≣I-<>>1' x) 
+... | step Vs (ruleEC E p refl refl) cs {idx} x =
+                     step (ruleEC (constr i Tss refl {idx} Vs cs E)
+                           p
+                           (constr-cong (trans (sym (lem-≣-<>> idx)) refl)
+                                         (trans (lem-≣I-<>>1' x)
                                                 (≡-subst-removable (IList (_⊢_ ∅)) (sym (lem-≣-<>> idx)) (trans (sym (lem-≣-<>> idx)) refl) _)))
                            refl)
-... | step Vs (ruleErr E refl) cs {idx} x = 
-             step (ruleErr (constr i Tss refl {idx} Vs cs E) 
-                    (constr-cong (trans (sym (lem-≣-<>> idx)) refl) 
-                                 (trans (lem-≣I-<>>1' x) 
-                                        (≡-subst-removable (IList (_⊢_ ∅)) (sym (lem-≣-<>> idx)) (trans (sym (lem-≣-<>> idx)) refl) _))) 
+... | step Vs (ruleErr E refl) cs {idx} x =
+             step (ruleErr (constr i Tss refl {idx} Vs cs E)
+                    (constr-cong (trans (sym (lem-≣-<>> idx)) refl)
+                                 (trans (lem-≣I-<>>1' x)
+                                        (≡-subst-removable (IList (_⊢_ ∅)) (sym (lem-≣-<>> idx)) (trans (sym (lem-≣-<>> idx)) refl) _)))
                   )
-progress (case M cases)  with progress M 
+progress (case M cases)  with progress M
 ... | step (ruleEC E p refl refl) = step (ruleEC (case cases E) p refl refl)
 ... | step (ruleErr E refl) = step (ruleErr (case cases E) refl)
 ... | done (V-constr e Tss refl refl vs refl) = step (ruleEC [] (β-case e Tss refl vs refl cases) refl refl)
 
- 
+

--- a/plutus-metatheory/src/Algorithmic/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/RenamingSubstitution.lagda.md
@@ -12,7 +12,7 @@ module Algorithmic.RenamingSubstitution where
 open import Function using (id; _∘_)
 open import Data.Nat using (suc;zero)
 open import Data.Fin using (Fin;zero;suc)
-open import Data.Vec as Vec using (Vec;[];_∷_;lookup) 
+open import Data.Vec as Vec using (Vec;[];_∷_;lookup)
 open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;trans;cong;cong₂;subst)
 
 open import Utils using (Kind;*)
@@ -64,13 +64,13 @@ ext⋆ ρ⋆ ρ (T {A = A} x) = conv∋
   (T (ρ x))
 ```
 
-A property showing that renaming and the creating the case type is the same as 
+A property showing that renaming and the creating the case type is the same as
 creating the case type and the renaming.
 
 ```
-ren-mkCaseType : ∀ {Φ Ψ} 
+ren-mkCaseType : ∀ {Φ Ψ}
            → (ρ⋆ : ⋆.Ren Φ Ψ)
-           → ∀{A} As 
+           → ∀{A} As
            → renNf ρ⋆ (Algorithmic.mkCaseType A As) ≡ Algorithmic.mkCaseType (renNf ρ⋆ A) (renNf-List ρ⋆ As)
 ren-mkCaseType ρ⋆ [] = refl
 ren-mkCaseType ρ⋆ (x ∷ As) = cong (renNf ρ⋆ x ⇒_) (ren-mkCaseType ρ⋆ As)
@@ -97,15 +97,15 @@ ren-ConstrArgs : ∀ {Φ Ψ Γ Δ n}
 ren-ConstrArgs-List : ∀ {Φ Ψ Γ Δ}
   → (ρ⋆ : ⋆.Ren Φ Ψ)
   → (ρ : Ren ρ⋆ Γ Δ)
-  → {As : List (Φ ⊢Nf⋆ *) } 
+  → {As : List (Φ ⊢Nf⋆ *) }
   → (x : ConstrArgs Γ As)
     -------------------------------
   → ConstrArgs Δ (renNf-List ρ⋆ As)
 
-ren-Cases : ∀ {Φ Ψ Γ Δ n} 
+ren-Cases : ∀ {Φ Ψ Γ Δ n}
          → (ρ⋆ : ⋆.Ren Φ Ψ)
          → (ρ : Ren ρ⋆ Γ Δ)
-         → {A : Φ ⊢Nf⋆ *} 
+         → {A : Φ ⊢Nf⋆ *}
          → {Tss : Vec (List (Φ ⊢Nf⋆ *)) n}
          → (cases : Cases Γ A Tss)
           -------------------------------------------
@@ -113,7 +113,7 @@ ren-Cases : ∀ {Φ Ψ Γ Δ n}
 
 ren ρ⋆ ρ (` x)             = ` (ρ x)
 ren ρ⋆ ρ (ƛ N)             = ƛ (ren ρ⋆ (ext ρ⋆ ρ) N)
-ren ρ⋆ ρ (L · M)           = ren ρ⋆ ρ L · ren ρ⋆ ρ M 
+ren ρ⋆ ρ (L · M)           = ren ρ⋆ ρ L · ren ρ⋆ ρ M
 ren ρ⋆ ρ (Λ N)             = Λ (ren (⋆.ext ρ⋆) (ext⋆ ρ⋆ ρ) N)
 ren ρ⋆ ρ (_·⋆_/_ {B = B} t A refl) = conv⊢
   refl
@@ -126,7 +126,7 @@ ren ρ⋆ ρ (wrap A B M)       = wrap
 ren ρ⋆ ρ (unwrap {A = A}{B} M refl) = conv⊢
   refl
   (sym (ren-nf-μ ρ⋆ A B))
-  (unwrap (ren ρ⋆ ρ M) refl) 
+  (unwrap (ren ρ⋆ ρ M) refl)
 ren ρ⋆ ρ (con {A} c refl)    = con c (subNf∅-renNf ρ⋆ A)
 ren ρ⋆ ρ (builtin b / refl)  = conv⊢ refl (btype-ren b ρ⋆) (builtin b / refl)
 ren ρ⋆ ρ (error A)           = error (renNf ρ⋆ A)
@@ -136,13 +136,13 @@ ren ρ⋆ ρ (case x cases)      = case (ren ρ⋆ ρ x) (ren-Cases ρ⋆ ρ cas
 ren-ConstrArgs-List ρ⋆ ρ [] = []
 ren-ConstrArgs-List ρ⋆ ρ (t ∷ xs) = ren ρ⋆ ρ t ∷ ren-ConstrArgs-List ρ⋆ ρ xs
 
-ren-ConstrArgs ρ⋆ ρ e Tss x 
+ren-ConstrArgs ρ⋆ ρ e Tss x
           rewrite lookup-renNf-VecList ρ⋆ e Tss = ren-ConstrArgs-List ρ⋆ ρ x
 
 ren-Cases ρ⋆ ρ [] = []
-ren-Cases {Δ = Δ} ρ⋆ ρ {Tss = As ∷ _} (c ∷ cases) =   subst (Δ ⊢_) 
-                                                            (ren-mkCaseType ρ⋆ As) 
-                                                            (ren ρ⋆ ρ c) 
+ren-Cases {Δ = Δ} ρ⋆ ρ {Tss = As ∷ _} (c ∷ cases) =   subst (Δ ⊢_)
+                                                            (ren-mkCaseType ρ⋆ As)
+                                                            (ren ρ⋆ ρ c)
                                                     ∷ (ren-Cases ρ⋆ ρ cases)
 ```
 
@@ -214,22 +214,22 @@ sub-ConstrList σ⋆ σ (t ∷ xs) = sub σ⋆ σ t ∷ sub-ConstrList σ⋆ σ 
 sub-VecList : ∀ {Φ Ψ Γ Δ n}
   → (σ⋆ : SubNf Φ Ψ)
   → (σ : Sub σ⋆ Γ Δ)
-  → (e : Fin n) 
+  → (e : Fin n)
   → (Tss : Vec (List (Φ ⊢Nf⋆ *)) n)
   → (x : ConstrArgs Γ (lookup Tss e))
     --------------------------------------
   → ConstrArgs Δ (lookup (eval-VecList (⋆.sub-VecList (λ x₁ → embNf (σ⋆ x₁)) (embNf-VecList Tss)) (idEnv Ψ)) e)
-sub-VecList σ⋆ σ e Tss x rewrite lookup-eval-VecList e (⋆.sub-VecList (λ x₁ → embNf (σ⋆ x₁)) (embNf-VecList Tss)) (idEnv _) 
-                             | ⋆.lookup-sub-VecList (λ x₁ → embNf (σ⋆ x₁)) e (embNf-VecList Tss)  
+sub-VecList σ⋆ σ e Tss x rewrite lookup-eval-VecList e (⋆.sub-VecList (λ x₁ → embNf (σ⋆ x₁)) (embNf-VecList Tss)) (idEnv _)
+                             | ⋆.lookup-sub-VecList (λ x₁ → embNf (σ⋆ x₁)) e (embNf-VecList Tss)
                              | lookup-embNf-VecList e Tss = sub-ConstrList σ⋆ σ x
 
-sub-mkCaseType : ∀ {Φ Ψ} 
+sub-mkCaseType : ∀ {Φ Ψ}
            → (σ⋆ : SubNf Φ Ψ)
-           → ∀{A} As 
-           →    subNf σ⋆ (Algorithmic.mkCaseType A As) 
+           → ∀{A} As
+           →    subNf σ⋆ (Algorithmic.mkCaseType A As)
              ≡  Algorithmic.mkCaseType (subNf σ⋆ A) (eval-List (⋆.sub-List (λ x₁ → embNf (σ⋆ x₁)) (embNf-List As)) (idEnv Ψ))
 sub-mkCaseType σ⋆ [] = refl
-sub-mkCaseType σ⋆ (x ∷ As) = cong (subNf σ⋆ x ⇒_) (sub-mkCaseType σ⋆ As) 
+sub-mkCaseType σ⋆ (x ∷ As) = cong (subNf σ⋆ x ⇒_) (sub-mkCaseType σ⋆ As)
 
 sub-Cases : ∀ {Φ Ψ Γ Δ n}
   → (σ⋆ : SubNf Φ Ψ)
@@ -240,10 +240,10 @@ sub-Cases : ∀ {Φ Ψ Γ Δ n}
     ---------------------------------
   → Cases Δ (subNf σ⋆ A) (eval-VecList (⋆.sub-VecList (λ x₁ → embNf (σ⋆ x₁)) (embNf-VecList Tss)) (idEnv Ψ))
 sub-Cases σ⋆ σ [] = []
-sub-Cases {Δ = Δ} σ⋆ σ {Tss = As ∷ _} (c ∷ cs) =    subst (Δ ⊢_) 
-                                                          (sub-mkCaseType σ⋆ As) 
-                                                          (sub σ⋆ σ c) 
-                                                  ∷ (sub-Cases σ⋆ σ cs)                            
+sub-Cases {Δ = Δ} σ⋆ σ {Tss = As ∷ _} (c ∷ cs) =    subst (Δ ⊢_)
+                                                          (sub-mkCaseType σ⋆ As)
+                                                          (sub σ⋆ σ c)
+                                                  ∷ (sub-Cases σ⋆ σ cs)
 
 sub σ⋆ σ (` k)                     = σ k
 sub σ⋆ σ (ƛ N)                     = ƛ (sub σ⋆ (exts σ⋆ σ) N)
@@ -284,7 +284,7 @@ subcons σ⋆ σ t (S x) = σ x
 ```
 _[_] : ∀{Φ Γ}{A B : Φ ⊢Nf⋆ *}
   → Γ , B ⊢ A
-  → Γ ⊢ B 
+  → Γ ⊢ B
     -----
   → Γ ⊢ A
 _[_] {A = A}{B} b a = conv⊢ refl
@@ -297,7 +297,7 @@ _[_] {A = A}{B} b a = conv⊢ refl
 ```
 
 ```
-lem : ∀ {Φ Γ K} {B : Φ ,⋆ K ⊢Nf⋆ *}{A : Φ ⊢Nf⋆ K} → (x : Γ ,⋆ K ∋ B) → 
+lem : ∀ {Φ Γ K} {B : Φ ,⋆ K ⊢Nf⋆ *}{A : Φ ⊢Nf⋆ K} → (x : Γ ,⋆ K ∋ B) →
   Γ ⊢ subNf (subNf-cons (λ x₁ → ne (` x₁)) A) B
 lem (T x) = conv⊢
   refl
@@ -359,7 +359,7 @@ renˢ-List : ∀ {Φ Γ Δ}
     ----------------------
   → ConstrArgs Δ As
 renˢ-List ρ [] = []
-renˢ-List ρ (x ∷ xs) = renˢ ρ x ∷ (renˢ-List ρ xs)  
+renˢ-List ρ (x ∷ xs) = renˢ ρ x ∷ (renˢ-List ρ xs)
 
 renˢ-ConstrArgs : ∀ {Φ Γ Δ n}
   → (ρ : Renˢ Γ Δ)
@@ -372,9 +372,9 @@ renˢ-ConstrArgs ρ zero (As ∷ Tss) xs = renˢ-List ρ xs
 renˢ-ConstrArgs ρ (suc e) (As ∷ Tss) xs = renˢ-ConstrArgs ρ e Tss xs
 
 renˢ-Cases : ∀ {Φ Γ Δ n}
-  → (ρ : Renˢ Γ Δ) 
-  → {A : Φ ⊢Nf⋆ *} 
-  → {Tss : Vec (List (Φ ⊢Nf⋆ *)) n} 
+  → (ρ : Renˢ Γ Δ)
+  → {A : Φ ⊢Nf⋆ *}
+  → {Tss : Vec (List (Φ ⊢Nf⋆ *)) n}
   → (cs : Cases Γ A Tss)
     ------------------------------
   → Cases Δ A Tss
@@ -473,7 +473,7 @@ renˢ-Cases-cong : ∀ {Φ} {Γ Δ : Ctx Φ} {ρ ρ' : Renˢ Γ Δ}
                     {A : Φ ⊢Nf⋆ *} {n}
                     {Tss : Vec (List (Φ ⊢Nf⋆ *)) n}
                     (cs : Cases Γ A Tss)
-                   --------------------------------------------------  
+                   --------------------------------------------------
                  → renˢ-Cases ρ cs ≡ renˢ-Cases ρ' cs
 renˢ-Cases-cong p [] = refl
 renˢ-Cases-cong p (c ∷ cs) = cong₂ _∷_ (renˢ-cong p c) (renˢ-Cases-cong p cs)
@@ -500,7 +500,7 @@ renˢ-List-id : ∀ {Φ} {Γ : Ctx Φ} {A : List (Φ ⊢Nf⋆ *)}
 renˢ-List-id [] = refl
 renˢ-List-id (t ∷ cs) = cong₂ _∷_ (renˢ-id t) (renˢ-List-id cs)
 
-renˢ-ConstrArgs-id : ∀ {Φ} {Γ : Ctx Φ} {n} 
+renˢ-ConstrArgs-id : ∀ {Φ} {Γ : Ctx Φ} {n}
                     (e : Fin n)
                     (Tss : Vec (List (Φ ⊢Nf⋆ *)) n)
                     (cs : ConstrArgs Γ (lookup Tss e))
@@ -534,16 +534,16 @@ renˢ-comp : ∀ {Φ Γ Δ Θ}{A : Φ ⊢Nf⋆ *}
   → renˢ (ρ ∘ ρ') M ≡ renˢ ρ (renˢ ρ' M)
 
 renˢ-List-comp : ∀ {Φ} {Γ Δ Θ : Ctx Φ} {ρ : Renˢ Δ Θ}
-                   {ρ' : Renˢ Γ Δ} 
+                   {ρ' : Renˢ Γ Δ}
                    {A : List (Φ ⊢Nf⋆ *)}
-                   (cs : ConstrArgs Γ A) 
+                   (cs : ConstrArgs Γ A)
             -------------------------------------------------
           → renˢ-List (ρ ∘ ρ') cs ≡ renˢ-List ρ (renˢ-List ρ' cs)
 renˢ-List-comp [] = refl
 renˢ-List-comp (t ∷ cs) = cong₂ _∷_ (renˢ-comp t) (renˢ-List-comp cs)
 
 renˢ-ConstrArgs-comp : ∀ {Φ} {Γ Δ Θ : Ctx Φ} {ρ : Renˢ Δ Θ}
-                         {ρ' : Renˢ Γ Δ} {n} 
+                         {ρ' : Renˢ Γ Δ} {n}
                          (e : Fin n)
                          (Tss : Vec (List (Φ ⊢Nf⋆ *)) n)
                          (x : ConstrArgs Γ (lookup Tss e))
@@ -555,7 +555,7 @@ renˢ-ConstrArgs-comp (suc e) (_ ∷ Tss) x = renˢ-ConstrArgs-comp e Tss x
 renˢ-Cases-comp : ∀ {Φ} {Γ Δ Θ : Ctx Φ} {A : Φ ⊢Nf⋆ *}
               {ρ : Renˢ Δ Θ} {ρ' : Renˢ Γ Δ} {n} {Tss : Vec (List (Φ ⊢Nf⋆ *)) n}
               (cs : Cases Γ A Tss)
-              -------------------------------------------------------       
+              -------------------------------------------------------
            →  renˢ-Cases (ρ ∘ ρ') cs ≡ renˢ-Cases ρ (renˢ-Cases ρ' cs)
 renˢ-Cases-comp [] = refl
 renˢ-Cases-comp (c ∷ cs) = cong₂ _∷_ (renˢ-comp c) (renˢ-Cases-comp cs)
@@ -595,4 +595,4 @@ exts⋆ˢ : ∀{Φ}{Γ Δ : Ctx Φ}
 -}
 ```
 
-   
+

--- a/plutus-metatheory/src/Algorithmic/Signature.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Signature.lagda.md
@@ -26,13 +26,13 @@ open _⊢Ne⋆_
 
 import Type.RenamingSubstitution as ⋆
 open import Type.BetaNBE.Completeness using (reifyCR;idext;exte-lem)
-open import Type.BetaNBE.RenamingSubstitution 
-                         using (subNf;SubNf;renNf-subNf;subNf-cong;subNf-comp;subNf-cons;extsNf;subNf-lemma;subNf∅;subNf∅≡subNf;subNf∅-subNf;subNf∅-renNf) 
+open import Type.BetaNBE.RenamingSubstitution
+                         using (subNf;SubNf;renNf-subNf;subNf-cong;subNf-comp;subNf-cons;extsNf;subNf-lemma;subNf∅;subNf∅≡subNf;subNf∅-subNf;subNf∅-renNf)
                          renaming (_[_]Nf to _[_])
 open import Builtin using (Builtin;signature)
 open import Type.BetaNBE using (nf;reify;eval;idEnv;exte)
 open import Builtin.Signature using ()
-open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π 
+open Builtin.Signature.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π
      using (sig2type;SigTy;sigTy2type;convSigTy;sig2typeΠ;sig2type⇒;⊢♯2TyNe♯;mkTy) public
 open SigTy
 ```
@@ -69,25 +69,25 @@ subNf-Π {Φ}{Ψ}{J} ρ B = begin
 subSigTy : ∀ {Φ Ψ}
    -- {n⋆ n♯}
   → (σ : SubNf Φ Ψ)
-  → ∀{tn tm tt} {pt : tn ∔ tm ≣ tt} 
-  → ∀{am an at} {pa : an ∔ am ≣ at} 
-  → {A : Φ ⊢Nf⋆ *} → SigTy pt pa A 
+  → ∀{tn tm tt} {pt : tn ∔ tm ≣ tt}
+  → ∀{am an at} {pa : an ∔ am ≣ at}
+  → {A : Φ ⊢Nf⋆ *} → SigTy pt pa A
   -------------------------
   → SigTy pt pa (subNf σ A)
 subSigTy σ (bresult _) = bresult _
 subSigTy σ (A B⇒ bt) = (subNf σ A) B⇒ (subSigTy σ bt)
-subSigTy σ (sucΠ bt) rewrite (subNf-Π σ (sigTy2type bt)) = sucΠ (subSigTy (extsNf σ) bt) 
+subSigTy σ (sucΠ bt) rewrite (subNf-Π σ (sigTy2type bt)) = sucΠ (subSigTy (extsNf σ) bt)
 
-_[_]SigTy : ∀{Φ K} 
-          → ∀{tn tm tt} {pt : tn ∔ tm ≣ tt} 
-          → ∀{am an at} {pa : an ∔ am ≣ at} 
-          → {B : Φ ,⋆ K ⊢Nf⋆ *} 
-          → SigTy pt pa B 
-          → (A : Φ ⊢Nf⋆ K) 
+_[_]SigTy : ∀{Φ K}
+          → ∀{tn tm tt} {pt : tn ∔ tm ≣ tt}
+          → ∀{am an at} {pa : an ∔ am ≣ at}
+          → {B : Φ ,⋆ K ⊢Nf⋆ *}
+          → SigTy pt pa B
+          → (A : Φ ⊢Nf⋆ K)
           → SigTy pt pa (B [ A ])
 _[_]SigTy bt A  = subSigTy (subNf-cons (ne ∘ `) A) bt
 
-uniqueSigTy :  
+uniqueSigTy :
       ∀{tn tm tt} → {pt : tn ∔ tm ≣ tt}
     → ∀{an am at} → {pa : an ∔ am ≣ at}
     → ∀{Φ} → {A : Φ ⊢Nf⋆ *}
@@ -95,6 +95,6 @@ uniqueSigTy :
     → s ≡ s'
 uniqueSigTy (bresult _) (bresult _) = refl
 uniqueSigTy (A B⇒ s) (.A B⇒ s') = cong (A B⇒_) (uniqueSigTy s s')
-uniqueSigTy (sucΠ s) (sucΠ s') = cong sucΠ (uniqueSigTy s s') 
+uniqueSigTy (sucΠ s) (sucΠ s') = cong sucΠ (uniqueSigTy s s')
 ```
- 
+

--- a/plutus-metatheory/src/Algorithmic/Soundness.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Soundness.lagda.md
@@ -10,7 +10,7 @@ open import Data.Empty using (⊥)
 open import Data.Vec using (Vec;[];_∷_)
 open import Data.Product using (_×_) renaming (_,_ to _,,_)
 open import Data.Unit using (⊤;tt)
-open import Relation.Binary.PropositionalEquality 
+open import Relation.Binary.PropositionalEquality
               using (_≡_;refl;sym;trans;cong;cong₂)
               renaming (subst to substEq)
 open Relation.Binary.PropositionalEquality.≡-Reasoning
@@ -135,7 +135,7 @@ lemsub A A' σ p = trans≡β
   (sym≡β (soundness (sub (embNf ∘ σ) A')))
 
 subNf-sub∅-lem : ∀ Φ (A : ∅ ⊢Nf⋆ ♯) → embNf {Φ} (subNf (λ()) A) ≡β sub∅ (embNf A)
-subNf-sub∅-lem Φ A = trans≡β (lemsub A (embNf A) (λ {J} → λ()) (refl≡β (embNf A))) 
+subNf-sub∅-lem Φ A = trans≡β (lemsub A (embNf A) (λ {J} → λ()) (refl≡β (embNf A)))
                              (≡2β (sub-cong (λ {()}) (embNf A)))
 
 subNf∅-sub∅-lem : ∀ Φ  (A : ∅ ⊢Nf⋆ ♯)  → embNf {Φ} (subNf∅ A) ≡β sub∅ (embNf A)
@@ -153,18 +153,18 @@ emb-ConstrArgs : ∀ {Φ} {Γ : Alg.Ctx Φ}
 emb-ConstrArgs [] = []
 emb-ConstrArgs (x ∷ cs) = (emb x) ∷ (emb-ConstrArgs cs)
 
-lema-mkCaseType : ∀{Φ}{A : Φ ⊢Nf⋆ *} As → 
+lema-mkCaseType : ∀{Φ}{A : Φ ⊢Nf⋆ *} As →
      embNf (Alg.mkCaseType A As) ≡ Dec.mkCaseType (embNf A) (embNf-List As)
 lema-mkCaseType [] = refl
-lema-mkCaseType (A ∷ As) = cong (embNf A ⇒_) (lema-mkCaseType As) 
+lema-mkCaseType (A ∷ As) = cong (embNf A ⇒_) (lema-mkCaseType As)
 
 emb-Cases : ∀ {Φ} {Γ : Alg.Ctx Φ} {A : Φ ⊢Nf⋆ *} {n}
          {Tss : Vec (List (Φ ⊢Nf⋆ *)) n}
-         (cases : Alg.Cases Γ A Tss) 
+         (cases : Alg.Cases Γ A Tss)
         → Dec.Cases (embCtx Γ) (embNf A) (embNf-VecList Tss)
 emb-Cases Alg.[] = Dec.[]
-emb-Cases (Alg._∷_ {Ts = Ts} c cases) = substEq (embCtx _ Dec.⊢_) (lema-mkCaseType Ts) (emb c) 
-                            Dec.∷ (emb-Cases cases)            
+emb-Cases (Alg._∷_ {Ts = Ts} c cases) = substEq (embCtx _ Dec.⊢_) (lema-mkCaseType Ts) (emb c)
+                            Dec.∷ (emb-Cases cases)
 
 emb (Alg.` α) = Dec.` (embVar α)
 emb (Alg.ƛ {A = A}{B} t) = Dec.ƛ (emb t)

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -29,7 +29,7 @@ open import Builtin.Signature using (Sig;sig;_⊢♯;_/_⊢⋆;Args)
                  using (integer;string;bytestring;unit;bool;pdata;bls12-381-g1-element;bls12-381-g2-element;bls12-381-mlresult)
 open _⊢♯ renaming (pair to bpair; list to blist)
 open _/_⊢⋆
-open import Builtin.Constant.AtomicType 
+open import Builtin.Constant.AtomicType
 
 open import Utils.Reflection using (defDec;defShow;defListConstructors)
 ```
@@ -155,13 +155,13 @@ private module SugaredSignature where
 Syntactic sugar for writing the signature of built-ins.
 This is defined in its own module so that these definitions are not exported.
 
-Signature types can have two kinds of polymorphic variables: variables that 
-range over arbitrary types (of kind *) and variables that range over builtin 
+Signature types can have two kinds of polymorphic variables: variables that
+range over arbitrary types (of kind *) and variables that range over builtin
 types (of kind ♯). In order to distinguish them in the sugares syntax we write
 with an uppercase variables of kind *, and with lowercase variables of kind ♯.
 
-The arguments of signature types (argument types) are of type `n⋆ / n♯ ⊢⋆`, for 
-n⋆ free variables of kind *, and n♯ free variables of kind ♯. However, 
+The arguments of signature types (argument types) are of type `n⋆ / n♯ ⊢⋆`, for
+n⋆ free variables of kind *, and n♯ free variables of kind ♯. However,
 shorthands for types, such  as `integer`, `bool`, etc are of type `n♯ ⊢♯`, and
 hence need to be embedded into `n⋆ / n♯ ⊢⋆` using the postfix constructor `↑`.
 
@@ -192,17 +192,17 @@ hence need to be embedded into `n⋆ / n♯ ⊢⋆` using the postfix constructo
 
     pair : ∀{n⋆ n♯} → n♯ ⊢♯ → n♯ ⊢♯ → n⋆ / n♯ ⊢⋆
     pair a b = (bpair a b) ↑
-    
+
     list :  ∀{n⋆ n♯} → n♯ ⊢♯ → n⋆ / n♯ ⊢⋆
     list a = (blist a) ↑
 ```
-    
+
 ### Operators for constructing signatures
 
 The following operators are used to express signatures in a familiar way,
-but ultimately, they construct a Sig 
+but ultimately, they construct a Sig
 
-An expression 
+An expression
   n⋆×n♯ [ t₁ , t₂ , t₃ ]⟶ tᵣ
 
 is actually parsed as
@@ -214,14 +214,14 @@ sig n⋆ n♯ (t₃ ∷ t₂ ∷ t₁) tᵣ
 
 ```
     ArgSet : Set
-    ArgSet = Σ (ℕ × ℕ) (λ { (n⋆ ,, n♯) → Args n⋆ n♯}) 
+    ArgSet = Σ (ℕ × ℕ) (λ { (n⋆ ,, n♯) → Args n⋆ n♯})
 
     ArgTy : ArgSet → Set
-    ArgTy ((n⋆ ,, n♯) ,, _) = n⋆ / n♯ ⊢⋆ 
+    ArgTy ((n⋆ ,, n♯) ,, _) = n⋆ / n♯ ⊢⋆
 
     infix 12 _[_
     _[_ : (nn : ℕ × ℕ)  → proj₁ nn / proj₂ nn ⊢⋆ → ArgSet
-    _[_ (n⋆ ,, n♯) x = (n⋆ ,, n♯) ,, [ x ]  
+    _[_ (n⋆ ,, n♯) x = (n⋆ ,, n♯) ,, [ x ]
 
     infixl 10 _,_
     _,_ : (p : ArgSet) → ArgTy p → ArgSet
@@ -236,7 +236,7 @@ sig n⋆ n♯ (t₃ ∷ t₂ ∷ t₁) tᵣ
 
 ```
     signature : Builtin → Sig
-    signature addInteger                      = ∙ [ integer ↑ , integer ↑ ]⟶ integer ↑ 
+    signature addInteger                      = ∙ [ integer ↑ , integer ↑ ]⟶ integer ↑
     signature subtractInteger                 = ∙ [ integer ↑ , integer ↑ ]⟶ integer ↑
     signature multiplyInteger                 = ∙ [ integer ↑ , integer ↑ ]⟶ integer ↑
     signature divideInteger                   = ∙ [ integer ↑ , integer ↑ ]⟶ integer ↑
@@ -284,7 +284,7 @@ sig n⋆ n♯ (t₃ ∷ t₂ ∷ t₁) tᵣ
     signature bData                           = ∙ [ bytestring ↑ ]⟶ pdata ↑
     signature unConstrData                    = ∙ [ pdata ↑ ]⟶ pair integer (blist pdata)
     signature unMapData                       = ∙ [ pdata ↑ ]⟶ list (bpair pdata pdata)
-    signature unListData                      = ∙ [ pdata ↑ ]⟶ list pdata 
+    signature unListData                      = ∙ [ pdata ↑ ]⟶ list pdata
     signature unIData                         = ∙ [ pdata ↑ ]⟶ integer ↑
     signature unBData                         = ∙ [ pdata ↑ ]⟶ bytestring ↑
     signature equalsData                      = ∙ [ pdata ↑ , pdata ↑ ]⟶ bool ↑
@@ -326,7 +326,7 @@ sig n⋆ n♯ (t₃ ∷ t₂ ∷ t₁) tᵣ
 open SugaredSignature using (signature) public
 
 -- The arity of a builtin, according to its signature.
-arity : Builtin → ℕ 
+arity : Builtin → ℕ
 arity b = length (Sig.args (signature b))
 
 ```
@@ -610,13 +610,13 @@ unquoteDef decBuiltin = defDec (quote Builtin) decBuiltin
 We define a show function for Builtins
 
 ```
-showBuiltin : Builtin → String 
-unquoteDef showBuiltin = defShow (quote Builtin) showBuiltin 
+showBuiltin : Builtin → String
+unquoteDef showBuiltin = defShow (quote Builtin) showBuiltin
 ```
 
-`builtinList` is a list with all builtins. 
+`builtinList` is a list with all builtins.
 
 ```
-builtinList : List Builtin 
+builtinList : List Builtin
 unquoteDef builtinList = defListConstructors (quote Builtin) builtinList
 ```

--- a/plutus-metatheory/src/Builtin/Constant/AtomicType.lagda.md
+++ b/plutus-metatheory/src/Builtin/Constant/AtomicType.lagda.md
@@ -28,11 +28,11 @@ We have nine base types referred to as atomic type constants:
 ```
 data AtomicTyCon : Set where
   aInteger              : AtomicTyCon
-  aBytestring           : AtomicTyCon 
-  aString               : AtomicTyCon 
-  aUnit                 : AtomicTyCon 
+  aBytestring           : AtomicTyCon
+  aString               : AtomicTyCon
+  aUnit                 : AtomicTyCon
   aBool                 : AtomicTyCon
-  aData                 : AtomicTyCon 
+  aData                 : AtomicTyCon
   aBls12-381-g1-element : AtomicTyCon
   aBls12-381-g2-element : AtomicTyCon
   aBls12-381-mlresult   : AtomicTyCon

--- a/plutus-metatheory/src/Builtin/Constant/Type.lagda.md
+++ b/plutus-metatheory/src/Builtin/Constant/Type.lagda.md
@@ -21,11 +21,11 @@ open import Builtin.Constant.AtomicType public
 ```
 
 Type constants are either atomic, or pair, or lists.
-They are indexed by Kind. 
+They are indexed by Kind.
 
 The use of higher-order constants like list and pair,
-means that we do not have to define renaming and substitution 
-for type constants, since the construction of a list applied to 
+means that we do not have to define renaming and substitution
+for type constants, since the construction of a list applied to
 some type uses the ordinary type application machinery.
 
 The use of kind ♯ limits the types for which we can construct lists and pairs.

--- a/plutus-metatheory/src/Builtin/Signature.lagda.md
+++ b/plutus-metatheory/src/Builtin/Signature.lagda.md
@@ -7,11 +7,11 @@ Module for abstract signatures of builtins:
 
 This module defines signatures for characterizing the types of built-in functions.
 
-The signatures defined in this module are abstract in the sense 
+The signatures defined in this module are abstract in the sense
 that they don't refer to any particular typing context or typing rule,
 except for the minimal rule of guaranteeing well-formedness.
 
-## Imports 
+## Imports
 
 ```
 module Builtin.Signature where
@@ -21,11 +21,11 @@ open import Data.Nat.Properties using (+-identityʳ;suc-injective)
 open import Data.Fin using (Fin) renaming (zero to Z; suc to S)
 open import Data.List using (List;[];_∷_;length)
 open import Data.List.NonEmpty using (List⁺;foldr;_∷_;toList;reverse) renaming (length to length⁺)
-open import Data.Product using (Σ;proj₁;proj₂) 
+open import Data.Product using (Σ;proj₁;proj₂)
                   renaming (_,_ to _,,_)
 open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;trans;subst)
 
-open import Utils using (Kind;♯;*;_⇒_;_∔_≣_;start;bubble;alldone;unique∔;_×_;∔2+) 
+open import Utils using (Kind;♯;*;_⇒_;_∔_≣_;start;bubble;alldone;unique∔;_×_;∔2+)
         renaming (List to UList)
 open import Type using (Ctx⋆;∅;_,⋆_;_⊢⋆_;_∋⋆_;Z;S;Φ)
 open import Builtin.Constant.AtomicType using (AtomicTyCon;⟦_⟧at)
@@ -34,53 +34,53 @@ open import Builtin.Constant.Type using (TyCon)
 open TyCon
 ```
 
-## Argument Types and Built-in Compatible Types 
+## Argument Types and Built-in Compatible Types
 
-The arguments of a built-in function can't be just any type, but are restricted 
+The arguments of a built-in function can't be just any type, but are restricted
 to certain types, which in this file are called *argument* types.
-They are either a variable of kind * (that is, ranging over any type) 
+They are either a variable of kind * (that is, ranging over any type)
 or a *built-in-compatible* type.
 
-The built-in compatible types are either type constants of kind ♯, type variables, 
+The built-in compatible types are either type constants of kind ♯, type variables,
 or type operators applied to built-in-compatible type.
 
-The type of built-in-compatible types (_⊢♯) is indexed by the number of 
+The type of built-in-compatible types (_⊢♯) is indexed by the number of
 distinct type variables of kind ♯.
 ```
 -- Builtin compatible types of kind ♯
 data _⊢♯ : ℕ → Set where
   -- a type variable
-  ` : ∀ {n♯} → 
-      Fin n♯ 
+  ` : ∀ {n♯} →
+      Fin n♯
       --------
     → n♯ ⊢♯
 
-  -- a type constant 
-  atomic : ∀ {n♯} 
-      → AtomicTyCon 
+  -- a type constant
+  atomic : ∀ {n♯}
+      → AtomicTyCon
         -----------
       → n♯ ⊢♯
   -- type operator applied to a built-in-compatible type
   list : ∀ {n♯}
-      → n♯ ⊢♯ 
+      → n♯ ⊢♯
         -------
       → n♯ ⊢♯
   pair : ∀ {n♯}
-      → n♯ ⊢♯ 
-      → n♯ ⊢♯ 
+      → n♯ ⊢♯
+      → n♯ ⊢♯
         -------
       → n♯ ⊢♯
 
 -- argument types are either a variable of kind * or a builtin compatible type
 data _/_⊢⋆ : ℕ → ℕ → Set where
   -- a type variable of kind *
-  ` : ∀ {n⋆ n♯} → 
-      Fin n⋆ 
+  ` : ∀ {n⋆ n♯} →
+      Fin n⋆
       --------
     → n⋆ / n♯ ⊢⋆
   -- a builtin compatible type
   _↑ : ∀ {n⋆ n♯} →
-        n♯ ⊢♯ 
+        n♯ ⊢♯
        -------
      → n⋆ / n♯ ⊢⋆
 
@@ -96,13 +96,13 @@ pattern bls12-381-mlresult   = atomic aBls12-381-mlresult
 ```
 
 The list of arguments is a non-empty list of argument types.
-It is indexed by the number of distinct type variables 
+It is indexed by the number of distinct type variables
 of kind ♯ and kind *  that may appear.
 
 ```
 
 Args : ℕ → ℕ → Set
-Args n⋆ n♯ = List⁺ (n⋆ / n♯ ⊢⋆) 
+Args n⋆ n♯ = List⁺ (n⋆ / n♯ ⊢⋆)
 
 ```
 
@@ -110,7 +110,7 @@ A Universe for return types.
 
 ```
 data _/_⊢r⋆ : ℕ → ℕ → Set where
-  argtype : ∀ {n⋆ n♯} → 
+  argtype : ∀ {n⋆ n♯} →
       n⋆ / n♯ ⊢⋆
       --------
     → n⋆ / n♯ ⊢r⋆
@@ -127,13 +127,13 @@ A signature is given by
   4. A result type
 
 ```
-record Sig : Set where 
+record Sig : Set where
    constructor sig
    field
      -- number of type variables of kind *
-    fv⋆ : ℕ  
+    fv⋆ : ℕ
      -- number of type variables of kind ♯
-    fv♯ : ℕ     
+    fv♯ : ℕ
      -- list of arguments
     args : Args fv⋆ fv♯
      -- type of result
@@ -153,13 +153,13 @@ fv σ = fv⋆ σ + fv♯ σ
 ### Auxiliary functions
 
 The following functions help to:
- * mkCtx⋆ : build a context with a certain number of *-kinded and ♯-kinded 
+ * mkCtx⋆ : build a context with a certain number of *-kinded and ♯-kinded
    variables.
  * fin♯2∋⋆ and fin⋆2∋⋆ : variables for a context obtained from mkCtx⋆.
 
 Note that we only need the number of variables of each kind because we always
  order them in a fixed way: first the * variables, and then the ♯ variables.
- This simplifies the treatment of variables and contexts, and in the context 
+ This simplifies the treatment of variables and contexts, and in the context
  of signatures, without losing generality.
 ```
 mkCtx⋆ : ∀ (n⋆ n♯ : ℕ) → Ctx⋆
@@ -176,12 +176,12 @@ fin♯2∋⋆ {suc n⋆} (S x) = S (fin♯2∋⋆ (S x))
 fin⋆2∋⋆ : ∀{n⋆ n♯} → Fin n⋆ → (mkCtx⋆ n⋆ n♯) ∋⋆ *
 fin⋆2∋⋆ Z = Z
 fin⋆2∋⋆ (S x) = S (fin⋆2∋⋆ x)
-```  
+```
 
 ## Obtaining concrete types from signatures
 
-Signatures represent abstract types which need to be made concrete in 
-order to use them. The following module may be instantiated to obtain 
+Signatures represent abstract types which need to be made concrete in
+order to use them. The following module may be instantiated to obtain
 a function `sig2type` which converts from an abstract into a concrete type.
 
 ### Module parameterised to allow for different notions of types.
@@ -198,20 +198,20 @@ The following parameters should be instantiated:
    8. the constructor for Π types.
 
 ```
-module FromSig (Ty : Ctx⋆ → Kind → Set) 
-               (TyNe : Ctx⋆ → Kind → Set) 
+module FromSig (Ty : Ctx⋆ → Kind → Set)
+               (TyNe : Ctx⋆ → Kind → Set)
                (ne : ∀{Φ K} → TyNe Φ K → Ty Φ K)
                (var : ∀{n⋆ n♯ K} → mkCtx⋆ n⋆ n♯ ∋⋆ K → TyNe (mkCtx⋆ n⋆ n♯) K)
                (_·_ : ∀{Φ K J} → TyNe Φ (K ⇒ J) → Ty Φ K → TyNe Φ J)
-               (^ : ∀{Φ K} → TyCon K → TyNe Φ K) 
+               (^ : ∀{Φ K} → TyCon K → TyNe Φ K)
                (mkCon : ∀{Φ} → Ty Φ ♯ → Ty Φ *)
                (_⇒_ : ∀{Φ} → Ty Φ * → Ty Φ *  → Ty Φ *)
                (Π : ∀{Φ K} → Ty (Φ ,⋆ K) * → Ty Φ *)
           where
 ```
 
-  The function mkTy constructs a type from an argument type. For that it 
-  uses the function ⊢♯2TyNe♯ which constructs a neutral type from a 
+  The function mkTy constructs a type from an argument type. For that it
+  uses the function ⊢♯2TyNe♯ which constructs a neutral type from a
   built-in compatible type.
 
 ```
@@ -220,7 +220,7 @@ module FromSig (Ty : Ctx⋆ → Kind → Set)
     ⊢♯2TyNe♯ (atomic x) = ^ (atomic x)
     ⊢♯2TyNe♯ (list x)   = ^ list · ne (⊢♯2TyNe♯ x)
     ⊢♯2TyNe♯ (pair x y) = ((^ pair) · ne (⊢♯2TyNe♯ x)) · ne (⊢♯2TyNe♯ y)
-    
+
     mkTy : ∀{n⋆ n♯} → n⋆ / n♯ ⊢⋆ → Ty (mkCtx⋆ n⋆ n♯) *
     mkTy (` x) = ne (var (fin⋆2∋⋆ x))
     mkTy (x ↑) = mkCon (ne (⊢♯2TyNe♯ x))
@@ -231,10 +231,10 @@ module FromSig (Ty : Ctx⋆ → Kind → Set)
 
    sig2type⇒ [ b₁ , b₂ , ... ,bₙ ] tᵣ = tₙ ⇒ ... ⇒ t₂ ⇒ t₁ ⇒ tᵣ
        where tᵢ = mkTy bᵢ
-   
+
 ```
-    sig2type⇒ : ∀{n⋆ n♯} 
-              → List (n⋆ / n♯ ⊢⋆) 
+    sig2type⇒ : ∀{n⋆ n♯}
+              → List (n⋆ / n♯ ⊢⋆)
               → Ty (mkCtx⋆ n⋆ n♯) * → Ty (mkCtx⋆ n⋆ n♯) *
     sig2type⇒ [] r = r
     sig2type⇒ (a ∷ as) r = sig2type⇒ as (mkTy a ⇒ r)
@@ -258,49 +258,49 @@ module FromSig (Ty : Ctx⋆ → Kind → Set)
 
 ### Types originating from a Signature
 
-The types produced by a signature have a particular form: possibly 
+The types produced by a signature have a particular form: possibly
 some Π applications and then at least one function argument.
 
-We define a predicate for concrete types of that shape as a datatype 
+We define a predicate for concrete types of that shape as a datatype
 indexed by the concrete types.
 
 ```
-    -- an : number of arguments to be added to the type 
+    -- an : number of arguments to be added to the type
     -- am : number of arguments expected
     -- at : total number of arguments
     -- tm : number of Π applied
     -- tn : number of Π yet to be applied
     -- tt: number of Π in the signature (fv♯)
-    data SigTy : ∀{tn tm tt} → tn ∔ tm ≣ tt 
-               → ∀{an am at} → an ∔ am ≣ at 
+    data SigTy : ∀{tn tm tt} → tn ∔ tm ≣ tt
+               → ∀{an am at} → an ∔ am ≣ at
                → ∀{Φ} → Ty Φ * → Set where
        bresult  : ∀{tt} → {pt : tt ∔ 0 ≣ tt}
                 → ∀{at} → {pa : at ∔ 0 ≣ at}
-                → ∀{Φ} (A : Ty Φ *) 
+                → ∀{Φ} (A : Ty Φ *)
                 → SigTy pt pa A
        _B⇒_ : ∀{tn tt} → {pt : tn ∔ 0 ≣ tt }        -- all Π yet to be applied
             → ∀{an am at} → {pa : an ∔ suc am ≣ at} -- there is one more argument to add
-            → ∀{Φ} → (A : Ty Φ *) 
-                   → {B : Ty Φ *} 
-            → SigTy pt (bubble pa) B 
+            → ∀{Φ} → (A : Ty Φ *)
+                   → {B : Ty Φ *}
+            → SigTy pt (bubble pa) B
             → SigTy pt pa (A ⇒ B)
        sucΠ : ∀{tn tm tt} → {pt : tn ∔ suc tm ≣ tt}
             → ∀{am an at} → {pa : an ∔ am ≣ at}
-            → ∀{Φ K}{A : Ty (Φ ,⋆ K) *} 
-            → SigTy (bubble pt) pa A 
+            → ∀{Φ K}{A : Ty (Φ ,⋆ K) *}
+            → SigTy (bubble pt) pa A
             → SigTy pt pa (Π A)
 
 ```
-   
-   A `SigTy (0 ∔ tn ≣ tn) (0 ∔ at ≣ at) A` is a type that expects the total number of 
-   type arguments `tn` and the total number of term arguments `at`.  
 
-Every type obtained from a Signature σ using sig2type is a SigType.    
+   A `SigTy (0 ∔ tn ≣ tn) (0 ∔ at ≣ at) A` is a type that expects the total number of
+   type arguments `tn` and the total number of term arguments `at`.
 
-```    
+Every type obtained from a Signature σ using sig2type is a SigType.
+
+```
     sig2SigTy⇒ : ∀{n⋆ n♯}{tt : ℕ}
              -- Additionally we could ask for the following condition to hold
-             --  → (pn : n⋆ + n♯ ≡ tt)   
+             --  → (pn : n⋆ + n♯ ≡ tt)
                → {pt : tt ∔ 0 ≣ tt}
                → (as : List (n⋆ / n♯ ⊢⋆))
                → ∀ {am at}(pa : length as ∔ am ≣ at)
@@ -309,21 +309,21 @@ Every type obtained from a Signature σ using sig2type is a SigType.
     sig2SigTy⇒ []       (start _)   bty = bty
     sig2SigTy⇒ (a ∷ as) (bubble pa) bty = sig2SigTy⇒ as pa (mkTy a B⇒ bty)
 
-    sig2SigTyΠ : ∀{n⋆ n♯ tn tm tt : ℕ} 
-                    → (pn : n⋆ + n♯ ≡ tn) 
-                    → (pt : tn ∔ tm ≣ tt) 
+    sig2SigTyΠ : ∀{n⋆ n♯ tn tm tt : ℕ}
+                    → (pn : n⋆ + n♯ ≡ tn)
+                    → (pt : tn ∔ tm ≣ tt)
                     → ∀ {at}{pa : 0 ∔ at ≣ at}
                     → ∀{A : Ty (mkCtx⋆ n⋆ n♯) *} → SigTy pt pa A
                     → SigTy (start tt) pa (sig2typeΠ A)
-    sig2SigTyΠ {zero} refl (start _)   bty = bty 
+    sig2SigTyΠ {zero} refl (start _)   bty = bty
     sig2SigTyΠ {zero} refl (bubble pt) bty = sig2SigTyΠ refl pt (sucΠ bty)
     sig2SigTyΠ {suc n⋆} p  (bubble pt) bty = sig2SigTyΠ (suc-injective p) pt (sucΠ bty)
-           
+
     -- From a signature obtain a signature type
     sig2SigTy : (σ : Sig) → SigTy (start (fv σ)) (start (args♯ σ)) (sig2type σ)
     sig2SigTy (sig n⋆ n♯ as r) =
                 sig2SigTyΠ refl (alldone (n⋆ + n♯)) (sig2SigTy⇒ (toList as) (alldone (length⁺ as)) (bresult (mkTy r)))
- 
+
     -- extract the concrete type from a signature type.
     sigTy2type : ∀{Φ tm tn tt an am at}{A : Ty Φ *} → {pt : tn ∔ tm ≣ tt} → {pa : an ∔ am ≣ at} → SigTy pt pa A → Ty Φ *
     sigTy2type {A = A} _ = A

--- a/plutus-metatheory/src/Check.lagda.md
+++ b/plutus-metatheory/src/Check.lagda.md
@@ -7,7 +7,7 @@ layout: page
 This module implements typechecking and inference for Scoped terms.
 
 Scoped terms `ScopedTm` have scoped types `ScopedTy` which don't have kinds, so
-kinds need to be inferred. Since we have two base kinds (`*` and `♯`) and the 
+kinds need to be inferred. Since we have two base kinds (`*` and `♯`) and the
 latter embeds into the former, there is some subtleties discussed below.
 ```
 module Check where
@@ -47,7 +47,7 @@ open import Utils as U using (Kind;*;♯;_⇒_;Either;inj₁;inj₂;withE;Monad;
 open Monad {{...}}
 
 open import RawU using (TmCon;tmCon;TyTag)
-open import Builtin.Signature using (_⊢♯) 
+open import Builtin.Signature using (_⊢♯)
 open import Builtin.Constant.Type
 
 open import Type.Equality using (_≡β_;≡2β)
@@ -109,8 +109,8 @@ decKind * * = yes refl
 decKind ♯ ♯ = yes refl
 decKind * ♯ = no λ()
 decKind ♯ * = no λ()
-decKind * (K' ⇒ J') = no λ() 
-decKind ♯ (K' ⇒ J') = no λ() 
+decKind * (K' ⇒ J') = no λ()
+decKind ♯ (K' ⇒ J') = no λ()
 decKind (K ⇒ J) * = no λ()
 decKind (K ⇒ J) ♯ = no λ()
 decKind (K ⇒ J) (K' ⇒ J') = dcong₂ _⇒_ (λ { refl → refl ,, refl}) (decKind K K') (decKind J J')
@@ -121,7 +121,7 @@ isFunKind : ∀{Φ}
 isFunKind (K ⇒ J ,, A) = return (K ,, J ,, A)
 isFunKind (♯ ,, _)     = inj₁ (notFunKind ♯ λ _ _ ())
 isFunKind (* ,, _)     = inj₁ (notFunKind * λ _ _ ())
-  
+
 isPat : ∀{Φ}
        → Σ Kind (Φ ⊢Nf⋆_)
        → Either TypeError (Σ Kind λ K → Φ ⊢Nf⋆ (K ⇒ *) ⇒ (K ⇒ *))
@@ -133,7 +133,7 @@ isPat (((K ⇒ K₂) ⇒ *) ,, A) = inj₁ (notPat ((K ⇒ K₂) ⇒ *) λ _ ())
 isPat (((K ⇒ K₂) ⇒ ♯) ,, A) = inj₁ (notPat ((K ⇒ K₂) ⇒ ♯) λ _ ())
 isPat (((K ⇒ *) ⇒ (K₁ ⇒ *)) ,, A) = do
       refl ← withE (kindMismatch _ _) (dec2Either (decKind K K₁))
-      return (K ,, A) 
+      return (K ,, A)
 isPat (((K ⇒ *) ⇒ (K₁ ⇒ ♯)) ,, A) = inj₁ (notPat ((K ⇒ *) ⇒ (K₁ ⇒ ♯)) λ _ ())
 isPat (((K ⇒ *) ⇒ (K₁ ⇒ (K₃ ⇒ K₄))) ,, A) = inj₁ (notPat ((K ⇒ *) ⇒ (K₁ ⇒ (K₃ ⇒ K₄))) λ _ ())
 isPat (((K ⇒ ♯) ⇒ (K₁ ⇒ K₃)) ,, A) = inj₁ (notPat ((K ⇒ ♯) ⇒ (K₁ ⇒ K₃)) λ _ ())
@@ -158,7 +158,7 @@ isFunType (ne A  ,, _ ) = inj₁ (notFunType (ne A) (λ _ _ ()))
 isFunType (con {Φ} c ,, _) = inj₁ (notFunType (con {Φ} c) (λ _ _ ()))
 isFunType (μ A B ,, _) = inj₁ (notFunType (μ A B) (λ _ _ ()))
 isFunType (SOP x ,, _) = inj₁ (notFunType (SOP x) (λ _ _ ()))
-  
+
 isMu :  ∀{Φ Γ}
        → Σ (Φ ⊢Nf⋆ *) (Γ ⊢_)
        → Either TypeError (Σ Kind λ K → Σ (Φ ⊢Nf⋆ (K ⇒ *) ⇒ (K ⇒ *)) λ A → Σ (Φ ⊢Nf⋆ K) λ B → Γ ⊢ μ A B)
@@ -170,7 +170,7 @@ isMu (A ⇒ B ,, _) = inj₁ (notMu (A ⇒ B) (λ _ _ ()))
 isMu (SOP x ,, _) = inj₁ (notMu (SOP x) (λ _ _ ()))
 
 isSOPType :  ∀{Φ}
-       → (Φ ⊢Nf⋆ *) 
+       → (Φ ⊢Nf⋆ *)
        → Either TypeError (Σ ℕ (Vec (List (Φ ⊢Nf⋆ *))))
 isSOPType (Π A) = inj₁ (notSOP (Π A) (λ _ ()))
 isSOPType (A ⇒ B) = inj₁ (notSOP (A ⇒ B) (λ _ ()))
@@ -181,7 +181,7 @@ isSOPType (SOP {n = n} Tss) = return (n ,, Tss)
 
 isSOP  : ∀{Φ Γ}
        → Σ (Φ ⊢Nf⋆ *) (Γ ⊢_)
-       → Either TypeError (Σ ℕ λ n → Σ (Vec (List (Φ ⊢Nf⋆ *)) n) λ Tss → Γ ⊢ SOP Tss) 
+       → Either TypeError (Σ ℕ λ n → Σ (Vec (List (Φ ⊢Nf⋆ *)) n) λ Tss → Γ ⊢ SOP Tss)
 isSOP (Π A ,, _) = inj₁ (notSOP (Π A) (λ _ ()))
 isSOP ((A ⇒ B) ,, _) = inj₁ (notSOP (A ⇒ B) (λ _ ()))
 isSOP (ne A ,, _) = inj₁ (notSOP (ne A) (λ _ ()))
@@ -190,7 +190,7 @@ isSOP (μ A B ,, x) = inj₁ (notSOP (μ A B) (λ _ ()))
 isSOP (SOP {n = n} Tss ,, x) = return (n ,, (Tss ,, x))
 
 chkIdx : ∀ (i n : ℕ) → Either TypeError (Fin n)
-chkIdx i n with i <? n 
+chkIdx i n with i <? n
 ... | no ¬p = inj₁ (IndexOutOfBounds ¬p)
 ... | yes p = return (fromℕ< p)
 ```
@@ -202,32 +202,32 @@ We have two base kinds, * and ♯, and we have an embedding of ♯ into *
 
 Hence, when inferring a kind we sometimes need to decide if we want a ♯ kind or a * kind. For example,
 
-  con (atomic aInteger) : ScopedTy 0 
+  con (atomic aInteger) : ScopedTy 0
 
   might be inferred as kind ♯
 
   1.    ne (^ (atomic aInteger))
-  
+
   or as kind *
-  
+
   2.    con (ne (^ (atomic aInteger)))
 
 Whenever we have a constant of kind `♯` we embed it into `*` using `con`.
-This means that a composition of, for instance a list (kind `♯ ⇒ ♯`) applied 
-to a constant (which will be of kind `*`) doesn't match exactly. So we relax 
+This means that a composition of, for instance a list (kind `♯ ⇒ ♯`) applied
+to a constant (which will be of kind `*`) doesn't match exactly. So we relax
 this condition  when checking kinds and allow
-  1. Checking a `*`-kinded type against `♯`, whenever the type is of the form `con A` : 
-       we "downgrade" the type to A of kind `♯`. 
-  2. Checking a `♯`-kinded type against `*`: 
+  1. Checking a `*`-kinded type against `♯`, whenever the type is of the form `con A` :
+       we "downgrade" the type to A of kind `♯`.
+  2. Checking a `♯`-kinded type against `*`:
        we "upgrade" the type to `*` using `con`.
 
 Another option to one may try is to leave alone kind `♯` and only upgrade it as
-needed. However, this is not easy, as when one detects the need to upgrade a ♯ 
-to *, it might be too late. One example of this, would be in the case of `μ`, 
-where one needs a kind (K ⇒ *) ⇒ (K ⇒ *). Here, it is difficult to upgrade a 
+needed. However, this is not easy, as when one detects the need to upgrade a ♯
+to *, it might be too late. One example of this, would be in the case of `μ`,
+where one needs a kind (K ⇒ *) ⇒ (K ⇒ *). Here, it is difficult to upgrade a
 kind (K ⇒ ♯) ⇒ (K ⇒ ♯) because one would need to find the places inside the type
 to insert the appropriate `con`s.
- 
+
 ```
 inferTyCon : ∀ {Φ} {K} → TyCon K → Σ Kind (Φ ⊢Nf⋆_)
 inferTyCon {K = K} tycon = K ,, (ne (^ tycon))
@@ -237,15 +237,15 @@ inferKind : ∀ Φ (A : ScopedTy (len⋆ Φ)) → Either TypeError (Σ Kind (Φ 
 
 inferKind-List : ∀ Φ (xs : U.List (ScopedTy (len⋆ Φ))) → Either TypeError (List (Φ ⊢Nf⋆ *))
 inferKind-List Φ U.[] = return []
-inferKind-List Φ (x U.∷ xs) = do 
-            A  ← checkKind Φ x * 
-            As ← inferKind-List Φ xs 
+inferKind-List Φ (x U.∷ xs) = do
+            A  ← checkKind Φ x *
+            As ← inferKind-List Φ xs
             return (A ∷ As)
 
 inferKind-VecList : ∀ Φ (xss : U.List (U.List (ScopedTy (len⋆ Φ)))) → Either TypeError (Vec (List (Φ ⊢Nf⋆ *)) (U.length xss))
 inferKind-VecList Φ U.[] = return []
-inferKind-VecList Φ (xs U.∷ xss) = do 
-              Ts ← inferKind-List Φ xs 
+inferKind-VecList Φ (xs U.∷ xss) = do
+              Ts ← inferKind-List Φ xs
               Tss ← (inferKind-VecList Φ xss)
               return (Ts ∷ Tss)
 
@@ -259,13 +259,13 @@ checkKind-aux (♯ ,, A)        ♯ = return A
 checkKind-aux ((K ⇒ J) ,, _)  ♯ = inj₁ (kindMismatch (K ⇒ J) ♯ (λ ()))
 checkKind-aux (* ,, A) (J ⇒ J₁) = inj₁ (kindMismatch * (J ⇒ J₁) (λ ()))
 checkKind-aux (♯ ,, A) (J ⇒ J₁) = inj₁ (kindMismatch ♯ (J ⇒ J₁) (λ ()))
-checkKind-aux (K ,, A) K'@(_ ⇒ _) = do 
+checkKind-aux (K ,, A) K'@(_ ⇒ _) = do
             refl ← withE (kindMismatch _ _) (dec2Either (decKind K K'))
             return A
 
-checkKind Φ A K = do 
+checkKind Φ A K = do
              KA ← inferKind Φ A
-             checkKind-aux KA K 
+             checkKind-aux KA K
 
 
 
@@ -278,7 +278,7 @@ addCon kA = kA
 inferKind Φ (` α) = let K ,, β = inferTyVar Φ α in return (K ,, ne (` β))
 inferKind Φ (A ⇒ B) = do
           A ← checkKind Φ A *
-          B ← checkKind Φ B * 
+          B ← checkKind Φ B *
           return (* ,, A ⇒ B)
 inferKind Φ (Π K A) = do
           A ← checkKind (Φ ,⋆ K) A *
@@ -297,25 +297,25 @@ inferKind Φ (μ A B) = do
           K ,, A ← isPat KA
           B ← checkKind Φ B K
           return (* ,, μ A B)
-inferKind Φ (SOP x) = do 
-              Tss ← inferKind-VecList Φ x  
+inferKind Φ (SOP x) = do
+              Tss ← inferKind-VecList Φ x
               return (* ,, SOP Tss)
 ```
 
 Some examples to check that everything is working as expected
 
 ```
-private module _ where 
+private module _ where
 
   int : ∀{n} → ScopedTy n
   int = con (atomic aInteger)
-   
+
   -- integer
   _ :  inferKind ∅ int ≡ inj₂ (* ,, con (ne (^ (atomic aInteger))))
   _ = refl
 
   -- list of integers
-  _ : inferKind ∅ (con list · int) ≡ inj₂ (* ,, con (ne (^ list · ne (^ (atomic aInteger))))) 
+  _ : inferKind ∅ (con list · int) ≡ inj₂ (* ,, con (ne (^ list · ne (^ (atomic aInteger)))))
   _ = refl
 
   -- list of lists of integers
@@ -337,7 +337,7 @@ private module _ where
   _ : inferKind ∅ ((con list · int) ⇒ int) ≡ inj₂ (* ,, (con (nf (^ list · ^ (atomic aInteger))) ⇒ con (ne (^ (atomic aInteger)))))
   _ = refl
 
-  -- Some Π type. Note that the variable is of kind ♯ 
+  -- Some Π type. Note that the variable is of kind ♯
   _ : inferKind ∅ (Π ♯ (con list · ` zero)) ≡ inj₂ (* ,, Π (con (ne (^ list · ne (` Z)))))
   _ = refl
 
@@ -358,7 +358,7 @@ len ∅        = Z
 len (Γ ,⋆ J) = Weirdℕ.T (len Γ)
 len (Γ , A)  = Weirdℕ.S (len Γ)
 
-inferVarType : ∀{Φ}(Γ : Ctx Φ) → WeirdFin (len Γ) 
+inferVarType : ∀{Φ}(Γ : Ctx Φ) → WeirdFin (len Γ)
              → Either TypeError (Σ (Φ ⊢Nf⋆ *) λ A → Γ ∋ A)
 inferVarType (Γ ,⋆ J) (WeirdFin.T x) = do
         A ,, α ← inferVarType Γ x
@@ -373,9 +373,9 @@ inferVarType (Γ , A) (S x) = do
 
 ```
 decTyVar : ∀{Φ K}(α α' : Φ ∋⋆ K) → Dec (α ≡ α')
-decTyVar Z     Z      = yes refl 
+decTyVar Z     Z      = yes refl
 decTyVar (S α) (S α') with (decTyVar α α')
-...        | yes refl = yes refl 
+...        | yes refl = yes refl
 ...        | no  ¬p   = (no (λ { refl → ¬p refl}))
 decTyVar Z     (S α') = (no λ())
 decTyVar (S α) Z      = (no λ())
@@ -398,16 +398,16 @@ decTyCon (atomic x) (atomic y) = dcong atomic (λ {refl → refl}) (decAtomicTyC
 decTyCon list list = yes refl
 decTyCon pair pair = yes refl
 
-decNfTy (Π {K = K} A) (Π {K = K'} A') = dhcong (λ k t → Π {K = k} t) 
-                                                (λ {refl → refl ,, refl}) 
+decNfTy (Π {K = K} A) (Π {K = K'} A') = dhcong (λ k t → Π {K = k} t)
+                                                (λ {refl → refl ,, refl})
                                                 (decKind K K')
-                                                (decNfTy A) 
+                                                (decNfTy A)
 decNfTy (Π _) (_ ⇒ _)     = no λ()
 decNfTy (Π _) (ne _)      = no λ()
 decNfTy (Π _) (con _)     = no λ()
 decNfTy (Π _) (μ _ _)     = no λ()
 decNfTy (_ ⇒ _) (Π _)     = no λ()
-decNfTy (A ⇒ B) (A' ⇒ B') = dcong₂ _⇒_ (λ {refl → refl ,, refl }) (decNfTy A A') (decNfTy B B') 
+decNfTy (A ⇒ B) (A' ⇒ B') = dcong₂ _⇒_ (λ {refl → refl ,, refl }) (decNfTy A A') (decNfTy B B')
 decNfTy (_ ⇒ _) (ne _)    = no λ()
 decNfTy (_ ⇒ _) (con _)   = no λ()
 decNfTy (_ ⇒ _) (μ _ _)   = no λ()
@@ -429,8 +429,8 @@ decNfTy (μ _ _) (u ⇒ u₁)  = no λ()
 decNfTy (μ _ _) (ne _)    = no λ()
 decNfTy (μ _ _) (con _)   = no λ()
 decNfTy (μ {K = K} A B) (μ {K = K'} A' B') = dhcong₂ (λ k x y → μ {K = k} x y)
-                                                     (λ { refl → refl ,, refl ,, refl }) 
-                                                     (decKind K K') 
+                                                     (λ { refl → refl ,, refl ,, refl })
+                                                     (decKind K K')
                                                      (decNfTy A)
                                                      (decNfTy B)
 decNfTy (SOP x) (Π A')     = no λ()
@@ -445,7 +445,7 @@ decNfTy (con A) (SOP x)    = no λ()
 decNfTy (μ A A₁) (SOP x)   = no λ()
 decNfTy (SOP {n = n} x) (SOP {n = m} y) with n ≟ m
 ... | no ¬p    = no (λ {refl → ¬p refl})
-... | yes refl with decNfTy-VecList x y                                         
+... | yes refl with decNfTy-VecList x y
 ...            | no ¬p = no (λ {refl  → ¬p refl})
 ...            | yes refl = yes refl
 
@@ -454,9 +454,9 @@ decNeTy (` _) (_ · _) = no λ()
 decNeTy (` _) (^ _)   = no λ()
 decNeTy (_ · _) (` _) = no λ()
 decNeTy (_·_ {K = K} A B) (_·_ {K = K'} A' B') = dhcong₂ (λ k t u → _·_ {K = k} t u)
-                                                         (λ { refl → refl ,, refl ,, refl }) 
-                                                         (decKind K K') 
-                                                         (decNeTy A) 
+                                                         (λ { refl → refl ,, refl ,, refl })
+                                                         (decKind K K')
+                                                         (decNeTy A)
                                                          (decNfTy B)
 decNeTy (_ · _) (^ _) = no λ()
 decNeTy (^ _) (` _)   = no λ()
@@ -478,31 +478,31 @@ checkType Γ L A = do
   let d = decNfTy A A'
   refl ← withE (typeMismatch _ _) (dec2Either d)
   return L
-  
-checkConstrArgs-List : ∀{Φ}(Γ : Ctx Φ) 
-               → U.List (ScopedTm (len Γ)) 
+
+checkConstrArgs-List : ∀{Φ}(Γ : Ctx Φ)
+               → U.List (ScopedTm (len Γ))
                → (As : List (Φ ⊢Nf⋆ *))
                → Either TypeError (ConstrArgs Γ As)
 checkConstrArgs-List Γ U.[] [] = return []
 checkConstrArgs-List Γ U.[] (A ∷ As) = inj₁ TooFewConstrArgs
 checkConstrArgs-List Γ (c U.∷ cs) [] = inj₁ TooManyConstrArgs
-checkConstrArgs-List Γ (c U.∷ cs) (A ∷ As) = do 
-         t ← checkType Γ c A 
+checkConstrArgs-List Γ (c U.∷ cs) (A ∷ As) = do
+         t ← checkType Γ c A
          ts ← checkConstrArgs-List Γ cs As
          return (t ∷ ts)
 
-checkCases-List : ∀{Φ}(Γ : Ctx Φ) 
+checkCases-List : ∀{Φ}(Γ : Ctx Φ)
                → (B : Φ ⊢Nf⋆ *)
-               → U.List (ScopedTm (len Γ)) 
+               → U.List (ScopedTm (len Γ))
                → ∀{n}(Tss : Vec (List (Φ ⊢Nf⋆ *)) n)
                → Either TypeError (Cases Γ B Tss)
 checkCases-List Γ B U.[] [] = return []
 checkCases-List Γ B U.[] (_ ∷ _) = inj₁ TooFewCases
 checkCases-List Γ B (_ U.∷ _) [] = inj₁ TooManyCases
-checkCases-List Γ B (c U.∷ cs) (Ts ∷ Tss) = do 
+checkCases-List Γ B (c U.∷ cs) (Ts ∷ Tss) = do
            x ← checkType Γ c (mkCaseType B Ts)
            xs ← checkCases-List Γ B cs Tss
-           return (x ∷ xs)               
+           return (x ∷ xs)
 
 inferType Γ (` x) = do
   A ,, α ← inferVarType Γ x
@@ -517,19 +517,19 @@ inferType Γ (L ·⋆ A) = do
   return (B [ A ]Nf ,, L ·⋆ A / refl)
 inferType Γ (ƛ A L) = do
   A ← checkKind _ A *
-  B ,, L ← inferType (Γ , A) L 
+  B ,, L ← inferType (Γ , A) L
   return (A ⇒ B ,, ƛ L)
 inferType {Φ} Γ (L · M) = do
   ty ← inferType Γ L
   A ,, B ,, L ← isFunType ty
   M ← checkType Γ M A
   return (B ,, L · M)
-inferType Γ (con (tmCon t x)) = do 
+inferType Γ (con (tmCon t x)) = do
   return (con (subNf∅ (sty2ty t)) ,, con x refl)
 inferType Γ (error A) = do
   A ← checkKind _ A *
   return (A ,, error A)
-inferType Γ (builtin b) = do 
+inferType Γ (builtin b) = do
   let bty = btype b
   return (bty ,, builtin b / refl)
 inferType Γ (wrap A B L) = do
@@ -548,10 +548,10 @@ inferType Γ (constr A i cs) = do
          (n ,, Tss) ← isSOPType B
          -- i < length cs
          e ← chkIdx i n
-         -- cs has type Vec.lookup Tss e           
+         -- cs has type Vec.lookup Tss e
          L ← checkConstrArgs-List Γ cs (Vec.lookup Tss e)
-         return ((SOP Tss) ,, (constr e Tss refl L)) 
-inferType Γ (case A x cs) = do 
+         return ((SOP Tss) ,, (constr e Tss refl L))
+inferType Γ (case A x cs) = do
              B ← checkKind _ A *
              -- check x is of SOP type
              L ← inferType Γ x

--- a/plutus-metatheory/src/Cost/Base.lagda.md
+++ b/plutus-metatheory/src/Cost/Base.lagda.md
@@ -3,7 +3,7 @@ title: Cost.Base
 layout: page
 ---
 ```
-module Cost.Base where 
+module Cost.Base where
 
 ```
 
@@ -24,45 +24,45 @@ open import Builtin using (Builtin;arity)
 open import Untyped.CEK using (Value)
 ```
 
-We will represent costs with Naturals. In the implementation `SatInt` is used, (integers that don't overflow, but saturate). 
+We will represent costs with Naturals. In the implementation `SatInt` is used, (integers that don't overflow, but saturate).
 As long as the budget is less than the maxInt then the result should be the same.
 
 ```
-CostingNat : Set 
+CostingNat : Set
 CostingNat = ℕ
 ```
 
 We define one constructor for each possible type of node in a UPLC term.
 
 ```
-data StepKind : Set where 
-    BConst 
+data StepKind : Set where
+    BConst
       BVar
       BLamAbs
       BApply
       BDelay
       BForce
       BBuiltin -- Cost of evaluating a Builtin AST node, not the function itself
-      BConstr 
+      BConstr
       BCase : StepKind
 ```
 
 We define a show function for StepKinds
 
 ```
-showStepKind' : StepKind → String 
-unquoteDef showStepKind' = defShow (quote StepKind) showStepKind' 
+showStepKind' : StepKind → String
+unquoteDef showStepKind' = defShow (quote StepKind) showStepKind'
 
-showStepKind : StepKind → String 
-showStepKind s = fromMaybe "" (tail (showStepKind' s))   
+showStepKind : StepKind → String
+showStepKind s = fromMaybe "" (tail (showStepKind' s))
 ```
 
 and a list of constructors names
 
-``` 
+```
 stepKindList : List StepKind
-unquoteDef stepKindList = defListConstructors (quote StepKind) stepKindList 
-``` 
+unquoteDef stepKindList = defListConstructors (quote StepKind) stepKindList
+```
 
 ## Recording expenditure
 
@@ -75,7 +75,7 @@ data ExBudgetCategory : Set where
     BStep       : StepKind → ExBudgetCategory
 
      -- Cost of evaluating a fully applied builtin function
-    BBuiltinApp : (b : Builtin) → Vec Value (arity b) → ExBudgetCategory  
+    BBuiltinApp : (b : Builtin) → Vec Value (arity b) → ExBudgetCategory
 
     -- Startup Cost
     BStartup    : ExBudgetCategory
@@ -93,6 +93,6 @@ record MachineParameters (Cost : Set) : Set where
       _∙_ : Cost → Cost → Cost
       costMonoid : IsMonoid _≡_ _∙_ ε
 
-    startupCost : Cost 
+    startupCost : Cost
     startupCost = cekMachineCost BStartup
-``` 
+```

--- a/plutus-metatheory/src/Cost/Size.lagda.md
+++ b/plutus-metatheory/src/Cost/Size.lagda.md
@@ -5,7 +5,7 @@ layout: page
 # Size of Constants
 
 ```
-module Cost.Size where 
+module Cost.Size where
 
 ```
 
@@ -25,7 +25,7 @@ open import Builtin.Constant.AtomicType using (AtomicTyCon)
 open AtomicTyCon
 open import Cost.Base
 open import Untyped.CEK using (Value;V-con)
-open import RawU using (TmCon;tmCon) 
+open import RawU using (TmCon;tmCon)
 ```
 
 ## Memory usage of type constants
@@ -75,17 +75,17 @@ defaultConstantMeasure (tmCon (atomic aBls12-381-g1-element) x) = g1ElementSize 
 defaultConstantMeasure (tmCon (atomic aBls12-381-g2-element) x) = g2ElementSize x
 defaultConstantMeasure (tmCon (atomic aBls12-381-mlresult) x) = mlResultElementSize x
 defaultConstantMeasure (tmCon (list t) []) = 1
-defaultConstantMeasure (tmCon (list t) (x ∷ xs)) = 
+defaultConstantMeasure (tmCon (list t) (x ∷ xs)) =
       3 + defaultConstantMeasure (tmCon t x)
       + defaultConstantMeasure (tmCon (list t) xs)
-defaultConstantMeasure (tmCon (pair t u) (x , y)) = 
-      1 + defaultConstantMeasure (tmCon t x) 
+defaultConstantMeasure (tmCon (pair t u) (x , y)) =
+      1 + defaultConstantMeasure (tmCon t x)
       + defaultConstantMeasure (tmCon u y)
 
 -- This is the main sizing function for Values
--- It only measures constants. Other types should use models where the size 
+-- It only measures constants. Other types should use models where the size
 -- of the non-constant does not matter.
-defaultValueMeasure : Value → CostingNat 
+defaultValueMeasure : Value → CostingNat
 defaultValueMeasure (V-con ty x) = defaultConstantMeasure (tmCon ty x)
 defaultValueMeasure _ = 0
 ```

--- a/plutus-metatheory/src/Declarative.lagda.md
+++ b/plutus-metatheory/src/Declarative.lagda.md
@@ -30,7 +30,7 @@ open import Builtin.Constant.Type using (TyCon)
 open TyCon
 
 open import Builtin.Signature using ()
-open Builtin.Signature.FromSig  (_⊢⋆_) (_⊢⋆_) (λ x → x) (`) _·_ ^ con _⇒_ Π 
+open Builtin.Signature.FromSig  (_⊢⋆_) (_⊢⋆_) (λ x → x) (`) _·_ ^ con _⇒_ Π
           using (sig2type;sig2type⇒;sig2typeΠ;⊢♯2TyNe♯;mkTy) public
 open import Type.BetaNBE using (nf)
 open import Algorithmic using (⟦_⟧;ty2sty)
@@ -120,7 +120,7 @@ We define it this way because it is easier to define the meaning of a normalised
 
 ```
 ty2TyTag : ∀ (A : ∅ ⊢⋆ ♯) → TyTag
-ty2TyTag A = ty2sty (nf A) 
+ty2TyTag A = ty2sty (nf A)
 ```
 
 ## Terms
@@ -132,11 +132,11 @@ application.
 
 ```
 mkCaseType : ∀{Φ} (A : Φ ⊢⋆ *) → List (Φ ⊢⋆ *) → Φ ⊢⋆ *
-mkCaseType A [] = A 
+mkCaseType A [] = A
 mkCaseType A (x ∷ xs) = x ⇒ (mkCaseType A xs)
 
 ConstrArgs : (Γ : Ctx Φ) → List (Φ ⊢⋆ *) → Set
-data Cases (Γ : Ctx Φ) (B : Φ ⊢⋆ *) : ∀{n} → Vec (List (Φ ⊢⋆ *)) n → Set 
+data Cases (Γ : Ctx Φ) (B : Φ ⊢⋆ *) : ∀{n} → Vec (List (Φ ⊢⋆ *)) n → Set
 
 data _⊢_ (Γ : Ctx Φ) : Φ ⊢⋆ * → Set where
 
@@ -184,7 +184,7 @@ data _⊢_ (Γ : Ctx Φ) : Φ ⊢⋆ * → Set where
       → (t : Γ ⊢ SOP Tss)
       → (cases : Cases Γ A Tss)
         --------------------------
-      → Γ ⊢ A  
+      → Γ ⊢ A
 
   conv : A ≡β B
        → Γ ⊢ A
@@ -207,12 +207,12 @@ data _⊢_ (Γ : Ctx Φ) : Φ ⊢⋆ * → Set where
 
 ConstrArgs Γ = IList (Γ ⊢_)
 
-data Cases Γ B where 
+data Cases Γ B where
    []  : Cases Γ B []
    _∷_ : ∀{n}{Ts}{Tss : Vec _ n}(
-         c : Γ ⊢ (mkCaseType B Ts)) 
+         c : Γ ⊢ (mkCaseType B Ts))
        → (cs : Cases Γ B Tss)
-         --------------------- 
+         ---------------------
        → Cases Γ B (Ts ∷ Tss)
 
 ```

--- a/plutus-metatheory/src/Declarative/Erasure.lagda.md
+++ b/plutus-metatheory/src/Declarative/Erasure.lagda.md
@@ -31,7 +31,7 @@ import Untyped.RenamingSubstitution as U
 open import Utils using (Kind;♯;*;Maybe;nothing;just;fromList)
 open import Utils.List using (List;IList;[];_∷_)
 open import RawU using (TmCon;tmCon;TyTag)
-open import Builtin.Signature using (_⊢♯) 
+open import Builtin.Signature using (_⊢♯)
 open import Builtin.Constant.Type
 
 open import Type.BetaNBE using (nf)
@@ -59,16 +59,16 @@ eraseVar (S α) = just (eraseVar α)
 eraseVar (T α) = eraseVar α
 
 eraseTC : (A : ∅ ⊢⋆ ♯) → ⟦ A ⟧d → TmCon
-eraseTC A t = tmCon (ty2TyTag A) (subst Algorithmic.⟦_⟧ (ty≅sty₁ (nf A)) t) 
+eraseTC A t = tmCon (ty2TyTag A) (subst Algorithmic.⟦_⟧ (ty≅sty₁ (nf A)) t)
 
 erase : ∀{Φ Γ}{A : Φ ⊢⋆ *} → Γ ⊢ A → len Γ ⊢
 
 erase-Sub : ∀{Φ Ψ}{Γ : Ctx Φ}{Δ : Ctx Ψ}(σ⋆ : T.Sub Φ Ψ)
-  → D.Sub Γ Δ σ⋆ → U.Sub (len Γ) (len Δ) 
+  → D.Sub Γ Δ σ⋆ → U.Sub (len Γ) (len Δ)
 
 erase-ConstrArgs : ∀ {Φ} {Γ : Ctx Φ}
                {Ts : List (Φ ⊢⋆ *)}
-               (cs : Dec.ConstrArgs Γ Ts) 
+               (cs : Dec.ConstrArgs Γ Ts)
           → List (len Γ ⊢)
 erase-ConstrArgs [] = []
 erase-ConstrArgs (c ∷ cs) = (erase c) ∷ (erase-ConstrArgs cs)
@@ -78,10 +78,10 @@ erase-Cases : ∀ {Φ} {Γ : Ctx Φ} {A : Φ ⊢⋆ *} {n}
                 (cs : Dec.Cases Γ A Tss) →
               List (len Γ ⊢)
 erase-Cases Dec.[] = []
-erase-Cases (c Dec.∷ cs) = (erase c) ∷ (erase-Cases cs) 
+erase-Cases (c Dec.∷ cs) = (erase c) ∷ (erase-Cases cs)
 
 erase (` α)           = ` (eraseVar α)
-erase (ƛ t)           = ƛ (erase t) 
+erase (ƛ t)           = ƛ (erase t)
 erase (t · u)         = erase t · erase u
 erase (Λ t)           = delay (erase t)
 erase (t ·⋆ A)        = force (erase t)
@@ -91,7 +91,7 @@ erase (conv p t)      = erase t
 erase (con {A = A} t _) = con (eraseTC A t)
 erase (builtin b)     = builtin b
 erase (error A)       = error
-erase (constr e Tss p cs) = constr (toℕ e) (erase-ConstrArgs cs) 
+erase (constr e Tss p cs) = constr (toℕ e) (erase-ConstrArgs cs)
 erase (case t cases)  = case (erase t) (erase-Cases cases)
 
 backVar⋆ : ∀{Φ}(Γ : Ctx Φ) → len Γ → Φ ⊢⋆ *

--- a/plutus-metatheory/src/Declarative/Examples.lagda.md
+++ b/plutus-metatheory/src/Declarative/Examples.lagda.md
@@ -64,7 +64,7 @@ From <http://lucacardelli.name/Papers/Notes/scott2.pdf>
     N = G M
     in  : N → M
     out : M → N
-    
+
     0    = Λ R . λ x : R . λ y : M → R . x
          : N
     succ = λ n : N . Λ R . λ x : R . λ y : M → R . y (in n)
@@ -80,22 +80,22 @@ From <http://lucacardelli.name/Papers/Notes/scott2.pdf>
 module ScottE where
   G : ∀{Γ} → Γ ,⋆  * ⊢⋆ *
   G = Π (` Z ⇒ (` (S Z) ⇒ ` Z) ⇒ ` Z)
-  
+
   M : ∀{Γ} → Γ ⊢⋆ *
   M = μ G
-  
+
   N : ∀{Γ} → Γ ⊢⋆ *
   N  =  G ⋆.[ M ]
-  
+
   Zero : ∀{Γ} → Γ ⊢ N
   Zero = Λ (ƛ (ƛ (` (S (Z )))))
-  
+
   Succ : ∀{Γ} → Γ ⊢ N ⇒ N
   Succ = ƛ (Λ (ƛ (ƛ (` Z · wrap G • (` (S (S (T Z)))) refl))))
-  
+
   One : ∀{Γ} → Γ ⊢ N
   One = Succ · Zero
-  
+
   Two : ∀{Γ} → Γ ⊢ N
   Two = Succ · One
 
@@ -110,7 +110,7 @@ module ScottE where
 
   -- Y : (a -> a) -> a
   -- Y f = (\x. f (x x)) (\x. f (x x))
-  -- Y f = (\x : mu x. x -> a. f (x x)) (\x : mu x. x -> a. f (x x)) 
+  -- Y f = (\x : mu x. x -> a. f (x x)) (\x : mu x. x -> a. f (x x))
 
   Y-comb : ∀{Γ} → Γ ⊢ Π ((` Z ⇒ ` Z) ⇒ ` Z)
   Y-comb = Λ (ƛ ((ƛ (` (S Z) · (unwrap • refl (` Z) · (` Z)))) · wrap (` Z ⇒ ` (S Z)) • (ƛ (` (S Z) · (unwrap • refl (` Z) · (` Z)))) refl ))
@@ -189,10 +189,10 @@ eval (gas 10000000) Scott.Two
 ```
 module Scott1 where
   open import Declarative.Examples.StdLib.Nat
-  
+
   One : ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ N
   One = Succ · Zero
-  
+
   Two : ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ N
   Two = Succ · One
 
@@ -224,7 +224,7 @@ module Scott1 where
 ```
 module Church where
   open Declarative.Examples.StdLib.ChurchNat
-  
+
   -- two plus two
   One : ∅ ⊢ N
   One = Succ · Zero

--- a/plutus-metatheory/src/Declarative/Examples/StdLib/ChurchNat.lagda.md
+++ b/plutus-metatheory/src/Declarative/Examples/StdLib/ChurchNat.lagda.md
@@ -44,10 +44,10 @@ Iter : ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ Π (` Z ⇒ (` Z ⇒ ` Z) ⇒ N ⇒ (` Z)
 Iter = Λ (ƛ (ƛ (ƛ ((` Z) ·⋆ (` Z) · (` (S (S Z))) · (` (S Z))))))
 
 con0 : ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ con (^ integer)
-con0 = con {A = ^ integer}(ℤ.pos 0) (refl≡β (^ (atomic aInteger))) 
+con0 = con {A = ^ integer}(ℤ.pos 0) (refl≡β (^ (atomic aInteger)))
 
 con1 : ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ con (^ integer)
-con1 = con {A = ^ integer}(ℤ.pos 1) (refl≡β (^ (atomic aInteger))) 
+con1 = con {A = ^ integer}(ℤ.pos 1) (refl≡β (^ (atomic aInteger)))
 
 inc : ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ con (^ integer) ⇒ con (^ integer)
 inc = ƛ (builtin addInteger · con1  · ` Z)

--- a/plutus-metatheory/src/Declarative/Examples/StdLib/Function.lagda.md
+++ b/plutus-metatheory/src/Declarative/Examples/StdLib/Function.lagda.md
@@ -48,7 +48,7 @@ unwrap0 {Γ} pat X = conv
 {-
   -- Y : (a -> a) -> a
   -- Y f = (\x. f (x x)) (\x. f (x x))
-  -- Y f = (\x : mu x. x -> a. f (x x)) (\x : mu x. x -> a. f (x x)) 
+  -- Y f = (\x : mu x. x -> a. f (x x)) (\x : mu x. x -> a. f (x x))
 
   -- Z : ((a -> b) -> a -> b) -> a -> b
   -- Z f = (\r. f (\x. r r x)) (\r. f (\x. r r x))

--- a/plutus-metatheory/src/Declarative/Examples/StdLib/Nat.lagda.md
+++ b/plutus-metatheory/src/Declarative/Examples/StdLib/Nat.lagda.md
@@ -37,7 +37,7 @@ Zero = Λ (ƛ (ƛ (` (S (Z )))))
 -- : N → N
 
 Succ : ∀{Φ}{Γ : Ctx Φ} → Γ ⊢ N ⇒ N
-Succ = ƛ (Λ (ƛ (ƛ 
+Succ = ƛ (Λ (ƛ (ƛ
   (` Z · (wrap0 (ƛ G) (conv (sym≡β (β≡β _ _)) (` (S (S (T Z))))))))))
 
 --FoldNat : ∀{Φ}{Γ : Ctx Φ} → {!!}

--- a/plutus-metatheory/src/Declarative/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Declarative/RenamingSubstitution.lagda.md
@@ -1,5 +1,5 @@
 ---
-title: (Declarative) Term Renaming and Substitution 
+title: (Declarative) Term Renaming and Substitution
 layout: page
 ---
 
@@ -50,7 +50,7 @@ ext : (ρ⋆ : ⋆.Ren Φ Ψ)
     → ∀{B}
       -------------------------------
     → Ren (Γ , B) (Δ , ⋆.ren ρ⋆ B) ρ⋆
-ext _ ρ Z     = Z 
+ext _ ρ Z     = Z
 ext _ ρ (S x) = S (ρ x)
 ```
 
@@ -100,12 +100,12 @@ ren-Cases : ∀ {Φ} {Ψ} {Γ : Ctx Φ} {Δ : Ctx Ψ} (ρ⋆ : ⋆.Ren Φ Ψ)
               (cases : Dec.Cases Γ A Tss) →
               Dec.Cases Δ (⋆.ren ρ⋆ A) (⋆.ren-VecList ρ⋆ Tss)
 ren-Cases ρ⋆ ρ Dec.[] = Dec.[]
-ren-Cases ρ⋆ ρ (Dec._∷_ {Ts = As} c cs) = subst (_ ⊢_) (lem-ren-mkCaseType  ρ⋆ ρ As) (ren ρ⋆ ρ c) 
+ren-Cases ρ⋆ ρ (Dec._∷_ {Ts = As} c cs) = subst (_ ⊢_) (lem-ren-mkCaseType  ρ⋆ ρ As) (ren ρ⋆ ρ c)
                                         Dec.∷ (ren-Cases ρ⋆ ρ cs)
 
 ren _ ρ (` x) = ` (ρ x)
 ren _ ρ (ƛ L) = ƛ (ren _ (ext _ ρ) L)
-ren _ ρ (L · M) = ren _ ρ L · ren _ ρ M 
+ren _ ρ (L · M) = ren _ ρ L · ren _ ρ M
 ren _ ρ (Λ L) = Λ (ren _ (ext⋆ _ ρ) L)
 ren ρ⋆ ρ (L ·⋆ A) =
   conv⊢ refl (⋆.ren-Π A (piBody L) ρ⋆) (ren _ ρ L ·⋆ ⋆.ren ρ⋆ A)
@@ -169,7 +169,7 @@ exts⋆ : (σ⋆ : ⋆.Sub Φ Ψ)
       → Sub Γ Δ σ⋆
       → ∀{K}
         ---------------------------------
-      → Sub (Γ ,⋆ K) (Δ ,⋆ K) (⋆.exts σ⋆) 
+      → Sub (Γ ,⋆ K) (Δ ,⋆ K) (⋆.exts σ⋆)
 exts⋆ _ σ (T {A = A} x) = conv⊢
   refl
   (trans (sym (⋆.ren-sub A)) (⋆.sub-ren A))
@@ -204,8 +204,8 @@ sub-Cases : ∀ {Φ} {Ψ} {Γ : Ctx Φ} {Δ : Ctx Ψ} (σ⋆ : ⋆.Sub Φ Ψ)
               (cases : Dec.Cases Γ A Tss) →
             Dec.Cases Δ (⋆.sub σ⋆ A) (⋆.sub-VecList σ⋆ Tss)
 sub-Cases σ⋆ σ Dec.[] = Dec.[]
-sub-Cases σ⋆ σ (Dec._∷_ {Ts = As} c cases) = subst (_ ⊢_) (lem-sub-mkCaseType σ⋆ σ As) (sub σ⋆ σ c) 
-                                 Dec.∷ (sub-Cases σ⋆ σ cases) 
+sub-Cases σ⋆ σ (Dec._∷_ {Ts = As} c cases) = subst (_ ⊢_) (lem-sub-mkCaseType σ⋆ σ As) (sub σ⋆ σ c)
+                                 Dec.∷ (sub-Cases σ⋆ σ cases)
 
 
 sub _  σ (` k)        = σ k

--- a/plutus-metatheory/src/Evaluator/Base.lagda.md
+++ b/plutus-metatheory/src/Evaluator/Base.lagda.md
@@ -3,7 +3,7 @@ title: Base
 layout: page
 ---
 ```
-module Evaluator.Base where 
+module Evaluator.Base where
 
 ```
 
@@ -15,9 +15,9 @@ open import Data.String using (String;_++_)
 
 open import Check using (TypeError)
 open TypeError
-open import Scoped using (FreeVariableError;ScopeError;extricateScopeTy) 
+open import Scoped using (FreeVariableError;ScopeError;extricateScopeTy)
 open import Scoped.Extrication using (extricateNf⋆)
-open import Raw using (RawTm;RawTy) 
+open import Raw using (RawTm;RawTy)
 import RawU as U using (Untyped)
 open import Utils using (RuntimeError)
 open RuntimeError

--- a/plutus-metatheory/src/Evaluator/Program.lagda.md
+++ b/plutus-metatheory/src/Evaluator/Program.lagda.md
@@ -15,7 +15,7 @@ open import Function using (_$_;_∘_)
 open import Data.String using (String;_++_)
 open import Agda.Builtin.Nat
 open import Data.Product using (Σ) renaming (_,_ to _,,_)
-open import Data.Empty using (⊥) 
+open import Data.Empty using (⊥)
 
 open import Type using (Ctx⋆;∅;_,⋆_)
 open import Check using (TypeError;inferType;inferKind;decKind;checkKind;checkType)
@@ -107,7 +107,7 @@ postulate
 ## Evaluators
 
 ```
-data BudgetMode (A : Set) : Set where 
+data BudgetMode (A : Set) : Set where
   Silent   : BudgetMode A
   Counting : A → BudgetMode A
   Tallying : A → BudgetMode A
@@ -178,18 +178,18 @@ showUPLCResult ◆     = inj₁ (runtimeError userError)
 showUPLCResult _     = inj₁ (runtimeError gasError)
 
 executeUPLCwithMP : ∀{A} → RawCostModel → (CostModel → MachineParameters A) → (A → String) → ⊥ U.⊢ → Either ERROR String
-executeUPLCwithMP (cekMachineCosts , rawmodel) mkMP report t with createMap rawmodel 
-... | just model = do 
+executeUPLCwithMP (cekMachineCosts , rawmodel) mkMP report t with createMap rawmodel
+... | just model = do
     let machineparam = mkMP (cekMachineCosts , model)
     let (ev , exBudget) = U.stepperC machineparam maxsteps (ε ; [] ▻ t)
     x ← withE runtimeError ev
     r ← showUPLCResult x
-    return (r ++ report exBudget) 
+    return (r ++ report exBudget)
 ... | nothing = inj₁ (jsonError "while processing parameters.")
 
 executeUPLC : BudgetMode RawCostModel → ⊥ U.⊢ → Either ERROR String
 executeUPLC Silent t = (withE runtimeError $ U.stepper maxsteps (ε ; [] ▻ t)) >>= showUPLCResult
-executeUPLC (Counting rcm) t = executeUPLCwithMP rcm machineParameters countingReport t 
+executeUPLC (Counting rcm) t = executeUPLCwithMP rcm machineParameters countingReport t
 executeUPLC (Tallying rcm) t = executeUPLCwithMP rcm tallyingMachineParameters tallyingReport t
 
 evalProgramNU : BudgetMode RawCostModel → ProgramNU → Either ERROR String
@@ -231,4 +231,4 @@ typeCheckProgramN namedprog = do
  -}
   return (prettyPrintTy (unshifterTy Z (extricateScopeTy (extricateNf⋆ A))))
 ```
- 
+

--- a/plutus-metatheory/src/Evaluator/Term.lagda.md
+++ b/plutus-metatheory/src/Evaluator/Term.lagda.md
@@ -8,10 +8,10 @@ This module contains functions that are meant to be called from Haskell code.
 It is mainly used by different testing programs.
 
 ```
-module Evaluator.Term where 
+module Evaluator.Term where
 ```
 
-## Imports 
+## Imports
 
 ```
 open import Agda.Builtin.Nat using (Nat)
@@ -27,7 +27,7 @@ open import Check using (TypeError;inferType;inferKind;decKind;checkKind;checkTy
 open TypeError
 
 open import Scoped using (extricateScopeTy;Weirdℕ;scopeCheckTm;shifter;unshifter;extricateScope;unshifterTy;scopeCheckTy;shifterTy;FreeVariableError)
-open Weirdℕ 
+open Weirdℕ
 open import Scoped.Extrication using (extricateNf⋆;extricate)
 open import Utils using (Either;inj₁;inj₂;withE;Kind;*;Maybe;nothing;just;Monad;RuntimeError;dec2Either;_×_;_,_)
 open RuntimeError
@@ -206,7 +206,7 @@ runTL t = do
   return (unconvTm (unshifter Z (extricateScope (extricate t))))
 
 {-# COMPILE GHC runTL as runTLAgda #-}
-``` 
+```
 
 Note the interfaces to evaluation below catch userErrors and replace them with error terms
 
@@ -243,7 +243,7 @@ runTCEK t = do
 ```
 
 Note that according to the specification ◆ should reduce to an error term,
-but here the untyped PLC term evaluator matches the behaviour of the 
+but here the untyped PLC term evaluator matches the behaviour of the
 Haskell implementation: an error is thrown with ◆.
 
 ```
@@ -258,7 +258,7 @@ runUValue t = do
 runU : TermU → Either ERROR TermU
 runU t = do
   tDB ← withE scopeError $ U.scopeCheckU0 (convTmU t)
-  V   ← runUValue tDB 
+  V   ← runUValue tDB
   return (unconvTmU (U.extricateU0 (U.discharge V)))
 
 {-# COMPILE GHC runU as runUAgda #-}
@@ -269,19 +269,19 @@ Run an untyped term with costing in Counting mode.
 From Haskell, this function should be called as `runUCountingAgda`
 where the first argument is a `CostModel`, as defined in
 `plutus-metatheory/src/Opts.hs` and the second argument is a
-`Term NamedDeBruijn DefaultUni DefaultFun ()`. 
+`Term NamedDeBruijn DefaultUni DefaultFun ()`.
 
-From Haskell, the return type is either an error or a tuple 
+From Haskell, the return type is either an error or a tuple
 `(Term NamedDeBruijn DefaultUni DefaultFun (), (Integer, Integer))` consisting
 of the result of evalution, and a pair of the CPU costs and the memory costs,
 respectively.
 
 ```
 runUCounting : RawCostModel → TermU → Either ERROR (TermU × (Nat × Nat))
-runUCounting (cekMachineCosts , rawmodel) t with createMap rawmodel 
-... | just model = do 
+runUCounting (cekMachineCosts , rawmodel) t with createMap rawmodel
+... | just model = do
         tDB ← withE scopeError $ U.scopeCheckU0 (convTmU t)
-        let machineParameters = machineParameters (cekMachineCosts , model) 
+        let machineParameters = machineParameters (cekMachineCosts , model)
             (ev , exBudget) = U.stepperC machineParameters maxsteps (ε ; [] ▻ tDB)
         □ V ← withE runtimeError ev
             where
@@ -338,6 +338,6 @@ alphaU plc1 plc2 | inj₂ plc1' | inj₂ plc2' with deBruijnifyTmU plc1' | deBru
 alphaU plc1 plc2 | inj₂ plc1' | inj₂ plc2' | inj₂ plc1'' | inj₂ plc2'' = U.decUTm (convTmU plc1'') (convTmU plc2'')
 alphaU plc1 plc2 | inj₂ plc1' | inj₂ plc2' | _ | _ = Bool.false
 alphaU plc1 plc2 | _ | _ = Bool.false
- 
+
 {-# COMPILE GHC alphaU as alphaU #-}
 ```

--- a/plutus-metatheory/src/Main.lagda.md
+++ b/plutus-metatheory/src/Main.lagda.md
@@ -16,7 +16,7 @@ open import Data.Integer.Show using (show)
 open import Data.Product using (Σ) renaming (_,_ to _,,_)
 open import Data.Bool using (Bool)
 open import Data.List using (List)
-open import Data.Empty using (⊥) 
+open import Data.Empty using (⊥)
 
 open import Type using (Ctx⋆;∅;_,⋆_)
 open import Check using (TypeError;inferType;inferKind;decKind;checkKind;checkType)
@@ -114,7 +114,7 @@ data Command (A : Set) : Set where
 {-# FOREIGN GHC import PlutusCore.Executable.Common  #-}
 {-# FOREIGN GHC import PlutusCore.Executable.Parsers #-}
 
-postulate 
+postulate
    execP : IO (Command RawCostModel)
    parse : Format → Input → IO ProgramN
    parseU : Format → Input → IO ProgramNU

--- a/plutus-metatheory/src/Raw.lagda.md
+++ b/plutus-metatheory/src/Raw.lagda.md
@@ -87,7 +87,7 @@ decRKi * * = true
 decRKi * _ = false
 decRKi ♯ ♯ = true
 decRKi ♯ _ = false
-decRKi (K ⇒ J) (K' ⇒ J') = decRKi K K' ∧ decRKi J J' 
+decRKi (K ⇒ J) (K' ⇒ J') = decRKi K K' ∧ decRKi J J'
 decRKi (K ⇒ J) _ = false
 
 decRTy : (A A' : RawTy) → Bool
@@ -137,7 +137,7 @@ decRTmList _ _ = false
 -- We have to different approaches to de Bruijn terms.
 -- one counts type and term binders separately the other counts them together
 
-addBrackets : String → String 
+addBrackets : String → String
 addBrackets xs = "[" ++ xs ++ "]"
 
 rawTyPrinter : RawTy → String
@@ -173,15 +173,15 @@ rawPrinter (error A) = "(error" ++ rawTyPrinter A ++ ")"
 rawPrinter (builtin b) = "(builtin)"
 rawPrinter (wrap pat ar t) = "(wrap" ++ ")"
 rawPrinter (unwrap t) = "(unwrap" ++ rawPrinter t ++ ")"
-rawPrinter (constr A i cs) = "(const"  ++ rawTyPrinter A 
-                               ++ " "  ++ show (ℤ.pos i) 
+rawPrinter (constr A i cs) = "(const"  ++ rawTyPrinter A
+                               ++ " "  ++ show (ℤ.pos i)
                                ++ " [" ++ rawListPrinter cs ++ "])"
-rawPrinter (case A arg cs) = "(case"  ++ rawTyPrinter A 
-                              ++ " "  ++ rawPrinter arg 
-                              ++ " [" ++ rawListPrinter cs ++"])"                               
+rawPrinter (case A arg cs) = "(case"  ++ rawTyPrinter A
+                              ++ " "  ++ rawPrinter arg
+                              ++ " [" ++ rawListPrinter cs ++"])"
 
 rawListPrinter [] = ""
 rawListPrinter (x ∷ []) = rawPrinter x
-rawListPrinter (x ∷ y ∷ xs) = rawPrinter x ++ " , " ++ rawListPrinter (y ∷ xs)                               
+rawListPrinter (x ∷ y ∷ xs) = rawPrinter x ++ " , " ++ rawListPrinter (y ∷ xs)
 ```
- 
+

--- a/plutus-metatheory/src/RawU.lagda.md
+++ b/plutus-metatheory/src/RawU.lagda.md
@@ -35,7 +35,7 @@ open import Builtin using (Builtin;equals)
 open Builtin.Builtin
 
 
-open import Builtin.Signature as B using (Sig;sig;_⊢♯) 
+open import Builtin.Signature as B using (Sig;sig;_⊢♯)
 open _⊢♯
 import Builtin.Constant.Type as T
 open import Builtin.Constant.AtomicType using (AtomicTyCon;decAtomicTyCon)
@@ -45,7 +45,7 @@ open import Type using (Ctx⋆;∅)
 open import Type.BetaNormal using (_⊢Nf⋆_;_⊢Ne⋆_)
 open _⊢Nf⋆_
 open _⊢Ne⋆_
-open B.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π 
+open B.FromSig _⊢Nf⋆_ _⊢Ne⋆_ ne ` _·_ ^ con _⇒_   Π
      using (⊢♯2TyNe♯;sig2type;SigTy;sigTy2type;convSigTy) public
 open import Algorithmic using (⟦_⟧)
 
@@ -93,47 +93,47 @@ data Tag : Set → Set where
 {-# FOREIGN GHC pattern TagBLS12_381_G1_Element = DefaultUniBLS12_381_G1_Element #-}
 {-# FOREIGN GHC pattern TagBLS12_381_G2_Element = DefaultUniBLS12_381_G2_Element #-}
 {-# FOREIGN GHC pattern TagBLS12_381_MlResult   = DefaultUniBLS12_381_MlResult #-}
-{-# COMPILE GHC Tag                             = data Tag (TagInt 
-                                                           | TagBS 
-                                                           | TagStr 
-                                                           | TagBool 
-                                                           | TagUnit 
-                                                           | TagData 
-                                                           | TagPair 
-                                                           | TagList 
-                                                           | TagBLS12_381_G1_Element 
-                                                           | TagBLS12_381_G2_Element 
-                                                           | TagBLS12_381_MlResult) 
+{-# COMPILE GHC Tag                             = data Tag (TagInt
+                                                           | TagBS
+                                                           | TagStr
+                                                           | TagBool
+                                                           | TagUnit
+                                                           | TagData
+                                                           | TagPair
+                                                           | TagList
+                                                           | TagBLS12_381_G1_Element
+                                                           | TagBLS12_381_G2_Element
+                                                           | TagBLS12_381_MlResult)
 #-}
 ```
 
 ## Term constants
 
-Term constants are pairs of a tag and the corresponding type. 
+Term constants are pairs of a tag and the corresponding type.
 
 ```
 data TagCon : Set where
   tagCon : ∀{A} → Tag (Esc A) → A → TagCon
 
 {-# FOREIGN GHC type TagCon = Some (ValueOf DefaultUni) #-}
-{-# FOREIGN GHC pattern TagCon t x = Some (ValueOf t x) #-} 
+{-# FOREIGN GHC pattern TagCon t x = Some (ValueOf t x) #-}
 {-# COMPILE GHC TagCon = data TagCon (TagCon) #-}
 
 decTagCon' : ∀{A B} → (t : Tag (Esc A)) → (x : A) → (t' : Tag (Esc B)) → (y : B) → Bool
-decTagCon' integer i integer i'                          = does (i Data.Integer.≟ i') 
+decTagCon' integer i integer i'                          = does (i Data.Integer.≟ i')
 decTagCon' bytestring b bytestring b'                    = equals b b'
 decTagCon' string s string s'                            = does (s Data.String.≟ s')
 decTagCon' bool b bool b'                                = does (b Data.Bool.≟ b')
 decTagCon' unit ⊤ unit ⊤                                = true
 decTagCon' pdata d pdata d'                              = eqDATA d d'
-decTagCon' (pair t₁ t₂) (x₁ , x₂) (pair u₁ u₂) (y₁ , y₂) = decTagCon' t₁ x₁ u₁ y₁ 
+decTagCon' (pair t₁ t₂) (x₁ , x₂) (pair u₁ u₂) (y₁ , y₂) = decTagCon' t₁ x₁ u₁ y₁
                                                          ∧ decTagCon' t₂ x₂ u₂ y₂
 decTagCon' (list t) [] (list t') []                      = true -- TODO: check that the tags t and t' are equal
-decTagCon' (list t) (x ∷ xs) (list t') (y ∷ ys)          = decTagCon' t x t' y 
+decTagCon' (list t) (x ∷ xs) (list t') (y ∷ ys)          = decTagCon' t x t' y
                                                          ∧ decTagCon' (list t) xs (list t') ys
 decTagCon' _ _ _ _                                       = false
 
--- Comparison of TagCon. Written with an auxiliary function to pass the termination checker. 
+-- Comparison of TagCon. Written with an auxiliary function to pass the termination checker.
 decTagCon : (C C' : TagCon) → Bool
 decTagCon (tagCon t x) (tagCon t' y) = decTagCon' t x t' y
 
@@ -174,7 +174,7 @@ an Agda type.
 
 ```
 ⟦_⟧tag : 0 ⊢♯ → Set
-⟦ t ⟧tag =  ⟦ ne (⊢♯2TyNe♯ t) ⟧ 
+⟦ t ⟧tag =  ⟦ ne (⊢♯2TyNe♯ t) ⟧
 ```
 
 
@@ -197,7 +197,7 @@ Again term constants are a pair of a tag, and its meaning, except
 this time the meaning is given by the semantic function ⟦_⟧tag.
 
 ```
-data TmCon : Set where 
+data TmCon : Set where
   tmCon : (t : TyTag) → ⟦ t ⟧tag → TmCon
 ```
 
@@ -264,9 +264,9 @@ tyTag2Tag (atomic aData) = DATA ,, pdata
 tyTag2Tag (atomic aBls12-381-g1-element) = Bls12-381-G1-Element ,, bls12-381-g1-element
 tyTag2Tag (atomic aBls12-381-g2-element) = Bls12-381-G2-Element ,, bls12-381-g2-element
 tyTag2Tag (atomic aBls12-381-mlresult) = Bls12-381-MlResult ,, bls12-381-mlresult
-tyTag2Tag (list t)  with tyTag2Tag t 
+tyTag2Tag (list t)  with tyTag2Tag t
 ... | A ,, a = List A ,, list a
-tyTag2Tag (pair t u)  with tyTag2Tag t | tyTag2Tag u  
+tyTag2Tag (pair t u)  with tyTag2Tag t | tyTag2Tag u
 ... | A ,, a | B ,, b  = (A × B) ,, pair a b
 
 tyTagLemma : (t : TyTag) → ⟦ t ⟧tag ≡ proj₁ (tyTag2Tag t)
@@ -293,6 +293,6 @@ tmCon2TagCon (tmCon (atomic aBls12-381-g1-element) x) = tagCon bls12-381-g1-elem
 tmCon2TagCon (tmCon (atomic aBls12-381-g2-element) x) = tagCon bls12-381-g2-element x
 tmCon2TagCon (tmCon (atomic aBls12-381-mlresult) x) = tagCon bls12-381-mlresult x
 tmCon2TagCon (tmCon (list t) x) rewrite tyTagLemma t = tagCon (list (proj₂ (tyTag2Tag t))) x
-tmCon2TagCon (tmCon (pair t u) (x , y)) rewrite tyTagLemma t | tyTagLemma u = 
+tmCon2TagCon (tmCon (pair t u) (x , y)) rewrite tyTagLemma t | tyTagLemma u =
     tagCon (pair (proj₂ (tyTag2Tag t)) (proj₂ (tyTag2Tag u))) (x , y)
 ```

--- a/plutus-metatheory/src/Scoped.lagda.md
+++ b/plutus-metatheory/src/Scoped.lagda.md
@@ -8,7 +8,7 @@ module Scoped where
 
 ```
 open import Data.Nat using (ℕ;zero;suc;∣_-_∣)
-open import Data.Fin using (Fin;zero;suc;toℕ) 
+open import Data.Fin using (Fin;zero;suc;toℕ)
 open import Data.Integer.Show using () renaming (show to ishow)
 open import Data.Vec using (Vec;[];_∷_)
 open import Data.Bool using (Bool)
@@ -20,7 +20,7 @@ open import Data.String using (String;_++_)
 open import Builtin using (Builtin)
 open Builtin.Builtin
 
-open import Builtin.Signature using (_⊢♯;integer;bytestring) 
+open import Builtin.Signature using (_⊢♯;integer;bytestring)
 open import Builtin.Constant.Type
 open import Builtin.Constant.AtomicType using (aBool)
 
@@ -286,19 +286,19 @@ scopeCheckTy (μ A B) = do
   A ← scopeCheckTy A
   B ← scopeCheckTy B
   return (μ A B)
-scopeCheckTy (SOP xss) = do 
-      A ← scopeCheckTyListList xss  
+scopeCheckTy (SOP xss) = do
+      A ← scopeCheckTyListList xss
       return (SOP A)
 
 scopeCheckTyList [] = return []
-scopeCheckTyList (x ∷ xs) = do 
-      A  ← scopeCheckTy x 
+scopeCheckTyList (x ∷ xs) = do
+      A  ← scopeCheckTy x
       As ← scopeCheckTyList xs
       return (A ∷ As)
 
 scopeCheckTyListList [] = return []
-scopeCheckTyListList (xs ∷ xss) = do 
-      Ts  ← scopeCheckTyList xs 
+scopeCheckTyListList (xs ∷ xss) = do
+      Ts  ← scopeCheckTyList xs
       Tss ← scopeCheckTyListList xss
       return (Ts ∷ Tss)
 
@@ -328,20 +328,20 @@ scopeCheckTm (wrap A B t) = do
   t ← scopeCheckTm t
   return (wrap A B t)
 scopeCheckTm (unwrap t) = fmap unwrap (scopeCheckTm t)
-scopeCheckTm (constr A i cs) = do 
-  A  ← scopeCheckTy A 
+scopeCheckTm (constr A i cs) = do
+  A  ← scopeCheckTy A
   cs ← scopeCheckTmList cs
   return (constr A i cs)
-scopeCheckTm (case A t cs) = do 
+scopeCheckTm (case A t cs) = do
   A  ← scopeCheckTy A
   t  ← scopeCheckTm t
   cs ← scopeCheckTmList cs
   return (case A t cs)
 
 scopeCheckTmList [] = return []
-scopeCheckTmList (x ∷ xs) = do 
-  x  ← scopeCheckTm x 
-  xs ← scopeCheckTmList xs 
+scopeCheckTmList (x ∷ xs) = do
+  x  ← scopeCheckTm x
+  xs ← scopeCheckTmList xs
   return (x ∷ xs)
 ```
 

--- a/plutus-metatheory/src/Scoped/Extrication.lagda.md
+++ b/plutus-metatheory/src/Scoped/Extrication.lagda.md
@@ -20,7 +20,7 @@ open import Utils as U using (Kind;*)
 open import Utils.List using ([];_∷_)
 
 open import RawU using (TmCon;tmCon;TyTag)
-open import Builtin.Signature using (_⊢♯) 
+open import Builtin.Signature using (_⊢♯)
 open import Builtin.Constant.Type
 
 open import Type using (Ctx⋆;∅;_,⋆_;_∋⋆_;Z;S)
@@ -109,11 +109,11 @@ extricate-ConstrArgs [] = U.[]
 extricate-ConstrArgs (c ∷ cs) = extricate c U.∷ extricate-ConstrArgs cs
 
 extricate-Cases : ∀ {Φ} {Γ : Ctx Φ} {A : Φ ⊢Nf⋆ *} {n}
-                 {Tss : Vec (List (Φ ⊢Nf⋆ *)) n} 
-                 (cases : Cases Γ A Tss) 
+                 {Tss : Vec (List (Φ ⊢Nf⋆ *)) n}
+                 (cases : Cases Γ A Tss)
                 → U.List (ScopedTm (len Γ))
 extricate-Cases [] = U.[]
-extricate-Cases (c ∷ cs) = (extricate c) U.∷ (extricate-Cases cs)                
+extricate-Cases (c ∷ cs) = (extricate c) U.∷ (extricate-Cases cs)
 
 extricate (` x)                   = ` (extricateVar x)
 extricate {Φ}{Γ} (ƛ {A = A} t)    = ƛ (extricateNf⋆ A) (extricate t)

--- a/plutus-metatheory/src/Scoped/Extrication/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Scoped/Extrication/RenamingSubstitution.lagda.md
@@ -56,14 +56,14 @@ lem-backVar (S α) = trans
   (sym (lem-S (lem-backVar₁ α) (proj₂ (backVar (extricateVar⋆ α)))))
   (cong S (lem-backVar α))
 
-extricateRenNf⋆ : ∀{Γ Δ}(ρ⋆ : ∀ {J} → Γ ∋⋆ J → Δ ∋⋆ J) 
+extricateRenNf⋆ : ∀{Γ Δ}(ρ⋆ : ∀ {J} → Γ ∋⋆ J → Δ ∋⋆ J)
   → Ren⋆ (len⋆ Γ) (len⋆ Δ)
 extricateRenNf⋆ ρ⋆ x = extricateVar⋆ (ρ⋆ (proj₂ (backVar x)))
 
 lift⋆-ext : ∀{Γ Δ K}
   → (ρ⋆ : ∀ {J} → Γ ∋⋆ J → Δ ∋⋆ J)
   → (α : Fin (len⋆ (Γ ,⋆ K)))
-  → lift⋆ (extricateRenNf⋆ ρ⋆) α ≡ extricateRenNf⋆ (T.ext ρ⋆ {K = K}) α -- 
+  → lift⋆ (extricateRenNf⋆ ρ⋆) α ≡ extricateRenNf⋆ (T.ext ρ⋆ {K = K}) α --
 lift⋆-ext ρ⋆ zero = refl
 lift⋆-ext ρ⋆ (suc α) = refl
 
@@ -93,7 +93,7 @@ ren-extricateNe⋆ ρ⋆ (^ x) = refl
 
 ren-extricateNf⋆-List :  ∀{Γ Δ J}
   → (ρ⋆ : ∀ {J} → Γ ∋⋆ J → Δ ∋⋆ J)
-  → (xs : List (Γ ⊢Nf⋆ J)) 
+  → (xs : List (Γ ⊢Nf⋆ J))
   → ren⋆-List (extricateRenNf⋆ ρ⋆) (extricateNf⋆-List xs) ≡ extricateNf⋆-List (renNf-List ρ⋆ xs)
 ren-extricateNf⋆-List ρ⋆ [] = refl
 ren-extricateNf⋆-List ρ⋆ (x ∷ xs) = cong₂ Utils._∷_ (ren-extricateNf⋆ ρ⋆ x) (ren-extricateNf⋆-List ρ⋆ xs)
@@ -120,7 +120,7 @@ ren-extricateNf⋆ ρ⋆ (μ A B)  =
   cong₂ μ (ren-extricateNf⋆ ρ⋆ A) (ren-extricateNf⋆ ρ⋆ B)
 ren-extricateNf⋆ ρ⋆ (SOP xss) = cong SOP (ren-extricateNf⋆-ListList ρ⋆ xss)
 
-extricateSubNf⋆ : ∀{Γ Δ}(σ⋆ : ∀ {J} → Γ ∋⋆ J → Δ ⊢Nf⋆ J) 
+extricateSubNf⋆ : ∀{Γ Δ}(σ⋆ : ∀ {J} → Γ ∋⋆ J → Δ ⊢Nf⋆ J)
   → Sub⋆ (len⋆ Γ) (len⋆ Δ)
 extricateSubNf⋆ σ⋆ α = extricateNf⋆ (σ⋆ (proj₂ (backVar α)))
 
@@ -131,7 +131,7 @@ suclem {Δ ,⋆ _} {K} (suc x) = cong suc (suclem {Δ}{K} x)
 slift⋆-exts : ∀{Γ Δ K}
   → (σ⋆ : ∀ {J} → Γ ∋⋆ J → Δ ⊢Nf⋆ J)
   → (α : Fin (len⋆ (Γ ,⋆ K)))
-  → slift⋆ (extricateSubNf⋆ σ⋆) α ≡ extricateSubNf⋆ (extsNf σ⋆ {K = K}) α -- 
+  → slift⋆ (extricateSubNf⋆ σ⋆) α ≡ extricateSubNf⋆ (extsNf σ⋆ {K = K}) α --
 slift⋆-exts σ⋆ zero = refl
 slift⋆-exts {K = K} σ⋆ (suc α) = trans
   (ren⋆-cong (suclem {K = K}) (extricateNf⋆ (σ⋆ (proj₂ (backVar α)))))

--- a/plutus-metatheory/src/Scoped/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Scoped/RenamingSubstitution.lagda.md
@@ -69,14 +69,14 @@ ren : ∀{m n}{w : Weirdℕ m}{v : Weirdℕ n} → Ren⋆ m n → Ren w v → Sc
 renT : ∀{m n o}{w : Weirdℕ m}{v : Weirdℕ n} → Ren⋆ m n → Ren w v
   → Tel w o → Tel v o
 
-ren-List : ∀{m n}{w : Weirdℕ m}{v : Weirdℕ n} → Ren⋆ m n → Ren w v 
+ren-List : ∀{m n}{w : Weirdℕ m}{v : Weirdℕ n} → Ren⋆ m n → Ren w v
          → List (ScopedTm w)
          → List (ScopedTm v)
 ren-List ρ⋆ ρ [] = []
 ren-List ρ⋆ ρ (x ∷ xs) = (ren ρ⋆ ρ x) ∷ (ren-List ρ⋆ ρ xs)
 
 ren ρ⋆ ρ (` x) = ` (ρ x)
-ren ρ⋆ ρ (Λ K t) = Λ K (ren (lift⋆ ρ⋆) (⋆lift ρ) t) 
+ren ρ⋆ ρ (Λ K t) = Λ K (ren (lift⋆ ρ⋆) (⋆lift ρ) t)
 ren ρ⋆ ρ (t ·⋆ A) = ren ρ⋆ ρ t ·⋆ ren⋆ ρ⋆ A
 ren ρ⋆ ρ (ƛ A t)  = ƛ (ren⋆ ρ⋆ A) (ren ρ⋆ (lift ρ) t)
 ren ρ⋆ ρ (t · u) = ren ρ⋆ ρ t · ren ρ⋆ ρ u
@@ -85,7 +85,7 @@ ren ρ⋆ ρ (error A) = error (ren⋆ ρ⋆ A)
 ren ρ⋆ ρ (builtin b) = builtin b
 ren ρ⋆ ρ (wrap A B t) = wrap (ren⋆ ρ⋆ A) (ren⋆ ρ⋆ B) (ren ρ⋆ ρ t)
 ren ρ⋆ ρ (unwrap t) = unwrap (ren ρ⋆ ρ t)
-ren ρ⋆ ρ (constr A i cs) =  constr (ren⋆ ρ⋆ A) i (ren-List ρ⋆ ρ cs) 
+ren ρ⋆ ρ (constr A i cs) =  constr (ren⋆ ρ⋆ A) i (ren-List ρ⋆ ρ cs)
 ren ρ⋆ ρ (case A x cs) = case (ren⋆ ρ⋆ A) (ren ρ⋆ ρ  x) (ren-List ρ⋆ ρ cs)
 
 renT ρ⋆ ρ []       = []
@@ -116,7 +116,7 @@ sub⋆ σ (ƛ K A) = ƛ K (sub⋆ (slift⋆ σ) A)
 sub⋆ σ (A · B) = sub⋆ σ A · sub⋆ σ B
 sub⋆ σ (con c) = con c
 sub⋆ σ (μ A B) = μ (sub⋆ σ A) (sub⋆ σ B)
-sub⋆ σ (SOP xss) = SOP (sub⋆-ListList σ xss) 
+sub⋆ σ (SOP xss) = SOP (sub⋆-ListList σ xss)
 
 sub⋆T : ∀{m n o} → Sub⋆ m n → Tel⋆ m o → Tel⋆ n o
 sub⋆T σ⋆ []       = []
@@ -191,7 +191,7 @@ ren⋆-cong : ∀{m n}{ρ ρ' : Ren⋆ m n}
   → ∀ x → ren⋆ ρ x ≡ ren⋆ ρ' x
 
 ren⋆-cong-List :  ∀{m n}{ρ ρ' : Ren⋆ m n}
-  → (∀ x → ρ x ≡ ρ' x) 
+  → (∀ x → ρ x ≡ ρ' x)
   → ∀ xs → ren⋆-List ρ xs ≡ ren⋆-List ρ' xs
 ren⋆-cong-List p [] = refl
 ren⋆-cong-List p (x ∷ xs) = cong₂ _∷_ (ren⋆-cong p x) (ren⋆-cong-List p xs)
@@ -215,7 +215,7 @@ slift⋆-cong : ∀{m n}{ρ ρ' : Sub⋆ m n}
   → (∀ x → ρ x ≡ ρ' x)
   → ∀ x → slift⋆ ρ x ≡ slift⋆ ρ' x
 slift⋆-cong p zero    = refl
-slift⋆-cong p (suc x) = cong (ren⋆ suc) (p x) 
+slift⋆-cong p (suc x) = cong (ren⋆ suc) (p x)
 
 sub⋆-cong : ∀{m n}{σ σ' : Sub⋆ m n}
   → (∀ x → σ x ≡ σ' x)
@@ -238,14 +238,14 @@ sub⋆-cong p (A ⇒ B)     = cong₂ _⇒_ (sub⋆-cong p A) (sub⋆-cong p B)
 sub⋆-cong p (Π K A)     = cong (Π K) (sub⋆-cong (slift⋆-cong p) A)
 sub⋆-cong p (ƛ K A)     = cong (ƛ K) (sub⋆-cong (slift⋆-cong p) A)
 sub⋆-cong p (A · B)     = cong₂ _·_ (sub⋆-cong p A) (sub⋆-cong p B)
-sub⋆-cong p (con c)     = refl 
+sub⋆-cong p (con c)     = refl
 sub⋆-cong p (μ pat arg) = cong₂ μ (sub⋆-cong p pat) (sub⋆-cong p arg)
 sub⋆-cong p (SOP xss)   = cong SOP (sub⋆-cong-ListList p xss)
 
 sub-cons : ∀{n n'}{w : Weirdℕ n}{w' : Weirdℕ n'} → Sub w w' → ScopedTm w' →
   Sub (S w) w'
 sub-cons σ t Z     = t
-sub-cons σ t (S x) = σ x  
+sub-cons σ t (S x) = σ x
 
 sub-cons⋆ : ∀{n n'}{w : Weirdℕ n}{w' : Weirdℕ n'} → Sub w w' → Sub (T w) w'
 sub-cons⋆ σ (T x) = σ x

--- a/plutus-metatheory/src/Type.lagda.md
+++ b/plutus-metatheory/src/Type.lagda.md
@@ -105,7 +105,7 @@ data _⊢⋆_ where
         ------
       → Φ ⊢⋆ *
 
-  ƛ : Φ ,⋆ K ⊢⋆ J 
+  ƛ : Φ ,⋆ K ⊢⋆ J
       -----------
     → Φ ⊢⋆ K ⇒ J
 
@@ -126,12 +126,12 @@ data _⊢⋆_ where
   con : Φ ⊢⋆ ♯
         ------
       → Φ ⊢⋆ *
-  
+
    -- Sum of Products
-  SOP : ∀{n} → 
-        Vec (List (Φ ⊢⋆ *)) n 
+  SOP : ∀{n} →
+        Vec (List (Φ ⊢⋆ *)) n
         ----------------------
-     →  Φ ⊢⋆ * 
+     →  Φ ⊢⋆ *
 ```
 
 Let `A`, `B`, `C` range over types:

--- a/plutus-metatheory/src/Type/BetaNBE.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNBE.lagda.md
@@ -182,7 +182,7 @@ module _ where
   open import Data.Vec using (lookup)
   open import Relation.Binary.PropositionalEquality using (_≡_;refl; cong; cong₂)
 
-  
+
   lookup-eval-VecList : ∀ {Φ Ψ n}
               → (e : Fin n)
               → (Tss : Vec (List (Ψ ⊢⋆ *)) n)

--- a/plutus-metatheory/src/Type/BetaNBE/Completeness.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNBE/Completeness.lagda.md
@@ -13,7 +13,7 @@ open import Data.Sum using (inj₁;inj₂)
 open import Function using (_∘_;id)
 open import Data.Vec using (Vec;[];_∷_)
 open import Data.List using (List;[];_∷_)
-open import Relation.Binary.PropositionalEquality 
+open import Relation.Binary.PropositionalEquality
    using (_≡_;refl;sym;trans;cong;cong₂)
 
 open import Utils using (*;♯;_⇒_;J;K)
@@ -133,8 +133,8 @@ reifyCR : ∀{K}{v v' : Val Φ K}
 reifyCR {K = *    }                    p              = p
 reifyCR {K = ♯    }                    p              = p
 reifyCR {K = K ⇒ J} {inj₁ n} {inj₁ n'} p              = cong ne p
-reifyCR {K = K ⇒ J} {inj₁ n} {inj₂ f'} ()             
-reifyCR {K = K ⇒ J} {inj₂ f} {inj₁ n'} ()             
+reifyCR {K = K ⇒ J} {inj₁ n} {inj₂ f'} ()
+reifyCR {K = K ⇒ J} {inj₂ f} {inj₁ n'} ()
 reifyCR {K = K ⇒ J} {inj₂ f} {inj₂ f'} (p , p' , p'') =
   cong ƛ (reifyCR (p'' S (reflectCR refl)))
 ```
@@ -143,7 +143,7 @@ reifyCR {K = K ⇒ J} {inj₂ f} {inj₂ f'} (p , p' , p'') =
 
 ```
 EnvCR : ∀ {Φ Ψ} → (η η' : Env Φ Ψ) →  Set
-EnvCR η η' = ∀{K}(α : _ ∋⋆ K) → CR K (η α) (η' α) 
+EnvCR η η' = ∀{K}(α : _ ∋⋆ K) → CR K (η α) (η' α)
 ```
 
 Closure under environment extension
@@ -162,7 +162,7 @@ CR,,⋆ p q (S α) = p α
 Closure under application
 
 ```
-AppCR : 
+AppCR :
     {f f' : Val Φ (K ⇒ J)}
   → CR (K ⇒ J) f f'
   → {v v' : Val Φ K}
@@ -200,17 +200,17 @@ ren-reify : ∀{K}{v v' : Val Φ K}
 ren-reify {K = *} p ρ =
   cong (renNf ρ) p
 ren-reify {K = ♯} p ρ =
-  cong (renNf ρ) p  
+  cong (renNf ρ) p
 ren-reify {K = K ⇒ J} {v = inj₁ n} {inj₁ n'} p ρ =
   cong (ne ∘ renNe ρ) p
 ren-reify {K = K ⇒ J} {v = inj₁ n} {inj₂ f'} () ρ
 ren-reify {K = K ⇒ J} {v = inj₂ f} {inj₁ n'} () ρ
 ren-reify {K = K ⇒ J} {v = inj₂ f} {inj₂ f'} (p , p' , p'') ρ = cong ƛ
   (trans (ren-reify (p'' S (reflectCR refl)) (ext ρ))
-         (reifyCR ((transCR ( p' S (ext ρ) _ _ (reflectCR refl)) 
-                            (AppCR {f = renVal (S ∘ ρ) (inj₂ f')}{renVal (S ∘ ρ) (inj₂ f')} 
-                                   ((λ ρ₁ ρ' v → p' (ρ₁ ∘ S ∘ ρ) ρ' v) , (λ ρ₁ ρ' v → p' (ρ₁ ∘ S ∘ ρ) ρ' v) ,  λ ρ' q → proj₂ (proj₂ (reflCR {v = inj₂ f'}{v' = inj₂ f} (symCR {v = inj₂ f}{v' = inj₂ f'}(p , p' , p'')))) 
-                                                                                                                                     (ρ' ∘ S ∘ ρ) q) 
+         (reifyCR ((transCR ( p' S (ext ρ) _ _ (reflectCR refl))
+                            (AppCR {f = renVal (S ∘ ρ) (inj₂ f')}{renVal (S ∘ ρ) (inj₂ f')}
+                                   ((λ ρ₁ ρ' v → p' (ρ₁ ∘ S ∘ ρ) ρ' v) , (λ ρ₁ ρ' v → p' (ρ₁ ∘ S ∘ ρ) ρ' v) ,  λ ρ' q → proj₂ (proj₂ (reflCR {v = inj₂ f'}{v' = inj₂ f} (symCR {v = inj₂ f}{v' = inj₂ f'}(p , p' , p''))))
+                                                                                                                                     (ρ' ∘ S ∘ ρ) q)
                                    (renVal-reflect (ext ρ) (` Z)))))))
 ```
 
@@ -225,7 +225,7 @@ renVal-id {K = *} p = trans (renNf-id _) p
 renVal-id {K = ♯} p = trans (renNf-id _) p
 renVal-id {K = K ⇒ J} {v = inj₁ n} {inj₁ n'} p = trans (renNe-id _) p
 renVal-id {K = K ⇒ J} {v = inj₁ n} {inj₂ f'} ()
-renVal-id {K = K ⇒ J} {v = inj₂ f} {inj₁ n'} () 
+renVal-id {K = K ⇒ J} {v = inj₂ f} {inj₁ n'} ()
 renVal-id {K = K ⇒ J} {v = inj₂ f} {inj₂ f'} p = p
 ```
 
@@ -287,7 +287,7 @@ renVal·V :
   → CR J (renVal ρ (f ·V v)) (renVal ρ f' ·V renVal ρ v')
 renVal·V {J = *} ρ {inj₁ n} {inj₁ n'} p {v}{v'}  q =
   cong₂ (λ x y → ne (x · y)) (cong (renNe ρ) p) (ren-reify q ρ)
-renVal·V {J = ♯} ρ {inj₁ n} {inj₁ n'} p q =  
+renVal·V {J = ♯} ρ {inj₁ n} {inj₁ n'} p q =
   cong₂ (λ x y → ne (x · y)) (cong (renNe ρ) p) (ren-reify q ρ)
 renVal·V {J = J ⇒ K} ρ {inj₁ n} {inj₁ n'} p      q = cong₂ _·_
   (cong (renNe ρ) p)
@@ -309,12 +309,12 @@ idext : ∀{K}{η η' : Env Φ Ψ}
 
 idext-List : ∀{η η' : Env Φ Ψ}
   → EnvCR η η'
-  → (xs : List (Φ ⊢⋆ *)) 
+  → (xs : List (Φ ⊢⋆ *))
   → eval-List xs η ≡ eval-List xs η'
 
 idext-VecList : ∀{η η' : Env Φ Ψ}{n}
   → EnvCR η η'
-  → (xss : Vec (List (Φ ⊢⋆ *)) n) 
+  → (xss : Vec (List (Φ ⊢⋆ *)) n)
   → eval-VecList xss η ≡ eval-VecList xss η'
 
 renVal-eval : ∀{Φ Ψ Θ K}
@@ -432,7 +432,7 @@ ren-eval-List :
   (ts : List (Θ ⊢⋆ *))
   {η η' : ∀{J} → Ψ ∋⋆ J → Val Φ J}
   (p : EnvCR η η')
-  (ρ : Ren Θ Ψ) → 
+  (ρ : Ren Θ Ψ) →
   ---------------------------------------------------
   eval-List (ren-List ρ ts) η ≡ eval-List ts (η' ∘ ρ)
 
@@ -440,7 +440,7 @@ ren-eval-VecList : ∀{n}
   (Tss : Vec (List (Θ ⊢⋆ *)) n)
   {η η' : ∀{J} → Ψ ∋⋆ J → Val Φ J}
   (p : EnvCR η η')
-  (ρ : Ren Θ Ψ) → 
+  (ρ : Ren Θ Ψ) →
   --------------------------------------------------------------
   eval-VecList (ren-VecList ρ Tss) η ≡ eval-VecList Tss (η' ∘ ρ)
 
@@ -452,7 +452,7 @@ ren-eval (Π B) p ρ =
                           (reflectCR refl)) (ext ρ))
        (idext (λ{ Z     → reflectCR refl
                 ; (S x) → (renCR S ∘ reflCR ∘ symCR ∘ p) (ρ x)}) B))
-ren-eval (A ⇒ B) p ρ = cong₂ _⇒_ (ren-eval A p ρ) (ren-eval B p ρ) 
+ren-eval (A ⇒ B) p ρ = cong₂ _⇒_ (ren-eval A p ρ) (ren-eval B p ρ)
 ren-eval (ƛ B) p ρ =
   (λ ρ' ρ'' v v' q → transCR
      (renVal-eval (ren (ext ρ) B) (CR,,⋆ (renCR ρ' ∘ reflCR ∘ p) q) ρ'')
@@ -601,7 +601,7 @@ fund p (ƛ≡β {B = B}{B'} q) =
   ,
   λ ρ r → fund (CR,,⋆ (renCR ρ ∘ p) r) q
 fund p (·≡β q r) = AppCR (fund p q) (fund p r)
-fund p (μ≡β q r) = cong₂ μ (reifyCR (fund p q)) (reifyCR (fund p r)) 
+fund p (μ≡β q r) = cong₂ μ (reifyCR (fund p q)) (reifyCR (fund p r))
 fund p (β≡β B A) =
   transCR (idext (λ { Z     → idext (reflCR ∘ p) A
                     ; (S x) → renVal-id (reflCR (p x))})

--- a/plutus-metatheory/src/Type/BetaNBE/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNBE/RenamingSubstitution.lagda.md
@@ -15,7 +15,7 @@ open import Type using (Ctx⋆;∅;_,⋆_;_⊢⋆_;_∋⋆_;Z;S)
 open _⊢⋆_
 open import Type.Equality using (_≡β_;≡2β)
 open _≡β_
-open import Type.RenamingSubstitution 
+open import Type.RenamingSubstitution
       using (Ren;ren;ext;ren-comp;sub;sub-id;sub-comp;sub-cong;exts;sub-ren;weaken;sub-∅)
 open import Type.BetaNormal using (_⊢Nf⋆_;_⊢Ne⋆_;renNf;embNf;weakenNf;ren-embNf)
 open _⊢Nf⋆_
@@ -23,7 +23,7 @@ open _⊢Ne⋆_
 open import Type.BetaNormal.Equality using (renNf-comp)
 open import Type.BetaNBE using (reify;reflect;Env;eval;nf;renVal;idEnv;_,,⋆_;fresh;exte)
 open import Type.BetaNBE.Soundness using (soundness)
-open import Type.BetaNBE.Completeness 
+open import Type.BetaNBE.Completeness
    using (EnvCR;CR;fund;ren-reify;idext;idCR;reifyCR;renCR;transCR;reflectCR;renVal-eval;renVal-reflect;symCR;ren-eval;sub-eval;completeness)
 open import Type.BetaNBE.Stability using (stability)
 ```
@@ -49,7 +49,7 @@ evalCRSubst : ∀{Φ Ψ K}{η η' : Env Φ Ψ}
   → {t t' : Φ ⊢⋆ K}
   → t ≡ t'
   → CR K (eval t η) (eval t' η')
-evalCRSubst p {t = t} q = fund p (≡2β q) 
+evalCRSubst p {t = t} q = fund p (≡2β q)
 ```
 
 ```
@@ -148,7 +148,7 @@ subNf-∋ : ∀ {Φ Ψ J}
   → (ρ : SubNf Φ Ψ)
   → (α : Φ ∋⋆ J)
   → subNf ρ (ne (` α)) ≡ ρ α
-subNf-∋ ρ α = stability (ρ α) 
+subNf-∋ ρ α = stability (ρ α)
 ```
 
 
@@ -231,7 +231,7 @@ Substitution of one variable
 ```
 _[_]Nf : ∀ {Φ J K}
         → Φ ,⋆ K ⊢Nf⋆ J
-        → Φ ⊢Nf⋆ K 
+        → Φ ⊢Nf⋆ K
           ------
         → Φ ⊢Nf⋆ J
 A [ B ]Nf = subNf (subNf-cons (ne ∘ `) B) A
@@ -341,7 +341,7 @@ sub[]Nf ρ A B = trans
     (subNf-cong
       {f = subNf ρ ∘ subNf-cons (ne ∘ `) A}
       {g = subNf (subNf-cons (ne ∘ `) (subNf ρ A)) ∘ extsNf ρ}
-      (λ { Z     → sym (subNf-∋ (subNf-cons (ne ∘ `) (subNf ρ A)) Z) 
+      (λ { Z     → sym (subNf-∋ (subNf-cons (ne ∘ `) (subNf ρ A)) Z)
          ; (S α) → trans
               (trans (subNf-∋ ρ α) (sym (subNf-id (ρ α))))
               (subNf-renNf
@@ -476,7 +476,7 @@ sub-nf-μ σ⋆ A B = trans
 ```
 
 ```
-subNf-cons-[]Nf : ∀{Φ K Ψ'}{σ : SubNf Ψ' Φ}{A : Φ ⊢Nf⋆ K}(X : Ψ' ,⋆ K ⊢Nf⋆ *) → 
+subNf-cons-[]Nf : ∀{Φ K Ψ'}{σ : SubNf Ψ' Φ}{A : Φ ⊢Nf⋆ K}(X : Ψ' ,⋆ K ⊢Nf⋆ *) →
   subNf (subNf-cons σ A) X
   ≡
   reify (eval (sub (exts (embNf ∘ σ)) (embNf X)) (exte (idEnv Φ))) [ A ]Nf
@@ -490,7 +490,7 @@ subNf-cons-[]Nf {σ = σ}{A} X = trans
 ```
 
 ```
--- A version of subNf that is definitionally the identity on the empty context 
+-- A version of subNf that is definitionally the identity on the empty context
 subNf∅ : ∀{Φ K} → ∅ ⊢Nf⋆ K → Φ ⊢Nf⋆ K
 subNf∅ {∅} t = t
 subNf∅ {Φ ,⋆ x} t = subNf (λ()) t

--- a/plutus-metatheory/src/Type/BetaNBE/Soundness.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNBE/Soundness.lagda.md
@@ -19,7 +19,7 @@ open import Type using (Ctx⋆;_,⋆_;_⊢⋆_;_∋⋆_;Z;S)
 open _⊢⋆_
 open import Type.Equality using (_≡β_;≡2β;ren≡β;_⟨[≡]⟩β_;_[≡]β_)
 open _≡β_
-open import Type.RenamingSubstitution 
+open import Type.RenamingSubstitution
      using (Ren;ren;ext;ext-id;ren-comp;ren-id;ren-cong;ext-comp;exts;weaken)
      using (Sub;sub;sub-cons;sub-id;sub-comp;sub-cong;sub-ren;sub-List;sub-VecList)
 open import Type.BetaNormal using (_⊢Ne⋆_;embNf;ren-embNf;embNe;ren-embNe;embNf-List;embNf-VecList)
@@ -160,7 +160,7 @@ SRweak : ∀{Φ Ψ}{σ : Sub Φ Ψ}{η : Env Φ Ψ}
     -------------------------------------------------------
   → SREnv (exts σ) ((renVal S ∘ η) ,,⋆ fresh {σ = K})
 SRweak p = subSREnv (sym ∘ exts-sub-cons _)
-                      (SR,,⋆ (renSR S ∘ p) (reflectSR (refl≡β (` Z)))) 
+                      (SR,,⋆ (renSR S ∘ p) (reflectSR (refl≡β (` Z))))
 ```
 
 SR is closed under ·V
@@ -242,5 +242,5 @@ Soundness Result
 
 ```
 soundness : ∀ {Φ J} → (A : Φ ⊢⋆ J) → A ≡β embNf (nf A)
-soundness A = trans≡β (≡2β (sym (sub-id A))) (reifySR (evalSR A idSR)) 
+soundness A = trans≡β (≡2β (sym (sub-id A))) (reifySR (evalSR A idSR))
 ```

--- a/plutus-metatheory/src/Type/BetaNBE/Stability.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNBE/Stability.lagda.md
@@ -30,9 +30,9 @@ perturb the expression.
 stability : ∀{K}(n : Φ ⊢Nf⋆ K) → nf (embNf n) ≡ n
 stabilityNe : (n : Φ ⊢Ne⋆ K) → CR K (eval (embNe n) (idEnv _)) (reflect n)
 
-stability-List : ∀(xs : List (Φ ⊢Nf⋆ *)) → 
+stability-List : ∀(xs : List (Φ ⊢Nf⋆ *)) →
   eval-List (embNf-List xs) (λ x → reflect (` x)) ≡ xs
-stability-VecList : ∀{n}(xss : Vec (List (Φ ⊢Nf⋆ *)) n) → 
+stability-VecList : ∀{n}(xss : Vec (List (Φ ⊢Nf⋆ *)) n) →
   eval-VecList (embNf-VecList xss) (λ x → reflect (` x)) ≡ xss
 
 stability (Π B) =

--- a/plutus-metatheory/src/Type/BetaNormal.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNormal.lagda.md
@@ -18,13 +18,13 @@ infix 4 _⊢Ne⋆_
 
 ```
 open import Data.Nat using (ℕ)
-open import Data.Vec using (Vec;[];_∷_) 
+open import Data.Vec using (Vec;[];_∷_)
 open import Data.List using (List;[];_∷_)
 open import Data.Product using (Σ;Σ-syntax)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong; cong₂)
 
 open import Utils using (Kind;J;K)
-open Kind 
+open Kind
 open import Type using (Ctx⋆;_,⋆_;Φ;Ψ;_⊢⋆_;_∋⋆_;S)
 open _⊢⋆_
 open import Type.RenamingSubstitution using (Ren;ren;ext;ren-List;ren-VecList)
@@ -53,7 +53,7 @@ data _⊢Ne⋆_ : Ctx⋆ → Kind → Set where
       → Φ ⊢Nf⋆ K
         ------
       → Φ ⊢Ne⋆ J
-      
+
   ^ : Nf.TyCon K → Φ ⊢Ne⋆ K
 
 data _⊢Nf⋆_ where
@@ -96,10 +96,10 @@ context) in normal forms so we define renaming which subsumes
 weakening.
 
 ```
-RenNf : Ctx⋆ → Ctx⋆ → Set 
+RenNf : Ctx⋆ → Ctx⋆ → Set
 RenNf Φ Ψ = ∀{J} → Φ ⊢Nf⋆ J → Ψ ⊢Nf⋆ J
 
-RenNe : Ctx⋆ → Ctx⋆ → Set 
+RenNe : Ctx⋆ → Ctx⋆ → Set
 RenNe Φ Ψ = ∀{J} → Φ ⊢Ne⋆ J → Ψ ⊢Ne⋆ J
 
 
@@ -211,7 +211,7 @@ module _ where
 
   open import Data.Fin using (Fin;zero;suc)
   open import Data.Vec using (lookup)
-  
+
   lookup-renNf-VecList : ∀ {Φ Ψ n}
               → (ρ⋆ : Ren Φ Ψ)
               → (e : Fin n)

--- a/plutus-metatheory/src/Type/BetaNormal/Equality.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNormal/Equality.lagda.md
@@ -9,7 +9,7 @@ module Type.BetaNormal.Equality where
 ## Imports
 
 ```
-open import Data.Vec using (Vec;[];_∷_) 
+open import Data.Vec using (Vec;[];_∷_)
 open import Data.List using (List;[];_∷_)
 open import Function using (id;_∘_)
 open import Relation.Binary.PropositionalEquality using (_≡_;refl;trans;cong;cong₂)
@@ -37,12 +37,12 @@ renNf-cong-List : ∀ {f g : Ren Φ Ψ}
               (p : ∀ {J} (α : Φ ∋⋆ J) → f α ≡ g α)
               (xs : List (Φ ⊢Nf⋆ *))
               -----------------------------------------
-            → renNf-List f xs ≡ renNf-List g xs         
+            → renNf-List f xs ≡ renNf-List g xs
 renNf-cong-VecList : ∀ {f g : Ren Φ Ψ}
               (p : ∀ {J} (α : Φ ∋⋆ J) → f α ≡ g α){n}
               (xss : Vec (List (Φ ⊢Nf⋆ *)) n)
               -----------------------------------------
-            → renNf-VecList f xss ≡ renNf-VecList g xss           
+            → renNf-VecList f xss ≡ renNf-VecList g xss
 renNf-cong p (Π A)     = cong Π (renNf-cong (ext-cong p) A)
 renNf-cong p (A ⇒ B)   = cong₂ _⇒_ (renNf-cong p A) (renNf-cong p B)
 renNf-cong p (ƛ A)     = cong ƛ (renNf-cong (ext-cong p) A)
@@ -68,14 +68,14 @@ renNf-id : (n : Φ ⊢Nf⋆ J)
 renNe-id : (n : Φ ⊢Ne⋆ J)
            --------------
          → renNe id n ≡ n
-renNe-id-List : 
+renNe-id-List :
            (n : List (Φ ⊢Nf⋆ J))
            ------------------------------
-         → renNf-List id n ≡ n 
+         → renNf-List id n ≡ n
 renNe-id-VecList : ∀{m}
            (n : Vec (List (Φ ⊢Nf⋆ J)) m)
            ------------------------------
-         → renNf-VecList id n ≡ n         
+         → renNf-VecList id n ≡ n
 
 renNf-id (Π A)     = cong Π (trans (renNf-cong ext-id A) (renNf-id A))
 renNf-id (A ⇒ B)   = cong₂ _⇒_ (renNf-id A) (renNf-id B)
@@ -107,15 +107,15 @@ renNe-comp : {g : Ren Φ Ψ}
              -------------------------------------
            → renNe (f ∘ g) A ≡ renNe f (renNe g A)
 renNf-comp-List :
-            {g : Ren Φ Ψ} 
+            {g : Ren Φ Ψ}
           → {f : Ren Ψ Θ}
           → (xs : List (Φ ⊢Nf⋆ *))
             ----------------------------------------------------------------
-          → renNf-List (f ∘ g) xs ≡ renNf-List f (renNf-List g xs)           
+          → renNf-List (f ∘ g) xs ≡ renNf-List f (renNf-List g xs)
 renNf-comp-VecList : ∀{n}
-            {g : Ren Φ Ψ} 
+            {g : Ren Φ Ψ}
           → {f : Ren Ψ Θ}
-          → (xss : Vec (List (Φ ⊢Nf⋆ *)) n) 
+          → (xss : Vec (List (Φ ⊢Nf⋆ *)) n)
             ----------------------------------------------------------------
           → renNf-VecList (f ∘ g) xss ≡ renNf-VecList f (renNf-VecList g xss)
 
@@ -138,4 +138,4 @@ renNf-comp-VecList [] = refl
 renNf-comp-VecList (xs ∷ xss) = cong₂ _∷_ (renNf-comp-List xs) (renNf-comp-VecList xss)
 
 ```
- 
+

--- a/plutus-metatheory/src/Type/Equality.lagda.md
+++ b/plutus-metatheory/src/Type/Equality.lagda.md
@@ -24,7 +24,7 @@ open import Relation.Binary.PropositionalEquality
 open import Utils using (*;♯;J;K)
 open import Type using (Ctx⋆;_,⋆_;Φ;Ψ;_⊢⋆_;A;A';B;B';C)
 open _⊢⋆_
-open import Type.RenamingSubstitution 
+open import Type.RenamingSubstitution
    using (_[_];Ren;ren;Sub;sub;ext;sub-ren;ren-sub;sub-cong;ren-sub-cons;exts;sub-comp)
    using (sub-sub-cons;ren-List;ren-VecList;sub-List;sub-VecList)
 ```
@@ -57,7 +57,7 @@ data _≡β_ : Φ ⊢⋆ J → Φ ⊢⋆ J → Set where
   refl≡β : (A : Φ ⊢⋆ J)
            ------------
          → A ≡β A
-    
+
   sym≡β : A ≡β B
           ------
         → B ≡β A
@@ -70,25 +70,25 @@ data _≡β_ : Φ ⊢⋆ J → Φ ⊢⋆ J → Set where
   -- congruence rules
 
   -- (no variable rule is needed)
- 
+
   ⇒≡β : A ≡β A'
       → B ≡β B'
         -----------------
       → A ⇒ B ≡β A' ⇒ B'
-    
+
   Π≡β : B ≡β B'
         -----------
       → Π B ≡β Π B'
-    
+
   ƛ≡β : B ≡β B'
         -----------
       → ƛ B ≡β ƛ B'
-    
+
   ·≡β : A ≡β A'
       → B ≡β B'
         --------------------
       → A · B ≡β A' · B'
-    
+
   μ≡β : A ≡β A'
       → B ≡β B'
         ----------------
@@ -98,7 +98,7 @@ data _≡β_ : Φ ⊢⋆ J → Φ ⊢⋆ J → Set where
         → c ≡β c'
           -----------
         → con c ≡β con c'
-  
+
   SOP≡β : ∀{n}{Tss Tss' : Vec (List (Φ ⊢⋆ *)) n}
         → Tss ⟨[≡]⟩β Tss'
          ---------------
@@ -110,7 +110,7 @@ data _≡β_ : Φ ⊢⋆ J → Φ ⊢⋆ J → Set where
         ------------------
       → ƛ B · A ≡β B [ A ]
 
-data _[≡]β_ where 
+data _[≡]β_ where
   nil[≡]β : _[≡]β_ {Φ} [] []
 
   cons[≡]β : ∀{A A' : Φ ⊢⋆ *}{As As' : List (Φ ⊢⋆ *)}
@@ -119,7 +119,7 @@ data _[≡]β_ where
              ----------------
            → (A ∷ As) [≡]β (A' ∷ As')
 
-data _⟨[≡]⟩β_ where 
+data _⟨[≡]⟩β_ where
   nil⟨[≡]⟩β : _⟨[≡]⟩β_ {Φ} [] []
 
   cons⟨[≡]⟩β : ∀{n}{As As' : List (Φ ⊢⋆ *)}{Tss Tss' : Vec (List (Φ ⊢⋆ *)) n}
@@ -169,7 +169,7 @@ ren≡β ρ (SOP≡β p)   = SOP≡β (ren≡β-VecList ρ p)
 ren≡β-List ρ nil[≡]β = nil[≡]β
 ren≡β-List ρ (cons[≡]β x p) = cons[≡]β (ren≡β ρ x) (ren≡β-List ρ p)
 ren≡β-VecList ρ nil⟨[≡]⟩β = nil⟨[≡]⟩β
-ren≡β-VecList ρ (cons⟨[≡]⟩β x p) = cons⟨[≡]⟩β (ren≡β-List ρ x) (ren≡β-VecList ρ p) 
+ren≡β-VecList ρ (cons⟨[≡]⟩β x p) = cons⟨[≡]⟩β (ren≡β-List ρ x) (ren≡β-VecList ρ p)
 ```
 
 ## Substitution for proofs of type equality
@@ -188,10 +188,10 @@ sub≡β-VecList : ∀{n}{Tss Bss : Vec (List (Φ ⊢⋆ *)) n}(σ : Sub Φ Ψ)
       → Tss ⟨[≡]⟩β Bss
         ------------------
       → sub-VecList σ Tss ⟨[≡]⟩β sub-VecList σ Bss
-  
+
 sub≡β σ (refl≡β A)    = refl≡β (sub σ A)
 sub≡β σ (sym≡β p)     = sym≡β (sub≡β σ p)
-sub≡β σ (trans≡β p q) = trans≡β (sub≡β σ p) (sub≡β σ q) 
+sub≡β σ (trans≡β p q) = trans≡β (sub≡β σ p) (sub≡β σ q)
 sub≡β σ (⇒≡β p q)     = ⇒≡β (sub≡β σ p) (sub≡β σ q)
 sub≡β σ (Π≡β p)       = Π≡β (sub≡β (exts σ) p)
 sub≡β σ (ƛ≡β p)       = ƛ≡β (sub≡β (exts σ) p)
@@ -203,11 +203,11 @@ sub≡β σ (β≡β B A)     = trans≡β
                      (sub-cong (sub-sub-cons σ A) B))
               (sub-comp B)))
 sub≡β ρ (con≡β p)     = con≡β (sub≡β ρ p)
-sub≡β σ (SOP≡β p)   = SOP≡β (sub≡β-VecList σ p) 
+sub≡β σ (SOP≡β p)   = SOP≡β (sub≡β-VecList σ p)
 
 sub≡β-List σ nil[≡]β = nil[≡]β
 sub≡β-List σ (cons[≡]β x xs) = cons[≡]β (sub≡β σ x) (sub≡β-List σ xs)
 sub≡β-VecList σ nil⟨[≡]⟩β = nil⟨[≡]⟩β
-sub≡β-VecList σ (cons⟨[≡]⟩β x p) = cons⟨[≡]⟩β (sub≡β-List σ x) (sub≡β-VecList σ p)     
+sub≡β-VecList σ (cons⟨[≡]⟩β x p) = cons⟨[≡]⟩β (sub≡β-List σ x) (sub≡β-VecList σ p)
 ```
 

--- a/plutus-metatheory/src/Type/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Type/RenamingSubstitution.lagda.md
@@ -11,12 +11,12 @@ module Type.RenamingSubstitution where
 
 ```
 open import Data.Fin using (Fin;zero;suc)
-open import Data.Vec using (Vec;[];_∷_;lookup) 
+open import Data.Vec using (Vec;[];_∷_;lookup)
 open import Data.List using (List;[];_∷_)
 open import Function using (id;_∘_)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; cong; cong₂; trans; sym)
-  renaming (subst to substEq) 
+  renaming (subst to substEq)
 
 open import Utils using (*;J;K)
 open import Type using (Ctx⋆;_,⋆_;∅;Φ;Ψ;_⊢⋆_;_∋⋆_;S;Z)
@@ -66,7 +66,7 @@ ext ρ (S α)  =  S (ρ α)
 # Apply a type renaming to a type.
 
 This is defined by recursion on the type. Observe that we lift the renaming when
-we go under a binder and actually apply the renaming when we hit a variable. 
+we go under a binder and actually apply the renaming when we hit a variable.
 
 ```
 ren : Ren Φ Ψ
@@ -85,7 +85,7 @@ ren ρ (A ⇒ B)     = ren ρ A ⇒ ren ρ B
 ren ρ (ƛ B)       = ƛ (ren (ext ρ) B)
 ren ρ (μ A B)     = μ (ren ρ A) (ren ρ B)
 ren ρ (^ x)       = ^ x
-ren ρ (con c)     = con (ren ρ c) 
+ren ρ (con c)     = con (ren ρ c)
 ren ρ (A · B)     = ren ρ A · ren ρ B
 ren ρ (SOP xss)   = SOP (ren-VecList ρ xss)
 
@@ -172,14 +172,14 @@ First functor law for `ren`
 ren-id : (A : Φ ⊢⋆ J)
          ------------
        → ren id A ≡ A
-ren-id-List : 
+ren-id-List :
          (As : List (Φ ⊢⋆ J))
          --------------------
-       → ren-List id As ≡ As       
+       → ren-List id As ≡ As
 ren-id-VecList : ∀{n}
          (Tss : Vec (List (Φ ⊢⋆ J)) n)
          --------------------
-       → ren-VecList id Tss ≡ Tss  
+       → ren-VecList id Tss ≡ Tss
 
 ren-id (` α)     = refl
 ren-id (Π A)     = cong Π (trans (ren-cong ext-id A) (ren-id A))
@@ -189,7 +189,7 @@ ren-id (A · B)   = cong₂ _·_ (ren-id A) (ren-id B)
 ren-id (μ A B)   = cong₂ μ (ren-id A) (ren-id B)
 ren-id (^ x)     = refl
 ren-id (con c)   = cong con (ren-id c)
-ren-id (SOP xss) = cong SOP (ren-id-VecList xss) 
+ren-id (SOP xss) = cong SOP (ren-id-VecList xss)
 
 ren-id-List [] = refl
 ren-id-List (x ∷ xs) = cong₂ _∷_ (ren-id x) (ren-id-List xs)
@@ -284,7 +284,7 @@ sub σ (A · B) = sub σ A · sub σ B
 sub σ (μ A B) = μ (sub σ A) (sub σ B)
 sub σ (^ x)   = ^ x
 sub σ (con c) = con (sub σ c)
-sub σ (SOP xss) = SOP (sub-VecList σ xss) 
+sub σ (SOP xss) = SOP (sub-VecList σ xss)
 
 sub-List σ [] = []
 sub-List σ (x ∷ xs) = sub σ x ∷ sub-List σ xs
@@ -307,7 +307,7 @@ sub-cons f A (S x) = f x
 A special case is substitution a type for the outermost free variable:
 ```
 _[_] : Φ ,⋆ K ⊢⋆ J
-     → Φ ⊢⋆ K 
+     → Φ ⊢⋆ K
        -----------
      → Φ ⊢⋆ J
 B [ A ] =  sub (sub-cons ` A) B
@@ -320,7 +320,7 @@ Extending the identity substitution yields the identity substitution
 ```
 exts-id : (α : Φ ,⋆ K ∋⋆ J)
           -----------------
-        → exts ` α ≡ ` α 
+        → exts ` α ≡ ` α
 exts-id Z     = refl
 exts-id (S α) = refl
 ```
@@ -359,7 +359,7 @@ sub-cong p (ƛ A)   = cong ƛ (sub-cong (exts-cong p) A)
 sub-cong p (A · B) = cong₂ _·_ (sub-cong p A) (sub-cong p B)
 sub-cong p (μ A B) = cong₂ μ (sub-cong p A) (sub-cong p B)
 sub-cong p (^ x)   = refl
-sub-cong p (con c) = cong con (sub-cong p c) 
+sub-cong p (con c) = cong con (sub-cong p c)
 sub-cong p (SOP xss) = cong SOP (sub-cong-VecList p xss)
 
 sub-cong-List p [] = refl
@@ -374,11 +374,11 @@ First relative monad `law` for `sub`
 sub-id : (A : Φ ⊢⋆ J)
          ------------
        → sub ` A ≡ A
-sub-id-List : 
+sub-id-List :
          (As : List (Φ ⊢⋆ J))
          --------------------
        → sub-List ` As ≡ As
-sub-id-VecList : ∀{n} 
+sub-id-VecList : ∀{n}
          (Tss : Vec (List (Φ ⊢⋆ J)) n)
          --------------------
        → sub-VecList ` Tss ≡ Tss
@@ -390,7 +390,7 @@ sub-id (ƛ A)      = cong ƛ (trans (sub-cong exts-id A) (sub-id A))
 sub-id (A · B)    = cong₂ _·_ (sub-id A) (sub-id B)
 sub-id (μ A B)    = cong₂ μ (sub-id A) (sub-id B)
 sub-id (^ x)      = refl
-sub-id (con c)    = cong con (sub-id c) 
+sub-id (con c)    = cong con (sub-id c)
 sub-id (SOP xss)  = cong SOP (sub-id-VecList xss)
 
 sub-id-List [] = refl
@@ -434,7 +434,7 @@ sub-ren (A · B)   = cong₂ _·_ (sub-ren A) (sub-ren B)
 sub-ren (μ A B)   = cong₂ μ (sub-ren A) (sub-ren B)
 sub-ren (^ x)     = refl
 sub-ren (con c)   = cong con (sub-ren c)
-sub-ren (SOP xss) = cong SOP (sub-ren-VecList xss) 
+sub-ren (SOP xss) = cong SOP (sub-ren-VecList xss)
 
 sub-ren-List [] = refl
 sub-ren-List (x ∷ xs) = cong₂ _∷_ (sub-ren x) (sub-ren-List xs)
@@ -477,7 +477,7 @@ ren-sub (A · B)   = cong₂ _·_ (ren-sub A) (ren-sub B)
 ren-sub (μ A B)   = cong₂ μ (ren-sub A) (ren-sub B)
 ren-sub (^ x)     = refl
 ren-sub (con c)   = cong con (ren-sub c)
-ren-sub (SOP xss) = cong SOP (ren-sub-VecList xss) 
+ren-sub (SOP xss) = cong SOP (ren-sub-VecList xss)
 
 ren-sub-List [] = refl
 ren-sub-List (x ∷ xs) = cong₂ _∷_ (ren-sub x) (ren-sub-List xs)
@@ -502,14 +502,14 @@ Fusion of substitutions/third relative monad law for `sub`
 sub-comp : ∀{J}(A : Φ ⊢⋆ J)
            -------------------------------------
          → sub (sub σ ∘ σ') A ≡ sub σ (sub σ' A)
-sub-com-List : ∀ {J} 
+sub-com-List : ∀ {J}
                 (As : List (Φ ⊢⋆ J))
-                ------------------------------------------------------------------     
+                ------------------------------------------------------------------
               → sub-List (sub σ ∘ σ') As ≡ sub-List σ (sub-List σ' As)
 
-sub-com-VecList : ∀ {n J} 
-                (Tss : Vec (List (Φ ⊢⋆ J)) n) 
-                ------------------------------------------------------------------     
+sub-com-VecList : ∀ {n J}
+                (Tss : Vec (List (Φ ⊢⋆ J)) n)
+                ------------------------------------------------------------------
               → sub-VecList (sub σ ∘ σ') Tss ≡ sub-VecList σ (sub-VecList σ' Tss)
 
 
@@ -521,7 +521,7 @@ sub-comp (A · B)    = cong₂ _·_ (sub-comp A) (sub-comp B)
 sub-comp (μ A B)    = cong₂ μ (sub-comp A) (sub-comp B)
 sub-comp (^ x)      = refl
 sub-comp (con c)    = cong con (sub-comp c)
-sub-comp (SOP xss)  = cong SOP (sub-com-VecList xss) 
+sub-comp (SOP xss)  = cong SOP (sub-com-VecList xss)
 
 sub-com-List [] = refl
 sub-com-List (x ∷ xs) = cong₂ _∷_ (sub-comp x) (sub-com-List xs)
@@ -615,7 +615,7 @@ If we start from a type in an empty context, we may weaken it to any context,
 and then we have two lemmas.
 ```
 sub∅ : ∀{Φ K} → ∅ ⊢⋆ K → Φ ⊢⋆ K
-sub∅ t = sub (λ()) t 
+sub∅ t = sub (λ()) t
 
 sub∅-ren : ∀{K} (t : ∅ ⊢⋆ K) (ρ : Ren Φ Ψ) → sub∅ t ≡ ren ρ (sub∅ t)
 sub∅-ren t ρ = trans (sub-cong (λ ()) t) (ren-sub t)

--- a/plutus-metatheory/src/Untyped.lagda.md
+++ b/plutus-metatheory/src/Untyped.lagda.md
@@ -29,7 +29,7 @@ open import Data.String using (String;_++_)
 open import Data.Empty using (⊥)
 open import Utils using (_×_;_,_)
 open import RawU using (TagCon;Tag;decTagCon;TmCon;TyTag;Untyped;tmCon;tmCon2TagCon;tagCon2TmCon)
-open import Builtin.Signature using (_⊢♯;integer;bool;string;pdata;bytestring;unit;bls12-381-g1-element;bls12-381-g2-element;bls12-381-mlresult) 
+open import Builtin.Signature using (_⊢♯;integer;bool;string;pdata;bytestring;unit;bls12-381-g1-element;bls12-381-g2-element;bls12-381-mlresult)
 open _⊢♯
 open import Builtin.Constant.AtomicType using (AtomicTyCon)
 open AtomicTyCon
@@ -157,14 +157,14 @@ scopeCheckU g (UBuiltin b)   = return (builtin b)
 scopeCheckU g (UDelay t)     = fmap delay (scopeCheckU g t)
 scopeCheckU g (UForce t)     = fmap force (scopeCheckU g t)
 scopeCheckU g (UConstr i ts) = fmap (constr i) (scopeCheckUList g ts)
-scopeCheckU g (UCase t ts)   = do 
-                 u  ← scopeCheckU g t 
+scopeCheckU g (UCase t ts)   = do
+                 u  ← scopeCheckU g t
                  us ← scopeCheckUList g ts
                  return (case u us)
-                 
+
 scopeCheckUList g [] = inj₂ L.[]
-scopeCheckUList g (x ∷ xs) = do 
-                 u  ← scopeCheckU g x 
+scopeCheckUList g (x ∷ xs) = do
+                 u  ← scopeCheckU g x
                  us ← scopeCheckUList g xs
                  return (u L.∷ us)
 

--- a/plutus-metatheory/src/Untyped/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Untyped/RenamingSubstitution.lagda.md
@@ -84,7 +84,7 @@ ren-cong p (constr i xs) = cong (constr i) (renList-cong p xs)
 ren-cong p (case t ts)   = cong₂ case (ren-cong p t) (renList-cong p ts)
 
 renList-cong p [] = refl
-renList-cong p (x ∷ xs) = cong₂ _∷_ (ren-cong p x) (renList-cong p xs) 
+renList-cong p (x ∷ xs) = cong₂ _∷_ (ren-cong p x) (renList-cong p xs)
 
 lift-id : ∀{X}(x : Maybe X) → id x ≡ lift id x
 lift-id nothing  = refl
@@ -98,10 +98,10 @@ lift-comp g f (just x) = refl
 renList-id : ∀{X}(ts : List (X ⊢)) → ts ≡ renList id ts
 ren-id : ∀{X}(t : X ⊢) → t ≡ ren id t
 ren-id (` x)         = refl
-ren-id (ƛ t)         = cong ƛ (trans (ren-id t) (ren-cong lift-id t)) 
+ren-id (ƛ t)         = cong ƛ (trans (ren-id t) (ren-cong lift-id t))
 ren-id (t · u)       = cong₂ _·_ (ren-id t) (ren-id u)
 ren-id (force t)     = cong force (ren-id t)
-ren-id (delay t)     = cong delay (ren-id t) 
+ren-id (delay t)     = cong delay (ren-id t)
 ren-id (con c)       = refl
 ren-id (builtin b)   = refl
 ren-id error         = refl
@@ -146,7 +146,7 @@ lifts ρ (just x) = ren just (ρ x)
 subList : {X Y : Set} → Sub X Y → List (X ⊢) → List (Y ⊢)
 sub : {X Y : Set} → Sub X Y → X ⊢ → Y ⊢
 sub σ (` x)         = σ x
-sub σ (ƛ t)         = ƛ (sub (lifts σ) t) 
+sub σ (ƛ t)         = ƛ (sub (lifts σ) t)
 sub σ (t · u)       = sub σ t · sub σ u
 sub σ (force t)     = force (sub σ t)
 sub σ (delay t)     = delay (sub σ t)
@@ -175,7 +175,7 @@ lifts-cong : ∀{X Y}{σ σ' : Sub X Y}
   → (x : Maybe X)
   → lifts σ x ≡ lifts σ' x
 lifts-cong p nothing  = refl
-lifts-cong p (just x) = cong (ren just) (p x) 
+lifts-cong p (just x) = cong (ren just) (p x)
 
 subList-cong : ∀{X Y}{σ σ' : Sub X Y}
   → (∀ x → σ x ≡ σ' x)
@@ -232,7 +232,7 @@ sub-ren ρ σ (` x)         = refl
 sub-ren ρ σ (ƛ t)         = cong ƛ (trans
   (sub-cong (lifts-lift ρ σ) t)
   (sub-ren (lift ρ) (lifts σ) t))
-sub-ren ρ σ (t · u)       = cong₂ _·_ (sub-ren ρ σ t) (sub-ren ρ σ u) 
+sub-ren ρ σ (t · u)       = cong₂ _·_ (sub-ren ρ σ t) (sub-ren ρ σ u)
 sub-ren ρ σ (force t)     = cong force (sub-ren ρ σ t)
 sub-ren ρ σ (delay t)     = cong delay (sub-ren ρ σ t)
 sub-ren ρ σ (con c)       = refl
@@ -252,14 +252,14 @@ ren-lift-lifts g f (just x) = trans
   (ren-comp just (lift f) (g x))
 
 renList-sub : ∀{X Y Z}(σ : Sub X Y)(ρ : Ren Y Z)(xs : List (X ⊢))
-            → subList (ren ρ ∘ σ) xs ≡ renList ρ (subList σ xs) 
+            → subList (ren ρ ∘ σ) xs ≡ renList ρ (subList σ xs)
 ren-sub : ∀{X Y Z}(σ : Sub X Y)(ρ : Ren Y Z)(t : X ⊢)
   → sub (ren ρ ∘ σ) t ≡ ren ρ (sub σ t)
 ren-sub σ ρ (` x)         = refl
 ren-sub σ ρ (ƛ t)         = cong ƛ (trans
   (sub-cong (ren-lift-lifts σ ρ) t)
   (ren-sub (lifts σ) (lift ρ) t))
-ren-sub σ ρ (t · u)       = cong₂ _·_ (ren-sub σ ρ t) (ren-sub σ ρ u) 
+ren-sub σ ρ (t · u)       = cong₂ _·_ (ren-sub σ ρ t) (ren-sub σ ρ u)
 ren-sub σ ρ (force t)     = cong force (ren-sub σ ρ t)
 ren-sub σ ρ (delay t)     = cong delay (ren-sub σ ρ t)
 ren-sub σ ρ (con c)       = refl

--- a/plutus-metatheory/src/Utils.lagda.md
+++ b/plutus-metatheory/src/Utils.lagda.md
@@ -23,7 +23,7 @@ open import Data.Empty using (⊥;⊥-elim)
 open import Data.Integer using (ℤ)
 open import Data.String using (String)
 open import Data.Bool using (Bool)
-open import Data.Maybe using (Maybe; just; nothing; maybe) 
+open import Data.Maybe using (Maybe; just; nothing; maybe)
                            renaming (_>>=_ to mbind) public
 open import Data.Unit using (⊤)
 
@@ -65,7 +65,7 @@ cong₃ f refl refl refl = refl
 ≡-subst-removable : ∀ {a p} {A : Set a}
                     (P : A → Set p) {x y} (p q : x ≡ y) z →
                     subst P p z ≡ subst P q z
-≡-subst-removable P refl refl z = refl 
+≡-subst-removable P refl refl z = refl
  ```
 ## Natural Sum Type
 
@@ -87,7 +87,7 @@ unique∔ (bubble p) (bubble p') = cong bubble (unique∔ p p')
 +2∔ zero m .(zero + m) refl = start _
 +2∔ (suc n) m t p = bubble (+2∔ n (suc m) t (trans (+-suc n m) p))
 
-∔2+ : ∀{n m t : ℕ} → n ∔ m ≣ t  → n + m ≡ t 
+∔2+ : ∀{n m t : ℕ} → n ∔ m ≣ t  → n + m ≡ t
 ∔2+ (start _) = refl
 ∔2+ (bubble bt) = trans (sym (+-suc _ _)) (∔2+ bt)
 
@@ -97,7 +97,7 @@ alldone n = +2∔ n 0 n (+-identityʳ n)
 ```
 ## Monads
 
-This introduces the Monad operators. 
+This introduces the Monad operators.
 
 ```
 record Monad (F : Set → Set) : Set₁ where
@@ -148,16 +148,16 @@ dec2Either (no ¬p) = inj₁ ¬p
 record Writer (M : Set)(A : Set) : Set where
    constructor _,_
    field
-     wrvalue : A 
+     wrvalue : A
      accum : M
 
 module WriterMonad {M : Set}(e : M)(_∙_ : M → M → M) where
-  instance 
+  instance
     WriterMonad : Monad (Writer M)
     Monad.return WriterMonad x = x , e
     (WriterMonad Monad.>>= (x , w)) f = let (y , w') = f x in y , (w ∙ w')
 
-  tell : (w : M) → Writer M ⊤ 
+  tell : (w : M) → Writer M ⊤
   tell w = _ , w
 
 ```
@@ -180,10 +180,10 @@ postulate ByteString : Set
 ```
 
 record _×_ (A B : Set) : Set where
-    constructor _,_ 
-    field 
+    constructor _,_
+    field
       proj₁ : A
-      proj₂ : B 
+      proj₂ : B
 
 infixr 4 _,_
 infixr 2 _×_
@@ -216,8 +216,8 @@ fromList L.[] = []
 fromList (x L.∷ xs) = x ∷ fromList xs
 
 map-cong : ∀{A B : Set}{xs : L.List A}{f g : A → B}
-     → (∀ x → f x ≡ g x) 
-     → L.map f xs ≡ L.map g xs 
+     → (∀ x → f x ≡ g x)
+     → L.map f xs ≡ L.map g xs
 map-cong {xs = L.[]} p = refl
 map-cong {xs = x L.∷ xs} p = cong₂ L._∷_ (p x) (map-cong p)
 
@@ -239,7 +239,7 @@ data DATA : Set where
 {-# FOREIGN GHC import PlutusCore.Data as D #-}
 {-# COMPILE GHC DATA = data Data (D.Constr | D.Map | D.List | D.I | D.B)   #-}
 
-postulate eqDATA : DATA → DATA → Bool 
+postulate eqDATA : DATA → DATA → Bool
 {-# COMPILE GHC eqDATA = (==) #-}
 
 postulate Bls12-381-G1-Element : Set
@@ -275,4 +275,4 @@ Let `I`, `J`, `K` range over kinds:
 variable
   I J K : Kind
 ```
- 
+

--- a/plutus-metatheory/src/Utils/Decidable.lagda.md
+++ b/plutus-metatheory/src/Utils/Decidable.lagda.md
@@ -36,7 +36,7 @@ dcong₂ : ∀ {α β γ} {A : Set α} {B : Set β} {C : Set γ} {x₁ x₂ y₁
        → Dec (y₁ ≡ y₂)
        → Dec (f x₁ y₁ ≡ f x₂ y₂)
 dcong₂ f inj (yes refl) (yes refl) = yes refl
-dcong₂ f inj (yes _) (no ¬q) = no (λ x → ¬q (proj₂ (inj x))) 
+dcong₂ f inj (yes _) (no ¬q) = no (λ x → ¬q (proj₂ (inj x)))
 dcong₂ f inj (no ¬p) _ = no (λ x → ¬p (proj₁ (inj x)))
 
 dhcong : ∀ {α β γ} {A : Set α} {B : A → Set β} {C : Set γ} {x₁ x₂ y₁ y₂}

--- a/plutus-metatheory/src/Utils/List.lagda.md
+++ b/plutus-metatheory/src/Utils/List.lagda.md
@@ -16,7 +16,7 @@ open import Data.Nat using (ℕ;zero;suc)
 open import Data.List using (List;[];_∷_;_++_;map;foldr;length;head) public
 open import Data.List.Properties using (foldr-++;++-cancelʳ;∷-injective)
 open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;trans;subst;subst-subst)
-open import Data.Empty using (⊥;⊥-elim) 
+open import Data.Empty using (⊥;⊥-elim)
 open import Data.Product using (Σ;_×_;_,_;proj₂)
 open import Relation.Nullary using (¬_)
 
@@ -36,15 +36,15 @@ bwd-length : ∀{A} → Bwd A → ℕ
 bwd-length [] = 0
 bwd-length (az :< a) = suc (bwd-length az)
 
-bwd-foldr : ∀{A B : Set} → (A → B → B) → B → Bwd A → B 
+bwd-foldr : ∀{A B : Set} → (A → B → B) → B → Bwd A → B
 bwd-foldr f e [] = e
 bwd-foldr f e (bs :< x) = bwd-foldr f (f x e) bs
 ```
 
 ### Fish and Chips
 
-Fish (<><) and chips (<>>) are two operators to concatenate a backwards list and 
-a list together, either by consing every snoc and obtaining a list, or by 
+Fish (<><) and chips (<>>) are two operators to concatenate a backwards list and
+a list together, either by consing every snoc and obtaining a list, or by
 snoc-ing every cons and obtaining a backwards list.
 
 ```
@@ -65,7 +65,7 @@ as :<L a = as ++ (a ∷ [])
 
 _∷B_ : ∀{A : Set} → A → Bwd A → Bwd A
 a ∷B []          = [] :< a
-a ∷B (as' :< a') = (a ∷B as') :< a' 
+a ∷B (as' :< a') = (a ∷B as') :< a'
 ```
 
 Useful lemmas
@@ -91,8 +91,8 @@ lemma-<>>-++ (bs :< x) as as' = lemma-<>>-++ bs (x ∷ as) as'
 
 lemma-bwd-foldr : ∀{A B}(f : A → B → B)(e : B)(bs : Bwd A) → foldr f e (bs <>> []) ≡ bwd-foldr f e bs
 lemma-bwd-foldr f e [] = refl
-lemma-bwd-foldr f e (bs :< b) = trans (trans ((cong (foldr f e) (lemma-<>>-++ bs [] (b ∷ [])))) 
-                                             (foldr-++ f e (bs <>> []) (b ∷ []))) 
+lemma-bwd-foldr f e (bs :< b) = trans (trans ((cong (foldr f e) (lemma-<>>-++ bs [] (b ∷ []))))
+                                             (foldr-++ f e (bs <>> []) (b ∷ [])))
                                       (lemma-bwd-foldr f (f b e) bs)
 ```
 
@@ -101,20 +101,20 @@ Some cancellation lemmas
 ```
 <><-cancelʳ : ∀{A : Set} (bs bs' : Bwd A) xs → bs <>< xs ≡ bs' <>< xs → bs ≡ bs'
 <><-cancelʳ bs bs' [] p = p
-<><-cancelʳ bs bs' (x ∷ xs) p with <><-cancelʳ (bs :< x) (bs' :< x) xs p  
+<><-cancelʳ bs bs' (x ∷ xs) p with <><-cancelʳ (bs :< x) (bs' :< x) xs p
 ... | refl = refl
 
-<>>[]-cancelʳ : ∀{A : Set} (bs bs' : Bwd A) → bs <>> [] ≡ bs' <>> [] → bs ≡ bs' 
+<>>[]-cancelʳ : ∀{A : Set} (bs bs' : Bwd A) → bs <>> [] ≡ bs' <>> [] → bs ≡ bs'
 <>>[]-cancelʳ bs bs' p = trans (sym (lemma<>2' bs (bs' <>> []) p)) (lemma<>2 bs' [])
 
-<>>-cancelʳ : ∀{A : Set} (bs bs' : Bwd A) xs → bs <>> xs ≡ bs' <>> xs → bs ≡ bs' 
-<>>-cancelʳ bs bs' xs p = <>>[]-cancelʳ bs bs' 
-        (++-cancelʳ (bs <>> []) (bs' <>> []) (trans (sym (lemma-<>>-++ bs [] xs)) 
+<>>-cancelʳ : ∀{A : Set} (bs bs' : Bwd A) xs → bs <>> xs ≡ bs' <>> xs → bs ≡ bs'
+<>>-cancelʳ bs bs' xs p = <>>[]-cancelʳ bs bs'
+        (++-cancelʳ (bs <>> []) (bs' <>> []) (trans (sym (lemma-<>>-++ bs [] xs))
                                              (trans p (lemma-<>>-++ bs' [] xs))))
- 
+
 <>>-cancelˡ : ∀{A : Set} (bs : Bwd A) xs xs' → bs <>> xs ≡ bs <>> xs' → xs ≡ xs'
 <>>-cancelˡ [] xs xs' p = p
-<>>-cancelˡ (bs :< x) xs xs' p with <>>-cancelˡ bs (x ∷ xs) (x ∷ xs') p 
+<>>-cancelˡ (bs :< x) xs xs' p with <>>-cancelˡ bs (x ∷ xs) (x ∷ xs') p
 ... | refl = refl
 ```
 
@@ -129,19 +129,19 @@ data IList {A : Set}(B : A → Set) : List A → Set where
   _∷_ : ∀{ty ts} → B ty → IList B ts →  IList B (ty ∷ ts)
 
 -- Concatenation for Indexed Lists
-_++I_ : ∀{A : Set}{B : A → Set}{ts ts' : List A} 
+_++I_ : ∀{A : Set}{B : A → Set}{ts ts' : List A}
       → IList B ts → IList B ts' → IList B (ts ++ ts')
 [] ++I bs = bs
 (x ∷ as) ++I bs = x ∷ (as ++I bs)
 
-lengthT : ∀{A : Set}{ts : List A}{B : A → Set} → IList B ts → ℕ 
-lengthT {ts = ts} _ = length ts 
+lengthT : ∀{A : Set}{ts : List A}{B : A → Set} → IList B ts → ℕ
+lengthT {ts = ts} _ = length ts
 
 iGetIdx : ∀{A : Set}{ts : List A}{B : A → Set} → IList B ts → List A
 iGetIdx {ts = ts} ils = ts
 
 -- snoc for Indexed Lists.
-_:<I_ : ∀{A : Set}{B : A → Set}{t}{ts : List A} → IList B ts → B t → IList B (ts :<L t) 
+_:<I_ : ∀{A : Set}{B : A → Set}{t}{ts : List A} → IList B ts → B t → IList B (ts :<L t)
 as :<I a = as ++I (a ∷ [])
 
 -- Injectivity of cons
@@ -149,7 +149,7 @@ as :<I a = as ++I (a ∷ [])
     {X Y : B t}{Xs : IList B ts}{Ys : IList B ts'}
     → (p : t ∷ ts' ≡ t ∷ ts)
     → _≡_ {_} {IList B (t ∷ ts)} (X ∷ Xs)  (subst (IList B) p (Y ∷ Ys))
-    → X ≡ Y × Xs ≡ subst (IList B) (proj₂ (∷-injective p)) Ys 
+    → X ≡ Y × Xs ≡ subst (IList B) (proj₂ (∷-injective p)) Ys
 ∷-injectiveI refl refl = refl , refl
 ```
 
@@ -161,27 +161,27 @@ data IBwd {A : Set}(B : A → Set) : Bwd A → Set where
   _:<_ : ∀{ty ts}  → IBwd B ts → B ty → IBwd B (ts :< ty)
 
 -- Chip for indexed lists
-_<>>I_ :  ∀{A : Set}{B : A → Set}{bs : Bwd A}{ts : List A} 
+_<>>I_ :  ∀{A : Set}{B : A → Set}{bs : Bwd A}{ts : List A}
       → IBwd B bs → IList B ts → IList B (bs <>> ts)
 [] <>>I tls = tls
 (tbs :< x) <>>I tls = tbs <>>I (x ∷ tls)
 
-_<><I_ :  ∀{A : Set}{B : A → Set}{bs : Bwd A}{ts : List A} 
+_<><I_ :  ∀{A : Set}{B : A → Set}{bs : Bwd A}{ts : List A}
       → IBwd B bs → IList B ts → IBwd B (bs <>< ts)
 ibs <><I [] = ibs
 ibs <><I (x ∷ its) = (ibs :< x) <><I its
 
-lemma<>I1 : ∀{A}{B : A → Set}{xs : Bwd A}{ys : List A} → (ixs : IBwd B xs) → (iys : IList B ys) 
+lemma<>I1 : ∀{A}{B : A → Set}{xs : Bwd A}{ys : List A} → (ixs : IBwd B xs) → (iys : IList B ys)
                   → (subst (IList B) (lemma<>1 xs ys) ((ixs <><I iys) <>>I [])) ≡ ixs <>>I iys
 lemma<>I1 ixs [] = refl
 lemma<>I1 ixs (iy ∷ iys) = lemma<>I1 (ixs :< iy) iys
 
-lemma<>I2 : ∀{A}{B : A → Set}{xs : Bwd A}{ys : List A}(ixs : IBwd B xs)(iys : IList B ys) 
+lemma<>I2 : ∀{A}{B : A → Set}{xs : Bwd A}{ys : List A}(ixs : IBwd B xs)(iys : IList B ys)
                   → subst (IBwd B) (lemma<>2 xs ys) ([] <><I (ixs <>>I iys)) ≡ ixs <><I iys
 lemma<>I2 [] iys = refl
 lemma<>I2 (ixs :< ix) iys = lemma<>I2 ixs (ix ∷ iys)
 
-lemma<>I2' : ∀{A}{B : A → Set}{xs : Bwd A}{ys : List A}(ixs : IBwd B xs)(iys : IList B ys) 
+lemma<>I2' : ∀{A}{B : A → Set}{xs : Bwd A}{ys : List A}(ixs : IBwd B xs)(iys : IList B ys)
                   → ([] <><I (ixs <>>I iys)) ≡ subst (IBwd B) (sym (lemma<>2 xs ys)) (ixs <><I iys)
 lemma<>I2' [] iys = refl
 lemma<>I2' (ixs :< ix) iys = lemma<>I2' ixs (ix ∷ iys)
@@ -196,19 +196,19 @@ IList2IBwd : ∀{A}{B : A → Set}{ts}{bs} → ([] <>< ts ≡ bs) → IList B ts
 IList2IBwd {ts = ts} p tbs = subst (IBwd _) p ([] <><I tbs)
 
 IBwd<>IList : ∀{A}{B : A → Set}{bs}{ts} → (p : bs <>> [] ≡ ts) → {ibs : IBwd B bs}
-            → {its : IList B ts} 
-            → IBwd2IList p ibs ≡ its 
+            → {its : IList B ts}
+            → IBwd2IList p ibs ≡ its
             → ibs ≡ IList2IBwd (lemma<>2' _ _ p) its
 IBwd<>IList refl {ibs} refl rewrite lemma<>I2 ibs [] = refl
 
 split :  ∀{A : Set} bs (ts : List A){B : A → Set} → IList B (bs <>> ts) → IBwd B bs × IList B ts
 split [] ts vs = [] , vs
-split (bs :< x) ts vs with split bs (x ∷ ts) vs 
+split (bs :< x) ts vs with split bs (x ∷ ts) vs
 ... | ls , (x ∷ rs) = ls :< x , rs
 
 bsplit : ∀{A : Set} bs (ts : List A){B : A → Set} → IBwd B (bs <>< ts) → IBwd B bs × IList B ts
 bsplit bs [] vs = vs , []
-bsplit bs (x ∷ ts) vs with bsplit (bs :< x) ts vs 
+bsplit bs (x ∷ ts) vs with bsplit (bs :< x) ts vs
 ... | ls :< x , rs = ls , (x ∷ rs)
 
 inj-IBwd2IList : ∀{A}{B : A → Set}{Bs}{As : List A}{ts ts' : IBwd B Bs}
@@ -225,10 +225,10 @@ The following datatype allow us to index zippers of indexed lists.
 ```
 data _≣_<>>_ {A : Set} : (as : List A) → Bwd A → List A → Set where
   start : ∀{as} → as ≣ [] <>> as
-  bubble : ∀{as}{vs : Bwd A}{t}{ts : List A} 
+  bubble : ∀{as}{vs : Bwd A}{t}{ts : List A}
          → as ≣ vs <>> (t ∷ ts)
            ---------------------------
-         → as ≣ (vs :< t) <>> ts 
+         → as ≣ (vs :< t) <>> ts
 
 lem-≣-<>> : ∀{A : Set}{tot vs}{ts : List A} → tot ≣ vs <>> ts → tot ≡ vs <>> ts
 lem-≣-<>> start = refl
@@ -244,17 +244,17 @@ done-≣-<>> = lem-≣-<>>' (sym (lemma<>1 [] _))
 no-empty-≣-<>> : ∀{A : Set}{vs}{h : A}{ts} → [] ≣ vs <>> (h ∷ ts) → ⊥
 no-empty-≣-<>> (bubble r) = no-empty-≣-<>> r
 
-unique-≣-<>> : ∀{A : Set}{tot vs}{ts : List A}(p q : tot ≣ vs <>> ts) → p ≡ q 
+unique-≣-<>> : ∀{A : Set}{tot vs}{ts : List A}(p q : tot ≣ vs <>> ts) → p ≡ q
 unique-≣-<>> start start = refl
 unique-≣-<>> (bubble p) (bubble q) with unique-≣-<>> p q
 ... | refl = refl
 
-lemma-≣-<>>-refl : ∀{A}(xs : Bwd A)(ys : List A) → (xs <>> ys) ≣ xs <>> ys 
+lemma-≣-<>>-refl : ∀{A}(xs : Bwd A)(ys : List A) → (xs <>> ys) ≣ xs <>> ys
 lemma-≣-<>>-refl [] ys = start
 lemma-≣-<>>-refl (xs :< x) ys = bubble (lemma-≣-<>>-refl xs (x ∷ ys))
 ```
 
-## Lists indexed by an indexed list 
+## Lists indexed by an indexed list
 
 ```
 data IIList {A : Set}{B : A → Set}(C : ∀{a : A}(b : B a) → Set) : ∀{is} → IList B is → Set where
@@ -267,40 +267,40 @@ data IIBwd {A : Set}{B : A → Set}(C : ∀{a : A}→ B a → Set) : ∀{is} →
   _:<_ : ∀{a as}{i : B a}{is : IBwd B as} → IIBwd C is → C i → IIBwd C (is :< i)
 
 -- Chip for double indexed lists
-_<>>II_ :  ∀{A : Set}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}{bs : Bwd A}{ts : List A} 
-        {ibs : IBwd B bs}{its : IList B ts} 
+_<>>II_ :  ∀{A : Set}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}{bs : Bwd A}{ts : List A}
+        {ibs : IBwd B bs}{its : IList B ts}
       → IIBwd C ibs → IIList C its → IIList C (ibs <>>I its)
 [] <>>II tls = tls
 (tbs :< x) <>>II tls = tbs <>>II (x ∷ tls)
 
 -- Convert an IIBwd into an IIList
-IIBwd2IIList : ∀{A}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}{bs}{ts : List A} 
-               {ibs : IBwd B bs}{its : IList B ts} 
-             → (p : bs <>> [] ≡ ts) 
-             → (q : subst (IList B) p (ibs <>>I []) ≡  its) 
-             → IIBwd C ibs 
+IIBwd2IIList : ∀{A}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}{bs}{ts : List A}
+               {ibs : IBwd B bs}{its : IList B ts}
+             → (p : bs <>> [] ≡ ts)
+             → (q : subst (IList B) p (ibs <>>I []) ≡  its)
+             → IIBwd C ibs
              → IIList C its
 IIBwd2IIList refl refl tbs = tbs <>>II []
 
 -- Split an IIList
-splitI : ∀{A : Set}{bs}{ts : List A}{B : A → Set}{C : ∀{a : A}(b : B a) → Set} 
+splitI : ∀{A : Set}{bs}{ts : List A}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}
            (ibs : IBwd B bs)(its : IList B ts)
         → IIList C (ibs <>>I its) → IIBwd C ibs × IIList C its
 splitI [] its xs = [] , xs
-splitI (ibs :< x) its xs with splitI ibs (x ∷ its) xs 
+splitI (ibs :< x) its xs with splitI ibs (x ∷ its) xs
 ... | ls , (y ∷ rs) = (ls :< y) , rs
 
 -- Split an IIBwd
-bsplitI : ∀{A : Set}{bs}{ts : List A}{B : A → Set}{C : ∀{a : A}(b : B a) → Set} 
+bsplitI : ∀{A : Set}{bs}{ts : List A}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}
            (ibs : IBwd B bs)(its : IList B ts)
         → IIBwd C (ibs <><I its) → IIBwd C ibs × IIList C its
 bsplitI ibs [] vs = vs , []
-bsplitI ibs (x ∷ its) vs with bsplitI (ibs :< x) its vs 
+bsplitI ibs (x ∷ its) vs with bsplitI (ibs :< x) its vs
 ... | ls :< x , rs = ls , (x ∷ rs)
 
 -- project from an IIList
-proj-IIList : ∀{A : Set}{B : A → Set}{C : ∀{a : A}(b : B a) → Set} 
-              {a} (b : B a) {Bs}{Fs} 
+proj-IIList : ∀{A : Set}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}
+              {a} (b : B a) {Bs}{Fs}
               (bs : IBwd B Bs) (fs : IList B Fs)
              → IIList C (bs <>>I (b ∷ fs))
              → C b
@@ -308,8 +308,8 @@ proj-IIList b bs fs xs with splitI bs (b ∷ fs) xs
 ... | _ , (Cb ∷ _) = Cb
 
 -- project from an IIBwd
-proj-IIBwd : ∀{A : Set}{B : A → Set}{C : ∀{a : A}(b : B a) → Set} 
-              {a} (b : B a) {Bs}{Fs} 
+proj-IIBwd : ∀{A : Set}{B : A → Set}{C : ∀{a : A}(b : B a) → Set}
+              {a} (b : B a) {Bs}{Fs}
               (bs : IBwd B Bs) (fs : IList B Fs)
              → IIBwd C (bs <><I (b ∷ fs))
              → C b
@@ -317,15 +317,15 @@ proj-IIBwd b bs fs xs with bsplitI bs (b ∷ fs) xs
 ... | _ , (Cb ∷ _) = Cb
 
 ```
- 
+
  Index for IIList zippers
 
  ```
-data _≣I_<>>_ {A : Set}{B : A → Set}{tot}(itot : IList B tot) : 
-                                        ∀{bs ts} 
+data _≣I_<>>_ {A : Set}{B : A → Set}{tot}(itot : IList B tot) :
+                                        ∀{bs ts}
                                       → IBwd B bs
-                                      → IList B ts 
-                                      → (tot ≣ bs <>> ts) 
+                                      → IList B ts
+                                      → (tot ≣ bs <>> ts)
                                       → Set where
   start : (itot ≣I [] <>> itot) start
   bubble : ∀{bs}{ibs : IBwd B bs}{t}{it : B t}{ts}{ils : IList B ts}{idx}
@@ -333,35 +333,35 @@ data _≣I_<>>_ {A : Set}{B : A → Set}{tot}(itot : IList B tot) :
            ------------------------------------------
          → (itot ≣I (ibs :< it) <>> ils) (bubble idx)
 
-lem-≣I-<>>1 : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs} 
-                                {ibs : IBwd B bs}{ls}{ils : IList B ls}  
-                                {idx : tot ≣ bs <>> ls}     
-                           → (itot ≣I ibs <>> ils) idx 
+lem-≣I-<>>1 : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs}
+                                {ibs : IBwd B bs}{ls}{ils : IList B ls}
+                                {idx : tot ≣ bs <>> ls}
+                           → (itot ≣I ibs <>> ils) idx
                            → subst (IList B) (lem-≣-<>> idx) itot ≡ (ibs <>>I ils)
 lem-≣I-<>>1 start = refl
 lem-≣I-<>>1 (bubble x) = lem-≣I-<>>1 x
 
-lem-≣I-<>>1' : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs} 
-                                {ibs : IBwd B bs}{ls}{ils : IList B ls}  
-                                {idx : tot ≣ bs <>> ls}     
-                           → (itot ≣I ibs <>> ils) idx 
+lem-≣I-<>>1' : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs}
+                                {ibs : IBwd B bs}{ls}{ils : IList B ls}
+                                {idx : tot ≣ bs <>> ls}
+                           → (itot ≣I ibs <>> ils) idx
                            → itot ≡ subst (IList B)  (sym (lem-≣-<>> idx)) (ibs <>>I ils)
 lem-≣I-<>>1' start = refl
 lem-≣I-<>>1' (bubble r) = lem-≣I-<>>1' r
 
-lem-≣I-<>>2 : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs} 
-                             {ibs : IBwd B bs}{ls}{ils : IList B ls}  
+lem-≣I-<>>2 : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs}
+                             {ibs : IBwd B bs}{ls}{ils : IList B ls}
                              (eq : bs <>> ls ≡ tot)
                            → itot ≡ subst (IList B) eq ((ibs <>>I ils))
-                           → (itot ≣I ibs <>> ils) (lem-≣-<>>' (sym eq)) 
+                           → (itot ≣I ibs <>> ils) (lem-≣-<>>' (sym eq))
 lem-≣I-<>>2 {ibs = []} refl refl = start
 lem-≣I-<>>2 {ibs = ibs :< x} refl refl = bubble (lem-≣I-<>>2 refl refl)
 
-lem-≣I-<>>2' : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs} 
-                             {ibs : IBwd B bs}{ls}{ils : IList B ls}  
+lem-≣I-<>>2' : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs}
+                             {ibs : IBwd B bs}{ls}{ils : IList B ls}
                              (eq : tot ≡ bs <>> ls)
                            → (subst (IList B) eq itot) ≡ ((ibs <>>I ils))
-                           → (itot ≣I ibs <>> ils) (lem-≣-<>>' eq) 
+                           → (itot ≣I ibs <>> ils) (lem-≣-<>>' eq)
 lem-≣I-<>>2' {ibs = []} refl refl = start
 lem-≣I-<>>2' {ibs = ibs :< x} refl refl = bubble (lem-≣I-<>>2' refl refl)
 
@@ -378,43 +378,43 @@ lem-<><I-subst :  ∀{A : Set}{B : A → Set}{tot tot' : List A}{itot : IList B 
       → ([] <><I subst (IList B) p itot) ≡ subst (IBwd B) (cong ([] <><_) p) ([] <><I itot)
 lem-<><I-subst refl = refl
 
-lemma-<>>I-++I : ∀{A : Set}{B : A → Set}{bs}{as as' : List A} 
+lemma-<>>I-++I : ∀{A : Set}{B : A → Set}{bs}{as as' : List A}
         → (ibs : IBwd B bs)(ias : IList B as)(ias' : IList B as')
         →  ibs <>>I (ias ++I ias') ≡  subst (IList B) (sym (lemma-<>>-++ bs as as')) ((ibs <>>I ias) ++I ias')
 lemma-<>>I-++I [] ias ias' = refl
-lemma-<>>I-++I (ibs :< x) ias ias' = lemma-<>>I-++I ibs (x ∷ ias) ias'        
+lemma-<>>I-++I (ibs :< x) ias ias' = lemma-<>>I-++I ibs (x ∷ ias) ias'
 ```
 
 Cancellation law for <>>I
 
 ```
 <>>I[]-cancelʳ : ∀{A : Set}{B : A → Set}{bs : Bwd A}(ibs ibs' : IBwd B bs)
-               → ibs <>>I [] ≡ ibs' <>>I [] → ibs ≡ ibs' 
-<>>I[]-cancelʳ ibs ibs' p = trans (sym (lemma<>I3 ibs (ibs' <>>I []) p)) (lemma<>I2 ibs' []) 
+               → ibs <>>I [] ≡ ibs' <>>I [] → ibs ≡ ibs'
+<>>I[]-cancelʳ ibs ibs' p = trans (sym (lemma<>I3 ibs (ibs' <>>I []) p)) (lemma<>I2 ibs' [])
 
 <>>I-cancelˡ : ∀{A : Set}{B : A → Set}{bs : Bwd A}{xs}
                 (ibs : IBwd B bs)
               → (ixs ixs' : IList B xs)
-              → ibs <>>I ixs ≡ ibs <>>I ixs' → ixs ≡ ixs' 
+              → ibs <>>I ixs ≡ ibs <>>I ixs' → ixs ≡ ixs'
 <>>I-cancelˡ [] ixs ixs' p = p
 <>>I-cancelˡ (ibs :< x) ixs ixs' p with <>>I-cancelˡ ibs (x ∷ ixs) (x ∷ ixs') p
 ... | refl = refl
 
 ```
-We may have that Bs <>>I (H :: Fs) ≡ Bs' <>>I (H' :: Fs'). 
+We may have that Bs <>>I (H :: Fs) ≡ Bs' <>>I (H' :: Fs').
 We cannot conclude that Bs ≡ Bs', H ≡ H' and Fs ≡ Fs', because the focus
 could be at different places of the same indexed list.
-However, if there is a predicate P such that P holds for every element of Bs and Bs', 
+However, if there is a predicate P such that P holds for every element of Bs and Bs',
 but ¬(P H) and ¬(P H'), then this determines where the focus is and we may conclude that
 Bs ≡ Bs', H ≡ H' and Fs ≡ Fs'.
 
 ```
 equalbyPredicate++ : ∀{A : Set}
-                    (P : A → Set) 
+                    (P : A → Set)
                     {bs bs' : List A}{fs fs'}
                     {tot : List A}
                     {h h' : A}
-                  → (p : tot ≡ bs ++ (h ∷ fs)) 
+                  → (p : tot ≡ bs ++ (h ∷ fs))
                   → (p' : tot ≡ bs' ++ (h' ∷ fs'))
                   → (IList P bs)
                   → (IList P bs')
@@ -424,15 +424,15 @@ equalbyPredicate++ : ∀{A : Set}
 equalbyPredicate++ P p p' [] [] ¬Ph ¬Ph' = refl
 equalbyPredicate++ P refl refl [] (x ∷ ps') ¬Ph ¬Ph' = ⊥-elim (¬Ph x)
 equalbyPredicate++ P refl refl (x ∷ ps) [] ¬Ph ¬Ph' = ⊥-elim (¬Ph' x)
-equalbyPredicate++ P {a ∷ as} refl p' (x ∷ ps) (x₁ ∷ ps') ¬Ph ¬Ph' with ∷-injective p' 
+equalbyPredicate++ P {a ∷ as} refl p' (x ∷ ps) (x₁ ∷ ps') ¬Ph ¬Ph' with ∷-injective p'
 ... | refl , q = cong (a ∷_) (equalbyPredicate++ P {as} refl q ps ps' ¬Ph ¬Ph')
 
 
 equalbyPredicate : ∀{A : Set}
-                    (P : A → Set) 
+                    (P : A → Set)
                     {bs bs' : Bwd A}{fs fs'}{tot}
                     {h h' : A}
-                  → (p : tot ≡ bs <>> (h ∷ fs)) 
+                  → (p : tot ≡ bs <>> (h ∷ fs))
                   → (p' : tot ≡ bs' <>> (h' ∷ fs'))
                   → (IBwd P bs)
                   → (IBwd P bs')
@@ -440,12 +440,12 @@ equalbyPredicate : ∀{A : Set}
                   → (¬Ph' : ¬(P h'))
                   → bs ≡ bs'
 equalbyPredicate P {bs} {bs'} {fs} {fs'} {tot} {h} {h'} p p' ps ps' ¬Ph ¬Ph' =
-    <>>[]-cancelʳ _ _ (equalbyPredicate++ P 
+    <>>[]-cancelʳ _ _ (equalbyPredicate++ P
                       (trans p (lemma-<>>-++ bs [] (h ∷ fs)))
-                      (trans p' (lemma-<>>-++ bs' [] (h' ∷ fs'))) 
+                      (trans p' (lemma-<>>-++ bs' [] (h' ∷ fs')))
                       (IBwd2IList refl ps)
                       (IBwd2IList refl ps')
-                      ¬Ph 
+                      ¬Ph
                       ¬Ph')
 
 equalbyPredicate++I : ∀{A : Set}{B : A → Set}{bs bs' : List A}{fs fs'}{tot}
@@ -455,7 +455,7 @@ equalbyPredicate++I : ∀{A : Set}{B : A → Set}{bs bs' : List A}{fs fs'}{tot}
                     {h h' : A}
                     {H : B h}{H' : B h'}
                   → (P : {a : A} → B a → Set)
-                  → (p : tot ≡ bs ++ (h ∷ fs)) 
+                  → (p : tot ≡ bs ++ (h ∷ fs))
                   → (p' : tot ≡ bs' ++ (h' ∷ fs'))
                   → (q : TOT ≡ subst (IList B) (sym p) (Bs ++I (H ∷ Fs)))
                   → (q' : TOT ≡ subst (IList B) (sym p') (Bs' ++I (H' ∷ Fs')))
@@ -463,18 +463,18 @@ equalbyPredicate++I : ∀{A : Set}{B : A → Set}{bs bs' : List A}{fs fs'}{tot}
                   → (ps' : IIList P Bs')
                   → (¬PH : ¬(P H))
                   → (¬PH' : ¬(P H'))
-                  → Σ (bs ≡ bs') (λ { refl → 
-                    Σ (h ≡ h')   (λ { refl → 
+                  → Σ (bs ≡ bs') (λ { refl →
+                    Σ (h ≡ h')   (λ { refl →
                     Σ (fs ≡ fs') (λ { refl → Bs ≡ Bs' }) }) })
-equalbyPredicate++I TOT P p p' q q' [] [] ¬PH ¬PH' with ∷-injective (trans (sym p) p') 
+equalbyPredicate++I TOT P p p' q q' [] [] ¬PH ¬PH' with ∷-injective (trans (sym p) p')
 ... | refl , refl = refl , (refl , (refl , refl))
 equalbyPredicate++I TOT P refl refl refl refl [] (x ∷ ps') ¬PH ¬PH' = ⊥-elim (¬PH x)
 equalbyPredicate++I TOT P refl refl refl refl (x ∷ ps) [] ¬PH ¬PH' = ⊥-elim (¬PH' x)
-equalbyPredicate++I TOT P refl p' refl q' (x ∷ ps) (x₁ ∷ ps') ¬PH ¬PH' with ∷-injective p' 
-... | refl , pt with ∷-injectiveI (sym p') q' 
-... | refl , qt with equalbyPredicate++I _ P refl pt refl 
+equalbyPredicate++I TOT P refl p' refl q' (x ∷ ps) (x₁ ∷ ps') ¬PH ¬PH' with ∷-injective p'
+... | refl , pt with ∷-injectiveI (sym p') q'
+... | refl , qt with equalbyPredicate++I _ P refl pt refl
                                        (trans qt (≡-subst-removable (IList _) (proj₂ (∷-injective (sym p'))) (sym pt) _))
-                                        ps ps' ¬PH ¬PH' 
+                                        ps ps' ¬PH ¬PH'
 ... | refl , refl , refl , refl = refl , (refl , (refl , refl))
 
 equalbyPredicateI : ∀{A : Set}{B : A → Set}{bs bs' : Bwd A}{fs fs'}{tot}
@@ -484,7 +484,7 @@ equalbyPredicateI : ∀{A : Set}{B : A → Set}{bs bs' : Bwd A}{fs fs'}{tot}
                     {h h' : A}
                     {H : B h}{H' : B h'}
                   → (P : {a : A} → B a → Set)
-                  → (p : tot ≡ bs <>> (h ∷ fs)) 
+                  → (p : tot ≡ bs <>> (h ∷ fs))
                   → (p' : tot ≡ bs' <>> (h' ∷ fs'))
                   → (q : TOT ≡ subst (IList B) (sym p) (Bs <>>I (H ∷ Fs)))
                   → (q' : TOT ≡ subst (IList B) (sym p') (Bs' <>>I (H' ∷ Fs')))
@@ -492,24 +492,24 @@ equalbyPredicateI : ∀{A : Set}{B : A → Set}{bs bs' : Bwd A}{fs fs'}{tot}
                   → (ps' : IIBwd P Bs')
                   → (¬PH : ¬(P H))
                   → (¬PH' : ¬(P H'))
-                  → Σ (bs ≡ bs') (λ { refl → 
-                    Σ (h ≡ h')   (λ { refl → 
-                    Σ (fs ≡ fs') (λ { refl → Bs ≡ Bs' }) }) }) 
+                  → Σ (bs ≡ bs') (λ { refl →
+                    Σ (h ≡ h')   (λ { refl →
+                    Σ (fs ≡ fs') (λ { refl → Bs ≡ Bs' }) }) })
 equalbyPredicateI {bs = bs}{bs'}{fs}{fs'}{tot} TOT {Bs} {Bs'} {Fs} {Fs'} {h} {h'} {H} {H'} P refl p' refl q' ps ps' ¬PH ¬PH' with
-     equalbyPredicate++I TOT 
-               P 
+     equalbyPredicate++I TOT
+               P
                (lemma-<>>-++ bs [] (h ∷ fs))
-               (trans p' (lemma-<>>-++ bs' [] (h' ∷ fs'))) 
+               (trans p' (lemma-<>>-++ bs' [] (h' ∷ fs')))
                ((lemma-<>>I-++I Bs [] (H ∷ Fs)))
-               (trans q' 
-                (trans (cong (subst (IList _) (sym p')) (lemma-<>>I-++I Bs' [] (H' ∷ Fs'))) 
-                 (trans (subst-subst {P = IList _} (sym (lemma-<>>-++ bs' [] (h' ∷ fs'))) {sym p'} {(Bs' <>>I []) ++I (H' ∷ Fs')}) 
-                         (≡-subst-removable (IList _) (trans (sym (lemma-<>>-++ bs' [] (h' ∷ fs'))) (sym p')) (sym (trans p' (lemma-<>>-++ bs' [] (h' ∷ fs')))) _)))) 
-               (IIBwd2IIList refl refl ps) 
-               (IIBwd2IIList refl refl ps') 
-               ¬PH 
-               ¬PH'  
-... | pbs , snd with <>>[]-cancelʳ bs bs' pbs 
-equalbyPredicateI TOT {Bs} {Bs'} P p p' q q' ps ps' ¬PH ¬PH' 
-     | refl , refl , refl , pBs | refl with <>>I[]-cancelʳ Bs Bs' pBs 
+               (trans q'
+                (trans (cong (subst (IList _) (sym p')) (lemma-<>>I-++I Bs' [] (H' ∷ Fs')))
+                 (trans (subst-subst {P = IList _} (sym (lemma-<>>-++ bs' [] (h' ∷ fs'))) {sym p'} {(Bs' <>>I []) ++I (H' ∷ Fs')})
+                         (≡-subst-removable (IList _) (trans (sym (lemma-<>>-++ bs' [] (h' ∷ fs'))) (sym p')) (sym (trans p' (lemma-<>>-++ bs' [] (h' ∷ fs')))) _))))
+               (IIBwd2IIList refl refl ps)
+               (IIBwd2IIList refl refl ps')
+               ¬PH
+               ¬PH'
+... | pbs , snd with <>>[]-cancelʳ bs bs' pbs
+equalbyPredicateI TOT {Bs} {Bs'} P p p' q q' ps ps' ¬PH ¬PH'
+     | refl , refl , refl , pBs | refl with <>>I[]-cancelʳ Bs Bs' pBs
 ... | refl = refl , refl , refl , refl

--- a/plutus-metatheory/src/Utils/Reflection.lagda.md
+++ b/plutus-metatheory/src/Utils/Reflection.lagda.md
@@ -36,13 +36,13 @@ constructors _ = []
 names : String → List String
 names = wordsBy (T? ∘ (_≈ᵇ '.'))
 
-lastName : String → List String → String 
-lastName s xs with last xs 
+lastName : String → List String → String
+lastName s xs with last xs
 ... | just x = x
 ... | nothing = s
 
-getLastName : Name → String 
-getLastName q = lastName "defconstructorname" (names (showName q)) 
+getLastName : Name → String
+getLastName q = lastName "defconstructorname" (names (showName q))
 
 
 mk-cls : Name → Clause
@@ -62,15 +62,15 @@ map2 {A = A} {B = B} f l = map2' f l l
   where
   map2' : (A → A → B) → List A → List A → List B
   map2' f [] _ = []
-  map2' f (x ∷ xs) l = map (f x) l ++ map2' f xs l 
+  map2' f (x ∷ xs) l = map (f x) l ++ map2' f xs l
 
 mk-DecCls : Name → Name → Clause
 mk-DecCls q1 q2 with primQNameEquality q1 q2
-... | true  = clause [] (vArg (con q1 []) ∷ vArg (con q2 []) ∷ []) 
-                        (con (quote _because_)  
+... | true  = clause [] (vArg (con q1 []) ∷ vArg (con q2 []) ∷ [])
+                        (con (quote _because_)
                              (vArg (con (quote true) []) ∷ vArg (con (quote ofʸ) [ vArg (con (quote refl) []) ]) ∷ []))
-... | false = clause [] (vArg (con q1 []) ∷ vArg (con q2 []) ∷ []) 
-                        (con (quote _because_)  
+... | false = clause [] (vArg (con q1 []) ∷ vArg (con q2 []) ∷ [])
+                        (con (quote _because_)
                         (vArg (con (quote false) []) ∷ vArg (con (quote ofⁿ) [ vArg absurd-lam ]) ∷ []))
 ```
 
@@ -96,23 +96,23 @@ defDec T defName = do
 
 The function `defShow` helps to define a show function for datatypes which are simple enumerations.
 
-``` 
+```
 mk-Show : Name → Clause
-mk-Show q = clause [] (vArg (con q []) ∷ []) 
-                      (lit (string (getLastName q))) 
+mk-Show q = clause [] (vArg (con q []) ∷ [])
+                      (lit (string (getLastName q)))
 
 defShow : Name → Name → TC ⊤
 defShow T defName = do
        d ← getDefinition T
        let cls = map mk-Show (constructors d)
        defineFun defName cls
- 
-``` 
+
+```
 
 Produce a list with all constructors
 
-``` 
-mkList : List Term → Term 
+```
+mkList : List Term → Term
 mkList [] = con (quote (List.[])) []
 mkList (x ∷ xs) = con (quote _∷_) (hArg unknown ∷  hArg unknown ∷ vArg x ∷ vArg (mkList xs) ∷ [])
 

--- a/plutus-metatheory/src/index.lagda.md
+++ b/plutus-metatheory/src/index.lagda.md
@@ -96,7 +96,7 @@ notions of type used in the formalisation.
 
 ```
 import Builtin.Signature
-``` 
+```
 
 ## Declarative syntax
 


### PR DESCRIPTION
In my [last PR](https://github.com/IntersectMBO/plutus/pull/6368) involving `plutus-metatheory` there were a lot of irrelevant changes because I/my editor had deleted some trailing spaces.  This removes the trailing spaces from all of the `.lagda.md`files to reduce the chances of that happening in future PRs.  We should really automate this.