### PR TITLE
add explicit type application on bls operations for G1/G2

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G1.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G1.hs
@@ -76,19 +76,19 @@ instance Hashable Element where
 -- | Add two G1 group elements
 {-# INLINE add #-}
 add :: Element -> Element -> Element
-add = coerce BlstBindings.blsAddOrDouble
+add = coerce (BlstBindings.blsAddOrDouble @BlstBindings.Curve1)
 
 -- | Negate a G1 group element
 {-# INLINE neg #-}
 neg :: Element -> Element
-neg = coerce BlstBindings.blsNeg
+neg = coerce (BlstBindings.blsNeg @BlstBindings.Curve1)
 
 -- | Multiplication of group elements by scalars. In the blst library the
 -- arguments are the other way round, but scalars acting on the left is more
 -- consistent with standard mathematical practice.
 {-# INLINE scalarMul #-}
 scalarMul :: Integer -> Element -> Element
-scalarMul = coerce $ flip BlstBindings.blsMult
+scalarMul = coerce $ flip (BlstBindings.blsMult @BlstBindings.Curve1)
 
 {- | Compress a G1 element to a bytestring. This serialises a curve point to its
  x coordinate only.  The compressed bytestring is 48 bytes long, with three
@@ -99,7 +99,7 @@ scalarMul = coerce $ flip BlstBindings.blsMult
 -}
 {-# INLINE compress #-}
 compress :: Element -> ByteString
-compress = coerce BlstBindings.blsCompress
+compress = coerce (BlstBindings.blsCompress @BlstBindings.Curve1)
 
 {- | Uncompress a bytestring to get a G1 point.  This will fail if any of the
    following are true.
@@ -112,7 +112,7 @@ compress = coerce BlstBindings.blsCompress
 -}
 {-# INLINE uncompress #-}
 uncompress :: ByteString -> Either BlstBindings.BLSTError Element
-uncompress = coerce BlstBindings.blsUncompress
+uncompress = coerce (BlstBindings.blsUncompress @BlstBindings.Curve1)
 
 {-  Note [Hashing and Domain Separation Tags].  The hashToGroup functions take a
    bytestring and hash it to obtain an element in the relevant group, as
@@ -143,23 +143,23 @@ hashToGroup :: ByteString -> ByteString -> Either BLS12_381_Error Element
 hashToGroup msg dst =
     if Data.ByteString.length dst > 255
     then Left HashToCurveDstTooBig
-    else Right . Element $ BlstBindings.blsHash msg (Just dst) Nothing
+    else Right . Element $ BlstBindings.blsHash @BlstBindings.Curve1 msg (Just dst) Nothing
 
 -- | The zero element of G1.  This cannot be flat-serialised and is provided
 -- only for off-chain testing.
 offchain_zero :: Element
-offchain_zero = coerce BlstBindings.Internal.blsZero
+offchain_zero = coerce (BlstBindings.Internal.blsZero @BlstBindings.Curve1)
 
 -- | The zero element of G1 compressed into a bytestring.  This is provided for
 -- convenience in PlutusTx and is not exported as a builtin.
 {-# INLINABLE compressed_zero #-}
 compressed_zero :: ByteString
-compressed_zero = compress $ coerce BlstBindings.Internal.blsZero
+compressed_zero = compress $ coerce (BlstBindings.Internal.blsZero @BlstBindings.Curve1)
 
 -- | The standard generator of G1 compressed into a bytestring.  This is
 -- provided for convenience in PlutusTx and is not exported as a builtin.
 compressed_generator :: ByteString
-compressed_generator = compress $ coerce BlstBindings.Internal.blsGenerator
+compressed_generator = compress $ coerce (BlstBindings.Internal.blsGenerator @BlstBindings.Curve1)
 
 -- Utilities (not exposed as builtins)
 

--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G2.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G2.hs
@@ -62,16 +62,16 @@ instance Hashable Element where
 -- | Add two G2 group elements
 {-# INLINE add #-}
 add :: Element -> Element -> Element
-add = coerce BlstBindings.blsAddOrDouble
+add = coerce (BlstBindings.blsAddOrDouble @BlstBindings.Curve2)
 
 -- | Negate a G2 group element
 {-# INLINE neg #-}
 neg :: Element -> Element
-neg = coerce BlstBindings.blsNeg
+neg = coerce (BlstBindings.blsNeg @BlstBindings.Curve2)
 
 {-# INLINE scalarMul #-}
 scalarMul :: Integer -> Element -> Element -- Other way round from library function
-scalarMul = coerce $ flip BlstBindings.blsMult
+scalarMul = coerce $ flip (BlstBindings.blsMult @BlstBindings.Curve2)
 
 {- | Compress a G2 element to a bytestring. This serialises a curve point to its x
  coordinate only, using an extra bit to determine which of two possible y
@@ -80,7 +80,7 @@ scalarMul = coerce $ flip BlstBindings.blsMult
 -}
 {-# INLINE compress #-}
 compress :: Element -> ByteString
-compress = coerce BlstBindings.blsCompress
+compress = coerce (BlstBindings.blsCompress @BlstBindings.Curve2)
 
 {- | Uncompress a bytestring to get a G2 point.  This will fail if any of the
    following are true:
@@ -93,7 +93,7 @@ compress = coerce BlstBindings.blsCompress
 -}
 {-# INLINE uncompress #-}
 uncompress :: ByteString -> Either BlstBindings.BLSTError Element
-uncompress = coerce BlstBindings.blsUncompress
+uncompress = coerce (BlstBindings.blsUncompress @BlstBindings.Curve2)
 
 -- Take an arbitrary bytestring and a Domain Separation Tag and hash them to a
 -- get point in G2.  See Note [Hashing and Domain Separation Tags].
@@ -101,22 +101,22 @@ hashToGroup :: ByteString -> ByteString -> Either BLS12_381_Error Element
 hashToGroup msg dst =
     if Data.ByteString.length dst > 255
     then Left HashToCurveDstTooBig
-    else Right . Element $ BlstBindings.blsHash msg (Just dst) Nothing
+    else Right . Element $ BlstBindings.blsHash @BlstBindings.Curve2 msg (Just dst) Nothing
 
 -- | The zero element of G2.  This cannot be flat-serialised and is provided
 -- only for off-chain testing.
 offchain_zero :: Element
-offchain_zero = coerce BlstBindings.Internal.blsZero
+offchain_zero = coerce (BlstBindings.Internal.blsZero @BlstBindings.Curve2)
 
 -- | The zero element of G2 compressed into a bytestring.  This is provided for
 -- convenience in PlutusTx and is not exported as a builtin.
 compressed_zero :: ByteString
-compressed_zero = compress $ coerce BlstBindings.Internal.blsZero
+compressed_zero = compress $ coerce (BlstBindings.Internal.blsZero @BlstBindings.Curve2)
 
 -- | The standard generator of G2 compressed into a bytestring.  This is
 -- provided for convenience in PlutusTx and is not exported as a builtin.
 compressed_generator :: ByteString
-compressed_generator = compress $ coerce BlstBindings.Internal.blsGenerator
+compressed_generator = compress $ coerce (BlstBindings.Internal.blsGenerator @BlstBindings.Curve2)
 
 -- Utilities (not exposed as builtins)
 


### PR DESCRIPTION
Hi team,

This simple PR makes the type applications for functions involving G1 and G2 explicit. The change is necessary due to a recent update in cardano-base ([PR #509](https://github.com/IntersectMBO/cardano-base/pull/509)), where internal constructors were exposed. Without this adjustment, plutus-core encounters issues when interacting with these updated types. More explicitly, it will throw for example
```bash
plutus-core/src/PlutusCore/Crypto/BLS12_381/G1.hs:162:42: error: [GHC-39999]
    • Ambiguous type variable ‘curve4’ arising from a use of ‘BlstBindings.Internal.blsGenerator’
      prevents the constraint ‘(BlstBindings.Internal.BLS
                                  curve4)’ from being solved.
      Probable fix: use a type annotation to specify what ‘curve4’ should be.
      Potentially matching instances:
        instance BlstBindings.Internal.BLS BlstBindings.Internal.Curve1
          -- Defined in ‘Cardano.Crypto.EllipticCurve.BLS12_381.Internal’
        instance BlstBindings.Internal.BLS BlstBindings.Internal.Curve2
          -- Defined in ‘Cardano.Crypto.EllipticCurve.BLS12_381.Internal’
    • In the first argument of ‘coerce’, namely
        ‘BlstBindings.Internal.blsGenerator’
      In the second argument of ‘($)’, namely
        ‘coerce BlstBindings.Internal.blsGenerator’
      In the expression:
        compress $ coerce BlstBindings.Internal.blsGenerator
    |
162 | compressed_generator = compress $ coerce BlstBindings.Internal.blsGenerator
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
if you add the srp
```
source-repository-package
  type: git
  location: https://github.com/intersectmbo/cardano-base
  tag: 97a3b8b76c8f6cc0021e1cef2806962f44d7a685
  --sha256: sha256-ZoFBF+Q/cqkwP2PcFqYgBhT6hoLlrDBzwMMDKVjDSf8=
  subdir:
    cardano-crypto-class
    cardano-mempool
```

This modification is particularly important for the haskell-accumulator package ([defined here](https://github.com/cardano-scaling/haskell-accumulator/blob/86d7bb20ab529878212191b766774e972297d4a9/cabal.project#L27)). This package relies on plutus while also utilizing the lower-level bls12-381 types, and the explicit type applications ensure compatibility across dependencies.

Thank you for reviewing!