### PR TITLE
Fix regression, ensure it doesn't come back with a property test

### DIFF
--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -109,9 +109,7 @@ agdaEvalUplcProg WithoutCosting =
  "test-cases/uplc/evaluation/builtin/semantics/addInteger/addInteger1"
 -}
 failingEvaluationTests :: [FilePath]
-failingEvaluationTests = [
-  "test-cases/uplc/evaluation/builtin/semantics/findFirstSetBit/case-7"  -- There seems to be a bug in findFirstSetBit
-  ]
+failingEvaluationTests = []
 
 {- | A list of budget tests which are currently expected to fail.  Once a fix for
  a test is pushed, the test will succeed and should be removed from the list.

--- a/plutus-conformance/haskell-steppable/Spec.hs
+++ b/plutus-conformance/haskell-steppable/Spec.hs
@@ -10,7 +10,7 @@ import UntypedPlutusCore.Evaluation.Machine.SteppableCek qualified as SCek
 import Control.Lens
 
 failingEvaluationTests :: [FilePath]
-failingEvaluationTests = [ "test-cases/uplc/evaluation/builtin/semantics/findFirstSetBit/case-7" ]
+failingEvaluationTests = []
 
 failingBudgetTests :: [FilePath]
 failingBudgetTests = []

--- a/plutus-conformance/haskell/Spec.hs
+++ b/plutus-conformance/haskell/Spec.hs
@@ -31,8 +31,7 @@ evalUplcProg = UplcEvaluatorWithCosting $ \modelParams (UPLC.Program a v t) ->
  "test-cases/uplc/evaluation/builtin/semantics/addInteger/addInteger1"
 -}
 failingEvaluationTests :: [FilePath]
-failingEvaluationTests = [ "test-cases/uplc/evaluation/builtin/semantics/findFirstSetBit/case-7" ]
-  -- There seems to be a bug in findFirstSetBit
+failingEvaluationTests = []
 
 {- | A list of budget tests which are currently expected to fail.  Once a fix for
  a test is pushed, the test will succeed and should be removed from the list.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -1068,6 +1068,8 @@ test_Bitwise =
                 mapTestLimitAtLeast 99 (`div` 10) Bitwise.ffsXor
             , testPropertyNamed "found index set, lower indices clear" "ffs_index" $
                 mapTestLimitAtLeast 50 (`div` 20) Bitwise.ffsIndex
+            , testPropertyNamed "regression #6453 check" "regression_6453" $
+                mapTestLimitAtLeast 99 (`div` 10) Bitwise.ffs6453
             ]
         ]
 


### PR DESCRIPTION
Supercedes #6459, with a cleaner history. Additionally, instead of unit tests for the regression cases, there's now a property test instead.