### PR TITLE
Add forgotten changelong entry

### DIFF
--- a/plutus-core/changelog.d/20240913_101059_kenneth.mackenzie.md
+++ b/plutus-core/changelog.d/20240913_101059_kenneth.mackenzie.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- A bug in the`findFirstSet` builtin has been fixed.
+- A bug in the`findFirstSetBit` builtin has been fixed.
 

--- a/plutus-core/changelog.d/20240913_101059_kenneth.mackenzie.md
+++ b/plutus-core/changelog.d/20240913_101059_kenneth.mackenzie.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- A bug in the`findFirstSet` builtin has been fixed.
+


### PR DESCRIPTION
We failed to add a changelog entry for the `findFirstSetBit` builtin bugfix in #6459/#6461, but it should probably be mentioned. 