### PR TITLE
Add a compiler flag for the evaluateBuiltins pass

### DIFF
--- a/doc/docusaurus/docs/delve-deeper/plutus-tx-compiler-options.md
+++ b/doc/docusaurus/docs/delve-deeper/plutus-tx-compiler-options.md
@@ -20,7 +20,7 @@ For each boolean option, you can add a `no-` prefix to switch it off, such as `n
 
 |Option|Value Type|Default|Description|
 |-|-|-|-|
-|`conservative-optimisation`|Bool|False|When conservative optimisation is used, only the optimisations that never make the program worse (in terms of cost or size) are employed. Implies `no-relaxed-float-in`, `no-inline-constants`, and `preserve-logging`.|
+|`conservative-optimisation`|Bool|False|When conservative optimisation is used, only the optimisations that never make the program worse (in terms of cost or size) are employed. Implies `no-relaxed-float-in`, `no-inline-constants`, `no-simplifier-evaluate-builtins`, and `preserve-logging`.|
 |`context-level`|Int|1|Set context level for error messages.|
 |`coverage-all`|Bool|False|Add all available coverage annotations in the trace output|
 |`coverage-boolean`|Bool|False|Add boolean coverage annotations in the trace output|

--- a/doc/docusaurus/docs/delve-deeper/plutus-tx-compiler-options.md
+++ b/doc/docusaurus/docs/delve-deeper/plutus-tx-compiler-options.md
@@ -41,6 +41,7 @@ For each boolean option, you can add a `no-` prefix to switch it off, such as `n
 |`relaxed-float-in`|Bool|True|Use a more aggressive float-in pass, which often leads to reduced costs but may occasionally lead to slightly increased costs. Implied by `no-conservative-optimisation`.|
 |`remove-trace`|Bool|False|Eliminate calls to `trace` from Plutus Core|
 |`simplifier-beta`|Bool|True|Run a simplification pass that performs beta transformations|
+|`simplifier-evaluate-builtins`|Bool|True|Run a simplification pass that evaluates fully saturated builtin applications. Implied by `no-conservative-optimisation`.|
 |`simplifier-inline`|Bool|True|Run a simplification pass that performs inlining|
 |`simplifier-remove-dead-bindings`|Bool|True|Run a simplification pass that removes dead bindings|
 |`simplifier-unwrap-cancel`|Bool|True|Run a simplification pass that cancels unwrap/wrap pairs|

--- a/plutus-tx-plugin/changelog.d/20240906_143413_unsafeFixIO_evaluate_builtins.md
+++ b/plutus-tx-plugin/changelog.d/20240906_143413_unsafeFixIO_evaluate_builtins.md
@@ -1,0 +1,4 @@
+
+### Added
+
+- A compiler flag `simplifier-evaluate-builtins` that controls whether to run the simplifier pass that evaluates fully saturated builtins at compile time.

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -157,8 +157,8 @@ pluginOptions =
           desc =
             "When conservative optimisation is used, only the optimisations that \
             \never make the program worse (in terms of cost or size) are employed. \
-            \Implies `no-relaxed-float-in`, `no-inline-constants`, and \
-            \`preserve-logging`."
+            \Implies `no-relaxed-float-in`, `no-inline-constants`, \
+            \`no-simplifier-evaluate-builtins`, and `preserve-logging`."
        in ( k
           , PluginOption
               typeRep

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -171,10 +171,12 @@ pluginOptions =
               , Implication (== True) posPreserveLogging True
               , Implication (== True) posCaseOfCaseConservative True
               , Implication (== True) posInlineConstants False
+              , Implication (== True) posDoSimplifierEvaluateBuiltins False
               , Implication (== False) posRelaxedFloatin True
               , Implication (== False) posPreserveLogging False
               , Implication (== False) posCaseOfCaseConservative False
               , Implication (== False) posInlineConstants True
+              , Implication (== False) posDoSimplifierEvaluateBuiltins True
               ]
           )
     , let k = "context-level"
@@ -230,6 +232,11 @@ pluginOptions =
     , let k = "simplifier-beta"
           desc = "Run a simplification pass that performs beta transformations"
        in (k, PluginOption typeRep (setTrue k) posDoSimplifierBeta desc [])
+    , let k = "simplifier-evaluate-builtins"
+          desc =
+            "Run a simplification pass that evaluates fully saturated builtin applications. \
+            \Implied by `no-conservative-optimisation`."
+       in (k, PluginOption typeRep (setTrue k) posDoSimplifierEvaluateBuiltins desc [])
     , let k = "simplifier-inline"
           desc = "Run a simplification pass that performs inlining"
        in (k, PluginOption typeRep (setTrue k) posDoSimplifierInline desc [])


### PR DESCRIPTION
This flag is currently missing, `_posDoSimplifierEvaluateBuiltins` is always true and cannot be turned off.