### PR TITLE
Fix typo

### DIFF
--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -211,7 +211,7 @@ test-suite plutus-ledger-api-plugin-test
     Spec.Value
 
   if os(windows)
-    buildable: false 
+    buildable: False 
 
   build-depends:
     , base                                                              >=4.9   && <5


### PR DESCRIPTION
I saw this message from cabal going past when I was doing something else.  This PR should fix it.

> Warning: plutus-ledger-api.cabal:214:21: Boolean values are case sensitive,
> use 'True' or 'False'.
