### PR TITLE
Remove extra-doc-files:README.md from plutus-executables.cabal

### DIFF
--- a/plutus-executables/plutus-executables.cabal
+++ b/plutus-executables/plutus-executables.cabal
@@ -12,9 +12,7 @@ author:          Plutus Core Team
 maintainer:      ana.pantilie@iohk.io
 category:        Development
 build-type:      Simple
-extra-doc-files:
-  CHANGELOG.md
-  README.md
+extra-doc-files: CHANGELOG.md
 
 source-repository head
   type:     git


### PR DESCRIPTION
This file does not exist and causes `cabal haddock` to fail.