### PR TITLE
update mesh

### DIFF
--- a/doc/docusaurus/docs/getting-started-plutus-tx.md
+++ b/doc/docusaurus/docs/getting-started-plutus-tx.md
@@ -26,6 +26,6 @@ The expected result is that the above process will have created the `validator.u
 
 Use `cardano-cli` to deploy your script. 
 
-Use an off-chain framework, such as [cardano-transaction-lib](https://github.com/Plutonomicon/cardano-transaction-lib) and [lucid](https://github.com/spacebudz/lucid), to interact with your script. 
+Use an off-chain framework, such as [cardano-transaction-lib](https://github.com/Plutonomicon/cardano-transaction-lib) and [mesh](https://meshjs.dev/), to interact with your script. 
 
 All these are based on the [Cardano API](https://github.com/IntersectMBO/cardano-api), a low-level API that provides the capability to do the off-chain work with a local running node.

--- a/doc/docusaurus/docs/simple-example/off-chain-code.md
+++ b/doc/docusaurus/docs/simple-example/off-chain-code.md
@@ -13,5 +13,5 @@ In addition to the on-chain code, one typically needs the accompanying off-chain
 A full suite of solutions is [in development](https://plutus-apps.readthedocs.io/en/latest/plutus/explanations/plutus-tools-component-descriptions.html).
 See the [plutus-apps](https://github.com/IntersectMBO/plutus-apps) repo and its accompanying [Plutus tools SDK user guide](https://plutus-apps.readthedocs.io/en/latest/) for more details.
 
-Some other alternatives include [cardano-transaction-lib](https://github.com/Plutonomicon/cardano-transaction-lib) and [lucid](https://github.com/spacebudz/lucid). 
+Some other alternatives include [cardano-transaction-lib](https://github.com/Plutonomicon/cardano-transaction-lib) and [mesh](https://meshjs.dev/). 
 All these are based on the [Cardano API](https://github.com/IntersectMBO/cardano-api), a low-level API that provides the capability to do the off-chain work with a local running node.


### PR DESCRIPTION
Update the link to Mesh, as lucid is not maintained and has become obsolete.

Mesh will release test files to showcase Chang readiness.