### PR TITLE
[Refactoring] Tweak 'PlutusTx.Data.AssocMap'

### DIFF
--- a/plutus-tx/src/PlutusTx/Data/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/Data/AssocMap.hs
@@ -209,11 +209,12 @@ safeFromList =
     . toOpaque
     . List.foldr (uncurry go) []
   where
+    go :: k -> a -> [(BuiltinData, BuiltinData)] -> [(BuiltinData, BuiltinData)]
     go k v [] = [(P.toBuiltinData k, P.toBuiltinData v)]
     go k v ((k', v') : rest) =
       if P.toBuiltinData k == k'
         then (P.toBuiltinData k, P.toBuiltinData v) : go k v rest
-        else (P.toBuiltinData k', P.toBuiltinData v') : go k v rest
+        else (k', v') : go k v rest
 
 {-# INLINEABLE unsafeFromList #-}
 -- | Unsafely create an 'Map' from a list of pairs.
@@ -238,7 +239,7 @@ noDuplicateKeys (Map m) = go m
         (\() -> True)
         ( \hd tl ->
             let k = BI.fst hd
-             in if member k (Map tl) then False else go tl
+             in if member' k tl then False else go tl
         )
 
 {-# INLINEABLE all #-}


### PR DESCRIPTION
I was looking into what relies upon these instances

```haskell
instance ToData BuiltinData where
    {-# INLINABLE toBuiltinData #-}
    toBuiltinData = id
instance FromData BuiltinData where
    {-# INLINABLE fromBuiltinData #-}
    fromBuiltinData d = Just d
instance UnsafeFromData BuiltinData where
    {-# INLINABLE unsafeFromBuiltinData #-}
    unsafeFromBuiltinData d = d
```

existing and a few things in `PlutusTx.Data.AssocMap` popped up, but none of them actually needs to rely on the instance, so I tweaked the code a bit.