### PR TITLE
[Errors] Swap operational and structural errors

### DIFF
--- a/plutus-core/changelog.d/20240903_180833_effectfully_swap_structural_and_operational_errors.md
+++ b/plutus-core/changelog.d/20240903_180833_effectfully_swap_structural_and_operational_errors.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Swapped around the type arguments of `EvaluationError` and `EvaluationException`.

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
@@ -107,8 +107,8 @@ instance AsEvaluationError UnliftingEvaluationError UnliftingError UnliftingErro
 -- | An 'UnliftingEvaluationError' /is/ an 'EvaluationError', hence for this instance we only
 -- require both @operational@ and @structural@ to have '_UnliftingError' prisms, so that we can
 -- handle both the cases pointwisely.
-instance (AsUnliftingError operational, AsUnliftingError structural) =>
-        AsUnliftingEvaluationError (EvaluationError operational structural) where
+instance (AsUnliftingError structural, AsUnliftingError operational) =>
+        AsUnliftingEvaluationError (EvaluationError structural operational) where
     _UnliftingEvaluationError = go . coerced where
         go =
             prism'

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -105,7 +105,7 @@ data CkUserError =
 
 -- | The CK machine-specific 'EvaluationException'.
 type CkEvaluationException uni fun =
-    EvaluationException CkUserError (MachineError fun) (Term TyName Name uni fun ())
+    EvaluationException (MachineError fun) CkUserError (Term TyName Name uni fun ())
 
 type CkM uni fun s =
     ReaderT (CkEnv uni fun s)

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
@@ -70,7 +70,7 @@ mtraverse makeClassyPrisms
     ]
 
 instance structural ~ MachineError fun =>
-        AsMachineError (EvaluationError operational structural) fun where
+        AsMachineError (EvaluationError structural operational) fun where
     _MachineError = _StructuralEvaluationError
     {-# INLINE _MachineError #-}
 
@@ -78,8 +78,8 @@ instance AsUnliftingError (MachineError fun) where
     _UnliftingError = _UnliftingMachineError
     {-# INLINE _UnliftingError #-}
 
-type EvaluationException operational structural =
-    ErrorWithCause (EvaluationError operational structural)
+type EvaluationException structural operational =
+    ErrorWithCause (EvaluationError structural operational)
 
 {- Note [Ignoring context in OperationalEvaluationError]
 The 'OperationalEvaluationError' error has a term argument, but 'extractEvaluationResult' just
@@ -96,7 +96,7 @@ context if available.
 -- | Preserve the contents of an 'StructuralEvaluationError' as a 'Left' and turn an
 -- 'OperationalEvaluationError' into a @Right EvaluationFailure@.
 extractEvaluationResult
-    :: Either (EvaluationException operational structural term) a
+    :: Either (EvaluationException structural operational term) a
     -> Either (ErrorWithCause structural term) (EvaluationResult a)
 extractEvaluationResult (Right term) = Right $ EvaluationSuccess term
 extractEvaluationResult (Left (ErrorWithCause evalErr cause)) = case evalErr of
@@ -106,8 +106,8 @@ extractEvaluationResult (Left (ErrorWithCause evalErr cause)) = case evalErr of
 -- | Throw on a 'StructuralEvaluationError' and turn an 'OperationalEvaluationError' into an
 -- 'EvaluationFailure'.
 unsafeToEvaluationResult
-    :: (PrettyPlc internal, PrettyPlc term, Typeable internal, Typeable term)
-    => Either (EvaluationException user internal term) a
+    :: (PrettyPlc structural, PrettyPlc term, Typeable structural, Typeable term)
+    => Either (EvaluationException structural operational term) a
     -> EvaluationResult a
 unsafeToEvaluationResult = unsafeFromEither . extractEvaluationResult
 

--- a/plutus-core/plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Machines.hs
@@ -25,7 +25,7 @@ testMachine
     => String
     -> (Term TyName Name uni fun () ->
            Either
-               (EvaluationException operational structural (Term TyName Name uni fun ()))
+               (EvaluationException structural operational (Term TyName Name uni fun ()))
                (Term TyName Name uni fun ()))
     -> TestTree
 testMachine machine eval =

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Test.hs
@@ -99,7 +99,7 @@ propEvaluate
        )
     => (Term TyName Name uni fun () ->
            Either
-            (EvaluationException operational structural (Term TyName Name uni fun ()))
+            (EvaluationException structural operational (Term TyName Name uni fun ()))
             (Term TyName Name uni fun ()))
        -- ^ An evaluator.
     -> TermGen a  -- ^ A term/value generator.

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypeEvalCheck.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypeEvalCheck.hs
@@ -98,7 +98,7 @@ typeEvalCheckBy
        )
     => (Term TyName Name uni fun () ->
            Either
-               (EvaluationException operational structural (Term TyName Name uni fun ()))
+               (EvaluationException structural operational (Term TyName Name uni fun ()))
                (Term TyName Name uni fun ()))
        -- ^ An evaluator.
     -> TermOf (Term TyName Name uni fun ()) a

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
@@ -111,21 +111,21 @@ not exploited.
 
 -- handle a user error and turn it back into an error term
 handleError :: Type TyName DefaultUni ()
-       -> U.ErrorWithCause (U.EvaluationError operational structural) term
-       -> Either (U.ErrorWithCause (U.EvaluationError operational structural) term)
+       -> U.ErrorWithCause (U.EvaluationError structural operational) term
+       -> Either (U.ErrorWithCause (U.EvaluationError structural operational) term)
                  (Term TyName Name DefaultUni DefaultFun ())
 handleError ty e = case U._ewcError e of
-  U.OperationalEvaluationError _ -> return (Error () ty)
   U.StructuralEvaluationError _  -> throwError e
+  U.OperationalEvaluationError _ -> return (Error () ty)
 
 -- untyped version of `handleError`
 handleUError ::
-          U.ErrorWithCause (U.EvaluationError operational structural) term
-       -> Either (U.ErrorWithCause (U.EvaluationError operational structural) term)
+          U.ErrorWithCause (U.EvaluationError structural operational) term
+       -> Either (U.ErrorWithCause (U.EvaluationError structural operational) term)
                  (U.Term Name DefaultUni DefaultFun ())
 handleUError e = case U._ewcError e of
-  U.OperationalEvaluationError _ -> return (U.Error ())
   U.StructuralEvaluationError _  -> throwError e
+  U.OperationalEvaluationError _ -> return (U.Error ())
 
 -- |Property: check if the type is preserved by evaluation.
 --

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -402,7 +402,7 @@ newtype CekM uni fun s a = CekM
 
 -- | The CEK machine-specific 'EvaluationException'.
 type CekEvaluationException name uni fun =
-    EvaluationException CekUserError (MachineError fun) (Term name uni fun ())
+    EvaluationException (MachineError fun) CekUserError (Term name uni fun ())
 
 {- Note [Throwing exceptions in ST]
 This note represents MPJ's best understanding right now, might be wrong.
@@ -435,7 +435,7 @@ But in our case this is okay, because:
 -- 'throwingWithCause' as the cause of the failure.
 throwingDischarged
     :: ThrowableBuiltins uni fun
-    => AReview (EvaluationError CekUserError (MachineError fun)) t
+    => AReview (EvaluationError (MachineError fun) CekUserError) t
     -> t
     -> CekValue uni fun ann
     -> CekM uni fun s x

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek/Internal.hs
@@ -416,7 +416,7 @@ cekStepCost costs = runIdentity . \case
 -- 'throwingWithCause' as the cause of the failure.
 throwingDischarged
     :: ThrowableBuiltins uni fun
-    => AReview (EvaluationError CekUserError (MachineError fun)) t
+    => AReview (EvaluationError (MachineError fun) CekUserError) t
     -> t
     -> CekValue uni fun ann
     -> CekM uni fun s x

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -44,7 +44,7 @@ testMachine
     => String
     -> (Term Name uni fun () ->
            Either
-               (EvaluationException operational structural (Term Name uni fun ()))
+               (EvaluationException structural operational (Term Name uni fun ()))
                (Term Name uni fun ()))
     -> TestTree
 testMachine machine eval =


### PR DESCRIPTION
This simply swaps around two type variables and two constructors, affecting `EvaluationError` and `EvaluationException`. Structural errors correspond to type errors and operational errors correspond to runtime errors, hence the former "precede" the latter. This PR finally reflects that perceived ordering. It's not really important, but I've got things mixed up before due to the previously counter-intuitive ordering, so I thought it'd be worth fixing it, given how easy that is.