### PR TITLE
[Builtins] Disable 'writeBits' for chang+1

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
@@ -122,12 +122,12 @@ builtinsIntroducedIn = Map.fromList [
           ]),
   ((PlutusV3, changPlus1PV), Set.fromList [
           AndByteString, OrByteString, XorByteString, ComplementByteString,
-          ReadBit, WriteBits, ReplicateByte,
+          ReadBit, ReplicateByte,
           ShiftByteString, RotateByteString, CountSetBits, FindFirstSetBit,
           Ripemd_160
           ]),
   ((PlutusV3, futurePV), Set.fromList [
-          ExpModInteger
+          WriteBits, ExpModInteger
           ])
   ]
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
@@ -288,10 +288,6 @@ data ParamName =
   | ComplementByteString'memory'arguments'slope
   | ReadBit'cpu'arguments
   | ReadBit'memory'arguments
-  | WriteBits'cpu'arguments'intercept
-  | WriteBits'cpu'arguments'slope
-  | WriteBits'memory'arguments'intercept
-  | WriteBits'memory'arguments'slope
   | ReplicateByte'cpu'arguments'intercept
   | ReplicateByte'cpu'arguments'slope
   | ReplicateByte'memory'arguments'intercept
@@ -315,6 +311,10 @@ data ParamName =
   | Ripemd_160'memory'arguments
 
 --  not enabled yet:
+--    WriteBits'cpu'arguments'intercept
+--    WriteBits'cpu'arguments'slope
+--    WriteBits'memory'arguments'intercept
+--    WriteBits'memory'arguments'slope
 --    ExpModInteger'cpu'arguments
 --    ExpModInteger'memory'arguments
     deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)

--- a/plutus-ledger-api/test/Spec/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/CostModelParams.hs
@@ -28,7 +28,7 @@ tests =
     [ testCase "length" $ do
             166 @=? length v1_ParamNames
             185 @=? length v2_ParamNames
-            297 @=? length v3_ParamNames
+            293 @=? length v3_ParamNames
     , testCase "tripping paramname" $ do
             for_ v1_ParamNames $ \ p ->
                 assertBool "tripping v1 cm params failed" $ Just p == readParamName (showParamName p)

--- a/plutus-ledger-api/test/Spec/Data/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/Data/CostModelParams.hs
@@ -26,7 +26,7 @@ tests =
     [ testCase "length" $ do
             166 @=? length v1_ParamNames
             185 @=? length v2_ParamNames
-            297 @=? length v3_ParamNames
+            293 @=? length v3_ParamNames
     , testCase "tripping paramname" $ do
             for_ v1_ParamNames $ \ p ->
                 assertBool "tripping v1 cm params failed" $ Just p == readParamName (showParamName p)

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/Data/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/Data/EvaluationContext.hs
@@ -76,13 +76,13 @@ clearBuiltinCostModel r = r
                , paramXorByteString = mempty
                , paramComplementByteString = mempty
                , paramReadBit = mempty
-               , paramWriteBits = mempty
                , paramReplicateByte = mempty
                , paramShiftByteString = mempty
                , paramRotateByteString = mempty
                , paramCountSetBits = mempty
                , paramFindFirstSetBit = mempty
                , paramRipemd_160 = mempty
+               , paramWriteBits = mempty
                , paramExpModInteger = mempty
                }
 
@@ -93,5 +93,6 @@ clearBuiltinCostModel' :: (m ~ MBuiltinCostModel) => m -> m
 clearBuiltinCostModel' r = r
                { -- , paramIntegerToByteString = mempty -- Required for V2
                -- , paramByteStringToInteger = mempty -- Required for V2
-                 paramExpModInteger = mempty
+                 paramWriteBits = mempty
+               , paramExpModInteger = mempty
                }

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
@@ -77,13 +77,13 @@ clearBuiltinCostModel r = r
                , paramXorByteString = mempty
                , paramComplementByteString = mempty
                , paramReadBit = mempty
-               , paramWriteBits = mempty
                , paramReplicateByte = mempty
                , paramShiftByteString = mempty
                , paramRotateByteString = mempty
                , paramCountSetBits = mempty
                , paramFindFirstSetBit = mempty
                , paramRipemd_160 = mempty
+               , paramWriteBits = mempty
                , paramExpModInteger = mempty
                }
 
@@ -94,5 +94,6 @@ clearBuiltinCostModel' :: (m ~ MBuiltinCostModel) => m -> m
 clearBuiltinCostModel' r = r
                { -- , paramIntegerToByteString = mempty -- Required for V2
                -- , paramByteStringToInteger = mempty -- Required for V2
-                 paramExpModInteger = mempty
+                 paramWriteBits = mempty
+               , paramExpModInteger = mempty
                }


### PR DESCRIPTION
This disables `writeBits` for chang+1, so that we have more time to fix it as per #6528.

I've checked that the neither `plutus-core` nor `plutus-ledger-api` mention `writeBits` in their changelogs.