### PR TITLE
Fix latex errors in old specification

### DIFF
--- a/doc/plutus-core-spec-old/figures/TypedCkMachine.tex
+++ b/doc/plutus-core-spec-old/figures/TypedCkMachine.tex
@@ -15,7 +15,7 @@
                        &        &     & \ckerror{}      & \textrm{throw an error}
     \end{array}\]
 
-    \captionof{figure}{Grammar of CK machine states}
+    \caption{Grammar of CK machine states}
     \label{fig:typed-ck-frames}
 \end{subfigure}
 

--- a/doc/plutus-core-spec-old/figures/UntypedCekMachine.tex
+++ b/doc/plutus-core-spec-old/figures/UntypedCekMachine.tex
@@ -13,7 +13,7 @@
         \textrm{State} & \sigma & ::= & s;\rho \compute M \enspace | \enspace s;\rho \return V  \enspace | \enspace \ckerror{} \enspace | \enspace \square (V,\rho)\\
     \end{array}\]
 
-    \captionof{figure}{Grammar of CEK machine states for type-erased Plutus Core}
+    \caption{Grammar of CEK machine states for type-erased Plutus Core}
     \label{fig:untyped-cek-frames}
 \end{subfigure}
 \begin{subfigure}[c]{\linewidth}

--- a/doc/plutus-core-spec-old/figures/UntypedCkMachine.tex
+++ b/doc/plutus-core-spec-old/figures/UntypedCkMachine.tex
@@ -15,7 +15,7 @@
                        &        &     & \ckerror{}     & \textrm{throw an error}
     \end{array}\]
 
-    \captionof{figure}{Grammar of CK machine states for type-erased Plutus Core}
+    \caption{Grammar of CK machine states for type-erased Plutus Core}
     \label{fig:untyped-ck-frames}
 \end{subfigure}
 \caption{A CK machine for type-erased Plutus Core}

--- a/doc/plutus-core-spec/README.md
+++ b/doc/plutus-core-spec/README.md
@@ -1,10 +1,10 @@
 This directory contains a draft of a version of the Plutus Core specification
 updated so that the language is parametric over a collection of built-in types
 and functions.  It also updates the specification to reflect the fact that
-built-in functions can now be partially applied.  ~Click
+built-in functions can now be partially applied.  Click
 [here](https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf)
 to open a PDF of the most recent version of the specification in the main branch
-of this repository.~  The link given in the previous sentence currently appears to be broken: would-be readers should build the PDF themselves.  On a Linux system, `make` in the main source directory should do this.
+of this repository.
 
 This version is currently restricted to untyped Plutus Core only. We will add a
 specification of a typed version of Plutus Core at a later date.  For the time

--- a/nix/latex-documents.nix
+++ b/nix/latex-documents.nix
@@ -46,11 +46,11 @@ let
       description = "Multi-currency paper";
     };
 
-    # plutus-core-spec-old = build-latex-doc {
-    #   name = "plutus-core-spec-old";
-    #   description = "Plutus core specification (old version)";
-    #   src = inputs.self + /doc/plutus-core-spec-old;
-    # };
+    plutus-core-spec-old = build-latex-doc {
+      name = "plutus-core-spec-old";
+      description = "Plutus core specification (old version)";
+      src = inputs.self + /doc/plutus-core-spec-old;
+    };
 
     plutus-core-spec = build-latex-doc {
       name = "plutus-core-spec";


### PR DESCRIPTION
A change in some package caused `\captionof` to stop working inside subfigures (I think) in the old version of the specification.  This replaces the problematic uses with `\caption`:  it doesn't seem to make any significant difference to the PDF apart from maybe some changes in spacing.  I also restored a link to the PDF of the new specification in a README file.