### PR TITLE
Test Sprint Issues Rollover Workflow On Private Project

### DIFF
--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -1,5 +1,6 @@
-# This workflows automatically moves issues and pull requests to the next 
-# iteration of our Plutus Backlog project when a new sprint begins.
+# This workflows moves issues and pull requests to the next iteration of our 
+# Plutus Backlog project when a new sprint begins.
+# To do so, this workflow must be run manually from the GitHub Actions page.
 
 name: "🛼 Sprint Issues Rollover"
 
@@ -16,9 +17,9 @@ jobs:
     - uses: blombard/move-to-next-iteration@master
       with:
         owner: IntersectMBO
-        number: 18
+        number: 35
         token: ${{ secrets.PROJECT_PAT }}
         iteration-field: Sprint
         iteration: last
         new-iteration: current
-        excluded-statuses: ❌ - won't do,🚀 - done
+        excluded-statuses: ❌ - Won't Do,🚀 - Done

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -1,6 +1,9 @@
-# This workflows moves issues and pull requests to the next iteration of our 
-# Plutus Backlog project when a new sprint begins.
-# To do so, this workflow must be run manually from the GitHub Actions page.
+# This workflows moves issues and pull requests to the next sprint iteration of 
+# the Plutus Backlog project. In practice, all open backlog items in the Last
+# iteration (the one that has just finished) the will be moved to the Current 
+# iteration (the one that has just started) 
+# This workflow must be run manually from the GitHub Actions page.
+# Make sure that the Current iteration has started before running this workflow.
 
 name: "🛼 Sprint Issues Rollover"
 
@@ -15,9 +18,9 @@ jobs:
     - uses: blombard/move-to-next-iteration@master
       with:
         owner: IntersectMBO
-        number: 35
-        token: ${{ secrets.PLUTUS_BACKLOG_AUTOMATION }}
+        number: 18 # Find this number by looking at the project's page URL
+        token: ${{ secrets.PLUTUS_BACKLOG_AUTOMATION }} # Needs project write permissions
         iteration-field: Sprint
-        iteration: current
-        new-iteration: next
-        excluded-statuses: ❌ - Won't Do,🚀 - Done
+        iteration: last
+        new-iteration: current
+        excluded-statuses: ❌ - won't do,🚀 - done

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -6,8 +6,6 @@ name: "🛼 Sprint Issues Rollover"
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 5 * * 3' # 5am on Wednesday
 
 jobs:
   Run:
@@ -18,7 +16,7 @@ jobs:
       with:
         owner: IntersectMBO
         number: 35
-        token: ${{ secrets.PROJECT_PAT }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         iteration-field: Sprint
         iteration: last
         new-iteration: current

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -18,6 +18,6 @@ jobs:
         number: 35
         token: ${{ secrets.PLUTUS_BACKLOG_AUTOMATION }}
         iteration-field: Sprint
-        iteration: last
-        new-iteration: current
+        iteration: current
+        new-iteration: next
         excluded-statuses: ❌ - Won't Do,🚀 - Done

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         owner: IntersectMBO
         number: 35
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PLUTUS_BACKLOG_AUTOMATION }}
         iteration-field: Sprint
         iteration: last
         new-iteration: current


### PR DESCRIPTION
The sprint-issues-rollover.yml has been tested on a private project and seems to work well.
The workflow will no longer run automatically to avoid unpleasant surprises.
It will be sufficient to run the workflow manually at any point *after* the new sprint has begun, once every two weeks.
To do so, click the `Run workflow (Branch: master)` button at [this link](https://github.com/IntersectMBO/plutus/actions/workflows/sprint-issues-rollover.yml).
