### PR TITLE
Refactor: reduce code duplication and make more uniform how plugin looks up GHC things (Names, Ids, etc.)

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -43,7 +43,6 @@ import PlutusCore.Quote
 import PlutusCore.StdLib.Data.Pair qualified as PLC
 
 import GHC.Plugins qualified as GHC
-import GHC.Types.TyThing qualified as GHC
 
 import Language.Haskell.TH.Syntax qualified as TH
 
@@ -300,7 +299,7 @@ builtinNames = [
 
 defineBuiltinTerm :: CompilingDefault uni fun m ann => Ann -> TH.Name -> PIRTerm uni fun -> m ()
 defineBuiltinTerm ann name term = do
-    ghcId <- GHC.tyThingId <$> getThing name
+    ghcId <- lookupGhcId name
     var <- compileVarFresh ann ghcId
     binfo <- asks ccBuiltinsInfo
     -- See Note [Builtin terms and values]
@@ -311,7 +310,7 @@ defineBuiltinTerm ann name term = do
 -- | Add definitions for all the builtin types to the environment.
 defineBuiltinType :: forall uni fun m ann. Compiling uni fun m ann => TH.Name -> PIRType uni -> m ()
 defineBuiltinType name ty = do
-    tc <- GHC.tyThingTyCon <$> getThing name
+    tc <- lookupGhcTyCon name
     var <- compileTcTyVarFresh tc
     PIR.defineType (LexName $ GHC.getName tc) (PIR.Def var ty) mempty
     -- these are all aliases for now
@@ -613,7 +612,7 @@ defineBuiltinTypes = do
 -- | Lookup a builtin term by its TH name. These are assumed to be present, so fails if it cannot find it.
 lookupBuiltinTerm :: Compiling uni fun m ann => TH.Name -> m (PIRTerm uni fun)
 lookupBuiltinTerm name = do
-    ghcName <- GHC.getName <$> getThing name
+    ghcName <- lookupGhcName name
     maybeTerm <- PIR.lookupTerm annMayInline (LexName ghcName)
     case maybeTerm of
         Just t  -> pure t
@@ -622,7 +621,7 @@ lookupBuiltinTerm name = do
 -- | Lookup a builtin type by its TH name. These are assumed to be present, so fails if it is cannot find it.
 lookupBuiltinType :: Compiling uni fun m ann => TH.Name -> m (PIRType uni)
 lookupBuiltinType name = do
-    ghcName <- GHC.getName <$> getThing name
+    ghcName <- lookupGhcName name
     maybeType <- PIR.lookupType annMayInline (LexName ghcName)
     case maybeType of
         Just t  -> pure t

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -698,11 +698,27 @@ entryExitTracing lamName displayName e ty =
    when boolean coverage is turned on.
 
    The annotation `<expr evaluated to True>` is implemented by adding a `CoverBool location True`
-   coverage annotation with the head function in `expr` as metadata. This means that in an expression
-   like:
-   `foo x < bar y && all isGood xs`
-   We will get annotations for `&&`, `<`, `all`, and `isGood` (given that `isGood` is defined in a module
-   with coverage turned on).
+   coverage annotation with the head function in `expr` as metadata. This means that in an
+   expression like: `foo x < bar y && all isGood xs`
+
+   We will get annotations for `&&`, `<`, `all`, and `isGood` (given that `isGood` is defined in a
+   module with coverage turned on).
+-}
+
+{- Note [GHC.Magic.noinline]
+   For some functions we have two conflicting desires:
+   - We want to have the unfolding available for the plugin.
+   - We don't want the function to *actually* get inlined before the plugin runs, since we rely
+   on being able to see the original function for some reason.
+
+   'INLINABLE' achieves the first, but may cause the function to be inlined too soon.
+
+   We can solve this at specific call sites by using the 'noinline' magic function from
+   GHC. This stops GHC from inlining it. As a bonus, it also won't be inlined if
+   that function is compiled later into the body of another function.
+
+   We do therefore need to handle 'noinline' in the plugin, as it itself does not have
+   an unfolding.
 -}
 
 compileExpr ::

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -30,7 +30,6 @@ import GHC.Plugins qualified as GHC
 import GHC.Types.CostCentre qualified as GHC
 import GHC.Types.Id.Make qualified as GHC
 import GHC.Types.Tickish qualified as GHC
-import GHC.Types.TyThing qualified as GHC
 
 #if MIN_VERSION_ghc(9,6,0)
 import GHC.Tc.Utils.TcType qualified as GHC
@@ -38,7 +37,7 @@ import GHC.Tc.Utils.TcType qualified as GHC
 
 import PlutusTx.Bool qualified
 import PlutusTx.Builtins qualified as Builtins
-import PlutusTx.Builtins.Internal qualified as Builtins
+import PlutusTx.Builtins.Internal qualified as BI
 import PlutusTx.Compiler.Binders
 import PlutusTx.Compiler.Builtins
 import PlutusTx.Compiler.Error
@@ -721,52 +720,26 @@ entryExitTracing lamName displayName e ty =
    an unfolding.
 -}
 
-compileExpr ::
-  (CompilingDefault uni fun m ann) =>
-  GHC.CoreExpr ->
-  m (PIRTerm uni fun)
+compileExpr :: CompilingDefault uni fun m ann => GHC.CoreExpr -> m (PIRTerm uni fun)
 compileExpr e = traceCompilation 2 ("Compiling expr:" GHC.<+> GHC.ppr e) $ do
   -- See Note [Scopes]
-  CompileContext{ccScope = scope, ccNameInfo = nameInfo, ccModBreaks = maybeModBreaks, ccBuiltinsInfo = binfo} <- ask
-
-  builtinIntegerTyCon <- case Map.lookup ''Builtins.BuiltinInteger nameInfo of
-    Just (GHC.ATyCon builtinInteger) -> pure builtinInteger
-    _                                -> throwPlain $ CompilationError "No info for Integer builtin"
-
-  builtinBoolTyCon <- case Map.lookup ''Builtins.BuiltinBool nameInfo of
-    Just (GHC.ATyCon builtinBool) -> pure builtinBool
-    _                             -> throwPlain $ CompilationError "No info for Bool builtin"
-
-  builtinDataTyCon <- case Map.lookup ''Builtins.BuiltinData nameInfo of
-    Just (GHC.ATyCon builtinData) -> pure builtinData
-    _                             -> throwPlain $ CompilationError "No info for Data builtin"
-
-  builtinPairTyCon <- case Map.lookup ''Builtins.BuiltinPair nameInfo of
-    Just (GHC.ATyCon builtinPair) -> pure builtinPair
-    _                             -> throwPlain $ CompilationError "No info for Pair builtin"
+  CompileContext {ccScope = scope, ccModBreaks = maybeModBreaks, ccBuiltinsInfo = binfo} <- ask
 
   -- TODO: Maybe share this to avoid repeated lookups. Probably cheap, though.
-  (stringTyName, sbsName) <-
-    case
-      ( Map.lookup ''Builtins.BuiltinString nameInfo
-      , Map.lookup 'Builtins.stringToBuiltinString nameInfo
-      ) of
-    (Just t1, Just t2) -> pure (GHC.getName t1, GHC.getName t2)
-    _                  -> throwPlain $ CompilationError "No info for String builtin"
+  builtinIntegerTyCon <- lookupGhcTyCon ''BI.BuiltinInteger
+  builtinBoolTyCon <- lookupGhcTyCon ''BI.BuiltinBool
+  builtinDataTyCon <- lookupGhcTyCon ''Builtins.BuiltinData
+  builtinPairTyCon <- lookupGhcTyCon ''BI.BuiltinPair
+  stringTyName <- lookupGhcName ''Builtins.BuiltinString
+  builtinByteStringTyName <- lookupGhcName ''Builtins.BuiltinByteString
+  sbsName <- lookupGhcName 'Builtins.stringToBuiltinString
+  sbbsName <- lookupGhcName 'Builtins.stringToBuiltinByteString
+  useToOpaqueName <- lookupGhcName 'Builtins.useToOpaque
+  useFromOpaqueName <- lookupGhcName 'Builtins.useFromOpaque
+  mkNilOpaqueName <- lookupGhcName 'Builtins.mkNilOpaque
+  boolOperatorOr <- lookupGhcName '(PlutusTx.Bool.||)
+  boolOperatorAnd <- lookupGhcName '(PlutusTx.Bool.&&)
 
-  (builtinByteStringTyName, sbbsName) <-
-    case
-      ( Map.lookup ''Builtins.BuiltinByteString nameInfo
-      , Map.lookup 'Builtins.stringToBuiltinByteString nameInfo
-      ) of
-      (Just t1, Just t2) -> pure (GHC.getName t1, GHC.getName t2)
-      _                  -> throwPlain $ CompilationError "No info for ByteString builtin"
-
-  useToOpaqueName <- GHC.getName <$> getThing 'Builtins.useToOpaque
-  useFromOpaqueName <- GHC.getName <$> getThing 'Builtins.useFromOpaque
-  mkNilOpaqueName <- GHC.getName <$> getThing 'Builtins.mkNilOpaque
-  boolOperatorOr <- GHC.getName <$> getThing '(PlutusTx.Bool.||)
-  boolOperatorAnd <- GHC.getName <$> getThing '(PlutusTx.Bool.&&)
   case e of
     {- Note [Lazy boolean operators]
       (||) and (&&) have a special treatment: we want them lazy in the second argument,
@@ -1251,41 +1224,35 @@ coverageCompile originalExpr exprType src compiledTerm covT =
     -- see Note [Boolean coverage]
     BooleanCoverage -> do
       -- Check if the thing we are compiling is a boolean
-      bool <- getThing ''Bool
-      true <- getThing 'True
-      false <- getThing 'False
+      boolName <- lookupGhcName ''Bool
+      trueName <- lookupGhcName 'True
+      falseName <-lookupGhcName 'False
       let tyHeadName = GHC.getName <$> GHC.tyConAppTyCon_maybe exprType
           headSymName = GHC.getName <$> findHeadSymbol originalExpr
           isTrueOrFalse = case originalExpr of
             GHC.Var v
               | GHC.DataConWorkId dc <- GHC.idDetails v ->
-                  GHC.getName dc `elem` [GHC.getName c | c <- [true, false]]
+                  GHC.getName dc `elem` [trueName, falseName]
             _ -> False
 
-      if tyHeadName /= Just (GHC.getName bool) || isTrueOrFalse
+      if tyHeadName /= Just boolName || isTrueOrFalse
         then return compiledTerm
-        else -- Generate the code:
-        -- ```
-        -- traceBool "<compiledTerm was true>" "<compiledTerm was false>" compiledTerm
-        -- ```
-        do
-          traceBoolThing <- getThing 'traceBool
-          case traceBoolThing of
-            GHC.AnId traceBoolId -> do
-              traceBoolCompiled <- compileExpr $ GHC.Var traceBoolId
-              let mkMetadata = CoverageMetadata . foldMap (Set.singleton . ApplicationHeadSymbol . GHC.getOccString)
-              fc <- addBoolCaseToCoverageIndex (toCovLoc src) False (mkMetadata headSymName)
-              tc <- addBoolCaseToCoverageIndex (toCovLoc src) True (mkMetadata headSymName)
-              pure $
-                PLC.mkIterApp traceBoolCompiled $
-                  (annMayInline,)
-                    <$> [ PLC.mkConstant annMayInline (T.pack . show $ tc)
-                        , PLC.mkConstant annMayInline (T.pack . show $ fc)
-                        , compiledTerm
-                        ]
-            _ ->
-              throwSd CompilationError $
-                "Lookup of traceBool failed. Expected to get AnId but saw: " GHC.<+> GHC.ppr traceBoolThing
+        else do
+          -- Generate the code:
+          -- ```
+          -- traceBool "<compiledTerm was true>" "<compiledTerm was false>" compiledTerm
+          -- ```
+          traceBoolCompiled <- compileExpr . GHC.Var =<< lookupGhcId 'traceBool
+          let mkMetadata = CoverageMetadata . foldMap
+                (Set.singleton . ApplicationHeadSymbol . GHC.getOccString)
+          fc <- addBoolCaseToCoverageIndex (toCovLoc src) False (mkMetadata headSymName)
+          tc <- addBoolCaseToCoverageIndex (toCovLoc src) True (mkMetadata headSymName)
+          pure . PLC.mkIterApp traceBoolCompiled $
+            (annMayInline,)
+              <$> [ PLC.mkConstant annMayInline (T.pack . show $ tc)
+                  , PLC.mkConstant annMayInline (T.pack . show $ fc)
+                  , compiledTerm
+                  ]
   where
     findHeadSymbol :: GHC.CoreExpr -> Maybe GHC.Id
     findHeadSymbol (GHC.Var n)    = Just n
@@ -1302,7 +1269,7 @@ coverageCompile originalExpr exprType src compiledTerm covT =
 -- define a PIR term for it: @integerNegate = \x -> 0 - x@.
 defineIntegerNegate :: (CompilingDefault PLC.DefaultUni fun m ann) => m ()
 defineIntegerNegate = do
-  ghcId <- GHC.tyThingId <$> getThing 'GHC.Num.Integer.integerNegate
+  ghcId <- lookupGhcId 'GHC.Num.Integer.integerNegate
   -- Always inline `integerNegate`.
   -- `let integerNegate = \x -> 0 - x in integerNegate 1 + integerNegate 2`
   -- is much more expensive than `(-1) + (-2)`. The inliner cannot currently
@@ -1325,7 +1292,7 @@ defineIntegerNegate = do
 
 lookupIntegerNegate :: (Compiling uni fun m ann) => m (PIRTerm uni fun)
 lookupIntegerNegate = do
-  ghcName <- GHC.getName <$> getThing 'GHC.Num.Integer.integerNegate
+  ghcName <- lookupGhcName 'GHC.Num.Integer.integerNegate
   PIR.lookupTerm annMayInline (LexName ghcName) >>= \case
     Just t -> pure t
     Nothing -> throwPlain $

--- a/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
@@ -25,10 +25,14 @@ import Prelude qualified as Haskell (String)
 import Prelude (type (~))
 #endif
 
+-- plutus-tx-plugin has a special case for this function,
+-- replacing its unfolding with something else.
 stringToBuiltinByteString :: Haskell.String -> BuiltinByteString
 stringToBuiltinByteString str = BuiltinByteString (fromString str)
 {-# OPAQUE stringToBuiltinByteString #-}
 
+-- plutus-tx-plugin has a special case for this function,
+-- replacing its unfolding with something else.
 stringToBuiltinString :: Haskell.String -> BuiltinString
 stringToBuiltinString str = BuiltinString (Text.pack str)
 {-# OPAQUE stringToBuiltinString #-}

--- a/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
@@ -25,23 +25,6 @@ import Prelude qualified as Haskell (String)
 import Prelude (type (~))
 #endif
 
-
-{- Note [GHC.Magic.noinline]
-For some functions we have two conflicting desires:
-- We want to have the unfolding available for the plugin.
-- We don't want the function to *actually* get inlined before the plugin runs, since we rely
-on being able to see the original function for some reason.
-
-'INLINABLE' achieves the first, but may cause the function to be inlined too soon.
-
-We can solve this at specific call sites by using the 'noinline' magic function from
-GHC. This stops GHC from inlining it. As a bonus, it also won't be inlined if
-that function is compiled later into the body of another function.
-
-We do therefore need to handle 'noinline' in the plugin, as it itself does not have
-an unfolding.
--}
-
 stringToBuiltinByteString :: Haskell.String -> BuiltinByteString
 stringToBuiltinByteString str = BuiltinByteString (fromString str)
 {-# OPAQUE stringToBuiltinByteString #-}


### PR DESCRIPTION
Some chores before adding new functionality:

Extracted 3 utility lookup functions:
  1. `lookupGhcId :: Compiling uni fun m ann => TH.Name -> m GHC.Id`
  2. `lookupGhcName :: Compiling uni fun m ann => TH.Name -> m GHC.Name`
  3. `lookupGhcTyCon :: Compiling uni fun m ann => TH.Name -> m GHC.TyCon`
  
and used them uniformly where appropriate. This allowed to reduce some code duplication in `compileExpr`
  