### PR TITLE
[Refactoring] Replace 'NOINLINE' with 'OPAQUE'

### DIFF
--- a/doc/adr/adr3.md
+++ b/doc/adr/adr3.md
@@ -73,7 +73,7 @@ enterComputeCek debug ctx (Closure term env) =
         -> Closure uni fun
         -> CekM uni fun s (CekState uni fun)
     computeCek = if debug then computeCekDebug else computeCekStep
-    {-# NOINLINE computeCek #-}  -- Making sure the `if` is only evaluated once.
+    {-# OPAQUE computeCek #-}  -- Making sure the `if` is only evaluated once.
 
     -- in debugging mode, immediately returns the current `CekState` and halts execution. Debugging mode details to be worked out.
     computeCekDebug
@@ -101,7 +101,7 @@ enterComputeCek debug ctx (Closure term env) =
     -- similarly for the returning step
 
     returnCek = if debug then returnCekDebug else returnCekStep
-    {-# NOINLINE returnCek #-}
+    {-# OPAQUE returnCek #-}
 
     returnCekDebug = ...
 

--- a/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
+++ b/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
@@ -61,7 +61,7 @@ import System.IO.Unsafe (unsafePerformIO)
 import Prelude (fromIntegral)
 
 -- Create a list containing n bytestrings of length l.  This could be better.
-{-# NOINLINE listOfByteStringsOfLength #-}
+{-# OPAQUE listOfByteStringsOfLength #-}
 listOfByteStringsOfLength :: Integer -> Integer -> [ByteString]
 listOfByteStringsOfLength n l = unsafePerformIO . G.sample $
                              G.list (R.singleton $ fromIntegral n)

--- a/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
+++ b/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
@@ -71,7 +71,7 @@ builtinHash :: BuiltinHashFun
 builtinHash = Tx.sha2_256
 
 -- Create a list containing n bytestrings of length l.  This could be better.
-{-# NOINLINE listOfByteStringsOfLength #-}
+{-# OPAQUE listOfByteStringsOfLength #-}
 listOfByteStringsOfLength :: Integer -> Integer -> [ByteString]
 listOfByteStringsOfLength n l = unsafePerformIO . G.sample $
                              G.list (R.singleton $ fromIntegral n)

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -40,26 +40,26 @@ same object in the heap) the underlying implementation may notice that and
 return immediately.  The code below attempts to avoid this by producing a
 completely new copy of an integer.  Experiments with 'realyUnsafePtrEquality#`
 indicate that it does what's required (in fact, `cloneInteger n = (n+1)-1` with
-NOINLINE suffices, but that's perhaps a bit too fragile).
+OPAQUE suffices, but that's perhaps a bit too fragile).
 -}
 
-{-# NOINLINE incInteger #-}
+{-# OPAQUE incInteger #-}
 incInteger :: Integer -> Integer
 incInteger n = n+1
 
-{-# NOINLINE decInteger #-}
+{-# OPAQUE decInteger #-}
 decInteger :: Integer -> Integer
 decInteger n = n-1
 
-{-# NOINLINE copyInteger #-}
+{-# OPAQUE copyInteger #-}
 copyInteger :: Integer -> Integer
 copyInteger = decInteger . incInteger
 
-{-# NOINLINE copyByteString #-}
+{-# OPAQUE copyByteString #-}
 copyByteString :: BS.ByteString -> BS.ByteString
 copyByteString = BS.copy
 
-{-# NOINLINE copyData #-}
+{-# OPAQUE copyData #-}
 copyData :: Data -> Data
 copyData =
     \case

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -417,7 +417,7 @@ toBuiltinsRuntime semvar cost =
     -- binding the @cost@ variable, which makes the optimizations useless.
     -- By using 'lazy' we tell GHC to create a separate thunk, which it can properly optimize,
     -- because the other bazillion things don't get in the way. We used to use an explicit
-    -- 'let'-binding marked with @NOINLINE@, but that turned out to be unreliable, because GHC
+    -- 'let'-binding marked with @OPAQUE@, but that turned out to be unreliable, because GHC
     -- feels free to turn it into a join point instead of a proper thunk.
     lazy . BuiltinsRuntime $ toBuiltinRuntime cost . inline toBuiltinMeaning semvar
 {-# INLINE toBuiltinsRuntime #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -125,7 +125,7 @@ instance GEq DefaultUni where
     -- We define 'geq' manually instead of using 'deriveGEq', because the latter creates a single
     -- recursive definition and we want two instead. The reason why we want two is because this
     -- allows GHC to inline the initial step that appears non-recursive to GHC, because recursion
-    -- is hidden in the other function that is marked as @NOINLINE@ and is chosen by GHC as a
+    -- is hidden in the other function that is marked as @OPAQUE@ and is chosen by GHC as a
     -- loop-breaker, see https://wiki.haskell.org/Inlining_and_Specialisation#What_is_a_loop-breaker
     -- (we're not really sure if this is a reliable solution, but if it stops working, we won't miss
     -- very much and we've failed to settle on any other approach).
@@ -176,7 +176,7 @@ instance GEq DefaultUni where
 
         geqRec :: DefaultUni a1 -> DefaultUni a2 -> Maybe (a1 :~: a2)
         geqRec = geqStep
-        {-# NOINLINE geqRec #-}
+        {-# OPAQUE geqRec #-}
 
 -- | For pleasing the coverage checker.
 noMoreTypeFunctions :: DefaultUni (Esc (f :: a -> b -> c -> d)) -> any

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -254,9 +254,9 @@ a lambda (see https://github.com/IntersectMBO/plutus/pull/4621), however it does
 faster, generates more Core and doesn't take much to break, hence we choose the hacky 'lazy'
 version.
 
-Since we want @run*Model@ functions to partially compute, we mark them as @NOINLINE@ to prevent GHC
-from inlining them and breaking the sharing friendliness. Without the @NOINLINE@ Core doesn't seem
-to be worse, however it was verified that no @NOINLINE@ causes a slowdown in both the @validation@
+Since we want @run*Model@ functions to partially compute, we mark them as @OPAQUE@ to prevent GHC
+from inlining them and breaking the sharing friendliness. Without the @OPAQUE@ Core doesn't seem
+to be worse, however it was verified that no @OPAQUE@ causes a slowdown in both the @validation@
 and @nofib@ benchmarks.
 
 Note that looking at the generated Core isn't really enough. We might have enemies down the pipeline,
@@ -299,7 +299,7 @@ runOneArgumentModel (ModelOneArgumentConstantCost c) =
     lazy $ \_ -> CostLast c
 runOneArgumentModel (ModelOneArgumentLinearInX (OneVariableLinearFunction intercept slope)) =
     lazy $ \costs1 -> scaleLinearly intercept slope costs1
-{-# NOINLINE runOneArgumentModel #-}
+{-# OPAQUE runOneArgumentModel #-}
 
 ---------------- Two-argument costing functions ----------------
 
@@ -586,7 +586,7 @@ runTwoArgumentModel
              let !size1 = sumCostStream costs1
                  !size2 = sumCostStream costs2
              in CostLast $ evaluateTwoVariableQuadraticFunction f size1 size2
-{-# NOINLINE runTwoArgumentModel #-}
+{-# OPAQUE runTwoArgumentModel #-}
 
 
 ---------------- Three-argument costing functions ----------------
@@ -657,7 +657,7 @@ runThreeArgumentModel
     (ModelThreeArgumentsLinearInYAndZ (TwoVariableLinearFunction intercept slope2 slope3)) =
         lazy $ \_costs1 costs2 costs3 ->
             scaleLinearlyTwoVariables intercept slope2 costs2 slope3 costs3
-{-# NOINLINE runThreeArgumentModel #-}
+{-# OPAQUE runThreeArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunThreeArguments
@@ -700,7 +700,7 @@ runFourArgumentModel
     -> CostStream
     -> CostStream
 runFourArgumentModel (ModelFourArgumentsConstantCost c) = lazy $ \_ _ _ _ -> CostLast c
-{-# NOINLINE runFourArgumentModel #-}
+{-# OPAQUE runFourArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunFourArguments
@@ -746,7 +746,7 @@ runFiveArgumentModel
     -> CostStream
     -> CostStream
 runFiveArgumentModel (ModelFiveArgumentsConstantCost c) = lazy $ \_ _ _ _ _ -> CostLast c
-{-# NOINLINE runFiveArgumentModel #-}
+{-# OPAQUE runFiveArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunFiveArguments
@@ -794,7 +794,7 @@ runSixArgumentModel
     -> CostStream
     -> CostStream
 runSixArgumentModel (ModelSixArgumentsConstantCost c) = lazy $ \_ _ _ _ _ _ -> CostLast c
-{-# NOINLINE runSixArgumentModel #-}
+{-# OPAQUE runSixArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunSixArguments

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -67,7 +67,7 @@ builtinCostModelVariantA :: BuiltinCostModel
 builtinCostModelVariantA =
     $$(readJSONFromFile DFP.builtinCostModelFileA)
 -- This is a huge record, inlining it is wasteful.
-{-# NOINLINE builtinCostModelVariantA #-}
+{-# OPAQUE builtinCostModelVariantA #-}
 
 {- Note [No inlining for CekMachineCosts]
 We don't want this to get inlined, as otherwise the default 'CekMachineCosts'
@@ -77,7 +77,7 @@ the costing parameters provided by the ledger. -}
 cekMachineCostsVariantA :: CekMachineCosts
 cekMachineCostsVariantA =
   $$(readJSONFromFile DFP.cekMachineCostsFileA)
-{-# NOINLINE cekMachineCostsVariantA #-}
+{-# OPAQUE cekMachineCostsVariantA #-}
 
 {-| The default cost model, including both builtin costs and machine step costs.
     Note that this is not necessarily the cost model in use on the chain at any
@@ -94,13 +94,13 @@ cekCostModelVariantA = CostModel cekMachineCostsVariantA builtinCostModelVariant
 builtinCostModelVariantB :: BuiltinCostModel
 builtinCostModelVariantB =
     $$(readJSONFromFile DFP.builtinCostModelFileB)
-{-# NOINLINE builtinCostModelVariantB #-}
+{-# OPAQUE builtinCostModelVariantB #-}
 
 -- See Note [No inlining for CekMachineCosts]
 cekMachineCostsVariantB :: CekMachineCosts
 cekMachineCostsVariantB =
   $$(readJSONFromFile DFP.cekMachineCostsFileB)
-{-# NOINLINE cekMachineCostsVariantB #-}
+{-# OPAQUE cekMachineCostsVariantB #-}
 
 cekCostModelVariantB :: CostModel CekMachineCosts BuiltinCostModel
 cekCostModelVariantB = CostModel cekMachineCostsVariantB builtinCostModelVariantB
@@ -108,13 +108,13 @@ cekCostModelVariantB = CostModel cekMachineCostsVariantB builtinCostModelVariant
 builtinCostModelVariantC :: BuiltinCostModel
 builtinCostModelVariantC =
     $$(readJSONFromFile DFP.builtinCostModelFileC)
-{-# NOINLINE builtinCostModelVariantC #-}
+{-# OPAQUE builtinCostModelVariantC #-}
 
 -- See Note [No inlining for CekMachineCosts]
 cekMachineCostsVariantC :: CekMachineCosts
 cekMachineCostsVariantC =
   $$(readJSONFromFile DFP.cekMachineCostsFileC)
-{-# NOINLINE cekMachineCostsVariantC #-}
+{-# OPAQUE cekMachineCostsVariantC #-}
 
 cekCostModelVariantC :: CostModel CekMachineCosts BuiltinCostModel
 cekCostModelVariantC = CostModel cekMachineCostsVariantC builtinCostModelVariantC

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
@@ -228,7 +228,7 @@ memoryUsageInteger 0 = 1
 memoryUsageInteger i = fromIntegral $ I# (integerLog2# (abs i) `quotInt#` integerToInt 64) + 1
 -- So that the produced GHC Core doesn't explode in size, we don't win anything by inlining this
 -- function anyway.
-{-# NOINLINE memoryUsageInteger #-}
+{-# OPAQUE memoryUsageInteger #-}
 
 instance ExMemoryUsage Integer where
     memoryUsage i = singletonRose $ memoryUsageInteger i
@@ -338,7 +338,7 @@ we make sure by defining a top level function for each of the size measures and
 getting the memoryUsage instances to call those.
 -}
 
-{-# NOINLINE g1ElementCost #-}
+{-# OPAQUE g1ElementCost #-}
 g1ElementCost :: CostRose
 g1ElementCost = singletonRose . unsafeToSatInt $ BLS12_381.G1.memSizeBytes `div` 8
 
@@ -346,7 +346,7 @@ instance ExMemoryUsage BLS12_381.G1.Element where
     memoryUsage _ = g1ElementCost
     -- Should be 18
 
-{-# NOINLINE g2ElementCost #-}
+{-# OPAQUE g2ElementCost #-}
 g2ElementCost :: CostRose
 g2ElementCost = singletonRose . unsafeToSatInt $ BLS12_381.G2.memSizeBytes `div` 8
 
@@ -354,7 +354,7 @@ instance ExMemoryUsage BLS12_381.G2.Element where
     memoryUsage _ = g2ElementCost
     -- Should be 36
 
-{-# NOINLINE mlResultElementCost #-}
+{-# OPAQUE mlResultElementCost #-}
 mlResultElementCost :: CostRose
 mlResultElementCost = singletonRose . unsafeToSatInt $ BLS12_381.Pairing.mlResultMemSizeBytes `div` 8
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -782,7 +782,7 @@ enterComputeCek = computeCek
         resetCounter ctr
     -- It's very important for this definition not to get inlined. Inlining it caused performance to
     -- degrade by 16+%: https://github.com/IntersectMBO/plutus/pull/5931
-    {-# NOINLINE spendAccumulatedBudget #-}
+    {-# OPAQUE spendAccumulatedBudget #-}
 
     -- Making this a definition of its own causes it to inline better than actually writing it inline, for
     -- some reason.

--- a/plutus-metatheory/Setup.hs
+++ b/plutus-metatheory/Setup.hs
@@ -68,7 +68,7 @@ data AgdaProgramStatus
 
 agdaProgramStatus :: IORef AgdaProgramStatus
 agdaProgramStatus = unsafePerformIO (newIORef NotRun)
-{-# NOINLINE agdaProgramStatus #-}
+{-# OPAQUE agdaProgramStatus #-}
 
 
 main :: IO ()

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -185,7 +185,7 @@ Note also, this `sm_pre_inline` pass doesn't include some of the inlining GHC do
 plugin.
 The GHC desugarer generates a large number of intermediate definitions and general clutter that
 should be removed quickly. So GHC's "simple optimiser" (GHC.Core.SimpleOpt) also inlines things with
-single occurrences. This is why the NOINLINE pragma is needed to avoid inlining of bindings that
+single occurrences. This is why the OPAQUE pragma is needed to avoid inlining of bindings that
 have single occurrence.
 None of -fmax-simplifier-iterations=0  -fforce-recomp -O0 would prevent it,
 nor will turning off `sm_pre_inline`.

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -384,7 +384,7 @@ associated :: CompiledCode (AType Bool -> AType Bool)
 associated = plc (Proxy @"associated") (\(x :: AType Bool) -> x)
 
 -- Despite the type family being applied to a parameterized type we can still reduce it
-{-# NOINLINE paramId #-}
+{-# OPAQUE paramId #-}
 paramId :: forall a . Param a -> AType (Param a) -> AType (Param a)
 paramId _ x = x
 
@@ -392,7 +392,7 @@ associatedParam :: CompiledCode Integer
 associatedParam = plc (Proxy @"associatedParam") (paramId (Param 1) 1)
 
 -- Here we cannot reduce the type family
-{-# NOINLINE tfId #-}
+{-# OPAQUE tfId #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 tfId :: forall a . a -> BasicClosed a -> BasicClosed a
 tfId _ x = x

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -34,12 +34,12 @@ laziness = testNested "Laziness" . pure $ testNestedGhc
 joinErrorPir :: CompiledCode (Bool -> Bool -> ())
 joinErrorPir = plc (Proxy @"joinError") joinError
 
-{-# NOINLINE monoId #-}
+{-# OPAQUE monoId #-}
 monoId :: Builtins.BuiltinByteString -> Builtins.BuiltinByteString
 monoId x = x
 
 -- This is a non-value let-binding, so will be delayed, and needs a dependency on Unit
-{-# NOINLINE aByteString #-}
+{-# OPAQUE aByteString #-}
 aByteString :: Builtins.BuiltinByteString
 aByteString = monoId Builtins.emptyByteString
 

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
@@ -80,7 +80,7 @@ instance PersonLike Alien where
 multiFunction :: CompiledCode (Person -> Bool)
 multiFunction = plc (Proxy @"multiFunction") (
     let
-        {-# NOINLINE predicate #-}
+        {-# OPAQUE predicate #-}
         predicate :: (PersonLike p) => p -> Bool
         predicate p = likesAnimal p Cat P.&& (age p `Builtins.lessThanInteger` 30)
     in \(p::Person) -> predicate p)
@@ -88,7 +88,7 @@ multiFunction = plc (Proxy @"multiFunction") (
 defaultMethods :: CompiledCode (Integer -> Integer)
 defaultMethods = plc (Proxy @"defaultMethods") (
     let
-        {-# NOINLINE f #-}
+        {-# OPAQUE f #-}
         f :: (DefaultMethods a) => a -> Integer
         f a = method2 a
     in \(a::Integer) -> f a)

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -7,7 +7,7 @@
 
 -- This ensures that we don't put *anything* about these functions into the interface
 -- file, otherwise GHC can be clever about the ones that are always error, even though
--- they're NOINLINE!
+-- they're OPAQUE!
 {-# OPTIONS_GHC -O0 #-}
 
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
@@ -90,7 +90,7 @@ otherwise GHC gets very keen to optimize through the newtype and e.g. our users
 see 'Addr#' popping up everywhere.
 -}
 
-{-# NOINLINE error #-}
+{-# OPAQUE error #-}
 error :: BuiltinUnit -> a
 error = Haskell.error "PlutusTx.Builtins.Internal.error"
 
@@ -101,15 +101,15 @@ BOOL
 -- See Note [Opaque builtin types]
 data BuiltinBool = BuiltinBool ~Bool deriving stock Data
 
-{-# NOINLINE true #-}
+{-# OPAQUE true #-}
 true :: BuiltinBool
 true = BuiltinBool True
 
-{-# NOINLINE false #-}
+{-# OPAQUE false #-}
 false :: BuiltinBool
 false = BuiltinBool False
 
-{-# NOINLINE ifThenElse #-}
+{-# OPAQUE ifThenElse #-}
 ifThenElse :: BuiltinBool -> a -> a -> a
 ifThenElse (BuiltinBool b) x y = if b then x else y
 
@@ -120,11 +120,11 @@ UNIT
 -- See Note [Opaque builtin types]
 data BuiltinUnit = BuiltinUnit ~() deriving stock Data
 
-{-# NOINLINE unitval #-}
+{-# OPAQUE unitval #-}
 unitval :: BuiltinUnit
 unitval = BuiltinUnit ()
 
-{-# NOINLINE chooseUnit #-}
+{-# OPAQUE chooseUnit #-}
 chooseUnit :: BuiltinUnit -> a -> a
 chooseUnit (BuiltinUnit ()) a = a
 
@@ -137,43 +137,43 @@ INTEGER
 -- opaque, but that's going to really mess with our users' code...
 type BuiltinInteger = Integer
 
-{-# NOINLINE addInteger #-}
+{-# OPAQUE addInteger #-}
 addInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 addInteger = coerce ((+) @Integer)
 
-{-# NOINLINE subtractInteger #-}
+{-# OPAQUE subtractInteger #-}
 subtractInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 subtractInteger = coerce ((-) @Integer)
 
-{-# NOINLINE multiplyInteger #-}
+{-# OPAQUE multiplyInteger #-}
 multiplyInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 multiplyInteger = coerce ((*) @Integer)
 
-{-# NOINLINE divideInteger #-}
+{-# OPAQUE divideInteger #-}
 divideInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 divideInteger = coerce (div @Integer)
 
-{-# NOINLINE modInteger #-}
+{-# OPAQUE modInteger #-}
 modInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 modInteger = coerce (mod @Integer)
 
-{-# NOINLINE quotientInteger #-}
+{-# OPAQUE quotientInteger #-}
 quotientInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 quotientInteger = coerce (quot @Integer)
 
-{-# NOINLINE remainderInteger #-}
+{-# OPAQUE remainderInteger #-}
 remainderInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 remainderInteger = coerce (rem @Integer)
 
-{-# NOINLINE lessThanInteger #-}
+{-# OPAQUE lessThanInteger #-}
 lessThanInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
 lessThanInteger x y = BuiltinBool $ coerce ((<) @Integer) x  y
 
-{-# NOINLINE lessThanEqualsInteger #-}
+{-# OPAQUE lessThanEqualsInteger #-}
 lessThanEqualsInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
 lessThanEqualsInteger x y = BuiltinBool $ coerce ((<=) @Integer) x y
 
-{-# NOINLINE equalsInteger #-}
+{-# OPAQUE equalsInteger #-}
 equalsInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
 equalsInteger x y = BuiltinBool $ coerce ((==) @Integer) x y
 
@@ -211,55 +211,55 @@ instance BA.ByteArray BuiltinByteString where
 instance Pretty BuiltinByteString where
     pretty = viaShow
 
-{-# NOINLINE appendByteString #-}
+{-# OPAQUE appendByteString #-}
 appendByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString
 appendByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinByteString $ BS.append b1 b2
 
-{-# NOINLINE consByteString #-}
+{-# OPAQUE consByteString #-}
 consByteString :: BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegral n) b
 
-{-# NOINLINE sliceByteString #-}
+{-# OPAQUE sliceByteString #-}
 sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 sliceByteString start n (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral n) (BS.drop (fromIntegral start) b)
 
-{-# NOINLINE lengthOfByteString #-}
+{-# OPAQUE lengthOfByteString #-}
 lengthOfByteString :: BuiltinByteString -> BuiltinInteger
 lengthOfByteString (BuiltinByteString b) = toInteger $ BS.length b
 
-{-# NOINLINE indexByteString #-}
+{-# OPAQUE indexByteString #-}
 indexByteString :: BuiltinByteString -> BuiltinInteger -> BuiltinInteger
 indexByteString (BuiltinByteString b) i = toInteger $ BS.index b (fromInteger i)
 
-{-# NOINLINE emptyByteString #-}
+{-# OPAQUE emptyByteString #-}
 emptyByteString :: BuiltinByteString
 emptyByteString = BuiltinByteString BS.empty
 
-{-# NOINLINE sha2_256 #-}
+{-# OPAQUE sha2_256 #-}
 sha2_256 :: BuiltinByteString -> BuiltinByteString
 sha2_256 (BuiltinByteString b) = BuiltinByteString $ Hash.sha2_256 b
 
-{-# NOINLINE sha3_256 #-}
+{-# OPAQUE sha3_256 #-}
 sha3_256 :: BuiltinByteString -> BuiltinByteString
 sha3_256 (BuiltinByteString b) = BuiltinByteString $ Hash.sha3_256 b
 
-{-# NOINLINE blake2b_224 #-}
+{-# OPAQUE blake2b_224 #-}
 blake2b_224 :: BuiltinByteString -> BuiltinByteString
 blake2b_224 (BuiltinByteString b) = BuiltinByteString $ Hash.blake2b_224 b
 
-{-# NOINLINE blake2b_256 #-}
+{-# OPAQUE blake2b_256 #-}
 blake2b_256 :: BuiltinByteString -> BuiltinByteString
 blake2b_256 (BuiltinByteString b) = BuiltinByteString $ Hash.blake2b_256 b
 
-{-# NOINLINE keccak_256 #-}
+{-# OPAQUE keccak_256 #-}
 keccak_256 :: BuiltinByteString -> BuiltinByteString
 keccak_256 (BuiltinByteString b) = BuiltinByteString $ Hash.keccak_256 b
 
-{-# NOINLINE ripemd_160 #-}
+{-# OPAQUE ripemd_160 #-}
 ripemd_160 :: BuiltinByteString -> BuiltinByteString
 ripemd_160 (BuiltinByteString b) = BuiltinByteString $ Hash.ripemd_160 b
 
-{-# NOINLINE verifyEd25519Signature #-}
+{-# OPAQUE verifyEd25519Signature #-}
 verifyEd25519Signature :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString -> BuiltinBool
 verifyEd25519Signature (BuiltinByteString vk) (BuiltinByteString msg) (BuiltinByteString sig) =
   case PlutusCore.Crypto.Ed25519.verifyEd25519Signature_V1 vk msg sig of
@@ -268,7 +268,7 @@ verifyEd25519Signature (BuiltinByteString vk) (BuiltinByteString msg) (BuiltinBy
     BuiltinFailure logs err       -> traceAll (logs <> pure (display err)) $
         Haskell.error "Ed25519 signature verification errored."
 
-{-# NOINLINE verifyEcdsaSecp256k1Signature #-}
+{-# OPAQUE verifyEcdsaSecp256k1Signature #-}
 verifyEcdsaSecp256k1Signature ::
   BuiltinByteString ->
   BuiltinByteString ->
@@ -281,7 +281,7 @@ verifyEcdsaSecp256k1Signature (BuiltinByteString vk) (BuiltinByteString msg) (Bu
     BuiltinFailure logs err       -> traceAll (logs <> pure (display err)) $
         Haskell.error "ECDSA SECP256k1 signature verification errored."
 
-{-# NOINLINE verifySchnorrSecp256k1Signature #-}
+{-# OPAQUE verifySchnorrSecp256k1Signature #-}
 verifySchnorrSecp256k1Signature ::
   BuiltinByteString ->
   BuiltinByteString ->
@@ -298,19 +298,19 @@ traceAll :: forall (a :: Type) (f :: Type -> Type) .
   (Foldable f) => f Text -> a -> a
 traceAll logs x = Foldable.foldl' (\acc t -> trace (BuiltinString t) acc) x logs
 
-{-# NOINLINE equalsByteString #-}
+{-# OPAQUE equalsByteString #-}
 equalsByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
 equalsByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 == b2
 
-{-# NOINLINE lessThanByteString #-}
+{-# OPAQUE lessThanByteString #-}
 lessThanByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
 lessThanByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 < b2
 
-{-# NOINLINE lessThanEqualsByteString #-}
+{-# OPAQUE lessThanEqualsByteString #-}
 lessThanEqualsByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
 lessThanEqualsByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 <= b2
 
-{-# NOINLINE decodeUtf8 #-}
+{-# OPAQUE decodeUtf8 #-}
 decodeUtf8 :: BuiltinByteString -> BuiltinString
 decodeUtf8 (BuiltinByteString b) = BuiltinString $ Text.decodeUtf8 b
 
@@ -328,23 +328,23 @@ instance Haskell.Eq BuiltinString where
 instance Haskell.Ord BuiltinString where
     compare (BuiltinString t) (BuiltinString t') = compare t t'
 
-{-# NOINLINE appendString #-}
+{-# OPAQUE appendString #-}
 appendString :: BuiltinString -> BuiltinString -> BuiltinString
 appendString (BuiltinString s1) (BuiltinString s2) = BuiltinString (s1 <> s2)
 
-{-# NOINLINE emptyString #-}
+{-# OPAQUE emptyString #-}
 emptyString :: BuiltinString
 emptyString = BuiltinString Text.empty
 
-{-# NOINLINE equalsString #-}
+{-# OPAQUE equalsString #-}
 equalsString :: BuiltinString -> BuiltinString -> BuiltinBool
 equalsString (BuiltinString s1) (BuiltinString s2) = BuiltinBool $ s1 == s2
 
-{-# NOINLINE trace #-}
+{-# OPAQUE trace #-}
 trace :: BuiltinString -> a -> a
 trace _ x = x
 
-{-# NOINLINE encodeUtf8 #-}
+{-# OPAQUE encodeUtf8 #-}
 encodeUtf8 :: BuiltinString -> BuiltinByteString
 encodeUtf8 (BuiltinString s) = BuiltinByteString $ Text.encodeUtf8 s
 
@@ -362,15 +362,15 @@ instance (Haskell.Eq a, Haskell.Eq b) => Haskell.Eq (BuiltinPair a b) where
 instance (Haskell.Ord a, Haskell.Ord b) => Haskell.Ord (BuiltinPair a b) where
     compare (BuiltinPair p) (BuiltinPair p') = compare p p'
 
-{-# NOINLINE fst #-}
+{-# OPAQUE fst #-}
 fst :: BuiltinPair a b -> a
 fst (BuiltinPair (a, _)) = a
 
-{-# NOINLINE snd #-}
+{-# OPAQUE snd #-}
 snd :: BuiltinPair a b -> b
 snd (BuiltinPair (_, b)) = b
 
-{-# NOINLINE mkPairData #-}
+{-# OPAQUE mkPairData #-}
 mkPairData :: BuiltinData -> BuiltinData -> BuiltinPair BuiltinData BuiltinData
 mkPairData d1 d2 = BuiltinPair (d1, d2)
 
@@ -388,35 +388,35 @@ instance Haskell.Eq a => Haskell.Eq (BuiltinList a) where
 instance Haskell.Ord a => Haskell.Ord (BuiltinList a) where
     compare (BuiltinList l) (BuiltinList l') = compare l l'
 
-{-# NOINLINE null #-}
+{-# OPAQUE null #-}
 null :: BuiltinList a -> BuiltinBool
 null (BuiltinList (_:_)) = BuiltinBool False
 null (BuiltinList [])    = BuiltinBool True
 
-{-# NOINLINE head #-}
+{-# OPAQUE head #-}
 head :: BuiltinList a -> a
 head (BuiltinList (x:_)) = x
 head (BuiltinList [])    = Haskell.error "empty list"
 
-{-# NOINLINE tail #-}
+{-# OPAQUE tail #-}
 tail :: BuiltinList a -> BuiltinList a
 tail (BuiltinList (_:xs)) = BuiltinList xs
 tail (BuiltinList [])     = Haskell.error "empty list"
 
-{-# NOINLINE chooseList #-}
+{-# OPAQUE chooseList #-}
 chooseList :: BuiltinList a -> b -> b -> b
 chooseList (BuiltinList [])    b1 _ = b1
 chooseList (BuiltinList (_:_)) _ b2 = b2
 
-{-# NOINLINE mkNilData #-}
+{-# OPAQUE mkNilData #-}
 mkNilData :: BuiltinUnit -> BuiltinList BuiltinData
 mkNilData _ = BuiltinList []
 
-{-# NOINLINE mkNilPairData #-}
+{-# OPAQUE mkNilPairData #-}
 mkNilPairData :: BuiltinUnit -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
 mkNilPairData _ = BuiltinList []
 
-{-# NOINLINE mkCons #-}
+{-# OPAQUE mkCons #-}
 mkCons :: a -> BuiltinList a -> BuiltinList a
 mkCons a (BuiltinList as) = BuiltinList (a:as)
 
@@ -450,19 +450,19 @@ instance NFData BuiltinData where
 instance Pretty BuiltinData where
     pretty (BuiltinData d) = pretty d
 
--- NOT a builtin, only safe off-chain, hence the NOINLINE
-{-# NOINLINE builtinDataToData #-}
+-- NOT a builtin, only safe off-chain, hence the OPAQUE
+{-# OPAQUE builtinDataToData #-}
 -- | Convert a 'BuiltinData' into a 'PLC.Data'. Only works off-chain.
 builtinDataToData :: BuiltinData -> PLC.Data
 builtinDataToData (BuiltinData d) = d
 
--- NOT a builtin, only safe off-chain, hence the NOINLINE
-{-# NOINLINE dataToBuiltinData #-}
+-- NOT a builtin, only safe off-chain, hence the OPAQUE
+{-# OPAQUE dataToBuiltinData #-}
 -- | Convert a 'PLC.Data' into a 'BuiltinData'. Only works off-chain.
 dataToBuiltinData :: PLC.Data -> BuiltinData
 dataToBuiltinData = BuiltinData
 
-{-# NOINLINE chooseData #-}
+{-# OPAQUE chooseData #-}
 chooseData :: forall a . BuiltinData -> a -> a -> a -> a -> a -> a
 chooseData (BuiltinData d) constrCase mapCase listCase iCase bCase = case d of
     PLC.Constr{} -> constrCase
@@ -471,60 +471,60 @@ chooseData (BuiltinData d) constrCase mapCase listCase iCase bCase = case d of
     PLC.I{}      -> iCase
     PLC.B{}      -> bCase
 
-{-# NOINLINE mkConstr #-}
+{-# OPAQUE mkConstr #-}
 mkConstr :: BuiltinInteger -> BuiltinList BuiltinData -> BuiltinData
 mkConstr i (BuiltinList args) = BuiltinData (PLC.Constr i (fmap builtinDataToData args))
 
-{-# NOINLINE mkMap #-}
+{-# OPAQUE mkMap #-}
 mkMap :: BuiltinList (BuiltinPair BuiltinData BuiltinData) -> BuiltinData
 mkMap (BuiltinList es) = BuiltinData (PLC.Map (fmap p2p es))
   where
       p2p (BuiltinPair (d, d')) = (builtinDataToData d, builtinDataToData d')
 
-{-# NOINLINE mkList #-}
+{-# OPAQUE mkList #-}
 mkList :: BuiltinList BuiltinData -> BuiltinData
 mkList (BuiltinList l) = BuiltinData (PLC.List (fmap builtinDataToData l))
 
-{-# NOINLINE mkI #-}
+{-# OPAQUE mkI #-}
 mkI :: BuiltinInteger -> BuiltinData
 mkI i = BuiltinData (PLC.I i)
 
-{-# NOINLINE mkB #-}
+{-# OPAQUE mkB #-}
 mkB :: BuiltinByteString -> BuiltinData
 mkB (BuiltinByteString b) = BuiltinData (PLC.B b)
 
-{-# NOINLINE unsafeDataAsConstr #-}
+{-# OPAQUE unsafeDataAsConstr #-}
 unsafeDataAsConstr :: BuiltinData -> BuiltinPair BuiltinInteger (BuiltinList BuiltinData)
 unsafeDataAsConstr (BuiltinData (PLC.Constr i args)) = BuiltinPair (i, BuiltinList $ fmap dataToBuiltinData args)
 unsafeDataAsConstr _                                 = Haskell.error "not a Constr"
 
-{-# NOINLINE unsafeDataAsMap #-}
+{-# OPAQUE unsafeDataAsMap #-}
 unsafeDataAsMap :: BuiltinData -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
 unsafeDataAsMap (BuiltinData (PLC.Map m)) = BuiltinList (fmap p2p m)
   where
       p2p (d, d') = BuiltinPair (dataToBuiltinData d, dataToBuiltinData d')
 unsafeDataAsMap _                         = Haskell.error "not a Map"
 
-{-# NOINLINE unsafeDataAsList #-}
+{-# OPAQUE unsafeDataAsList #-}
 unsafeDataAsList :: BuiltinData -> BuiltinList BuiltinData
 unsafeDataAsList (BuiltinData (PLC.List l)) = BuiltinList (fmap dataToBuiltinData l)
 unsafeDataAsList _                          = Haskell.error "not a List"
 
-{-# NOINLINE unsafeDataAsI #-}
+{-# OPAQUE unsafeDataAsI #-}
 unsafeDataAsI :: BuiltinData -> BuiltinInteger
 unsafeDataAsI (BuiltinData (PLC.I i)) = i
 unsafeDataAsI _                       = Haskell.error "not an I"
 
-{-# NOINLINE unsafeDataAsB #-}
+{-# OPAQUE unsafeDataAsB #-}
 unsafeDataAsB :: BuiltinData -> BuiltinByteString
 unsafeDataAsB (BuiltinData (PLC.B b)) = BuiltinByteString b
 unsafeDataAsB _                       = Haskell.error "not a B"
 
-{-# NOINLINE equalsData #-}
+{-# OPAQUE equalsData #-}
 equalsData :: BuiltinData -> BuiltinData -> BuiltinBool
 equalsData (BuiltinData b1) (BuiltinData b2) = BuiltinBool $ b1 Haskell.== b2
 
-{-# NOINLINE serialiseData #-}
+{-# OPAQUE serialiseData #-}
 serialiseData :: BuiltinData -> BuiltinByteString
 serialiseData (BuiltinData b) = BuiltinByteString $ BSL.toStrict $ serialise b
 
@@ -561,45 +561,45 @@ instance NFData BuiltinBLS12_381_G1_Element where
 instance Pretty BuiltinBLS12_381_G1_Element where
     pretty (BuiltinBLS12_381_G1_Element a) = pretty a
 
-{-# NOINLINE bls12_381_G1_equals #-}
+{-# OPAQUE bls12_381_G1_equals #-}
 bls12_381_G1_equals :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element -> BuiltinBool
 bls12_381_G1_equals a b = BuiltinBool $ coerce ((==) @BuiltinBLS12_381_G1_Element) a b
 
-{-# NOINLINE bls12_381_G1_add #-}
+{-# OPAQUE bls12_381_G1_add #-}
 bls12_381_G1_add :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_add (BuiltinBLS12_381_G1_Element a) (BuiltinBLS12_381_G1_Element b) = BuiltinBLS12_381_G1_Element (BLS12_381.G1.add a b)
 
-{-# NOINLINE bls12_381_G1_neg #-}
+{-# OPAQUE bls12_381_G1_neg #-}
 bls12_381_G1_neg :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_neg (BuiltinBLS12_381_G1_Element a) = BuiltinBLS12_381_G1_Element (BLS12_381.G1.neg a)
 
-{-# NOINLINE bls12_381_G1_scalarMul #-}
+{-# OPAQUE bls12_381_G1_scalarMul #-}
 bls12_381_G1_scalarMul :: BuiltinInteger -> BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_scalarMul n (BuiltinBLS12_381_G1_Element a) = BuiltinBLS12_381_G1_Element (BLS12_381.G1.scalarMul n a)
 
-{-# NOINLINE bls12_381_G1_compress #-}
+{-# OPAQUE bls12_381_G1_compress #-}
 bls12_381_G1_compress :: BuiltinBLS12_381_G1_Element -> BuiltinByteString
 bls12_381_G1_compress (BuiltinBLS12_381_G1_Element a) = BuiltinByteString (BLS12_381.G1.compress a)
 
-{-# NOINLINE bls12_381_G1_uncompress #-}
+{-# OPAQUE bls12_381_G1_uncompress #-}
 bls12_381_G1_uncompress :: BuiltinByteString -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_uncompress (BuiltinByteString b) =
     case BLS12_381.G1.uncompress b of
       Left err -> Haskell.error $ "BSL12_381 G1 uncompression error: " ++ show err
       Right a  -> BuiltinBLS12_381_G1_Element a
 
-{-# NOINLINE bls12_381_G1_hashToGroup #-}
+{-# OPAQUE bls12_381_G1_hashToGroup #-}
 bls12_381_G1_hashToGroup ::  BuiltinByteString -> BuiltinByteString -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_hashToGroup (BuiltinByteString msg) (BuiltinByteString dst) =
     case BLS12_381.G1.hashToGroup msg dst of
       Left err -> Haskell.error $ show err
       Right p  -> BuiltinBLS12_381_G1_Element p
 
-{-# NOINLINE bls12_381_G1_compressed_zero #-}
+{-# OPAQUE bls12_381_G1_compressed_zero #-}
 bls12_381_G1_compressed_zero :: BuiltinByteString
 bls12_381_G1_compressed_zero = BuiltinByteString BLS12_381.G1.compressed_zero
 
-{-# NOINLINE bls12_381_G1_compressed_generator #-}
+{-# OPAQUE bls12_381_G1_compressed_generator #-}
 bls12_381_G1_compressed_generator :: BuiltinByteString
 bls12_381_G1_compressed_generator = BuiltinByteString BLS12_381.G1.compressed_generator
 
@@ -616,45 +616,45 @@ instance NFData BuiltinBLS12_381_G2_Element where
 instance Pretty BuiltinBLS12_381_G2_Element where
     pretty (BuiltinBLS12_381_G2_Element a) = pretty a
 
-{-# NOINLINE bls12_381_G2_equals #-}
+{-# OPAQUE bls12_381_G2_equals #-}
 bls12_381_G2_equals :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBool
 bls12_381_G2_equals a b = BuiltinBool $ coerce ((==) @BuiltinBLS12_381_G2_Element) a b
 
-{-# NOINLINE bls12_381_G2_add #-}
+{-# OPAQUE bls12_381_G2_add #-}
 bls12_381_G2_add :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_add (BuiltinBLS12_381_G2_Element a) (BuiltinBLS12_381_G2_Element b) = BuiltinBLS12_381_G2_Element (BLS12_381.G2.add a b)
 
-{-# NOINLINE bls12_381_G2_neg #-}
+{-# OPAQUE bls12_381_G2_neg #-}
 bls12_381_G2_neg :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_neg (BuiltinBLS12_381_G2_Element a) = BuiltinBLS12_381_G2_Element (BLS12_381.G2.neg a)
 
-{-# NOINLINE bls12_381_G2_scalarMul #-}
+{-# OPAQUE bls12_381_G2_scalarMul #-}
 bls12_381_G2_scalarMul :: BuiltinInteger -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_scalarMul n (BuiltinBLS12_381_G2_Element a) = BuiltinBLS12_381_G2_Element (BLS12_381.G2.scalarMul n a)
 
-{-# NOINLINE bls12_381_G2_compress #-}
+{-# OPAQUE bls12_381_G2_compress #-}
 bls12_381_G2_compress :: BuiltinBLS12_381_G2_Element -> BuiltinByteString
 bls12_381_G2_compress (BuiltinBLS12_381_G2_Element a) = BuiltinByteString (BLS12_381.G2.compress a)
 
-{-# NOINLINE bls12_381_G2_uncompress #-}
+{-# OPAQUE bls12_381_G2_uncompress #-}
 bls12_381_G2_uncompress :: BuiltinByteString -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_uncompress (BuiltinByteString b) =
     case BLS12_381.G2.uncompress b of
       Left err -> Haskell.error $ "BSL12_381 G2 uncompression error: " ++ show err
       Right a  -> BuiltinBLS12_381_G2_Element a
 
-{-# NOINLINE bls12_381_G2_hashToGroup #-}
+{-# OPAQUE bls12_381_G2_hashToGroup #-}
 bls12_381_G2_hashToGroup ::  BuiltinByteString -> BuiltinByteString -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_hashToGroup (BuiltinByteString msg) (BuiltinByteString dst) =
     case BLS12_381.G2.hashToGroup msg dst of
       Left err -> Haskell.error $ show err
       Right p  -> BuiltinBLS12_381_G2_Element p
 
-{-# NOINLINE bls12_381_G2_compressed_zero #-}
+{-# OPAQUE bls12_381_G2_compressed_zero #-}
 bls12_381_G2_compressed_zero :: BuiltinByteString
 bls12_381_G2_compressed_zero = BuiltinByteString BLS12_381.G2.compressed_zero
 
-{-# NOINLINE bls12_381_G2_compressed_generator #-}
+{-# OPAQUE bls12_381_G2_compressed_generator #-}
 bls12_381_G2_compressed_generator :: BuiltinByteString
 bls12_381_G2_compressed_generator = BuiltinByteString BLS12_381.G2.compressed_generator
 
@@ -672,17 +672,17 @@ instance NFData BuiltinBLS12_381_MlResult where
 instance Pretty BuiltinBLS12_381_MlResult where
     pretty (BuiltinBLS12_381_MlResult a) = pretty a
 
-{-# NOINLINE bls12_381_millerLoop #-}
+{-# OPAQUE bls12_381_millerLoop #-}
 bls12_381_millerLoop :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_MlResult
 bls12_381_millerLoop (BuiltinBLS12_381_G1_Element a) (BuiltinBLS12_381_G2_Element b) =
     BuiltinBLS12_381_MlResult $ BLS12_381.Pairing.millerLoop a b
 
-{-# NOINLINE bls12_381_mulMlResult #-}
+{-# OPAQUE bls12_381_mulMlResult #-}
 bls12_381_mulMlResult :: BuiltinBLS12_381_MlResult -> BuiltinBLS12_381_MlResult -> BuiltinBLS12_381_MlResult
 bls12_381_mulMlResult (BuiltinBLS12_381_MlResult a) (BuiltinBLS12_381_MlResult b)
     = BuiltinBLS12_381_MlResult $ BLS12_381.Pairing.mulMlResult a b
 
-{-# NOINLINE bls12_381_finalVerify #-}
+{-# OPAQUE bls12_381_finalVerify #-}
 bls12_381_finalVerify ::  BuiltinBLS12_381_MlResult ->  BuiltinBLS12_381_MlResult -> BuiltinBool
 bls12_381_finalVerify (BuiltinBLS12_381_MlResult a) (BuiltinBLS12_381_MlResult b)
     = BuiltinBool $ BLS12_381.Pairing.finalVerify a b
@@ -691,7 +691,7 @@ bls12_381_finalVerify (BuiltinBLS12_381_MlResult a) (BuiltinBLS12_381_MlResult b
 CONVERSION
 -}
 
-{-# NOINLINE integerToByteString #-}
+{-# OPAQUE integerToByteString #-}
 integerToByteString
     :: BuiltinBool
     -> BuiltinInteger
@@ -704,7 +704,7 @@ integerToByteString (BuiltinBool endiannessArg) paddingArg input =
     BuiltinFailure logs err        -> traceAll (logs <> pure (display err)) $
         Haskell.error "Integer to ByteString conversion errored."
 
-{-# NOINLINE byteStringToInteger #-}
+{-# OPAQUE byteStringToInteger #-}
 byteStringToInteger
     :: BuiltinBool
     -> BuiltinByteString
@@ -716,7 +716,7 @@ byteStringToInteger (BuiltinBool statedEndianness) (BuiltinByteString input) =
 BITWISE
 -}
 
-{-# NOINLINE shiftByteString #-}
+{-# OPAQUE shiftByteString #-}
 shiftByteString ::
   BuiltinByteString ->
   BuiltinInteger ->
@@ -724,7 +724,7 @@ shiftByteString ::
 shiftByteString (BuiltinByteString bs) =
   BuiltinByteString . Bitwise.shiftByteString bs
 
-{-# NOINLINE rotateByteString #-}
+{-# OPAQUE rotateByteString #-}
 rotateByteString ::
   BuiltinByteString ->
   BuiltinInteger ->
@@ -732,13 +732,13 @@ rotateByteString ::
 rotateByteString (BuiltinByteString bs) =
   BuiltinByteString . Bitwise.rotateByteString bs
 
-{-# NOINLINE countSetBits #-}
+{-# OPAQUE countSetBits #-}
 countSetBits ::
   BuiltinByteString ->
   BuiltinInteger
 countSetBits (BuiltinByteString bs) = fromIntegral . Bitwise.countSetBits $ bs
 
-{-# NOINLINE findFirstSetBit #-}
+{-# OPAQUE findFirstSetBit #-}
 findFirstSetBit ::
   BuiltinByteString ->
   BuiltinInteger
@@ -749,7 +749,7 @@ findFirstSetBit (BuiltinByteString bs) =
 LOGICAL
 -}
 
-{-# NOINLINE andByteString #-}
+{-# OPAQUE andByteString #-}
 andByteString ::
   BuiltinBool ->
   BuiltinByteString ->
@@ -758,7 +758,7 @@ andByteString ::
 andByteString (BuiltinBool isPaddingSemantics) (BuiltinByteString data1) (BuiltinByteString data2) =
   BuiltinByteString . Bitwise.andByteString isPaddingSemantics data1 $ data2
 
-{-# NOINLINE orByteString #-}
+{-# OPAQUE orByteString #-}
 orByteString ::
   BuiltinBool ->
   BuiltinByteString ->
@@ -767,7 +767,7 @@ orByteString ::
 orByteString (BuiltinBool isPaddingSemantics) (BuiltinByteString data1) (BuiltinByteString data2) =
   BuiltinByteString . Bitwise.orByteString isPaddingSemantics data1 $ data2
 
-{-# NOINLINE xorByteString #-}
+{-# OPAQUE xorByteString #-}
 xorByteString ::
   BuiltinBool ->
   BuiltinByteString ->
@@ -776,14 +776,14 @@ xorByteString ::
 xorByteString (BuiltinBool isPaddingSemantics) (BuiltinByteString data1) (BuiltinByteString data2) =
   BuiltinByteString . Bitwise.xorByteString isPaddingSemantics data1 $ data2
 
-{-# NOINLINE complementByteString #-}
+{-# OPAQUE complementByteString #-}
 complementByteString ::
   BuiltinByteString ->
   BuiltinByteString
 complementByteString (BuiltinByteString bs) =
   BuiltinByteString . Bitwise.complementByteString $ bs
 
-{-# NOINLINE readBit #-}
+{-# OPAQUE readBit #-}
 readBit ::
   BuiltinByteString ->
   BuiltinInteger ->
@@ -795,7 +795,7 @@ readBit (BuiltinByteString bs) i =
     BuiltinSuccess b -> BuiltinBool b
     BuiltinSuccessWithLogs logs b -> traceAll logs $ BuiltinBool b
 
-{-# NOINLINE writeBits #-}
+{-# OPAQUE writeBits #-}
 writeBits ::
   BuiltinByteString ->
   BuiltinList BuiltinInteger ->
@@ -808,7 +808,7 @@ writeBits (BuiltinByteString bs) (BuiltinList ixes) (BuiltinList bits) =
     BuiltinSuccess bs' -> BuiltinByteString bs'
     BuiltinSuccessWithLogs logs bs' -> traceAll logs $ BuiltinByteString bs'
 
-{-# NOINLINE replicateByte #-}
+{-# OPAQUE replicateByte #-}
 replicateByte ::
   BuiltinInteger ->
   BuiltinInteger ->
@@ -820,7 +820,7 @@ replicateByte n w8 =
     BuiltinSuccess bs -> BuiltinByteString bs
     BuiltinSuccessWithLogs logs bs -> traceAll logs $ BuiltinByteString bs
 
-{-# NOINLINE expModInteger #-}
+{-# OPAQUE expModInteger #-}
 expModInteger ::
   BuiltinInteger ->
   BuiltinInteger ->

--- a/plutus-tx/src/PlutusTx/Plugin/Utils.hs
+++ b/plutus-tx/src/PlutusTx/Plugin/Utils.hs
@@ -24,7 +24,7 @@ a Proxy to avoid this.
 
 -- This needs to be defined here so we can reference it in the TH functions.
 -- If we inline this then we won't be able to find it later!
-{-# NOINLINE plc #-}
+{-# OPAQUE plc #-}
 -- | Marks the given expression for compilation to PLC.
 plc :: forall (loc::Symbol) a . Proxy loc -> a -> CompiledCode a
 -- this constructor is only really there to get rid of the unused warning


### PR DESCRIPTION
This replaces all occurrences of `NOINLINE` with the more reliable `OPAQUE`. However unlike `NOINLINE` `OPAQUE` prevents specialization, so let's benchmark this to make sure there's no unexpected slowdown. 

Resolves #6269.