### PR TITLE
[Test] Get the seed in 'noStructuralErrors'

### DIFF
--- a/plutus-core/plutus-ir/test/PlutusIR/Generators/QuickCheck/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Generators/QuickCheck/Tests.hs
@@ -210,7 +210,8 @@ noStructuralErrors term =
 prop_noStructuralErrors :: Property
 prop_noStructuralErrors = withMaxSuccess 99 $
   forAllDoc "ty,tm" genTypeAndTerm_ shrinkClosedTypedTerm $ \(_, termPir) -> ioProperty $ do
-    termUPlc <- fmap UPLC._progTerm . modifyError throw . toUPlc $ Program () latestVersion termPir
+    termUPlc <- fmap UPLC._progTerm . modifyError (userError . displayException) . toUPlc $
+        Program () latestVersion termPir
     noStructuralErrors termUPlc
 
 -- | Test that evaluation of an ill-typed terms fails with a structural error.


### PR DESCRIPTION
Copying a Slack comment:

Apparently with `QuickCheck` you can throw exceptions in `IO` and of type `IO smth`, but what you can't do is throw an exception of type `IOException`, i.e. you can't throw an exception while you're throwing an exception, because in that case you won't get a seed. It is of course entirely accidental that we throw an exception while throwing an exception, but I didn't expect that to break `QuickCheck`. 