### PR TITLE
add `MINIMAL` pragma to ord

### DIFF
--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
@@ -13,6 +13,7 @@
 {-# OPTIONS_GHC -fno-warn-name-shadowing      #-}
 {-# OPTIONS_GHC -fno-warn-orphans             #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches      #-}
+{-# OPTIONS_GHC -Wno-missing-methods #-}
 
 module PlutusBenchmark.NoFib.Queens where
 
@@ -203,7 +204,6 @@ instance TxPrelude.Eq Assign
     where (a := b) == (a' := b') = a==a' && b==b'
 instance TxPrelude.Ord Assign
     where (a := b) < (a' := b') = (a<a') || (a==a' && b < b')
-          (a := b) <= (a' := b') = (a<a') || (a==a' && b <= b')
 
 type Relation = Assign -> Assign -> Bool
 

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
@@ -203,6 +203,7 @@ instance TxPrelude.Eq Assign
     where (a := b) == (a' := b') = a==a' && b==b'
 instance TxPrelude.Ord Assign
     where (a := b) < (a' := b') = (a<a') || (a==a' && b < b')
+          (a := b) <= (a' := b') = (a<a') || (a==a' && b <= b')
 
 type Relation = Assign -> Assign -> Bool
 

--- a/plutus-tx/src/PlutusTx/Ord.hs
+++ b/plutus-tx/src/PlutusTx/Ord.hs
@@ -52,6 +52,7 @@ class Eq a => Ord a where
     max x y = if x <= y then y else x
     {-# INLINABLE min #-}
     min x y = if x <= y then x else y
+    {-# MINIMAL compare | (<=) #-}
 
 instance Eq Ordering where
     {-# INLINABLE (==) #-}


### PR DESCRIPTION
addresses #6270 
- [x] fix `PlutusTx.Ord`
- [x] check the existence of other minimal pragmas where such applies
  - [x] get the list of all Type Classes in plinth
       `git grep -e "^class .* where" -- **/*.hs`
  - [x] get the list of Type Classes where the pragma needs to be added.
- [x] [fix commit signing](https://github.com/aleeusgr/nix-things/issues/88) 

## Background
[`Ord`](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-Ord.html) is a type class that defines a total ordering for types. 

A pragma is a special instruction or directive that provides additional information to the compiler, allowing for optimizations or modifications in how the code is processed. Pragmas are denoted by the syntax `{-# ... #-}`, and they do not generally affect the semantic meaning of the program, but they can influence performance and behavior during compilation.

the `MINIMAL` pragma is used to specify the minimal complete definition of a type class, indicating which methods must be implemented for an instance of that class. This is particularly useful for classes that have methods with circular defaults, ensuring that instances adhere to a defined interface. 

https://downloads.haskell.org/~ghc/7.8.1/docs/html/users_guide/pragmas.html

[`base`](https://hackage.haskell.org/package/base)

## Checklist
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
