### PR TITLE
Fix printing of type variables in print-builtin-signatures

### DIFF
--- a/plutus-core/executables/src/PlutusCore/Executable/Common.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Common.hs
@@ -510,7 +510,10 @@ instance Show Signature where
             case ty of
                 PLC.TyBuiltin _ t -> show $ PP.pretty t
                 PLC.TyApp{}       -> showMultiTyApp $ unwrapTyApp ty
-                _                 -> show $ PP.pretty ty
+                -- prettyPlcClassicSimple -> omit indices in type variables.
+                _                 -> show $ PP.prettyPlcClassicSimple ty
+                -- We may want more cases here if more complex types (eg function types)
+                -- are allowed for builtin arguments.
         unwrapTyApp ty =
             case ty of
                 PLC.TyApp _ t1 t2 -> unwrapTyApp t1 ++ [t2]


### PR DESCRIPTION
`uplc print-builtin-signatures` prints out a table of all of the builtins and their signatures.  After some changes in the prettyprinter a while ago this was printing out things like

```
ifThenElse                         : [ forall a, bool, a-0, a-0 ] -> a-0
```

This PR jsut makes it use a vesion of the prettyprinter that gives

```
ifThenElse                         : [ forall a, bool, a, a ] -> a
```
instead.