### PR TITLE
[Builtins] Make all builtins strict

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -302,7 +302,7 @@ instance
         -- exception at any stage, that would be a bug regardless.
         toMonoF @val @args @res $! do
             (f, exF) <- getBoth
-            x <- readKnown arg
+            !x <- readKnown arg
             -- See Note [Strict application in runtime denotations].
             let !exY = exF x
             pure (f x, exY)


### PR DESCRIPTION
I was investigating a weird behavior of a test and this is where it led me to. This PR is gonna be blocked by broken benchmarking though, but we really should make builtins strict, because laziness only reduces the quality of tests.