### PR TITLE
Fix broken tests

### DIFF
--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -109,9 +109,7 @@ agdaEvalUplcProg WithoutCosting =
  "test-cases/uplc/evaluation/builtin/semantics/addInteger/addInteger1"
 -}
 failingEvaluationTests :: [FilePath]
-failingEvaluationTests = [
-  "test-cases/uplc/evaluation/builtin/semantics/findFirstSetBit/case-7"  -- There seems to be a bug in findFirstSetBit
-  ]
+failingEvaluationTests = []
 
 {- | A list of budget tests which are currently expected to fail.  Once a fix for
  a test is pushed, the test will succeed and should be removed from the list.

--- a/plutus-conformance/haskell-steppable/Spec.hs
+++ b/plutus-conformance/haskell-steppable/Spec.hs
@@ -10,7 +10,7 @@ import UntypedPlutusCore.Evaluation.Machine.SteppableCek qualified as SCek
 import Control.Lens
 
 failingEvaluationTests :: [FilePath]
-failingEvaluationTests = [ "test-cases/uplc/evaluation/builtin/semantics/findFirstSetBit/case-7" ]
+failingEvaluationTests = []
 
 failingBudgetTests :: [FilePath]
 failingBudgetTests = []

--- a/plutus-conformance/haskell/Spec.hs
+++ b/plutus-conformance/haskell/Spec.hs
@@ -31,8 +31,7 @@ evalUplcProg = UplcEvaluatorWithCosting $ \modelParams (UPLC.Program a v t) ->
  "test-cases/uplc/evaluation/builtin/semantics/addInteger/addInteger1"
 -}
 failingEvaluationTests :: [FilePath]
-failingEvaluationTests = [ "test-cases/uplc/evaluation/builtin/semantics/findFirstSetBit/case-7" ]
-  -- There seems to be a bug in findFirstSetBit
+failingEvaluationTests = []
 
 {- | A list of budget tests which are currently expected to fail.  Once a fix for
  a test is pushed, the test will succeed and should be removed from the list.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Bitwise.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Bitwise.hs
@@ -22,7 +22,9 @@ module Evaluation.Builtins.Bitwise (
   ffsIndex,
   ffsZero,
   shiftMinBound,
-  rotateMinBound
+  rotateMinBound,
+  ffs41Bytes,
+  ffs61Bytes
   ) where
 
 import Evaluation.Helpers (assertEvaluatesToConstant, evaluateTheSame, evaluateToHaskell,
@@ -41,6 +43,22 @@ import Hedgehog.Range qualified as Range
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.HUnit (testCase)
+
+-- | Ensure that a 40-byte sequence of zeroes, followed by a 1, gives 320 as the index.
+ffs41Bytes :: TestTree
+ffs41Bytes = testCase "40 zero bytes" $ do
+  let lhs = mkIterAppNoAnn (builtin () PLC.FindFirstSetBit) [
+        mkConstant @ByteString () . BS.cons 0x01 . BS.replicate 40 $ 0x00
+        ]
+  assertEvaluatesToConstant @Integer 320 lhs
+
+-- | Ensure that a 60-byte sequence of zeroes, followed by a 1, gives 480 as the index.
+ffs61Bytes :: TestTree
+ffs61Bytes = testCase "60 zero bytes" $ do
+  let lhs = mkIterAppNoAnn (builtin () PLC.FindFirstSetBit) [
+        mkConstant @ByteString () . BS.cons 0x01 . BS.replicate 60 $ 0x00
+        ]
+  assertEvaluatesToConstant @Integer 480 lhs
 
 -- | If given 'Int' 'minBound' as an argument, rotations behave sensibly.
 rotateMinBound :: Property

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -1068,6 +1068,10 @@ test_Bitwise =
                 mapTestLimitAtLeast 99 (`div` 10) Bitwise.ffsXor
             , testPropertyNamed "found index set, lower indices clear" "ffs_index" $
                 mapTestLimitAtLeast 50 (`div` 20) Bitwise.ffsIndex
+            , testGroup "Regression #6453"
+                [ Bitwise.ffs41Bytes
+                , Bitwise.ffs61Bytes
+                ]
             ]
         ]
 


### PR DESCRIPTION
This fixes the issues with `findFirstSetBit` found in the original PR. Furthermore, we add some unit tests to ensure this regression does not re-occur.
