### PR TITLE
Re-format prettyprinter-configurable with Fourmolu

### DIFF
--- a/prettyprinter-configurable/src/Text/Fixity.hs
+++ b/prettyprinter-configurable/src/Text/Fixity.hs
@@ -1,34 +1,34 @@
 -- | Machinery for deciding whether an expression needs to be wrapped in parentheses or not.
-
-module Text.Fixity
-    ( Precedence
-    , Associativity (..)
-    , FixityOver (..)
-    , Fixity
-    , Direction (..)
-    , RenderContextOver (..)
-    , RenderContext
-    , encloseIn
-    , botFixity
-    , juxtFixity
-    , unitFixity
-    , topFixity
-    , botRenderContext
-    , topRenderContext
-    ) where
+module Text.Fixity (
+  Precedence,
+  Associativity (..),
+  FixityOver (..),
+  Fixity,
+  Direction (..),
+  RenderContextOver (..),
+  RenderContext,
+  encloseIn,
+  botFixity,
+  juxtFixity,
+  unitFixity,
+  topFixity,
+  botRenderContext,
+  topRenderContext,
+) where
 
 import Text.Fixity.Internal
 
--- | Fractional precedence, so that it's always possible to squeeze an operator precedence between
--- two existing precedences. Ranges over @[-20, 120]@. A normal operator should have a precedence
--- within @[0, 100)@. It might be useful to have a negative precedence if you're trying to model
--- some already existing system, for example in Haskell @($)@ has precedence @0@, but clearly
--- @if b then y else f $ x@ should be rendered without any parens, hence the precedence of
--- @if_then_else_@ is less than 0, i.e. negative.
---
--- The precedence of juxtaposition is @100@. Normally you want juxtaposition to have the highest
--- precedence, but some languages have operators that bind tighter than juxtaposition, e.g.
--- Haskell's postfix @_{_}@: @f z { x = y }@ means @f (z {x = y})@.
+{-| Fractional precedence, so that it's always possible to squeeze an operator precedence between
+two existing precedences. Ranges over @[-20, 120]@. A normal operator should have a precedence
+within @[0, 100)@. It might be useful to have a negative precedence if you're trying to model
+some already existing system, for example in Haskell @($)@ has precedence @0@, but clearly
+@if b then y else f $ x@ should be rendered without any parens, hence the precedence of
+@if_then_else_@ is less than 0, i.e. negative.
+
+The precedence of juxtaposition is @100@. Normally you want juxtaposition to have the highest
+precedence, but some languages have operators that bind tighter than juxtaposition, e.g.
+Haskell's postfix @_{_}@: @f z { x = y }@ means @f (z {x = y})@.
+-}
 type Precedence = Double
 
 -- | 'FixityOver' instantiated at 'Precedence'.
@@ -37,8 +37,9 @@ type Fixity = FixityOver Precedence
 -- | 'FixityOver' instantiated at 'Precedence'.
 type RenderContext = RenderContextOver Precedence
 
--- | A fixity with the lowest precedence.
--- When used as a part of an outer context, never causes addition of parens.
+{-| A fixity with the lowest precedence.
+When used as a part of an outer context, never causes addition of parens.
+-}
 botFixity :: Fixity
 botFixity = Fixity NonAssociative (-20)
 
@@ -46,22 +47,26 @@ botFixity = Fixity NonAssociative (-20)
 juxtFixity :: Fixity
 juxtFixity = Fixity LeftAssociative 100
 
--- | The fixity of a unitary expression which is safe to render
--- without parens in any context.
+{-| The fixity of a unitary expression which is safe to render
+without parens in any context.
+-}
 unitFixity :: Fixity
 unitFixity = Fixity NonAssociative 110
 
--- | A fixity with the highest precedence.
--- When used as a part of an outer context, always causes addition of parens.
+{-| A fixity with the highest precedence.
+When used as a part of an outer context, always causes addition of parens.
+-}
 topFixity :: Fixity
 topFixity = Fixity NonAssociative 120
 
--- | An initial 'RenderContext'.
--- An expression printed in this context never gets enclosed in parens.
+{-| An initial 'RenderContext'.
+An expression printed in this context never gets enclosed in parens.
+-}
 botRenderContext :: RenderContext
 botRenderContext = RenderContext ToTheRight botFixity
 
--- | An initial 'RenderContext'.
--- An expression printed in this context always gets enclosed in parens.
+{-| An initial 'RenderContext'.
+An expression printed in this context always gets enclosed in parens.
+-}
 topRenderContext :: RenderContext
 topRenderContext = RenderContext ToTheRight topFixity

--- a/prettyprinter-configurable/src/Text/Pretty.hs
+++ b/prettyprinter-configurable/src/Text/Pretty.hs
@@ -1,6 +1,6 @@
 -- | A module alias for way too verbose "Prettyprinter".
-module Text.Pretty
-    ( module Export
-    ) where
+module Text.Pretty (
+  module Export,
+) where
 
 import Prettyprinter as Export

--- a/prettyprinter-configurable/src/Text/PrettyBy.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy.hs
@@ -1,20 +1,19 @@
 -- | The main module of the library.
-
-module Text.PrettyBy
-    ( PrettyBy (..)
-    , IgnorePrettyConfig (..)
-    , AttachPrettyConfig (..)
-    , PrettyAny (..)
-    , withAttachPrettyConfig
-    , defaultPrettyFunctorBy
-    , defaultPrettyBifunctorBy
-    , NonDefaultPrettyBy (..)
-    , HasPrettyDefaults
-    , PrettyDefaultBy
-    , Render (..)
-    , display
-    , displayBy
-    ) where
+module Text.PrettyBy (
+  PrettyBy (..),
+  IgnorePrettyConfig (..),
+  AttachPrettyConfig (..),
+  PrettyAny (..),
+  withAttachPrettyConfig,
+  defaultPrettyFunctorBy,
+  defaultPrettyBifunctorBy,
+  NonDefaultPrettyBy (..),
+  HasPrettyDefaults,
+  PrettyDefaultBy,
+  Render (..),
+  display,
+  displayBy,
+) where
 
 import Text.PrettyBy.Default
 import Text.PrettyBy.Internal

--- a/prettyprinter-configurable/src/Text/PrettyBy/Default.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Default.hs
@@ -3,13 +3,12 @@
 {-# LANGUAGE TypeOperators  #-}
 
 -- | Default rendering to string types.
-
-module Text.PrettyBy.Default
-    ( layoutDef
-    , Render (..)
-    , display
-    , displayBy
-    ) where
+module Text.PrettyBy.Default (
+  layoutDef,
+  Render (..),
+  display,
+  displayBy,
+) where
 
 import Text.Pretty
 import Text.PrettyBy.Internal
@@ -25,17 +24,17 @@ layoutDef = layoutSmart defaultLayoutOptions
 
 -- | A class for rendering 'Doc's as string types.
 class Render str where
-    -- | Render a 'Doc' as a string type.
-    render :: Doc ann -> str
+  -- | Render a 'Doc' as a string type.
+  render :: Doc ann -> str
 
-instance a ~ Char => Render [a] where
-    render = renderString . layoutDef
+instance (a ~ Char) => Render [a] where
+  render = renderString . layoutDef
 
 instance Render Strict.Text where
-    render = renderStrict . layoutDef
+  render = renderStrict . layoutDef
 
 instance Render Lazy.Text where
-    render = renderLazy . layoutDef
+  render = renderLazy . layoutDef
 
 -- | Pretty-print and render a value as a string type.
 display :: forall str a. (Pretty a, Render str) => a -> str

--- a/prettyprinter-configurable/src/Text/PrettyBy/Fixity.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Fixity.hs
@@ -8,14 +8,14 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
--- | Configurable precedence-aware pretty-printing.
---
--- Look into @test/Expr.hs@ for an extended example.
+{-| Configurable precedence-aware pretty-printing.
 
-module Text.PrettyBy.Fixity
-    ( module Export
-    , module Text.PrettyBy.Fixity
-    ) where
+Look into @test/Expr.hs@ for an extended example.
+-}
+module Text.PrettyBy.Fixity (
+  module Export,
+  module Text.PrettyBy.Fixity,
+) where
 
 import Text.Fixity as Export
 import Text.Pretty
@@ -29,112 +29,122 @@ import Lens.Micro
 
 -- | A constraint for \"'RenderContext' is a part of @config@\".
 class HasRenderContext config where
-    renderContext :: Lens' config RenderContext
+  renderContext :: Lens' config RenderContext
 
 instance HasRenderContext RenderContext where
-    renderContext = id
+  renderContext = id
 
 -- | A constraint for \"@m@ is a 'Monad' supporting configurable precedence-aware pretty-printing\".
 type MonadPrettyContext config env m = (MonadPretty config env m, HasRenderContext config)
 
 -- | A @newtype@ wrapper around @a@ introduced for its 'HasPrettyConfig' instance.
 newtype Sole a = Sole
-    { unSole :: a
-    }
+  { unSole :: a
+  }
 
--- | It's not possible to have @HasPrettyConfig config config@, because that would mean that every
--- environment is a pretty-printing config on its own, which doesn't make sense. We could have an
--- OVERLAPPABLE instance, but I'd rather not.
+{-| It's not possible to have @HasPrettyConfig config config@, because that would mean that every
+environment is a pretty-printing config on its own, which doesn't make sense. We could have an
+OVERLAPPABLE instance, but I'd rather not.
+-}
 instance HasPrettyConfig (Sole config) config where
-    prettyConfig f (Sole x) = Sole <$> f x
+  prettyConfig f (Sole x) = Sole <$> f x
 
 -- | A monad for precedence-aware pretty-printing.
 newtype InContextM config a = InContextM
-    { unInContextM :: Reader (Sole config) a
-    } deriving newtype (Functor, Applicative, Monad, MonadReader (Sole config))
+  { unInContextM :: Reader (Sole config) a
+  }
+  deriving newtype (Functor, Applicative, Monad, MonadReader (Sole config))
 
 -- | Run 'InContextM' by supplying a @config@.
 runInContextM :: config -> InContextM config a -> a
 runInContextM config (InContextM a) = runReader a $ Sole config
 
--- | Takes a monadic pretty-printer and turns it into one that receives a @config@ explicitly.
--- Useful for defining instances of 'PrettyBy' monadically when writing precedence-aware
--- pretty-printing code (and since all functions below are monadic, it's currenty the only option).
+{-| Takes a monadic pretty-printer and turns it into one that receives a @config@ explicitly.
+Useful for defining instances of 'PrettyBy' monadically when writing precedence-aware
+pretty-printing code (and since all functions below are monadic, it's currenty the only option).
+-}
 inContextM :: (a -> InContextM config (Doc ann)) -> config -> a -> Doc ann
 inContextM pM config = runInContextM config . pM
 
 -- | A string written in the 'InContextM' monad gets enclosed with 'unitDocM' automatically.
 instance (HasRenderContext config, doc ~ Doc ann) => IsString (InContextM config doc) where
-    fromString = unitDocM . fromString
+  fromString = unitDocM . fromString
 
 -- TODO: when writing a precedence-aware pretty-printer we basically always want to specify a
 -- fixity in each clause. Would be nice to enforce that in types.
--- | Enclose a 'Doc' in parentheses if required or leave it as is. The need for enclosing is
--- determined from an outer 'RenderContext' (stored in the environment of the monad) and the inner
--- fixity provided as an argument.
-encloseM :: MonadPrettyContext config env m => Fixity -> Doc ann -> m (Doc ann)
+
+{-| Enclose a 'Doc' in parentheses if required or leave it as is. The need for enclosing is
+determined from an outer 'RenderContext' (stored in the environment of the monad) and the inner
+fixity provided as an argument.
+-}
+encloseM :: (MonadPrettyContext config env m) => Fixity -> Doc ann -> m (Doc ann)
 encloseM fixity doc =
-    view (prettyConfig . renderContext) <&> \context ->
-        encloseIn parens context fixity doc
+  view (prettyConfig . renderContext) <&> \context ->
+    encloseIn parens context fixity doc
 
 -- | The type of a general @config@-based pretty-printer.
-type AnyToDoc config ann = forall a. PrettyBy config a => a -> Doc ann
+type AnyToDoc config ann = forall a. (PrettyBy config a) => a -> Doc ann
 
 -- | Instantiate a supplied continuation with a precedence-aware pretty-printer.
 withPrettyIn
-    :: MonadPrettyContext config env m
-    => ((forall a. PrettyBy config a => Direction -> Fixity -> a -> Doc ann) -> m r) -> m r
+  :: (MonadPrettyContext config env m)
+  => ((forall a. (PrettyBy config a) => Direction -> Fixity -> a -> Doc ann) -> m r) -> m r
 withPrettyIn cont = do
-    config <- view prettyConfig
-    cont $ \dir fixity -> prettyBy $ config & renderContext .~ RenderContext dir fixity
+  config <- view prettyConfig
+  cont $ \dir fixity -> prettyBy $ config & renderContext .~ RenderContext dir fixity
 
--- | Instantiate a supplied continuation with a pretty-printer specialized to supplied
--- 'Fixity' and 'Direction'.
+{-| Instantiate a supplied continuation with a pretty-printer specialized to supplied
+'Fixity' and 'Direction'.
+-}
 withPrettyAt
-    :: MonadPrettyContext config env m
-    => Direction -> Fixity -> (AnyToDoc config ann -> m r) -> m r
+  :: (MonadPrettyContext config env m)
+  => Direction -> Fixity -> (AnyToDoc config ann -> m r) -> m r
 withPrettyAt dir fixity cont = withPrettyIn $ \prettyIn -> cont $ prettyIn dir fixity
 
 -- | Call 'encloseM' on 'unitFixity'.
-unitDocM :: MonadPrettyContext config env m => Doc ann -> m (Doc ann)
+unitDocM :: (MonadPrettyContext config env m) => Doc ann -> m (Doc ann)
 unitDocM = encloseM unitFixity
 
--- | Instantiate a supplied continuation with a pretty-printer and apply 'encloseM',
--- specialized to supplied 'Fixity', to the result.
+{-| Instantiate a supplied continuation with a pretty-printer and apply 'encloseM',
+specialized to supplied 'Fixity', to the result.
+-}
 compoundDocM
-    :: MonadPrettyContext config env m
-    => Fixity
-    -> ((forall a. PrettyBy config a => Direction -> Fixity -> a -> Doc ann) -> Doc ann)
-    -> m (Doc ann)
+  :: (MonadPrettyContext config env m)
+  => Fixity
+  -> ((forall a. (PrettyBy config a) => Direction -> Fixity -> a -> Doc ann) -> Doc ann)
+  -> m (Doc ann)
 compoundDocM fixity k = withPrettyIn $ \prettyIn -> encloseM fixity $ k prettyIn
 
--- | Instantiate a supplied continuation with a pretty-printer specialized to supplied
--- 'Fixity' and 'Direction' and apply 'encloseM' specialized to the provided fixity to the result.
--- This can be useful for pretty-printing a sequence of values (possibly consisting of a single
--- value).
+{-| Instantiate a supplied continuation with a pretty-printer specialized to supplied
+'Fixity' and 'Direction' and apply 'encloseM' specialized to the provided fixity to the result.
+This can be useful for pretty-printing a sequence of values (possibly consisting of a single
+value).
+-}
 sequenceDocM
-    :: MonadPrettyContext config env m
-    => Direction -> Fixity -> (AnyToDoc config ann -> Doc ann) -> m (Doc ann)
+  :: (MonadPrettyContext config env m)
+  => Direction -> Fixity -> (AnyToDoc config ann -> Doc ann) -> m (Doc ann)
 sequenceDocM dir fixity k = compoundDocM fixity $ \prettyIn -> k $ prettyIn dir fixity
 
--- | Instantiate a supplied continuation with two pretty-printers (one is going in the 'ToTheLeft'
--- direction, the other is in the 'ToTheRight' direction) specialized to supplied 'Fixity'
--- and apply 'encloseM', specialized to the same fixity, to the result.
--- The idea is that to the outside an infix operator has the same inner fixity as
--- it has the outer fixity to inner subexpressions.
+{-| Instantiate a supplied continuation with two pretty-printers (one is going in the 'ToTheLeft'
+direction, the other is in the 'ToTheRight' direction) specialized to supplied 'Fixity'
+and apply 'encloseM', specialized to the same fixity, to the result.
+The idea is that to the outside an infix operator has the same inner fixity as
+it has the outer fixity to inner subexpressions.
+-}
 infixDocM
-    :: MonadPrettyContext config env m
-    => Fixity
-    -> (AnyToDoc config ann -> AnyToDoc config ann -> Doc ann)
-    -> m (Doc ann)
+  :: (MonadPrettyContext config env m)
+  => Fixity
+  -> (AnyToDoc config ann -> AnyToDoc config ann -> Doc ann)
+  -> m (Doc ann)
 infixDocM fixity k =
-    compoundDocM fixity $ \prettyIn ->
-        k (prettyIn ToTheLeft fixity) (prettyIn ToTheRight fixity)
+  compoundDocM fixity $ \prettyIn ->
+    k (prettyIn ToTheLeft fixity) (prettyIn ToTheRight fixity)
 
--- | Pretty-print two things with a space between them. The fixity of the context in which the
--- arguments get pretty-printed is set to 'juxtFixity'.
+{-| Pretty-print two things with a space between them. The fixity of the context in which the
+arguments get pretty-printed is set to 'juxtFixity'.
+-}
 juxtPrettyM
-    :: (MonadPrettyContext config env m, PrettyBy config a, PrettyBy config b)
-    => a -> b -> m (Doc ann)
+  :: (MonadPrettyContext config env m, PrettyBy config a, PrettyBy config b)
+  => a -> b -> m (Doc ann)
 juxtPrettyM fun arg =
-    infixDocM juxtFixity $ \prettyL prettyR -> prettyL fun <+> prettyR arg
+  infixDocM juxtFixity $ \prettyL prettyR -> prettyL fun <+> prettyR arg

--- a/prettyprinter-configurable/src/Text/PrettyBy/Internal.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Internal.hs
@@ -16,38 +16,38 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
--- | Internal module defining the core machinery of configurable pretty-printing.
---
--- We introduce an internal module, because most users won't need stuff like 'DefaultPrettyBy', so
--- it doesn't make much sense to export that from the top-level module. But 'DefaultPrettyBy' can
--- still can be useful occasionally and there are some docs explaining details of the implementation
--- (see e.g. 'DispatchPrettyDefaultBy'), hence it's exported from here.
---
--- Versioning is not affected by the fact that the module is called \"Internal\", i.e. we track
--- changes using the usual PVP.
+{-| Internal module defining the core machinery of configurable pretty-printing.
 
-module Text.PrettyBy.Internal
-    ( PrettyBy (..)
-    , HasPrettyDefaults
-    , IgnorePrettyConfig (..)
-    , AttachPrettyConfig (..)
-    , withAttachPrettyConfig
-    , defaultPrettyFunctorBy
-    , defaultPrettyBifunctorBy
-    , StarsOfHead
-    , DispatchDefaultFor (..)
-    , DefaultFor (..)
-    , AttachDefaultPrettyConfig (..)
-    , DefaultPrettyBy (..)
-    , NonDefaultPrettyBy (..)
-    , PrettyDefaultBy
-    , PrettyCommon (..)
-    , ThrowOnStuck
-    , HasPrettyDefaultsStuckError
-    , NonStuckHasPrettyDefaults
-    , DispatchPrettyDefaultBy (..)
-    , PrettyAny (..)
-    ) where
+We introduce an internal module, because most users won't need stuff like 'DefaultPrettyBy', so
+it doesn't make much sense to export that from the top-level module. But 'DefaultPrettyBy' can
+still can be useful occasionally and there are some docs explaining details of the implementation
+(see e.g. 'DispatchPrettyDefaultBy'), hence it's exported from here.
+
+Versioning is not affected by the fact that the module is called \"Internal\", i.e. we track
+changes using the usual PVP.
+-}
+module Text.PrettyBy.Internal (
+  PrettyBy (..),
+  HasPrettyDefaults,
+  IgnorePrettyConfig (..),
+  AttachPrettyConfig (..),
+  withAttachPrettyConfig,
+  defaultPrettyFunctorBy,
+  defaultPrettyBifunctorBy,
+  StarsOfHead,
+  DispatchDefaultFor (..),
+  DefaultFor (..),
+  AttachDefaultPrettyConfig (..),
+  DefaultPrettyBy (..),
+  NonDefaultPrettyBy (..),
+  PrettyDefaultBy,
+  PrettyCommon (..),
+  ThrowOnStuck,
+  HasPrettyDefaultsStuckError,
+  NonStuckHasPrettyDefaults,
+  DispatchPrettyDefaultBy (..),
+  PrettyAny (..),
+) where
 
 import Text.Pretty
 
@@ -70,167 +70,170 @@ import GHC.TypeLits
 -- ## The 'PrettyBy' class ##
 -- ##########################
 
--- | A class for pretty-printing values in a configurable manner.
---
--- A basic example:
---
--- >>> data Case = UpperCase | LowerCase
--- >>> data D = D
--- >>> instance PrettyBy Case D where prettyBy UpperCase D = "D"; prettyBy LowerCase D = "d"
--- >>> prettyBy UpperCase D
--- D
--- >>> prettyBy LowerCase D
--- d
---
--- The library provides instances for common types like 'Integer' or 'Bool', so you can't define
--- your own @PrettyBy SomeConfig Integer@ instance. And for the same reason you should not define
--- instances like @PrettyBy SomeAnotherConfig a@ for universally quantified @a@, because such an
--- instance would overlap with the existing ones. Take for example
---
--- >>> data ViaShow = ViaShow
--- >>> instance Show a => PrettyBy ViaShow a where prettyBy ViaShow = pretty . show
---
--- with such an instance @prettyBy ViaShow (1 :: Int)@ throws an error about overlapping instances:
---
--- > • Overlapping instances for PrettyBy ViaShow Int
--- >     arising from a use of ‘prettyBy’
--- >   Matching instances:
--- >     instance PrettyDefaultBy config Int => PrettyBy config Int
--- >     instance [safe] Show a => PrettyBy ViaShow a
---
--- There's a @newtype@ provided specifically for the purpose of defining a 'PrettyBy' instance for
--- any @a@: 'PrettyAny'. Read its docs for details on when you might want to use it.
---
--- The 'PrettyBy' instance for common types is defined in a way that allows to override default
--- pretty-printing behaviour, read the docs of 'HasPrettyDefaults' for details.
-class PrettyBy config a where
-    -- | Pretty-print a value of type @a@ the way a @config@ specifies it.
-    -- The default implementation of 'prettyBy' is in terms of 'pretty', 'defaultPrettyFunctorBy'
-    -- or 'defaultPrettyBifunctorBy' depending on the kind of the data type that you're providing
-    -- an instance for. For example, the default implementation of 'prettyBy' for a monomorphic type
-    -- is going to be "ignore the config and call 'pretty' over the value":
-    --
-    -- >>> newtype N = N Int deriving newtype (Pretty)
-    -- >>> instance PrettyBy () N
-    -- >>> prettyBy () (N 42)
-    -- 42
-    --
-    -- The default implementation of 'prettyBy' for a 'Functor' is going to be in terms of
-    -- 'defaultPrettyFunctorBy':
-    --
-    -- >>> newtype N a = N a deriving stock (Functor) deriving newtype (Pretty)
-    -- >>> instance PrettyBy () a => PrettyBy () (N a)
-    -- >>> prettyBy () (N (42 :: Int))
-    -- 42
-    --
-    -- It's fine for the data type to have a phantom parameter as long as the data type is still a
-    -- 'Functor' (i.e. the parameter has to be of kind @Type@). Then 'defaultPrettyFunctorBy' is used
-    -- again:
-    --
-    -- >>> newtype N a = N Int deriving stock (Functor) deriving newtype (Pretty)
-    -- >>> instance PrettyBy () (N b)
-    -- >>> prettyBy () (N 42)
-    -- 42
-    --
-    -- If the data type has a single parameter of any other kind, then it's not a functor and so
-    -- like in the monomorphic case 'pretty' is used:
-    --
-    -- >>> newtype N (b :: Bool) = N Int deriving newtype (Pretty)
-    -- >>> instance PrettyBy () (N b)
-    -- >>> prettyBy () (N 42)
-    -- 42
-    --
-    -- Same applies to a data type with two parameters: if both the parameters are of kind @Type@,
-    -- then the data type is assumed to be a 'Bifunctor' and hence 'defaultPrettyBifunctorBy' is
-    -- used. If the right parameter is of kind @Type@ and the left parameter is of any other kind,
-    -- then we fallback to assuming the data type is a 'Functor' and defining 'prettyBy' as
-    -- 'defaultPrettyFunctorBy'. If both the parameters are not of kind @Type@, we fallback to
-    -- implementing 'prettyBy' in terms of 'pretty' like in the monomorphic case.
-    --
-    -- Note that in all those cases a 'Pretty' instance for the data type has to already exist,
-    -- so that we can derive a 'PrettyBy' one in terms of it. If it doesn't exist or if your data
-    -- type is not supported (for example, if it has three or more parameters of kind @Type@), then
-    -- you'll need to provide the implementation manually.
-    prettyBy :: config -> a -> Doc ann
-    default prettyBy :: DefaultFor "prettyBy" config a => config -> a -> Doc ann
-    prettyBy = defaultFor @"prettyBy"
+{-| A class for pretty-printing values in a configurable manner.
 
-    -- Defaulting to 'prettyList' would require the user to either provide a 'Pretty' instance for
-    -- each data type implementing 'PrettyBy' or to supply the sensible default implementation as
-    -- 'defaultPrettyFunctorBy' manually and both the options are silly.
-    -- | 'prettyListBy' is used to define the default 'PrettyBy' instance for @[a]@ and @NonEmpty a@.
-    -- In normal circumstances only the 'prettyBy' function is used.
-    -- The default implementation of 'prettyListBy' is in terms of 'defaultPrettyFunctorBy'.
-    prettyListBy :: config -> [a] -> Doc ann
-    default prettyListBy :: config -> [a] -> Doc ann
-    prettyListBy = defaultPrettyFunctorBy
+A basic example:
+
+>>> data Case = UpperCase | LowerCase
+>>> data D = D
+>>> instance PrettyBy Case D where prettyBy UpperCase D = "D"; prettyBy LowerCase D = "d"
+>>> prettyBy UpperCase D
+D
+>>> prettyBy LowerCase D
+d
+
+The library provides instances for common types like 'Integer' or 'Bool', so you can't define
+your own @PrettyBy SomeConfig Integer@ instance. And for the same reason you should not define
+instances like @PrettyBy SomeAnotherConfig a@ for universally quantified @a@, because such an
+instance would overlap with the existing ones. Take for example
+
+>>> data ViaShow = ViaShow
+>>> instance Show a => PrettyBy ViaShow a where prettyBy ViaShow = pretty . show
+
+with such an instance @prettyBy ViaShow (1 :: Int)@ throws an error about overlapping instances:
+
+> • Overlapping instances for PrettyBy ViaShow Int
+>     arising from a use of ‘prettyBy’
+>   Matching instances:
+>     instance PrettyDefaultBy config Int => PrettyBy config Int
+>     instance [safe] Show a => PrettyBy ViaShow a
+
+There's a @newtype@ provided specifically for the purpose of defining a 'PrettyBy' instance for
+any @a@: 'PrettyAny'. Read its docs for details on when you might want to use it.
+
+The 'PrettyBy' instance for common types is defined in a way that allows to override default
+pretty-printing behaviour, read the docs of 'HasPrettyDefaults' for details.
+-}
+class PrettyBy config a where
+  -- | Pretty-print a value of type @a@ the way a @config@ specifies it.
+  -- The default implementation of 'prettyBy' is in terms of 'pretty', 'defaultPrettyFunctorBy'
+  -- or 'defaultPrettyBifunctorBy' depending on the kind of the data type that you're providing
+  -- an instance for. For example, the default implementation of 'prettyBy' for a monomorphic type
+  -- is going to be "ignore the config and call 'pretty' over the value":
+  --
+  -- >>> newtype N = N Int deriving newtype (Pretty)
+  -- >>> instance PrettyBy () N
+  -- >>> prettyBy () (N 42)
+  -- 42
+  --
+  -- The default implementation of 'prettyBy' for a 'Functor' is going to be in terms of
+  -- 'defaultPrettyFunctorBy':
+  --
+  -- >>> newtype N a = N a deriving stock (Functor) deriving newtype (Pretty)
+  -- >>> instance PrettyBy () a => PrettyBy () (N a)
+  -- >>> prettyBy () (N (42 :: Int))
+  -- 42
+  --
+  -- It's fine for the data type to have a phantom parameter as long as the data type is still a
+  -- 'Functor' (i.e. the parameter has to be of kind @Type@). Then 'defaultPrettyFunctorBy' is used
+  -- again:
+  --
+  -- >>> newtype N a = N Int deriving stock (Functor) deriving newtype (Pretty)
+  -- >>> instance PrettyBy () (N b)
+  -- >>> prettyBy () (N 42)
+  -- 42
+  --
+  -- If the data type has a single parameter of any other kind, then it's not a functor and so
+  -- like in the monomorphic case 'pretty' is used:
+  --
+  -- >>> newtype N (b :: Bool) = N Int deriving newtype (Pretty)
+  -- >>> instance PrettyBy () (N b)
+  -- >>> prettyBy () (N 42)
+  -- 42
+  --
+  -- Same applies to a data type with two parameters: if both the parameters are of kind @Type@,
+  -- then the data type is assumed to be a 'Bifunctor' and hence 'defaultPrettyBifunctorBy' is
+  -- used. If the right parameter is of kind @Type@ and the left parameter is of any other kind,
+  -- then we fallback to assuming the data type is a 'Functor' and defining 'prettyBy' as
+  -- 'defaultPrettyFunctorBy'. If both the parameters are not of kind @Type@, we fallback to
+  -- implementing 'prettyBy' in terms of 'pretty' like in the monomorphic case.
+  --
+  -- Note that in all those cases a 'Pretty' instance for the data type has to already exist,
+  -- so that we can derive a 'PrettyBy' one in terms of it. If it doesn't exist or if your data
+  -- type is not supported (for example, if it has three or more parameters of kind @Type@), then
+  -- you'll need to provide the implementation manually.
+  prettyBy :: config -> a -> Doc ann
+  default prettyBy :: (DefaultFor "prettyBy" config a) => config -> a -> Doc ann
+  prettyBy = defaultFor @"prettyBy"
+
+  -- Defaulting to 'prettyList' would require the user to either provide a 'Pretty' instance for
+  -- each data type implementing 'PrettyBy' or to supply the sensible default implementation as
+  -- 'defaultPrettyFunctorBy' manually and both the options are silly.
+
+  -- | 'prettyListBy' is used to define the default 'PrettyBy' instance for @[a]@ and @NonEmpty a@.
+  -- In normal circumstances only the 'prettyBy' function is used.
+  -- The default implementation of 'prettyListBy' is in terms of 'defaultPrettyFunctorBy'.
+  prettyListBy :: config -> [a] -> Doc ann
+  default prettyListBy :: config -> [a] -> Doc ann
+  prettyListBy = defaultPrettyFunctorBy
 
 -- #########################################
 -- ## The 'HasPrettyDefaults' type family ##
 -- #########################################
 
--- | Determines whether a pretty-printing config allows default pretty-printing for types that
--- support it. I.e. it's possible to create a new config and get access to pretty-printing for
--- all types supporting default pretty-printing just by providing the right type instance. Example:
---
--- >>> data DefCfg = DefCfg
--- >>> type instance HasPrettyDefaults DefCfg = 'True
--- >>> prettyBy DefCfg (['a', 'b', 'c'], (1 :: Int), Just True)
--- (abc, 1, True)
---
--- The set of types supporting default pretty-printing is determined by the @prettyprinter@
--- library: whatever __there__ has a 'Pretty' instance also supports default pretty-printing
--- in this library and the behavior of @pretty x@ and @prettyBy config_with_defaults x@ must
--- be identical when @x@ is one of such types.
---
--- It is possible to override default pretty-printing. For this you need to specify that
--- 'HasPrettyDefaults' is @'False@ for your config and then define a @NonDefaultPrettyBy config@
--- instance for each of the types supporting default pretty-printing that you want to pretty-print
--- values of. Note that once 'HasPrettyDefaults' is specified to be @'False@,
--- __all defaults are lost__ for your config, so you can't override default pretty-printing for one
--- type and keep the defaults for all the others. I.e. if you have
---
--- >>> data NonDefCfg = NonDefCfg
--- >>> type instance HasPrettyDefaults NonDefCfg = 'False
---
--- then you have no defaults available and an attempt to pretty-print a value of a type supporting
--- default pretty-printing
---
--- > prettyBy NonDefCfg True
---
--- results in a type error:
---
--- > • No instance for (NonDefaultPrettyBy NonDef Bool)
--- >      arising from a use of ‘prettyBy’
---
--- As the error suggests you need to provide a 'NonDefaultPrettyBy' instance explicitly:
---
--- >>> instance NonDefaultPrettyBy NonDefCfg Bool where nonDefaultPrettyBy _ b = if b then "t" else "f"
--- >>> prettyBy NonDefCfg True
--- t
---
--- It is also possible not to provide any implementation for 'nonDefaultPrettyBy', in which case
--- it defaults to being the default pretty-printing for the given type. This can be useful to
--- recover default pretty-printing for types pretty-printing of which you don't want to override:
---
--- >>> instance NonDefaultPrettyBy NonDefCfg Int
--- >>> prettyBy NonDefCfg (42 :: Int)
--- 42
---
--- Look into @test/NonDefault.hs@ for an extended example.
---
--- We could give the user more fine-grained control over what defaults to override instead of
--- requiring to explicitly provide all the instances whenever there's a need to override any
--- default behavior, but that would complicate the library even more, so we opted for not doing
--- that at the moment.
---
--- Note that you can always override default behavior by wrapping a type in @newtype@ and
--- providing a @PrettyBy config_name@ instance for that @newtype@.
---
--- Also note that if you want to extend the set of types supporting default pretty-printing
--- it's not enough to provide a 'Pretty' instance for your type (such logic is hardly expressible
--- in present day Haskell). Read the docs of 'DefaultPrettyBy' for how to extend the set of types
--- supporting default pretty-printing.
+{-| Determines whether a pretty-printing config allows default pretty-printing for types that
+support it. I.e. it's possible to create a new config and get access to pretty-printing for
+all types supporting default pretty-printing just by providing the right type instance. Example:
+
+>>> data DefCfg = DefCfg
+>>> type instance HasPrettyDefaults DefCfg = 'True
+>>> prettyBy DefCfg (['a', 'b', 'c'], (1 :: Int), Just True)
+(abc, 1, True)
+
+The set of types supporting default pretty-printing is determined by the @prettyprinter@
+library: whatever __there__ has a 'Pretty' instance also supports default pretty-printing
+in this library and the behavior of @pretty x@ and @prettyBy config_with_defaults x@ must
+be identical when @x@ is one of such types.
+
+It is possible to override default pretty-printing. For this you need to specify that
+'HasPrettyDefaults' is @'False@ for your config and then define a @NonDefaultPrettyBy config@
+instance for each of the types supporting default pretty-printing that you want to pretty-print
+values of. Note that once 'HasPrettyDefaults' is specified to be @'False@,
+__all defaults are lost__ for your config, so you can't override default pretty-printing for one
+type and keep the defaults for all the others. I.e. if you have
+
+>>> data NonDefCfg = NonDefCfg
+>>> type instance HasPrettyDefaults NonDefCfg = 'False
+
+then you have no defaults available and an attempt to pretty-print a value of a type supporting
+default pretty-printing
+
+> prettyBy NonDefCfg True
+
+results in a type error:
+
+> • No instance for (NonDefaultPrettyBy NonDef Bool)
+>      arising from a use of ‘prettyBy’
+
+As the error suggests you need to provide a 'NonDefaultPrettyBy' instance explicitly:
+
+>>> instance NonDefaultPrettyBy NonDefCfg Bool where nonDefaultPrettyBy _ b = if b then "t" else "f"
+>>> prettyBy NonDefCfg True
+t
+
+It is also possible not to provide any implementation for 'nonDefaultPrettyBy', in which case
+it defaults to being the default pretty-printing for the given type. This can be useful to
+recover default pretty-printing for types pretty-printing of which you don't want to override:
+
+>>> instance NonDefaultPrettyBy NonDefCfg Int
+>>> prettyBy NonDefCfg (42 :: Int)
+42
+
+Look into @test/NonDefault.hs@ for an extended example.
+
+We could give the user more fine-grained control over what defaults to override instead of
+requiring to explicitly provide all the instances whenever there's a need to override any
+default behavior, but that would complicate the library even more, so we opted for not doing
+that at the moment.
+
+Note that you can always override default behavior by wrapping a type in @newtype@ and
+providing a @PrettyBy config_name@ instance for that @newtype@.
+
+Also note that if you want to extend the set of types supporting default pretty-printing
+it's not enough to provide a 'Pretty' instance for your type (such logic is hardly expressible
+in present day Haskell). Read the docs of 'DefaultPrettyBy' for how to extend the set of types
+supporting default pretty-printing.
+-}
 type family HasPrettyDefaults config :: Bool
 
 -- | @prettyBy ()@ works like @pretty@ for types supporting default pretty-printing.
@@ -240,215 +243,247 @@ type instance HasPrettyDefaults () = 'True
 -- ## Interop with 'Pretty' ##
 -- ###########################
 
--- | A newtype wrapper around @a@ whose point is to provide a @PrettyBy config@ instance
--- for anything that has a 'Pretty' instance.
+{-| A newtype wrapper around @a@ whose point is to provide a @PrettyBy config@ instance
+for anything that has a 'Pretty' instance.
+-}
 newtype IgnorePrettyConfig a = IgnorePrettyConfig
-    { unIgnorePrettyConfig :: a
-    }
+  { unIgnorePrettyConfig :: a
+  }
 
--- |
--- >>> data Cfg = Cfg
--- >>> data D = D
--- >>> instance Pretty D where pretty D = "D"
--- >>> prettyBy Cfg $ IgnorePrettyConfig D
--- D
-instance Pretty a => PrettyBy config (IgnorePrettyConfig a) where
-    prettyBy _ = pretty . unIgnorePrettyConfig
+{-|
+>>> data Cfg = Cfg
+>>> data D = D
+>>> instance Pretty D where pretty D = "D"
+>>> prettyBy Cfg $ IgnorePrettyConfig D
+D
+-}
+instance (Pretty a) => PrettyBy config (IgnorePrettyConfig a) where
+  prettyBy _ = pretty . unIgnorePrettyConfig
 
--- | A config together with some value. The point is to provide a 'Pretty' instance
--- for anything that has a @PrettyBy config@ instance.
+{-| A config together with some value. The point is to provide a 'Pretty' instance
+for anything that has a @PrettyBy config@ instance.
+-}
 data AttachPrettyConfig config a = AttachPrettyConfig !config !a
 
--- |
--- >>> data Cfg = Cfg
--- >>> data D = D
--- >>> instance PrettyBy Cfg D where prettyBy Cfg D = "D"
--- >>> pretty $ AttachPrettyConfig Cfg D
--- D
-instance PrettyBy config a => Pretty (AttachPrettyConfig config a) where
-    pretty (AttachPrettyConfig config x) = prettyBy config x
+{-|
+>>> data Cfg = Cfg
+>>> data D = D
+>>> instance PrettyBy Cfg D where prettyBy Cfg D = "D"
+>>> pretty $ AttachPrettyConfig Cfg D
+D
+-}
+instance (PrettyBy config a) => Pretty (AttachPrettyConfig config a) where
+  pretty (AttachPrettyConfig config x) = prettyBy config x
 
 -- | Pass @AttachPrettyConfig config@ to the continuation.
 withAttachPrettyConfig
-    :: config -> ((forall a. a -> AttachPrettyConfig config a) -> r) -> r
+  :: config -> ((forall a. a -> AttachPrettyConfig config a) -> r) -> r
 withAttachPrettyConfig config k = k $ AttachPrettyConfig config
 
--- | Default configurable pretty-printing for a 'Functor' in terms of 'Pretty'.
--- Attaches the config to each value in the functor and calls 'pretty' over the result,
--- i.e. the spine of the functor is pretty-printed the way the 'Pretty' class specifies it,
--- while the elements are printed by 'prettyBy'.
+{-| Default configurable pretty-printing for a 'Functor' in terms of 'Pretty'.
+Attaches the config to each value in the functor and calls 'pretty' over the result,
+i.e. the spine of the functor is pretty-printed the way the 'Pretty' class specifies it,
+while the elements are printed by 'prettyBy'.
+-}
 defaultPrettyFunctorBy
-    :: (Functor f, Pretty (f (AttachPrettyConfig config a)))
-    => config -> f a -> Doc ann
+  :: (Functor f, Pretty (f (AttachPrettyConfig config a)))
+  => config -> f a -> Doc ann
 defaultPrettyFunctorBy config a =
-    pretty $ AttachPrettyConfig config <$> a
+  pretty $ AttachPrettyConfig config <$> a
 
--- | Default configurable pretty-printing for a 'Bifunctor' in terms of 'Pretty'
--- Attaches the config to each value in the bifunctor and calls 'pretty' over the result,
--- i.e. the spine of the bifunctor is pretty-printed the way the 'Pretty' class specifies it,
--- while the elements are printed by 'prettyBy'.
+{-| Default configurable pretty-printing for a 'Bifunctor' in terms of 'Pretty'
+Attaches the config to each value in the bifunctor and calls 'pretty' over the result,
+i.e. the spine of the bifunctor is pretty-printed the way the 'Pretty' class specifies it,
+while the elements are printed by 'prettyBy'.
+-}
 defaultPrettyBifunctorBy
-    :: (Bifunctor f, Pretty (f (AttachPrettyConfig config a) (AttachPrettyConfig config b)))
-    => config -> f a b -> Doc ann
+  :: (Bifunctor f, Pretty (f (AttachPrettyConfig config a) (AttachPrettyConfig config b)))
+  => config -> f a b -> Doc ann
 defaultPrettyBifunctorBy config a =
-    withAttachPrettyConfig config $ \attach -> pretty $ bimap attach attach a
+  withAttachPrettyConfig config $ \attach -> pretty $ bimap attach attach a
 
 -- ##################################################################################
 -- ## Dispatching between default implementations for 'prettyBy'/'defaultPrettyBy' ##
 -- ##################################################################################
 
--- | Return the longest sequence of @Type@ in the kind (right-to-left) of the head of an application.
--- (but no longer than @Type -> Type -> Type@, because we can't support longer ones in 'DispatchDefaultFor').
+{-| Return the longest sequence of @Type@ in the kind (right-to-left) of the head of an application.
+(but no longer than @Type -> Type -> Type@, because we can't support longer ones in
+ 'DispatchDefaultFor').
+-}
 type family StarsOfHead (target :: Symbol) (a :: Type) :: Type where
-    StarsOfHead target ((f :: Type -> Type -> Type -> Type) a b c) = TypeError
-        (     'Text "Automatic derivation of ‘"':<>: 'Text target ':<>: 'Text "’"
-        ':$$: 'Text "is not possible for data types that receive three and more arguments of kind ‘Type’"
-        )
-    StarsOfHead _      ((f :: k -> Type -> Type -> Type) a b c) = Type -> Type -> Type
-    StarsOfHead _      ((f :: Type -> Type -> Type)      a b  ) = Type -> Type -> Type
-    StarsOfHead _      ((f :: k -> Type -> Type)      a b  ) = Type -> Type
-    StarsOfHead _      ((f :: Type -> Type)           a    ) = Type -> Type
-    StarsOfHead _      ((f :: k -> Type)           a    ) = Type
-    StarsOfHead _      a                               = Type
+  StarsOfHead target ((f :: Type -> Type -> Type -> Type) a b c) =
+    TypeError
+      ( 'Text "Automatic derivation of ‘" ':<>: 'Text target ':<>: 'Text "’"
+          ':$$: 'Text
+                  "is not possible for data types that \
+                  \receive three and more arguments of kind ‘Type’"
+      )
+  StarsOfHead _ ((f :: k -> Type -> Type -> Type) a b c) = Type -> Type -> Type
+  StarsOfHead _ ((f :: Type -> Type -> Type) a b) = Type -> Type -> Type
+  StarsOfHead _ ((f :: k -> Type -> Type) a b) = Type -> Type
+  StarsOfHead _ ((f :: Type -> Type) a) = Type -> Type
+  StarsOfHead _ ((f :: k -> Type) a) = Type
+  StarsOfHead _ a = Type
 
--- | This allows us to have different default implementations for 'prettyBy' and 'defaultPrettyBy'
--- depending on whether @a@ is a monomorphic type or a 'Functor' or a 'Bifunctor'. Read the docs of
--- 'prettyBy' for details.
-class StarsOfHead target a ~ k => DispatchDefaultFor target k config a where
-    dispatchDefaultFor :: config -> a -> Doc ann
+{-| This allows us to have different default implementations for 'prettyBy' and 'defaultPrettyBy'
+depending on whether @a@ is a monomorphic type or a 'Functor' or a 'Bifunctor'. Read the docs of
+'prettyBy' for details.
+-}
+class (StarsOfHead target a ~ k) => DispatchDefaultFor target k config a where
+  dispatchDefaultFor :: config -> a -> Doc ann
 
 instance (StarsOfHead target a ~ Type, Pretty a) => DispatchDefaultFor target Type config a where
-    dispatchDefaultFor _ = pretty
+  dispatchDefaultFor _ = pretty
 
-instance ( StarsOfHead target fa ~ (k -> Type), fa ~ f a
-         , Functor f, Pretty (f (AttachPrettyConfig config a))
-         ) => DispatchDefaultFor target (k -> Type) config fa where
-    dispatchDefaultFor = defaultPrettyFunctorBy
+instance
+  ( StarsOfHead target fa ~ (k -> Type)
+  , fa ~ f a
+  , Functor f
+  , Pretty (f (AttachPrettyConfig config a))
+  )
+  => DispatchDefaultFor target (k -> Type) config fa
+  where
+  dispatchDefaultFor = defaultPrettyFunctorBy
 
-instance ( StarsOfHead target fab ~ (k1 -> k2 -> Type), fab ~ f a b
-         , Bifunctor f, Pretty (f (AttachPrettyConfig config a) (AttachPrettyConfig config b))
-         ) => DispatchDefaultFor target (k1 -> k2 -> Type) config fab where
-    dispatchDefaultFor = defaultPrettyBifunctorBy
+instance
+  ( StarsOfHead target fab ~ (k1 -> k2 -> Type)
+  , fab ~ f a b
+  , Bifunctor f
+  , Pretty (f (AttachPrettyConfig config a) (AttachPrettyConfig config b))
+  )
+  => DispatchDefaultFor target (k1 -> k2 -> Type) config fab
+  where
+  dispatchDefaultFor = defaultPrettyBifunctorBy
 
--- | Introducing a class just for the nice name of the method and in case the defaulting machinery
--- somehow blows up in the user's face.
-class DispatchDefaultFor target (StarsOfHead target a) config a =>
-            DefaultFor target config a where
-    defaultFor :: config -> a -> Doc ann
+{-| Introducing a class just for the nice name of the method and in case the defaulting machinery
+somehow blows up in the user's face.
+-}
+class
+  (DispatchDefaultFor target (StarsOfHead target a) config a) =>
+  DefaultFor target config a
+  where
+  defaultFor :: config -> a -> Doc ann
 
-instance DispatchDefaultFor target (StarsOfHead target a) config a =>
-            DefaultFor target config a where
-    defaultFor = dispatchDefaultFor @target
+instance
+  (DispatchDefaultFor target (StarsOfHead target a) config a)
+  => DefaultFor target config a
+  where
+  defaultFor = dispatchDefaultFor @target
 
 -- ###################################################
 -- ## The 'DefaultPrettyBy' class and its instances ##
 -- ###################################################
 
--- | Same as 'AttachPrettyConfig', but for providing a 'Pretty' instance for anything that has
--- a 'DefaultPrettyBy' instance. Needed for the default implementation of 'defaultPrettyListBy'.
+{-| Same as 'AttachPrettyConfig', but for providing a 'Pretty' instance for anything that has
+a 'DefaultPrettyBy' instance. Needed for the default implementation of 'defaultPrettyListBy'.
+-}
 data AttachDefaultPrettyConfig config a = AttachDefaultPrettyConfig !config !a
 
-instance DefaultPrettyBy config a => Pretty (AttachDefaultPrettyConfig config a) where
-    pretty (AttachDefaultPrettyConfig config x) = defaultPrettyBy config x
+instance (DefaultPrettyBy config a) => Pretty (AttachDefaultPrettyConfig config a) where
+  pretty (AttachDefaultPrettyConfig config x) = defaultPrettyBy config x
 
--- | A class for pretty-printing values is some default manner. Basic example:
---
--- >>> data D = D
--- >>> instance PrettyBy () D where prettyBy () D = "D"
--- >>> defaultPrettyBy () (Just D)
--- D
---
--- 'DefaultPrettyBy' and 'PrettyBy' are mutually recursive in a sense: 'PrettyBy' delegates
--- to 'DefaultPrettyBy' (provided the config supports defaults) when given a value of a type
--- supporting default pretty-printing and 'DefaultPrettyBy' delegates back to 'PrettyBy' for
--- elements of a polymorphic container.
---
--- It is possible to extend the set of types supporting default pretty-printing. If you have a
--- @newtype@ wrapping a type that already supports default pretty-printing, then "registering"
--- that @newtype@ amounts to making a standalone newtype-deriving declaration:
---
--- >>> newtype AlsoInt = AlsoInt Int
--- >>> deriving newtype instance PrettyDefaultBy config Int => PrettyBy config AlsoInt
--- >>> prettyBy () (AlsoInt 42)
--- 42
---
--- Note that you have to use standalone deriving as
---
--- > newtype AlsoInt = AlsoInt Int deriving newtype (PrettyBy config)
---
--- doesn't please GHC.
---
--- It's also good practice to preserve coherence of 'Pretty' and 'PrettyBy', so I'd also add
--- @deriving newtype (Pretty)@ to the definition of @AlsoInt@, even though it's not necessary.
---
--- When you want to extend the set of types supporting default pretty-printing with a data type
--- that is a @data@ rather than a @newtype@, you can directly implement 'DefaultPrettyBy' and
--- and via-derive 'PrettyBy':
---
--- >>> data D = D
--- >>> instance DefaultPrettyBy config D where defaultPrettyBy _ D = "D"
--- >>> deriving via PrettyCommon D instance PrettyDefaultBy config D => PrettyBy config D
--- >>> prettyBy () D
--- D
---
--- But since it's best to preserve coherence of 'Pretty' and 'PrettyBy' for types supporting
--- default pretty-printing, it's recommended (not mandatory) to define a 'Pretty' instance and
--- anyclass-derive 'DefaultPrettyBy' in terms of it:
---
--- >>> data D = D
--- >>> instance Pretty D where pretty D = "D"
--- >>> instance DefaultPrettyBy config D
--- >>> deriving via PrettyCommon D instance PrettyDefaultBy config D => PrettyBy config D
--- >>> prettyBy () [D, D, D]
--- [D, D, D]
---
--- Note that 'DefaultPrettyBy' is specifically designed to handle __all__ configs in its instances,
--- i.e. you only specify a data type in a 'DefaultPrettyBy' instance and leave @config@ universally
--- quantified. This is because default pretty-printing behavior should be the same for all configs
--- supporting default pretty-printing (it's the default after all). If you want to override the
--- defaults, read the docs of 'HasPrettyDefaults'.
---
--- Since @config@ in a 'DefaultPrettyBy' instance is meant to be universally quantified,
--- 'defaultPrettyBy' (the main method of 'DefaultPrettyBy') has to ignore the config in the
--- monomorphic case as it can't use it in any way anyway, i.e. in the monomorphic case
--- 'defaultPrettyBy' has the exact same info as simple 'pretty', which is another reason to
--- anyclass-derive 'DefaultPrettyBy' in terms of 'Pretty'.
---
--- Like in the case of 'prettyBy', the default implementation of 'defaultPrettyBy' for a 'Functor'
--- is 'defaultPrettyFunctorBy' (and for a 'Bifunctor' -- 'defaultPrettyBifunctorBy'):
---
--- >>> data Twice a = Twice a a deriving stock (Functor)
--- >>> instance Pretty a => Pretty (Twice a) where pretty (Twice x y) = pretty x <+> "&" <+> pretty y
--- >>> instance PrettyBy config a => DefaultPrettyBy config (Twice a)
--- >>> deriving via PrettyCommon (Twice a) instance PrettyDefaultBy config (Twice a) => PrettyBy config (Twice a)
--- >>> prettyBy () (Twice True False)
--- True & False
---
--- Since preserving coherence of 'Pretty' and 'PrettyBy' is only a good practice and not
--- mandatory, it's fine not to provide an instance for 'Pretty'. Then a 'DefaultPrettyBy' can be
--- implemented directly:
---
--- >>> data Twice a = Twice a a
--- >>> instance PrettyBy config a => DefaultPrettyBy config (Twice a) where defaultPrettyBy config (Twice x y) = prettyBy config x <+> "&" <+> prettyBy config y
--- >>> deriving via PrettyCommon (Twice a) instance PrettyDefaultBy config (Twice a) => PrettyBy config (Twice a)
--- >>> prettyBy () (Twice True False)
--- True & False
---
--- But make sure that if both a 'Pretty' and a 'DefaultPrettyBy' instances exist, then they're in
--- sync.
+{-| A class for pretty-printing values is some default manner. Basic example:
+
+>>> data D = D
+>>> instance PrettyBy () D where prettyBy () D = "D"
+>>> defaultPrettyBy () (Just D)
+D
+
+'DefaultPrettyBy' and 'PrettyBy' are mutually recursive in a sense: 'PrettyBy' delegates
+to 'DefaultPrettyBy' (provided the config supports defaults) when given a value of a type
+supporting default pretty-printing and 'DefaultPrettyBy' delegates back to 'PrettyBy' for
+elements of a polymorphic container.
+
+It is possible to extend the set of types supporting default pretty-printing. If you have a
+@newtype@ wrapping a type that already supports default pretty-printing, then "registering"
+that @newtype@ amounts to making a standalone newtype-deriving declaration:
+
+>>> newtype AlsoInt = AlsoInt Int
+>>> deriving newtype instance PrettyDefaultBy config Int => PrettyBy config AlsoInt
+>>> prettyBy () (AlsoInt 42)
+42
+
+Note that you have to use standalone deriving as
+
+> newtype AlsoInt = AlsoInt Int deriving newtype (PrettyBy config)
+
+doesn't please GHC.
+
+It's also good practice to preserve coherence of 'Pretty' and 'PrettyBy', so I'd also add
+@deriving newtype (Pretty)@ to the definition of @AlsoInt@, even though it's not necessary.
+
+When you want to extend the set of types supporting default pretty-printing with a data type
+that is a @data@ rather than a @newtype@, you can directly implement 'DefaultPrettyBy' and
+and via-derive 'PrettyBy':
+
+>>> data D = D
+>>> instance DefaultPrettyBy config D where defaultPrettyBy _ D = "D"
+>>> deriving via PrettyCommon D instance PrettyDefaultBy config D => PrettyBy config D
+>>> prettyBy () D
+D
+
+But since it's best to preserve coherence of 'Pretty' and 'PrettyBy' for types supporting
+default pretty-printing, it's recommended (not mandatory) to define a 'Pretty' instance and
+anyclass-derive 'DefaultPrettyBy' in terms of it:
+
+>>> data D = D
+>>> instance Pretty D where pretty D = "D"
+>>> instance DefaultPrettyBy config D
+>>> deriving via PrettyCommon D instance PrettyDefaultBy config D => PrettyBy config D
+>>> prettyBy () [D, D, D]
+[D, D, D]
+
+Note that 'DefaultPrettyBy' is specifically designed to handle __all__ configs in its instances,
+i.e. you only specify a data type in a 'DefaultPrettyBy' instance and leave @config@ universally
+quantified. This is because default pretty-printing behavior should be the same for all configs
+supporting default pretty-printing (it's the default after all). If you want to override the
+defaults, read the docs of 'HasPrettyDefaults'.
+
+Since @config@ in a 'DefaultPrettyBy' instance is meant to be universally quantified,
+'defaultPrettyBy' (the main method of 'DefaultPrettyBy') has to ignore the config in the
+monomorphic case as it can't use it in any way anyway, i.e. in the monomorphic case
+'defaultPrettyBy' has the exact same info as simple 'pretty', which is another reason to
+anyclass-derive 'DefaultPrettyBy' in terms of 'Pretty'.
+
+Like in the case of 'prettyBy', the default implementation of 'defaultPrettyBy' for a 'Functor'
+is 'defaultPrettyFunctorBy' (and for a 'Bifunctor' -- 'defaultPrettyBifunctorBy'):
+
+>>> data Twice a = Twice a a deriving stock (Functor)
+>>> instance Pretty a => Pretty (Twice a) where pretty (Twice x y) = pretty x <+> "&" <+> pretty y
+>>> instance PrettyBy config a => DefaultPrettyBy config (Twice a)
+>>> deriving via PrettyCommon (Twice a)
+  instance PrettyDefaultBy config (Twice a) => PrettyBy config (Twice a)
+>>> prettyBy () (Twice True False)
+True & False
+
+Since preserving coherence of 'Pretty' and 'PrettyBy' is only a good practice and not
+mandatory, it's fine not to provide an instance for 'Pretty'. Then a 'DefaultPrettyBy' can be
+implemented directly:
+
+>>> data Twice a = Twice a a
+>>> instance PrettyBy config a => DefaultPrettyBy config (Twice a)
+  where defaultPrettyBy config (Twice x y) = prettyBy config x <+> "&" <+> prettyBy config y
+>>> deriving via PrettyCommon (Twice a)
+  instance PrettyDefaultBy config (Twice a) => PrettyBy config (Twice a)
+>>> prettyBy () (Twice True False)
+True & False
+
+But make sure that if both a 'Pretty' and a 'DefaultPrettyBy' instances exist, then they're in
+sync.
+-}
 class DefaultPrettyBy config a where
-    -- | Pretty-print a value of type @a@ in some default manner.
-    -- The default implementation works equally to the one of 'prettyBy'.
-    defaultPrettyBy :: config -> a -> Doc ann
-    default defaultPrettyBy :: DefaultFor "defaultPrettyBy" config a => config -> a -> Doc ann
-    defaultPrettyBy = defaultFor @"defaultPrettyBy"
+  -- | Pretty-print a value of type @a@ in some default manner.
+  -- The default implementation works equally to the one of 'prettyBy'.
+  defaultPrettyBy :: config -> a -> Doc ann
+  default defaultPrettyBy :: (DefaultFor "defaultPrettyBy" config a) => config -> a -> Doc ann
+  defaultPrettyBy = defaultFor @"defaultPrettyBy"
 
-    -- | 'defaultPrettyListBy' to 'prettyListBy' is what 'defaultPrettyBy' to 'prettyBy'.
-    -- The default implementation is \"pretty-print the spine of a list the way 'pretty' does that
-    -- and pretty-print the elements using 'defaultPrettyBy'\".
-    defaultPrettyListBy :: config -> [a] -> Doc ann
-    default defaultPrettyListBy :: config -> [a] -> Doc ann
-    defaultPrettyListBy config = pretty . map (AttachDefaultPrettyConfig config)
+  -- | 'defaultPrettyListBy' to 'prettyListBy' is what 'defaultPrettyBy' to 'prettyBy'.
+  -- The default implementation is \"pretty-print the spine of a list the way 'pretty' does that
+  -- and pretty-print the elements using 'defaultPrettyBy'\".
+  defaultPrettyListBy :: config -> [a] -> Doc ann
+  default defaultPrettyListBy :: config -> [a] -> Doc ann
+  defaultPrettyListBy config = pretty . map (AttachDefaultPrettyConfig config)
 
 -- Monomorphic instances.
 
@@ -474,73 +509,81 @@ instance DefaultPrettyBy config Lazy.Text
 
 -- Straightforward polymorphic instances.
 
-instance PrettyBy config a => DefaultPrettyBy config (Identity a)
-instance PrettyBy config a => DefaultPrettyBy config (Const a (b :: Type))
+instance (PrettyBy config a) => DefaultPrettyBy config (Identity a)
+instance (PrettyBy config a) => DefaultPrettyBy config (Const a (b :: Type))
 instance (PrettyBy config a, PrettyBy config b) => DefaultPrettyBy config (a, b)
 
 -- We don't have @Trifunctor@ in base, unfortunately, hence writing things out manually. Could we
 -- do that via generics? I feel like that would amount to implementing n-ary 'Functor' anyway.
-instance (PrettyBy config a, PrettyBy config b, PrettyBy config c) =>
-            DefaultPrettyBy config (a, b, c) where
-    defaultPrettyBy config (x, y, z) =
-        withAttachPrettyConfig config $ \attach -> pretty (attach x, attach y, attach z)
+instance
+  (PrettyBy config a, PrettyBy config b, PrettyBy config c)
+  => DefaultPrettyBy config (a, b, c)
+  where
+  defaultPrettyBy config (x, y, z) =
+    withAttachPrettyConfig config $ \attach -> pretty (attach x, attach y, attach z)
 
 -- Peculiar instances.
 
-instance PrettyBy config Strict.Text => DefaultPrettyBy config Char where
-    defaultPrettyListBy config = prettyBy config . Strict.pack
+instance (PrettyBy config Strict.Text) => DefaultPrettyBy config Char where
+  defaultPrettyListBy config = prettyBy config . Strict.pack
 
-instance PrettyBy config a => DefaultPrettyBy config (Maybe a) where
-    defaultPrettyListBy config = prettyListBy config . catMaybes
+instance (PrettyBy config a) => DefaultPrettyBy config (Maybe a) where
+  defaultPrettyListBy config = prettyListBy config . catMaybes
 
-instance PrettyBy config a => DefaultPrettyBy config [a] where
-    defaultPrettyBy = prettyListBy
+instance (PrettyBy config a) => DefaultPrettyBy config [a] where
+  defaultPrettyBy = prettyListBy
 
-instance PrettyBy config a => DefaultPrettyBy config (NonEmpty a) where
-    defaultPrettyBy config (x :| xs) = prettyListBy config (x : xs)
+instance (PrettyBy config a) => DefaultPrettyBy config (NonEmpty a) where
+  defaultPrettyBy config (x :| xs) = prettyListBy config (x : xs)
 
 -- ###########################################################
 -- ## The 'NonDefaultPrettyBy' class and its none instances ##
 -- ###########################################################
 
--- | A class for overriding default pretty-printing behavior for types having it.
--- Read the docs of 'HasPrettyDefaults' for how to use the class.
+{-| A class for overriding default pretty-printing behavior for types having it.
+Read the docs of 'HasPrettyDefaults' for how to use the class.
+-}
 class NonDefaultPrettyBy config a where
-    -- | Pretty-print a value of a type supporting default pretty-printing in a possibly
-    -- non-default way. The "possibly" is due to 'nonDefaultPrettyBy' having a default
-    -- implementation as 'defaultPrettyBy'. See docs for 'HasPrettyDefaults' for details.
-    nonDefaultPrettyBy :: config -> a -> Doc ann
-    default nonDefaultPrettyBy :: DefaultPrettyBy config a => config -> a -> Doc ann
-    nonDefaultPrettyBy = defaultPrettyBy
+  -- | Pretty-print a value of a type supporting default pretty-printing in a possibly
+  -- non-default way. The "possibly" is due to 'nonDefaultPrettyBy' having a default
+  -- implementation as 'defaultPrettyBy'. See docs for 'HasPrettyDefaults' for details.
+  nonDefaultPrettyBy :: config -> a -> Doc ann
+  default nonDefaultPrettyBy :: (DefaultPrettyBy config a) => config -> a -> Doc ann
+  nonDefaultPrettyBy = defaultPrettyBy
 
-    -- | 'nonDefaultPrettyListBy' to 'prettyListBy' is what 'nonDefaultPrettyBy' to 'prettyBy'.
-    -- Analogously, the default implementation is 'defaultPrettyListBy'.
-    nonDefaultPrettyListBy :: config -> [a] -> Doc ann
-    default nonDefaultPrettyListBy :: DefaultPrettyBy config a => config -> [a] -> Doc ann
-    nonDefaultPrettyListBy = defaultPrettyListBy
+  -- | 'nonDefaultPrettyListBy' to 'prettyListBy' is what 'nonDefaultPrettyBy' to 'prettyBy'.
+  -- Analogously, the default implementation is 'defaultPrettyListBy'.
+  nonDefaultPrettyListBy :: config -> [a] -> Doc ann
+  default nonDefaultPrettyListBy :: (DefaultPrettyBy config a) => config -> [a] -> Doc ann
+  nonDefaultPrettyListBy = defaultPrettyListBy
 
 -- ####################################################################
 -- ## Dispatching between 'DefaultPrettyBy' and 'NonDefaultPrettyBy' ##
 -- ####################################################################
 
--- | 'DispatchPrettyDefaultBy' is a class for dispatching on @HasPrettyDefaults config@:
--- if it's @'True@, then 'dispatchPrettyDefaultBy' is instantiated as 'defaultPrettyBy',
--- otherwise as 'nonDefaultPrettyBy' (and similarly for 'dispatchPrettyDefaultListBy').
--- I.e. depending on whether a config allows to pretty-print values using default
--- pretty-printing, either the default or non-default pretty-printing strategy is used.
-class HasPrettyDefaults config ~ b => DispatchPrettyDefaultBy (b :: Bool) config a where
-    dispatchPrettyDefaultBy     :: config -> a   -> Doc ann
-    dispatchPrettyDefaultListBy :: config -> [a] -> Doc ann
+{-| 'DispatchPrettyDefaultBy' is a class for dispatching on @HasPrettyDefaults config@:
+if it's @'True@, then 'dispatchPrettyDefaultBy' is instantiated as 'defaultPrettyBy',
+otherwise as 'nonDefaultPrettyBy' (and similarly for 'dispatchPrettyDefaultListBy').
+I.e. depending on whether a config allows to pretty-print values using default
+pretty-printing, either the default or non-default pretty-printing strategy is used.
+-}
+class (HasPrettyDefaults config ~ b) => DispatchPrettyDefaultBy (b :: Bool) config a where
+  dispatchPrettyDefaultBy :: config -> a -> Doc ann
+  dispatchPrettyDefaultListBy :: config -> [a] -> Doc ann
 
-instance (HasPrettyDefaults config ~ 'True, DefaultPrettyBy config a) =>
-            DispatchPrettyDefaultBy 'True config a where
-    dispatchPrettyDefaultBy     = defaultPrettyBy
-    dispatchPrettyDefaultListBy = defaultPrettyListBy
+instance
+  (HasPrettyDefaults config ~ 'True, DefaultPrettyBy config a)
+  => DispatchPrettyDefaultBy 'True config a
+  where
+  dispatchPrettyDefaultBy = defaultPrettyBy
+  dispatchPrettyDefaultListBy = defaultPrettyListBy
 
-instance (HasPrettyDefaults config ~ 'False, NonDefaultPrettyBy config a) =>
-            DispatchPrettyDefaultBy 'False config a where
-    dispatchPrettyDefaultBy     = nonDefaultPrettyBy
-    dispatchPrettyDefaultListBy = nonDefaultPrettyListBy
+instance
+  (HasPrettyDefaults config ~ 'False, NonDefaultPrettyBy config a)
+  => DispatchPrettyDefaultBy 'False config a
+  where
+  dispatchPrettyDefaultBy = nonDefaultPrettyBy
+  dispatchPrettyDefaultListBy = nonDefaultPrettyListBy
 
 {- Note [Definition of PrettyDefaultBy]
 A class alias throws "this makes type inference for inner bindings fragile" warnings
@@ -574,256 +617,339 @@ application is implemented.
 
 -- | Throw @err@ when @b@ is stuck.
 type family ThrowOnStuck err (b :: Bool) :: Bool where
-    ThrowOnStuck _   'True  = 'True
-    ThrowOnStuck _   'False = 'False
-    ThrowOnStuck err _      = err
+  ThrowOnStuck _ 'True = 'True
+  ThrowOnStuck _ 'False = 'False
+  ThrowOnStuck err _ = err
 
--- We have to use a type family here rather than a type alias, because otherwise it evaluates too early.
+-- We have to use a type family here rather than a type alias,
+-- because otherwise it evaluates too early.
+
 -- | The error thrown when @HasPrettyDefaults config@ is stuck.
 type family HasPrettyDefaultsStuckError config :: Bool where
-    HasPrettyDefaultsStuckError config = TypeError
-        (     'Text "No ’HasPrettyDefaults’ is specified for " ':<>: 'ShowType config
-        ':$$: 'Text "Either you're trying to derive an instance, in which case you have to use"
-        ':$$: 'Text "  standalone deriving and need to explicitly put a ‘PrettyDefaultBy config’"
-        ':$$: 'Text "  constraint in the instance context for each type in your data type"
-        ':$$: 'Text "  that supports default pretty-printing"
-        ':$$: 'Text "Or you're trying to pretty-print a value of a type supporting default"
-        ':$$: 'Text "  pretty-printing using a config, for which ‘HasPrettyDefaults’ is not specified."
-        ':$$: 'Text "  If the config is a bound type variable, then you need to add"
-        ':$$: 'Text "    ‘HasPrettyDefaults <config_variable_name> ~ 'True’"
-        ':$$: 'Text "  to the context."
-        ':$$: 'Text "  If the config is a data type, then you need to add"
-        ':$$: 'Text "    ‘type instance HasPrettyDefaults <config_name> = 'True’"
-        ':$$: 'Text "  at the top level."
-        )
+  HasPrettyDefaultsStuckError config =
+    TypeError
+      ( 'Text "No ’HasPrettyDefaults’ is specified for " ':<>: 'ShowType config
+          ':$$: 'Text "Either you're trying to derive an instance, in which case you have to use"
+          ':$$: 'Text "  standalone deriving and need to explicitly put a ‘PrettyDefaultBy config’"
+          ':$$: 'Text "  constraint in the instance context for each type in your data type"
+          ':$$: 'Text "  that supports default pretty-printing"
+          ':$$: 'Text "Or you're trying to pretty-print a value of a type supporting default"
+          ':$$: 'Text
+                  "  pretty-printing using a config, \
+                  \for which ‘HasPrettyDefaults’ is not specified."
+          ':$$: 'Text "  If the config is a bound type variable, then you need to add"
+          ':$$: 'Text "    ‘HasPrettyDefaults <config_variable_name> ~ 'True’"
+          ':$$: 'Text "  to the context."
+          ':$$: 'Text "  If the config is a data type, then you need to add"
+          ':$$: 'Text "    ‘type instance HasPrettyDefaults <config_name> = 'True’"
+          ':$$: 'Text "  at the top level."
+      )
 
--- | A version of 'HasPrettyDefaults' that is never stuck: it either immediately evaluates
--- to a 'Bool' or fails with a 'TypeError'.
+{-| A version of 'HasPrettyDefaults' that is never stuck: it either immediately evaluates
+to a 'Bool' or fails with a 'TypeError'.
+-}
 type NonStuckHasPrettyDefaults config =
-    ThrowOnStuck (HasPrettyDefaultsStuckError config) (HasPrettyDefaults config)
+  ThrowOnStuck (HasPrettyDefaultsStuckError config) (HasPrettyDefaults config)
 
 -- See Note [Definition of PrettyDefaultBy].
--- | @PrettyDefaultBy config a@ is the same thing as @PrettyBy config a@, when @a@ supports
--- default pretty-printing. Thus @PrettyDefaultBy config a@ and @PrettyBy config a@ are
--- interchangeable constraints for such types, but the latter throws an annoying
--- \"this makes type inference for inner bindings fragile\" warning, unlike the former.
--- @PrettyDefaultBy config a@ reads as \"@a@ supports default pretty-printing and can be
--- pretty-printed via @config@ in either default or non-default manner depending on whether
--- @config@ supports default pretty-printing\".
+
+{-| @PrettyDefaultBy config a@ is the same thing as @PrettyBy config a@, when @a@ supports
+default pretty-printing. Thus @PrettyDefaultBy config a@ and @PrettyBy config a@ are
+interchangeable constraints for such types, but the latter throws an annoying
+\"this makes type inference for inner bindings fragile\" warning, unlike the former.
+@PrettyDefaultBy config a@ reads as \"@a@ supports default pretty-printing and can be
+pretty-printed via @config@ in either default or non-default manner depending on whether
+@config@ supports default pretty-printing\".
+-}
 type PrettyDefaultBy config = DispatchPrettyDefaultBy (NonStuckHasPrettyDefaults config) config
 
--- | A newtype wrapper defined for its 'PrettyBy' instance that allows to via-derive a 'PrettyBy'
--- instance for a type supporting default pretty-printing.
+{-| A newtype wrapper defined for its 'PrettyBy' instance that allows to via-derive a 'PrettyBy'
+instance for a type supporting default pretty-printing.
+-}
 newtype PrettyCommon a = PrettyCommon
-    { unPrettyCommon :: a
-    }
+  { unPrettyCommon :: a
+  }
 
-coerceDispatchPrettyDefaults :: Coercible a b => (config -> a -> Doc ann) -> config -> b -> Doc ann
+coerceDispatchPrettyDefaults
+  :: (Coercible a b) => (config -> a -> Doc ann) -> config -> b -> Doc ann
 coerceDispatchPrettyDefaults = coerce
 
-instance PrettyDefaultBy config a => PrettyBy config (PrettyCommon a) where
-    prettyBy     = coerceDispatchPrettyDefaults @a   dispatchPrettyDefaultBy
-    prettyListBy = coerceDispatchPrettyDefaults @[a] dispatchPrettyDefaultListBy
+instance (PrettyDefaultBy config a) => PrettyBy config (PrettyCommon a) where
+  prettyBy = coerceDispatchPrettyDefaults @a dispatchPrettyDefaultBy
+  prettyListBy = coerceDispatchPrettyDefaults @[a] dispatchPrettyDefaultListBy
 
 -- #######################################################################
 -- ## 'PrettyBy' instances for types supporting default pretty-printing ##
 -- #######################################################################
 
--- |
--- >>> prettyBy () ([] :: [Void])
--- []
-deriving via PrettyCommon Void
-    instance PrettyDefaultBy config Void => PrettyBy config Void
+{-|
+>>> prettyBy () ([] :: [Void])
+[]
+-}
+deriving via
+  PrettyCommon Void
+  instance
+    (PrettyDefaultBy config Void) => PrettyBy config Void
 
--- |
--- >>> prettyBy () ()
--- ()
---
--- The argument is not used:
---
--- >>> prettyBy () (error "Strict?" :: ())
--- ()
-deriving via PrettyCommon ()
-    instance PrettyDefaultBy config () => PrettyBy config ()
+{-|
+>>> prettyBy () ()
+()
 
--- |
--- >>> prettyBy () True
--- True
-deriving via PrettyCommon Bool
-    instance PrettyDefaultBy config Bool => PrettyBy config Bool
+The argument is not used:
 
--- |
--- >>> prettyBy () (123 :: Natural)
--- 123
-deriving via PrettyCommon Natural
-    instance PrettyDefaultBy config Natural => PrettyBy config Natural
+>>> prettyBy () (error "Strict?" :: ())
+()
+-}
+deriving via
+  PrettyCommon ()
+  instance
+    (PrettyDefaultBy config ()) => PrettyBy config ()
 
--- |
--- >>> prettyBy () (2^(123 :: Int) :: Integer)
--- 10633823966279326983230456482242756608
-deriving via PrettyCommon Integer
-    instance PrettyDefaultBy config Integer => PrettyBy config Integer
+{-|
+>>> prettyBy () True
+True
+-}
+deriving via
+  PrettyCommon Bool
+  instance
+    (PrettyDefaultBy config Bool) => PrettyBy config Bool
 
--- |
--- >>> prettyBy () (123 :: Int)
--- 123
-deriving via PrettyCommon Int
-    instance PrettyDefaultBy config Int => PrettyBy config Int
-deriving via PrettyCommon Int8
-    instance PrettyDefaultBy config Int8 => PrettyBy config Int8
-deriving via PrettyCommon Int16
-    instance PrettyDefaultBy config Int16 => PrettyBy config Int16
-deriving via PrettyCommon Int32
-    instance PrettyDefaultBy config Int32 => PrettyBy config Int32
-deriving via PrettyCommon Int64
-    instance PrettyDefaultBy config Int64 => PrettyBy config Int64
-deriving via PrettyCommon Word
-    instance PrettyDefaultBy config Word => PrettyBy config Word
-deriving via PrettyCommon Word8
-    instance PrettyDefaultBy config Word8 => PrettyBy config Word8
-deriving via PrettyCommon Word16
-    instance PrettyDefaultBy config Word16 => PrettyBy config Word16
-deriving via PrettyCommon Word32
-    instance PrettyDefaultBy config Word32 => PrettyBy config Word32
-deriving via PrettyCommon Word64
-    instance PrettyDefaultBy config Word64 => PrettyBy config Word64
+{-|
+>>> prettyBy () (123 :: Natural)
+123
+-}
+deriving via
+  PrettyCommon Natural
+  instance
+    (PrettyDefaultBy config Natural) => PrettyBy config Natural
 
--- |
--- >>> prettyBy () (pi :: Float)
--- 3.1415927
-deriving via PrettyCommon Float
-    instance PrettyDefaultBy config Float => PrettyBy config Float
+{-|
+>>> prettyBy () (2^(123 :: Int) :: Integer)
+10633823966279326983230456482242756608
+-}
+deriving via
+  PrettyCommon Integer
+  instance
+    (PrettyDefaultBy config Integer) => PrettyBy config Integer
 
--- |
--- >>> prettyBy () (pi :: Double)
--- 3.141592653589793
-deriving via PrettyCommon Double
-    instance PrettyDefaultBy config Double => PrettyBy config Double
+{-|
+>>> prettyBy () (123 :: Int)
+123
+-}
+deriving via
+  PrettyCommon Int
+  instance
+    (PrettyDefaultBy config Int) => PrettyBy config Int
 
--- | Automatically converts all newlines to @line@.
---
--- >>> prettyBy () ("hello\nworld" :: Strict.Text)
--- hello
--- world
-deriving via PrettyCommon Strict.Text
-    instance PrettyDefaultBy config Strict.Text => PrettyBy config Strict.Text
+deriving via
+  PrettyCommon Int8
+  instance
+    (PrettyDefaultBy config Int8) => PrettyBy config Int8
+deriving via
+  PrettyCommon Int16
+  instance
+    (PrettyDefaultBy config Int16) => PrettyBy config Int16
+deriving via
+  PrettyCommon Int32
+  instance
+    (PrettyDefaultBy config Int32) => PrettyBy config Int32
+deriving via
+  PrettyCommon Int64
+  instance
+    (PrettyDefaultBy config Int64) => PrettyBy config Int64
+deriving via
+  PrettyCommon Word
+  instance
+    (PrettyDefaultBy config Word) => PrettyBy config Word
+deriving via
+  PrettyCommon Word8
+  instance
+    (PrettyDefaultBy config Word8) => PrettyBy config Word8
+deriving via
+  PrettyCommon Word16
+  instance
+    (PrettyDefaultBy config Word16) => PrettyBy config Word16
+deriving via
+  PrettyCommon Word32
+  instance
+    (PrettyDefaultBy config Word32) => PrettyBy config Word32
+deriving via
+  PrettyCommon Word64
+  instance
+    (PrettyDefaultBy config Word64) => PrettyBy config Word64
+
+{-|
+>>> prettyBy () (pi :: Float)
+3.1415927
+-}
+deriving via
+  PrettyCommon Float
+  instance
+    (PrettyDefaultBy config Float) => PrettyBy config Float
+
+{-|
+>>> prettyBy () (pi :: Double)
+3.141592653589793
+-}
+deriving via
+  PrettyCommon Double
+  instance
+    (PrettyDefaultBy config Double) => PrettyBy config Double
+
+{-| Automatically converts all newlines to @line@.
+
+>>> prettyBy () ("hello\nworld" :: Strict.Text)
+hello
+world
+-}
+deriving via
+  PrettyCommon Strict.Text
+  instance
+    (PrettyDefaultBy config Strict.Text) => PrettyBy config Strict.Text
 
 -- | An instance for lazy @Text@. Identitical to the strict one.
-deriving via PrettyCommon Lazy.Text
-    instance PrettyDefaultBy config Lazy.Text => PrettyBy config Lazy.Text
+deriving via
+  PrettyCommon Lazy.Text
+  instance
+    (PrettyDefaultBy config Lazy.Text) => PrettyBy config Lazy.Text
 
--- |
--- >>> prettyBy () (Identity True)
--- True
-deriving via PrettyCommon (Identity a)
-    instance PrettyDefaultBy config (Identity a) => PrettyBy config (Identity a)
+{-|
+>>> prettyBy () (Identity True)
+True
+-}
+deriving via
+  PrettyCommon (Identity a)
+  instance
+    (PrettyDefaultBy config (Identity a)) => PrettyBy config (Identity a)
 
--- |
--- >>> prettyBy () (False, "abc")
--- (False, abc)
-deriving via PrettyCommon (a, b)
-    instance PrettyDefaultBy config (a, b) => PrettyBy config (a, b)
+{-|
+>>> prettyBy () (False, "abc")
+(False, abc)
+-}
+deriving via
+  PrettyCommon (a, b)
+  instance
+    (PrettyDefaultBy config (a, b)) => PrettyBy config (a, b)
 
--- |
--- >>> prettyBy () ('a', "bcd", True)
--- (a, bcd, True)
-deriving via PrettyCommon (a, b, c)
-    instance PrettyDefaultBy config (a, b, c) => PrettyBy config (a, b, c)
+{-|
+>>> prettyBy () ('a', "bcd", True)
+(a, bcd, True)
+-}
+deriving via
+  PrettyCommon (a, b, c)
+  instance
+    (PrettyDefaultBy config (a, b, c)) => PrettyBy config (a, b, c)
 
--- | Non-polykinded, because @Pretty (Const a b)@ is not polykinded either.
---
--- >>> prettyBy () (Const 1 :: Const Integer Bool)
--- 1
-deriving via PrettyCommon (Const a b)
-    instance PrettyDefaultBy config (Const a b) => PrettyBy config (Const a b)
+{-| Non-polykinded, because @Pretty (Const a b)@ is not polykinded either.
 
--- | 'prettyBy' for @[a]@ is defined in terms of 'prettyListBy' by default.
---
--- >>> prettyBy () [True, False]
--- [True, False]
--- >>> prettyBy () "abc"
--- abc
--- >>> prettyBy () [Just False, Nothing, Just True]
--- [False, True]
-deriving via PrettyCommon [a]
-    instance PrettyDefaultBy config [a] => PrettyBy config [a]
+>>> prettyBy () (Const 1 :: Const Integer Bool)
+1
+-}
+deriving via
+  PrettyCommon (Const a b)
+  instance
+    (PrettyDefaultBy config (Const a b)) => PrettyBy config (Const a b)
 
--- | 'prettyBy' for @NonEmpty a@ is defined in terms of 'prettyListBy' by default.
---
--- >>> prettyBy () (True :| [False])
--- [True, False]
--- >>> prettyBy () ('a' :| "bc")
--- abc
--- >>> prettyBy () (Just False :| [Nothing, Just True])
--- [False, True]
-deriving via PrettyCommon (NonEmpty a)
-    instance PrettyDefaultBy config (NonEmpty a) => PrettyBy config (NonEmpty a)
+{-| 'prettyBy' for @[a]@ is defined in terms of 'prettyListBy' by default.
 
--- | By default a 'String' (i.e. @[Char]@) is converted to a @Text@ first and then pretty-printed.
--- So make sure that if you have any non-default pretty-printing for @Char@ or @Text@,
--- they're in sync.
---
--- >>> prettyBy () 'a'
--- a
--- >>> prettyBy () "abc"
--- abc
-deriving via PrettyCommon Char
-    instance PrettyDefaultBy config Char => PrettyBy config Char
+>>> prettyBy () [True, False]
+[True, False]
+>>> prettyBy () "abc"
+abc
+>>> prettyBy () [Just False, Nothing, Just True]
+[False, True]
+-}
+deriving via
+  PrettyCommon [a]
+  instance
+    (PrettyDefaultBy config [a]) => PrettyBy config [a]
 
--- | By default a @[Maybe a]@ is converted to @[a]@ first and only then pretty-printed.
---
--- >>> braces $ prettyBy () (Just True)
--- {True}
--- >>> braces $ prettyBy () (Nothing :: Maybe Bool)
--- {}
--- >>> prettyBy () [Just False, Nothing, Just True]
--- [False, True]
--- >>> prettyBy () [Nothing, Just 'a', Just 'b', Nothing, Just 'c']
--- abc
-deriving via PrettyCommon (Maybe a)
-    instance PrettyDefaultBy config (Maybe a) => PrettyBy config (Maybe a)
+{-| 'prettyBy' for @NonEmpty a@ is defined in terms of 'prettyListBy' by default.
+
+>>> prettyBy () (True :| [False])
+[True, False]
+>>> prettyBy () ('a' :| "bc")
+abc
+>>> prettyBy () (Just False :| [Nothing, Just True])
+[False, True]
+-}
+deriving via
+  PrettyCommon (NonEmpty a)
+  instance
+    (PrettyDefaultBy config (NonEmpty a)) => PrettyBy config (NonEmpty a)
+
+{-| By default a 'String' (i.e. @[Char]@) is converted to a @Text@ first and then pretty-printed.
+So make sure that if you have any non-default pretty-printing for @Char@ or @Text@,
+they're in sync.
+
+>>> prettyBy () 'a'
+a
+>>> prettyBy () "abc"
+abc
+-}
+deriving via
+  PrettyCommon Char
+  instance
+    (PrettyDefaultBy config Char) => PrettyBy config Char
+
+{-| By default a @[Maybe a]@ is converted to @[a]@ first and only then pretty-printed.
+
+>>> braces $ prettyBy () (Just True)
+{True}
+>>> braces $ prettyBy () (Nothing :: Maybe Bool)
+{}
+>>> prettyBy () [Just False, Nothing, Just True]
+[False, True]
+>>> prettyBy () [Nothing, Just 'a', Just 'b', Nothing, Just 'c']
+abc
+-}
+deriving via
+  PrettyCommon (Maybe a)
+  instance
+    (PrettyDefaultBy config (Maybe a)) => PrettyBy config (Maybe a)
 
 -- #############################
 -- ## The 'PrettyAny' newtype ##
 -- #############################
 
--- | A @newtype@ wrapper around @a@ provided for the purporse of defining 'PrettyBy' instances
--- handling any @a@. For example you can wrap values with the @PrettyAny@ constructor directly
--- like in this last line of
---
--- >>> data ViaShow = ViaShow
--- >>> instance Show a => PrettyBy ViaShow (PrettyAny a) where prettyBy ViaShow = pretty . show . unPrettyAny
--- >>> prettyBy ViaShow $ PrettyAny True
--- True
---
--- or you can use the type to via-derive instances:
---
--- >>> data D = D deriving stock (Show)
--- >>> deriving via PrettyAny D instance PrettyBy ViaShow D
--- >>> prettyBy ViaShow D
--- D
---
--- One important use case is handling sum-type configs. For example having two configs you can
--- define their sum and derive 'PrettyBy' for the unified config in terms of its components:
---
--- >>> data UpperCase = UpperCase
--- >>> data LowerCase = LowerCase
--- >>> data Case = CaseUpperCase UpperCase | CaseLowerCase LowerCase
--- >>> instance (PrettyBy UpperCase a, PrettyBy LowerCase a) => PrettyBy Case (PrettyAny a) where prettyBy (CaseUpperCase upper) = prettyBy upper . unPrettyAny; prettyBy (CaseLowerCase lower) = prettyBy lower . unPrettyAny
---
--- Then having a data type implementing both @PrettyBy UpperCase@ and @PrettyBy LowerCase@ you can
--- derive @PrettyBy Case@ for that data type:
---
--- >>> data D = D
--- >>> instance PrettyBy UpperCase D where prettyBy UpperCase D = "D"
--- >>> instance PrettyBy LowerCase D where prettyBy LowerCase D = "d"
--- >>> deriving via PrettyAny D instance PrettyBy Case D
--- >>> prettyBy UpperCase D
--- D
--- >>> prettyBy LowerCase D
--- d
---
--- Look into @test/Universal.hs@ for an extended example.
+{-| A @newtype@ wrapper around @a@ provided for the purporse of defining 'PrettyBy' instances
+handling any @a@. For example you can wrap values with the @PrettyAny@ constructor directly
+like in this last line of
+
+>>> data ViaShow = ViaShow
+>>> instance Show a => PrettyBy ViaShow (PrettyAny a) where prettyBy ViaShow = pretty . show . unPrettyAny
+>>> prettyBy ViaShow $ PrettyAny True
+True
+
+or you can use the type to via-derive instances:
+
+>>> data D = D deriving stock (Show)
+>>> deriving via PrettyAny D instance PrettyBy ViaShow D
+>>> prettyBy ViaShow D
+D
+
+One important use case is handling sum-type configs. For example having two configs you can
+define their sum and derive 'PrettyBy' for the unified config in terms of its components:
+
+>>> data UpperCase = UpperCase
+>>> data LowerCase = LowerCase
+>>> data Case = CaseUpperCase UpperCase | CaseLowerCase LowerCase
+>>> instance (PrettyBy UpperCase a, PrettyBy LowerCase a) => PrettyBy Case (PrettyAny a) where prettyBy (CaseUpperCase upper) = prettyBy upper . unPrettyAny; prettyBy (CaseLowerCase lower) = prettyBy lower . unPrettyAny
+
+Then having a data type implementing both @PrettyBy UpperCase@ and @PrettyBy LowerCase@ you can
+derive @PrettyBy Case@ for that data type:
+
+>>> data D = D
+>>> instance PrettyBy UpperCase D where prettyBy UpperCase D = "D"
+>>> instance PrettyBy LowerCase D where prettyBy LowerCase D = "d"
+>>> deriving via PrettyAny D instance PrettyBy Case D
+>>> prettyBy UpperCase D
+D
+>>> prettyBy LowerCase D
+d
+
+Look into @test/Universal.hs@ for an extended example.
+-}
 newtype PrettyAny a = PrettyAny
-    { unPrettyAny :: a
-    }
+  { unPrettyAny :: a
+  }

--- a/prettyprinter-configurable/src/Text/PrettyBy/Internal/Utils.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Internal/Utils.hs
@@ -1,17 +1,14 @@
--- editorconfig-checker-disable-file
 -- | Utils used internally.
+module Text.PrettyBy.Internal.Utils (
+  view,
+) where
 
-module Text.PrettyBy.Internal.Utils
-    ( view
-    ) where
-
-import Control.Monad.Reader
-import Data.Functor.Const
-import Lens.Micro
+import Control.Monad.Reader (MonadReader, asks)
+import Data.Functor.Const (Const (Const, getConst))
+import Lens.Micro (Getting)
 import Lens.Micro.Internal ((#.))
 
--- | An inlined https://hackage.haskell.org/package/microlens-mtl-0.2.0.1/docs/Lens-Micro-Mtl.html#v:view
--- (just not to depend on this package).
-view :: MonadReader s m => Getting a s a -> m a
+-- | An inlined 'Lens.Micro.Mtl.view' (just not to depend on this package).
+view :: (MonadReader s m) => Getting a s a -> m a
 view l = asks (getConst #. l Const)
 {-# INLINE view #-}

--- a/prettyprinter-configurable/src/Text/PrettyBy/Monad.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Monad.hs
@@ -5,30 +5,29 @@
 {-# LANGUAGE RankNTypes             #-}
 
 -- | A monadic interface to configurable pretty-printing.
+module Text.PrettyBy.Monad (
+  HasPrettyConfig (..),
+  MonadPretty,
+  prettyM,
+  displayM,
+) where
 
-module Text.PrettyBy.Monad
-    ( HasPrettyConfig (..)
-    , MonadPretty
-    , prettyM
-    , displayM
-    ) where
-
-import Text.Pretty
-import Text.PrettyBy.Default
-import Text.PrettyBy.Internal
-import Text.PrettyBy.Internal.Utils
-
-import Control.Monad.Reader
-import Lens.Micro
+import Control.Monad.Reader (MonadReader)
+import Lens.Micro (Lens')
+import Text.Pretty (Doc)
+import Text.PrettyBy.Default (Render (..))
+import Text.PrettyBy.Internal (PrettyBy (prettyBy))
+import Text.PrettyBy.Internal.Utils (view)
 
 -- | A constraint for \"@config@ is a part of @env@\".
 class HasPrettyConfig env config | env -> config where
-    prettyConfig :: Lens' env config
+  prettyConfig :: Lens' env config
 
 -- @env@ is an artefact of the encoding, it shouldn't be necessary as @m@ determines what it is
 -- and we're not interested in reflecting @env@ explicitly (unlike @config@, which is also
 -- determined by @m@ through @env@, but is useful to have explicitly). But GHC does not like it
 -- when @env@ is left implicit, see https://gitlab.haskell.org/ghc/ghc/issues/3490
+
 -- | A constraint for \"@m@ is a monad that allows to pretty-print values in it by a @config@\".
 type MonadPretty config env m = (MonadReader env m, HasPrettyConfig env config)
 
@@ -36,9 +35,14 @@ type MonadPretty config env m = (MonadReader env m, HasPrettyConfig env config)
 prettyM :: (MonadPretty config env m, PrettyBy config a) => a -> m (Doc ann)
 prettyM x = flip prettyBy x <$> view prettyConfig
 
--- | Pretty-print and render a value as a string type in a configurable way in a monad holding
--- a config.
+{-| Pretty-print and render a value as a string type in a configurable way in a monad holding
+a config.
+-}
 displayM
-    :: forall str a m env config. (MonadPretty config env m, PrettyBy config a, Render str)
-    => a -> m str
+  :: forall str a m env config
+   . ( MonadPretty config env m
+     , PrettyBy config a
+     , Render str
+     )
+  => a -> m str
 displayM = fmap render . prettyM


### PR DESCRIPTION
- [x] Apply fourmolu to the `prettyprinter-configurable` package.
- [x] Apply `stylish-haskell` on top of it.

Closes https://github.com/IntersectMBO/plutus/issues/6682