### PR TITLE
Swap cases for availability of taskset

### DIFF
--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -66,9 +66,9 @@ echo "[ci-plutus-benchmark]: Clearing caches with cabal clean ..."
 cabal clean
 
 if [[ -z $(which taskset) ]]; then
-   TASKSET="taskset -c $CAPABILITY_NUM"
-else
    TASKSET=""
+else
+   TASKSET="taskset -c $CAPABILITY_NUM"
 fi
 
 echo "[ci-plutus-benchmark]: Running benchmark for PR branch at $PR_BRANCH_REF ..."


### PR DESCRIPTION
I think the cases for what to do when `taskset` is/isn't available were the wrong way round in #6646.  This swaps them around.