### PR TITLE
Move some pragmas to below functions

### DIFF
--- a/cardano-constitution/src/Cardano/Constitution/Config.hs
+++ b/cardano-constitution/src/Cardano/Constitution/Config.hs
@@ -17,14 +17,14 @@ import PlutusTx.Ord as Tx
 import Data.Aeson.THReader as Aeson
 
 -- | The default config read from "data/defaultConstitution.json"
-{-# INLINABLE defaultConstitutionConfig #-}
 defaultConstitutionConfig :: ConstitutionConfig
 defaultConstitutionConfig = $$(Aeson.readJSONFromFile DFP.defaultConstitutionConfigFile)
+{-# INLINABLE defaultConstitutionConfig #-}
 
-{-# INLINABLE defaultPredMeanings #-}
 -- | NOTE: **BE CAREFUL** of the ordering. Expected value is first arg, Proposed Value is second arg
 defaultPredMeanings :: PredKey -> PredMeaning a
 defaultPredMeanings = \case
     MinValue -> (Tx.<=)
     MaxValue -> (Tx.>=)
     NotEqual -> (Tx./=)
+{-# INLINABLE defaultPredMeanings #-}

--- a/cardano-constitution/src/Cardano/Constitution/Validator/Common.hs
+++ b/cardano-constitution/src/Cardano/Constitution/Validator/Common.hs
@@ -55,7 +55,6 @@ validateParamValue = \case
               && validateParamValues paramValueTl (BI.tail actualValueData)
           -- if reached the end of list of param-values to check, ensure no more proposed data are left
           [] -> B.fromOpaque . BI.null
-{-# INLINABLE validateParamValue #-}
 
       validatePreds :: forall a. Tx.Ord a => Predicates a -> a -> Bool
       validatePreds (Predicates preds) (validatePred -> validatePredAppliedToActual) =
@@ -69,6 +68,7 @@ validateParamValue = \case
           meaning = defaultPredMeanings predKey
           -- apply the meaning to actual value: expectedValue is 1st argument, actualValue is 2nd argument
           meaningWithActual = (`meaning` actualValue)
+{-# INLINABLE validateParamValue #-}
 
 scriptContextToValidGovAction :: BuiltinData -> Maybe ChangedParams
 scriptContextToValidGovAction = scriptContextToScriptInfo
@@ -82,7 +82,6 @@ scriptContextToValidGovAction = scriptContextToScriptInfo
                                >>> BI.tail
                                >>> BI.tail
                                >>> BI.head
-{-# INLINABLE scriptContextToValidGovAction #-}
 
     scriptInfoToProposalProcedure :: BuiltinData -> BuiltinData
     scriptInfoToProposalProcedure (BI.unsafeDataAsConstr -> si) =
@@ -104,3 +103,4 @@ scriptContextToValidGovAction = scriptContextToScriptInfo
         -- Constructor Index of `TreasuryWithdrawals` is 2
         | govActionConstr `B.equalsInteger` 2 = Nothing -- means treasurywithdrawal
         | otherwise = traceError "Not a ChangedParams or TreasuryWithdrawals. This should not ever happen, because ledger should guard before, against it."
+{-# INLINABLE scriptContextToValidGovAction #-}

--- a/cardano-constitution/src/Cardano/Constitution/Validator/Common.hs
+++ b/cardano-constitution/src/Cardano/Constitution/Validator/Common.hs
@@ -30,7 +30,6 @@ type ChangedParams = [(BuiltinData, BuiltinData)]
 
 {- HLINT ignore "Redundant lambda" -} -- I like to see until where it supposed to be first applied.
 {- HLINT ignore "Collapse lambdas" -} -- I like to see and comment on each arg
-{-# INLINABLE withChangedParams #-}
 withChangedParams :: (ChangedParams -> Bool) -> ConstitutionValidator
 withChangedParams fun (scriptContextToValidGovAction -> validGovAction) =
     case validGovAction of
@@ -38,8 +37,8 @@ withChangedParams fun (scriptContextToValidGovAction -> validGovAction) =
             then BI.unitval
             else traceError "ChangedParams failed to validate"
         Nothing -> BI.unitval -- this is a treasury withdrawal, we just accept it
+{-# INLINABLE withChangedParams #-}
 
-{-# INLINABLE validateParamValue #-}
 validateParamValue :: ParamValue -> BuiltinData -> Bool
 validateParamValue = \case
     ParamInteger preds -> validatePreds preds . B.unsafeDataAsI
@@ -56,6 +55,7 @@ validateParamValue = \case
               && validateParamValues paramValueTl (BI.tail actualValueData)
           -- if reached the end of list of param-values to check, ensure no more proposed data are left
           [] -> B.fromOpaque . BI.null
+{-# INLINABLE validateParamValue #-}
 
       validatePreds :: forall a. Tx.Ord a => Predicates a -> a -> Bool
       validatePreds (Predicates preds) (validatePred -> validatePredAppliedToActual) =
@@ -70,7 +70,6 @@ validateParamValue = \case
           -- apply the meaning to actual value: expectedValue is 1st argument, actualValue is 2nd argument
           meaningWithActual = (`meaning` actualValue)
 
-{-# INLINABLE scriptContextToValidGovAction #-}
 scriptContextToValidGovAction :: BuiltinData -> Maybe ChangedParams
 scriptContextToValidGovAction = scriptContextToScriptInfo
                            >>> scriptInfoToProposalProcedure
@@ -83,6 +82,7 @@ scriptContextToValidGovAction = scriptContextToScriptInfo
                                >>> BI.tail
                                >>> BI.tail
                                >>> BI.head
+{-# INLINABLE scriptContextToValidGovAction #-}
 
     scriptInfoToProposalProcedure :: BuiltinData -> BuiltinData
     scriptInfoToProposalProcedure (BI.unsafeDataAsConstr -> si) =

--- a/cardano-constitution/src/Cardano/Constitution/Validator/Unsorted.hs
+++ b/cardano-constitution/src/Cardano/Constitution/Validator/Unsorted.hs
@@ -36,7 +36,6 @@ validateParam (ConstitutionConfig cfg) (B.unsafeDataAsI -> actualPid, actualValu
       (lookupUnsafe actualPid cfg)
       actualValueData
 
-{-# INLINEABLE lookupUnsafe #-}
 -- | An unsafe version of PlutusTx.AssocMap.lookup, specialised to Integer keys
 lookupUnsafe :: Integer -> [(Integer, v)] -> v
 lookupUnsafe k = go
@@ -45,6 +44,7 @@ lookupUnsafe k = go
    go ((k', i) : xs') = if k `B.equalsInteger` k'
                         then i
                         else go xs'
+{-# INLINEABLE lookupUnsafe #-}
 
 -- | Statically configure the validator with the `defaultConstitutionConfig`.
 defaultConstitutionValidator :: ConstitutionValidator

--- a/doc/docusaurus/static/code/AuctionMintingPolicy.hs
+++ b/doc/docusaurus/static/code/AuctionMintingPolicy.hs
@@ -32,7 +32,6 @@ import PlutusTx.Prelude qualified as PlutusTx
 type AuctionMintingParams = PubKeyHash
 type AuctionMintingRedeemer = ()
 
-{-# INLINEABLE auctionTypedMintingPolicy #-}
 auctionTypedMintingPolicy ::
   AuctionMintingParams ->
   AuctionMintingRedeemer ->
@@ -47,6 +46,7 @@ auctionTypedMintingPolicy pkh _redeemer ctx =
         currencySymbol PlutusTx.== ownCurrencySymbol ctx PlutusTx.&& quantity PlutusTx.== 1
       _ -> False
 -- BLOCK2
+{-# INLINEABLE auctionTypedMintingPolicy #-}
 
 auctionUntypedMintingPolicy ::
   AuctionMintingParams ->

--- a/doc/docusaurus/static/code/AuctionValidator.hs
+++ b/doc/docusaurus/static/code/AuctionValidator.hs
@@ -241,7 +241,6 @@ auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx@(ScriptConte
 
 -- BLOCK8
 -- AuctionValidator.hs
-{-# INLINEABLE auctionUntypedValidator #-}
 auctionUntypedValidator ::
   AuctionParams ->
   BuiltinData ->
@@ -256,6 +255,7 @@ auctionUntypedValidator params datum redeemer ctx =
         (PlutusTx.unsafeFromBuiltinData redeemer)
         (PlutusTx.unsafeFromBuiltinData ctx)
     )
+{-# INLINEABLE auctionUntypedValidator #-}
 
 auctionValidatorScript ::
   AuctionParams ->

--- a/doc/docusaurus/static/code/BasicPlutusTx.hs
+++ b/doc/docusaurus/static/code/BasicPlutusTx.hs
@@ -64,11 +64,11 @@ myProgram =
         -- Local functions do not need to be marked as 'INLINABLE'.
         plusOneLocal :: Integer -> Integer
         plusOneLocal x = x `addInteger` 1
-{-# INLINABLE myProgram #-}
 
         localTwo = plusOneLocal 1
         externalTwo = plusOne 1
     in localTwo `addInteger` externalTwo
+{-# INLINABLE myProgram #-}
 
 functions :: CompiledCode Integer
 functions = $$(compile [|| myProgram ||])

--- a/doc/docusaurus/static/code/BasicPlutusTx.hs
+++ b/doc/docusaurus/static/code/BasicPlutusTx.hs
@@ -52,19 +52,19 @@ integerIdentity = $$(compile [|| \(x:: Integer) -> x ||])
   GHC to keep the information that the Plutus Tx compiler needs. While
   you may be able to get away with omitting it, it is good practice to
   always include it. -}
-{-# INLINABLE plusOne #-}
 plusOne :: Integer -> Integer
 {- 'addInteger' comes from 'PlutusTx.Builtins', and is
   mapped to the builtin integer addition function in Plutus Core. -}
 plusOne x = x `addInteger` 1
+{-# INLINABLE plusOne #-}
 
-{-# INLINABLE myProgram #-}
 myProgram :: Integer
 myProgram =
     let
         -- Local functions do not need to be marked as 'INLINABLE'.
         plusOneLocal :: Integer -> Integer
         plusOneLocal x = x `addInteger` 1
+{-# INLINABLE myProgram #-}
 
         localTwo = plusOneLocal 1
         externalTwo = plusOne 1

--- a/doc/docusaurus/static/code/BasicPolicies.hs
+++ b/doc/docusaurus/static/code/BasicPolicies.hs
@@ -36,6 +36,7 @@ currencyValueOf :: Value -> CurrencySymbol -> Value
 currencyValueOf (Value m) c = case Map.lookup c m of
     Nothing -> mempty
     Just t  -> Value (Map.singleton c t)
+{-# INLINABLE currencyValueOf #-}
 -- BLOCK2
 -- The 'plutus-ledger' package from 'plutus-apps' provides helper functions to automate
 -- some of this boilerplate.
@@ -43,7 +44,6 @@ oneAtATimePolicyUntyped :: BuiltinData -> BuiltinData -> BuiltinUnit
 -- 'check' fails with 'error' if the argument is not 'True'.
 oneAtATimePolicyUntyped r c =
     check $ oneAtATimePolicy (unsafeFromBuiltinData r) (unsafeFromBuiltinData c)
-{-# INLINABLE currencyValueOf #-}
 
 -- We can use 'compile' to turn a minting policy into a compiled Plutus Core program,
 -- just as for validator scripts.

--- a/doc/docusaurus/static/code/BasicPolicies.hs
+++ b/doc/docusaurus/static/code/BasicPolicies.hs
@@ -31,7 +31,6 @@ oneAtATimePolicy _ ctx =
     -- will assume we've got from elsewhere for now.
     in currencyValueOf minted ownSymbol == singleton ownSymbol tname 1
 
-{-# INLINABLE currencyValueOf #-}
 -- | Get the quantities of just the given 'CurrencySymbol' in the 'Value'.
 currencyValueOf :: Value -> CurrencySymbol -> Value
 currencyValueOf (Value m) c = case Map.lookup c m of
@@ -44,6 +43,7 @@ oneAtATimePolicyUntyped :: BuiltinData -> BuiltinData -> BuiltinUnit
 -- 'check' fails with 'error' if the argument is not 'True'.
 oneAtATimePolicyUntyped r c =
     check $ oneAtATimePolicy (unsafeFromBuiltinData r) (unsafeFromBuiltinData c)
+{-# INLINABLE currencyValueOf #-}
 
 -- We can use 'compile' to turn a minting policy into a compiled Plutus Core program,
 -- just as for validator scripts.

--- a/plutus-benchmark/bitwise/src/PlutusBenchmark/Ed25519.hs
+++ b/plutus-benchmark/bitwise/src/PlutusBenchmark/Ed25519.hs
@@ -8,7 +8,6 @@ import PlutusBenchmark.SHA512 (sha512)
 import PlutusTx.Prelude hiding (inv)
 
 -- Based on https://ed25519.cr.yp.to/python/ed25519.py
-{-# INLINEABLE checkValid #-}
 checkValid ::
   BuiltinByteString ->
   BuiltinByteString ->
@@ -27,6 +26,7 @@ checkValid sig message pubKey =
     by = 4 * inv 5
     bx :: Integer
     bx = xRecover by
+{-# INLINEABLE checkValid #-}
 
 -- Helpers
 
@@ -36,7 +36,6 @@ instance Eq Point where
   {-# INLINEABLE (==) #-}
   Point (x1, y1) == Point (x2, y2) = x1 == x2 && y1 == y2
 
-{-# INLINEABLE decodePoint #-}
 decodePoint :: BuiltinByteString -> Point
 decodePoint bs
   | odd x /= x_0 = Point (q - x, yInt)
@@ -45,8 +44,8 @@ decodePoint bs
     x_0 = readBit bs 7
     x = xRecover yInt
     yInt = decodeInt $ clearBit 7 bs
+{-# INLINEABLE decodePoint #-}
 
-{-# INLINEABLE encodePoint #-}
 encodePoint :: Point -> BuiltinByteString
 encodePoint (Point (x, y)) = result
   where
@@ -56,8 +55,8 @@ encodePoint (Point (x, y)) = result
     yBS = integerToByteString LittleEndian 32 y
     xBS = integerToByteString LittleEndian 32 x
     xLSBVal = readBit xBS 248
+{-# INLINEABLE encodePoint #-}
 
-{-# INLINEABLE scalarMult #-}
 scalarMult :: Point -> Integer -> Point
 scalarMult p e =
   if e == 0
@@ -66,8 +65,8 @@ scalarMult p e =
       let q' = scalarMult p (e `divide` 2)
           q'' = edwards q' q'
        in if odd e then edwards q'' p else q''
+{-# INLINEABLE scalarMult #-}
 
-{-# INLINEABLE edwards #-}
 edwards :: Point -> Point -> Point
 edwards (Point (x1, y1)) (Point (x2, y2)) = Point (x3 `modulo` q, y3 `modulo` q)
   where
@@ -75,21 +74,21 @@ edwards (Point (x1, y1)) (Point (x2, y2)) = Point (x3 `modulo` q, y3 `modulo` q)
     x3 = (x1 * y2 + x2 * y1) * inv (1 + d * x1 * x2 * y1 * y2)
     y3 :: Integer
     y3 = (y1 * y2 + x1 * x2) * inv (1 - d * x1 * x2 * y1 * y2)
+{-# INLINEABLE edwards #-}
 
-{-# INLINEABLE asSha512Integer #-}
 asSha512Integer :: BuiltinByteString -> Integer
 asSha512Integer = byteStringToInteger LittleEndian . sha512
+{-# INLINEABLE asSha512Integer #-}
 
-{-# INLINEABLE decodeInt #-}
 decodeInt :: BuiltinByteString -> Integer
 decodeInt = byteStringToInteger LittleEndian
+{-# INLINEABLE decodeInt #-}
 
-{-# INLINEABLE q #-}
 -- 2 ^ 255 - 19, but as a constant
 q :: Integer
 q = 57896044618658097711785492504343953926634992332820282019728792003956564819949
+{-# INLINEABLE q #-}
 
-{-# INLINEABLE xRecover #-}
 xRecover :: Integer -> Integer
 xRecover y =
   if
@@ -114,20 +113,20 @@ xRecover y =
     cond2 = if cond1 then odd xA else odd x
     i :: Integer
     i = expModManual 2 ((q - 1) `divide` 4) q
+{-# INLINEABLE xRecover #-}
 
-{-# INLINEABLE clearBit #-}
 clearBit :: Integer -> BuiltinByteString -> BuiltinByteString
 clearBit ix bs = writeBits bs [ix] False
+{-# INLINEABLE clearBit #-}
 
-{-# INLINEABLE inv #-}
 inv :: Integer -> Integer
 inv x = expModManual x (q - 2) q
+{-# INLINEABLE inv #-}
 
-{-# INLINEABLE d #-}
 d :: Integer
 d = (-121665) * inv 121666
+{-# INLINEABLE d #-}
 
-{-# INLINEABLE expModManual #-}
 -- TODO: switch to the builtin `expMod` (aka ExpModInteger)?
 expModManual :: Integer -> Integer -> Integer -> Integer
 expModManual b' e m =
@@ -139,3 +138,4 @@ expModManual b' e m =
        in if odd e
             then (t * b') `modulo` m
             else t
+{-# INLINEABLE expModManual #-}

--- a/plutus-benchmark/bitwise/src/PlutusBenchmark/NQueens.hs
+++ b/plutus-benchmark/bitwise/src/PlutusBenchmark/NQueens.hs
@@ -11,7 +11,6 @@ import PlutusTx.Prelude
 -- For simplicity, this only accepts multiples of 8 for the dimension (so 8, 16,
 -- 24, etc): in all other cases it will return an empty list. Results are (row,
 -- column) pairs.
-{-# INLINE nqueens #-}
 nqueens :: Integer -> [(Integer, Integer)]
 nqueens dim
   | dim < 8 = []
@@ -60,10 +59,10 @@ nqueens dim
                           next -> (row, available) : next
     lastRow :: Integer
     lastRow = dim - 1
+{-# INLINE nqueens #-}
 
 -- Helpers
 
-{-# INLINE selectByteString #-}
 selectByteString :: Integer -> BuiltinByteString -> Integer
 selectByteString which bs
   | which <= 0 = findFirstSetBit bs
@@ -71,7 +70,8 @@ selectByteString which bs
       in if i == (-1)
          then (-1)
          else i + 1 + findFirstSetBit (shiftByteString bs $ negate (i + 1))
+{-# INLINE selectByteString #-}
 
-{-# INLINE writeBit #-}
 writeBit :: BuiltinByteString -> Integer -> Bool -> BuiltinByteString
 writeBit bs i b = writeBits bs [i] b
+{-# INLINE writeBit #-}

--- a/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
+++ b/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
@@ -61,11 +61,11 @@ import System.IO.Unsafe (unsafePerformIO)
 import Prelude (fromIntegral)
 
 -- Create a list containing n bytestrings of length l.  This could be better.
-{-# OPAQUE listOfByteStringsOfLength #-}
 listOfByteStringsOfLength :: Integer -> Integer -> [ByteString]
 listOfByteStringsOfLength n l = unsafePerformIO . G.sample $
                              G.list (R.singleton $ fromIntegral n)
                                   (G.bytes (R.singleton $ fromIntegral l))
+{-# OPAQUE listOfByteStringsOfLength #-}
 
 -- | Treat string of hexidecimal bytes literally, without encoding. Useful for hashes.
 bytesFromHex :: BS.ByteString -> BuiltinByteString
@@ -77,25 +77,25 @@ bytesFromHex = toBuiltin . P.bytes . fromEither . P.fromHex
 blsSigBls12381G2XmdSha256SswuRoNul :: BuiltinByteString
 blsSigBls12381G2XmdSha256SswuRoNul = toBuiltin $ C8.pack "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_"
 
-{-# INLINABLE byteString16Null #-}
 byteString16Null :: BuiltinByteString
 byteString16Null = bytesFromHex "00000000000000000000000000000000"
+{-# INLINABLE byteString16Null #-}
 
 -- Little-endian bytestring to integer conversion
-{-# INLINABLE byteStringToIntegerLE #-}
 byteStringToIntegerLE :: BuiltinByteString -> Integer
 byteStringToIntegerLE = Tx.byteStringToInteger LittleEndian
+{-# INLINABLE byteStringToIntegerLE #-}
 
 ---------------- Examples ----------------
 
 -- Hash some bytestrings onto G1 and add them all together
 
-{-# INLINABLE hashAndAddG1 #-}
 hashAndAddG1 :: [BuiltinByteString] -> BuiltinBLS12_381_G1_Element
 hashAndAddG1 l =
     go l (Tx.bls12_381_G1_uncompress Tx.bls12_381_G1_compressed_zero)
     where go [] !acc     = acc
           go (q:qs) !acc = go qs $ Tx.bls12_381_G1_add (Tx.bls12_381_G1_hashToGroup q emptyByteString) acc
+{-# INLINABLE hashAndAddG1 #-}
 
 mkHashAndAddG1Script :: [ByteString] -> UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun ()
 mkHashAndAddG1Script l =
@@ -103,12 +103,12 @@ mkHashAndAddG1Script l =
     in Tx.getPlcNoAnn $ $$(Tx.compile [|| hashAndAddG1 ||]) `Tx.unsafeApplyCode` Tx.liftCodeDef points
 
 -- Hash some bytestrings onto G2 and add them all together
-{-# INLINABLE hashAndAddG2 #-}
 hashAndAddG2 :: [BuiltinByteString] -> BuiltinBLS12_381_G2_Element
 hashAndAddG2 l =
     go l (Tx.bls12_381_G2_uncompress Tx.bls12_381_G2_compressed_zero)
     where go [] !acc     = acc
           go (q:qs) !acc = go qs $ Tx.bls12_381_G2_add (Tx.bls12_381_G2_hashToGroup q emptyByteString) acc
+{-# INLINABLE hashAndAddG2 #-}
 
 mkHashAndAddG2Script :: [ByteString] -> UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun ()
 mkHashAndAddG2Script l =
@@ -116,12 +116,12 @@ mkHashAndAddG2Script l =
     in Tx.getPlcNoAnn $ $$(Tx.compile [|| hashAndAddG2 ||]) `Tx.unsafeApplyCode` Tx.liftCodeDef points
 
 -- Uncompress a list of compressed G1 points and add them all together
-{-# INLINABLE uncompressAndAddG1 #-}
 uncompressAndAddG1 :: [BuiltinByteString] -> BuiltinBLS12_381_G1_Element
 uncompressAndAddG1 l =
     go l (Tx.bls12_381_G1_uncompress Tx.bls12_381_G1_compressed_zero)
     where go [] acc     = acc
           go (q:qs) acc = go qs $ Tx.bls12_381_G1_add (Tx.bls12_381_G1_uncompress q) acc
+{-# INLINABLE uncompressAndAddG1 #-}
 
 mkUncompressAndAddG1Script :: [ByteString] -> UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun ()
 mkUncompressAndAddG1Script l =
@@ -130,12 +130,12 @@ mkUncompressAndAddG1Script l =
     in Tx.getPlcNoAnn $ $$(Tx.compile [|| uncompressAndAddG1 ||]) `Tx.unsafeApplyCode` Tx.liftCodeDef points
 
 -- Uncompress a list of compressed G1 points and add them all together
-{-# INLINABLE uncompressAndAddG2 #-}
 uncompressAndAddG2 :: [BuiltinByteString] -> BuiltinBLS12_381_G2_Element
 uncompressAndAddG2 l =
     go l (Tx.bls12_381_G2_uncompress Tx.bls12_381_G2_compressed_zero)
     where go [] acc     = acc
           go (q:qs) acc = go qs $ Tx.bls12_381_G2_add (Tx.bls12_381_G2_uncompress q) acc
+{-# INLINABLE uncompressAndAddG2 #-}
 
 mkUncompressAndAddG2Script :: [ByteString] -> UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun ()
 mkUncompressAndAddG2Script l =
@@ -147,7 +147,6 @@ mkUncompressAndAddG2Script l =
 
 -- Take two points p1 and p2 in G1 and two points q1 and q2 in G2, apply the
 -- Miller loop to (p1,q1) and (p2,q2), and then call finalVerify on the results.
-{-# INLINABLE runPairingFunctions #-}
 runPairingFunctions
     :: BuiltinByteString  -- G1
     -> BuiltinByteString  -- G2
@@ -158,6 +157,7 @@ runPairingFunctions p1 q1 p2 q2 =
     let r1 = Tx.bls12_381_millerLoop (Tx.bls12_381_G1_uncompress p1) (Tx.bls12_381_G2_uncompress q1)
         r2 = Tx.bls12_381_millerLoop (Tx.bls12_381_G1_uncompress p2) (Tx.bls12_381_G2_uncompress q2)
     in Tx.bls12_381_finalVerify r1 r2
+{-# INLINABLE runPairingFunctions #-}
 
 mkPairingScript
     :: BuiltinBLS12_381_G1_Element
@@ -241,7 +241,6 @@ groth16c :: CompressedG1Element
 groth16c = mkG1Element ("b569cc491b4df035cbf49e951fd4fe30aa8236b0e2af68f4" <>
                         "c1592cd40debeb718af33639db6bc1e2da9d98e553e5eaed")
 
-{-# INLINABLE groth16Verify #-}
 groth16Verify
     :: BuiltinByteString  -- G1
     -> BuiltinByteString  -- G2
@@ -270,6 +269,7 @@ groth16Verify (Tx.bls12_381_G1_uncompress -> alpha)
                       l4 = Tx.bls12_381_millerLoop p gamma
                       y  = Tx.bls12_381_mulMlResult l2 (Tx.bls12_381_mulMlResult l3 l4)
                   in Tx.bls12_381_finalVerify l1 y
+{-# INLINABLE groth16Verify #-}
 
 {- | Make a UPLC script applying groth16Verify to the inputs.  Passing the
  newtype inputs increases the size and CPU cost slightly, so we unwrap them
@@ -298,18 +298,18 @@ checkGroth16Verify_Haskell =
 
 ---------------- Simple Sign and Verify ----------------
 
-{-# INLINABLE simpleVerifyPrivKey #-}
 simpleVerifyPrivKey :: Integer
 simpleVerifyPrivKey = 50166937291276222007610100461546392414157570314060957244808461481762532157524
+{-# INLINABLE simpleVerifyPrivKey #-}
 
-{-# INLINABLE simpleVerifyMessage #-}
 simpleVerifyMessage :: BuiltinByteString
 simpleVerifyMessage  = "I am a message"
+{-# INLINABLE simpleVerifyMessage #-}
 
-{-# INLINABLE verifyBlsSimpleScript #-}
 verifyBlsSimpleScript :: Integer -> BuiltinByteString -> Bool
 verifyBlsSimpleScript privKey message =
   let g1generator = Tx.bls12_381_G1_uncompress Tx.bls12_381_G1_compressed_generator
+{-# INLINABLE verifyBlsSimpleScript #-}
 
       -- calculate public key
       pubKey = Tx.bls12_381_G1_scalarMul privKey g1generator
@@ -339,13 +339,13 @@ mkVerifyBlsSimplePolicy =
    and more readable and mathematical in nature see https://eprint.iacr.org/2017/099.pdf.
 -}
 
-{-# INLINABLE vrfPrivKey #-}
 vrfPrivKey :: Integer
 vrfPrivKey = 50166937291276222007610100461546392414157570314060957244808461481762532157524 :: Integer
+{-# INLINABLE vrfPrivKey #-}
 
-{-# INLINABLE vrfMessage #-}
 vrfMessage :: BuiltinByteString
 vrfMessage = "I am a message" :: BuiltinByteString
+{-# INLINABLE vrfMessage #-}
 
 data VrfProof = VrfProof
   { vrfProofGamma :: BuiltinByteString
@@ -362,12 +362,12 @@ data VrfProofWithOutput = VrfProofWithOutput
 Tx.makeLift ''VrfProofWithOutput
 Tx.unstableMakeIsData ''VrfProofWithOutput
 
-{-# INLINABLE vrfBlsScript #-}
 vrfBlsScript :: BuiltinByteString -> BuiltinByteString -> VrfProofWithOutput -> Bool
 vrfBlsScript message pubKey (VrfProofWithOutput beta (VrfProof gamma c s)) =
   let
       -- cofactor of G2
       f = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041692990889188039904403802465579155252111 :: Integer
+{-# INLINABLE vrfBlsScript #-}
 
       -- The proof of that the VRF hash of input alpha under our priv key is beta
       -- To verify a VRF hash given an
@@ -450,22 +450,21 @@ mkVrfBlsPolicy =
     * Check that pairing(pk_deser, hashed_msg) = pairing(G1Generator, sig_deser)
 -}
 
-{-# INLINABLE g1VerifyMessage #-}
 g1VerifyMessage :: BuiltinByteString
 g1VerifyMessage  = bytesFromHex "3e00ef2f895f40d67f5bb8e81f09a5a12c840ec3ce9a7f3b181be188ef711a1e"
+{-# INLINABLE g1VerifyMessage #-}
 
-{-# INLINABLE g1VerifyPubKey #-}
 g1VerifyPubKey :: BuiltinByteString
 g1VerifyPubKey = bytesFromHex ("aa04a34d4db073e41505ebb84eee16c0094fde9fa22ec974" <>
                                "adb36e5b3df5b2608639f091bff99b5f090b3608c3990173")
+{-# INLINABLE g1VerifyPubKey #-}
 
-{-# INLINABLE g1VerifySignature #-}
 g1VerifySignature :: BuiltinByteString
 g1VerifySignature = bytesFromHex
                    ("808ccec5435a63ae01e10d81be2707ab55cd0dfc235dfdf9f70ad32799e42510d67c9f61d98a6578a96a76cf6f4c105d" <>
                     "09262ec1d86b06515360b290e7d52d347e48438de2ea2233f3c72a0c2221ed2da5e115367bca7a2712165032340e0b29")
+{-# INLINABLE g1VerifySignature #-}
 
-{-# INLINABLE g1VerifyScript #-}
 g1VerifyScript ::
      BuiltinByteString
   -> BuiltinByteString
@@ -477,6 +476,7 @@ g1VerifyScript message pubKey signature dst =
       pkDeser = Tx.bls12_381_G1_uncompress pubKey
       sigDeser = Tx.bls12_381_G2_uncompress signature
       hashedMsg = Tx.bls12_381_G2_hashToGroup message dst
+{-# INLINABLE g1VerifyScript #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop pkDeser hashedMsg)
          (Tx.bls12_381_millerLoop g1generator sigDeser)
@@ -502,22 +502,21 @@ mkG1VerifyPolicy =
     * Check that pairing(hashed_msg, pk_deser) = pairing(sig_deser, G2Generator)
 -}
 
-{-# INLINABLE g2VerifyMessage #-}
 g2VerifyMessage :: BuiltinByteString
 g2VerifyMessage  = bytesFromHex "5032ec38bbc5da98ee0c6f568b872a65a08abf251deb21bb4b56e5d8821e68aa"
+{-# INLINABLE g2VerifyMessage #-}
 
-{-# INLINABLE g2VerifyPubKey #-}
 g2VerifyPubKey :: BuiltinByteString
 g2VerifyPubKey = bytesFromHex
                   ("b4953c4ba10c4d4196f90169e76faf154c260ed73fc77bb65dc3be31e0cec614a7287cda94195343676c2c57494f0e65" <>
                   "1527e6504c98408e599a4eb96f7c5a8cfb85d2fdc772f28504580084ef559b9b623bc84ce30562ed320f6b7f65245ad4")
+{-# INLINABLE g2VerifyPubKey #-}
 
-{-# INLINABLE g2VerifySignature #-}
 g2VerifySignature :: BuiltinByteString
 g2VerifySignature  = bytesFromHex ("a9d4de7b0b2805fe52bccb86415ef7b8ffecb313c3c25404" <>
                                    "4dfc1bdc531d3eae999d87717822a052692140774bd7245c")
+{-# INLINABLE g2VerifySignature #-}
 
-{-# INLINABLE g2VerifyScript #-}
 g2VerifyScript ::
      BuiltinByteString
   -> BuiltinByteString
@@ -529,6 +528,7 @@ g2VerifyScript message pubKey signature dst =
       pkDeser = Tx.bls12_381_G2_uncompress pubKey
       sigDeser = Tx.bls12_381_G1_uncompress signature
       hashedMsg = Tx.bls12_381_G1_hashToGroup message dst
+{-# INLINABLE g2VerifyScript #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop hashedMsg pkDeser) (Tx.bls12_381_millerLoop sigDeser g2generator)
 
@@ -557,7 +557,6 @@ mkG2VerifyPolicy =
     * Check that pairing(pk_deser, aggr_msg) = pairing(G1Generator, aggr_sig_deser)
 -}
 
-{-# INLINABLE aggregateSingleKeyG1Messages #-}
 aggregateSingleKeyG1Messages :: [BuiltinByteString]
 aggregateSingleKeyG1Messages  = [
         bytesFromHex "2ba037cdb63cb5a7277dc5d6dc549e4e28a15c70670f0e97787c170485829264"
@@ -571,21 +570,21 @@ aggregateSingleKeyG1Messages  = [
       , bytesFromHex "4e73ba04bae3a083c8a2109f15b8c4680ae4ba1c70df5b513425349a77e95d3b"
       , bytesFromHex "565825a0227d45068e61eb90aa1a4dc414c0976911a52d46b39f40c5849e5abe"
       ]
+{-# INLINABLE aggregateSingleKeyG1Messages #-}
 
-{-# INLINABLE aggregateSingleKeyG1PubKey #-}
 aggregateSingleKeyG1PubKey :: BuiltinByteString
 aggregateSingleKeyG1PubKey = bytesFromHex ("97c919babda8d928d771d107a69adfd85a75cee2cedc4afa" <>
                                            "4c0a7e902f38b340ea21a701a46df825210dd6942632b46c")
+{-# INLINABLE aggregateSingleKeyG1PubKey #-}
 
-{-# INLINABLE aggregateSingleKeyG1Signature #-}
 aggregateSingleKeyG1Signature :: BuiltinByteString
 aggregateSingleKeyG1Signature = bytesFromHex
                                  ("b425291f423235b022cdd038e1a3cbdcc73b5a4470251634" <>
                                   "abb874c7585a3a05b8ea54ceb93286edb0e9184bf9a852a1" <>
                                   "138c6dd860e4b756c63dff65c433a6c5aa06834f00ac5a1a" <>
                                   "1acf6bedc44bd4354f9d36d4f20f66318f39116428fabb88")
+{-# INLINABLE aggregateSingleKeyG1Signature #-}
 
-{-# INLINABLE aggregateSingleKeyG1Script #-}
 aggregateSingleKeyG1Script
     :: [BuiltinByteString]
     -> BuiltinByteString
@@ -598,6 +597,7 @@ aggregateSingleKeyG1Script messages pubKey aggregateSignature dst =
       pkDeser = Tx.bls12_381_G1_uncompress pubKey
       aggrSigDeser = Tx.bls12_381_G2_uncompress aggregateSignature
       aggrMsg = foldl1 Tx.bls12_381_G2_add hashedMsgs
+{-# INLINABLE aggregateSingleKeyG1Script #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop pkDeser aggrMsg) (Tx.bls12_381_millerLoop g1generator aggrSigDeser)
     where
@@ -638,12 +638,11 @@ mkAggregateSingleKeyG1Policy =
     * Check that pairing(hashed_msg, aggr_pk) = pairing(aggr_sig_deser, G2Generator)
 -}
 
-{-# INLINABLE aggregateMultiKeyG2Message #-}
 aggregateMultiKeyG2Message :: BuiltinByteString
 aggregateMultiKeyG2Message  = bytesFromHex
                                 "e345b7f2c017b16bb335c696bc0cc302f3db897fa25365a2ead1f149d87a97e8"
+{-# INLINABLE aggregateMultiKeyG2Message #-}
 
-{-# INLINABLE aggregateMultiKeyG2PubKeys #-}
 aggregateMultiKeyG2PubKeys :: [BuiltinByteString]
 aggregateMultiKeyG2PubKeys = [
     bytesFromHex
@@ -677,13 +676,13 @@ aggregateMultiKeyG2PubKeys = [
       ("96f8d678f40dd83b2060e14372d0bc43a423fecac44f082afd89cb481b855885ac83fb366516dc74023cc41a0c606be2" <>
       "067ba826ea612f84c9f0e895d02bc04d6c34e201ff8c26cc22cb4c426c53f503d8948eafceb12e2f4b6ad49b4e051690")
   ]
+{-# INLINABLE aggregateMultiKeyG2PubKeys #-}
 
-{-# INLINABLE aggregateMultiKeyG2Signature #-}
 aggregateMultiKeyG2Signature :: BuiltinByteString
 aggregateMultiKeyG2Signature = bytesFromHex ("b24d876661d0d1190c796bf7eaa7e02b807ff603093b1733" <>
                                              "6289d4de0477f6c17afb487275cb9de44325016edfeda042")
+{-# INLINABLE aggregateMultiKeyG2Signature #-}
 
-{-# INLINABLE aggregateMultiKeyG2Script #-}
 aggregateMultiKeyG2Script
     :: BuiltinByteString
     -> [BuiltinByteString]
@@ -700,6 +699,7 @@ aggregateMultiKeyG2Script message pubKeys aggregateSignature bs16Null dst =
                     (Tx.sha2_256 (foldl1 Tx.appendByteString pubKeys)) `Tx.appendByteString` bs16Null)
       aggrSigDeser = Tx.bls12_381_G1_uncompress aggregateSignature
       aggrPk = calcAggregatedPubkeys dsScalar pksDeser
+{-# INLINABLE aggregateMultiKeyG2Script #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop hashedMsg aggrPk) (Tx.bls12_381_millerLoop aggrSigDeser g2generator)
     where
@@ -776,23 +776,22 @@ mkAggregateMultiKeyG2Policy =
     * Check that r_deser * G1Generator = A_deser + c * pk_deser
 -}
 
-{-# INLINABLE schnorrG1VerifyMessage #-}
 schnorrG1VerifyMessage :: BuiltinByteString
 schnorrG1VerifyMessage  = bytesFromHex "0558db9aff738e5421439601e7f30e88b74f43b80c1d172b5d371ce0dc05c912"
+{-# INLINABLE schnorrG1VerifyMessage #-}
 
-{-# INLINABLE schnorrG1VerifyPubKey #-}
 schnorrG1VerifyPubKey :: BuiltinByteString
 schnorrG1VerifyPubKey = bytesFromHex ("b91cacee903a53383c504e9e9a39e57d1eaa6403d5d38fc9" <>
                                       "496e5007d54ca92d106d1059f09461972aa98514d07000ae")
+{-# INLINABLE schnorrG1VerifyPubKey #-}
 
-{-# INLINABLE schnorrG1VerifySignature #-}
 schnorrG1VerifySignature :: (BuiltinByteString, BuiltinByteString)
 schnorrG1VerifySignature =
                  (bytesFromHex
                     "8477e8491acc1cfbcf675acf7cf6b92e027cad7dd604a0e8205703aa2cc590066c1746f89e10d492d0230e6620c29726",
                   bytesFromHex "4e908280c0100cfe53501171ffa93528b9e2bb551d1025decb4a5b416a0aee53")
+{-# INLINABLE schnorrG1VerifySignature #-}
 
-{-# INLINABLE schnorrG1VerifyScript #-}
 schnorrG1VerifyScript ::
      BuiltinByteString
   -> BuiltinByteString
@@ -816,6 +815,7 @@ schnorrG1VerifyScript message pubKey signature bs16Null =
          (rDeser `Tx.bls12_381_G1_scalarMul` g1generator)
          `Tx.bls12_381_G1_add` (Tx.bls12_381_G1_neg aDeser)
               == c `Tx.bls12_381_G1_scalarMul` pkDeser
+{-# INLINABLE schnorrG1VerifyScript #-}
 
 checkSchnorrG1VerifyScript :: Bool
 checkSchnorrG1VerifyScript = schnorrG1VerifyScript schnorrG1VerifyMessage schnorrG1VerifyPubKey
@@ -840,25 +840,24 @@ mkSchnorrG1VerifyPolicy =
     * Check that r_deser * G2Generator = A_deser + c * pk_deser
 -}
 
-{-# INLINABLE schnorrG2VerifyMessage #-}
 schnorrG2VerifyMessage :: BuiltinByteString
 schnorrG2VerifyMessage  = bytesFromHex "2b71175d0486006a33f14bc4e1fe711a3d4a3a3549b230013240e8f80e54372f"
+{-# INLINABLE schnorrG2VerifyMessage #-}
 
-{-# INLINABLE schnorrG2VerifyPubKey #-}
 schnorrG2VerifyPubKey :: BuiltinByteString
 schnorrG2VerifyPubKey = bytesFromHex
      ("88370a4b4ddc627613b0396498fb068f1c1ff8f2aa6b946a9fc65f930d24394ddc45042e602094f6a88d49a8a037e781" <>
      "08dce014586ff5ff5744842f382e3917d180c7eb969585748d20ae8c6e07ca786e8da7ea2c7bdef5ae1becebe4da59ad")
+{-# INLINABLE schnorrG2VerifyPubKey #-}
 
-{-# INLINABLE schnorrG2VerifySignature #-}
 schnorrG2VerifySignature :: (BuiltinByteString, BuiltinByteString)
 schnorrG2VerifySignature  =
                 (bytesFromHex
                   ("964851eb8823492c8720bf8c515b87043f5bab648000e63cfb6fc6fcdf6709061e0035c315cd23d239866471dea907d9" <>
                   "1568b69297dc8c4360f65d0bd399c2de19781c13bbf3a82ff1fcab8ac9f688ed96d6f2ea9a8ed057e76f0347d858ae22"),
                  bytesFromHex "2c5a22cb1e2fb77586c0c6908060b38107675a6277b8a61b1d6394a162af6718")
+{-# INLINABLE schnorrG2VerifySignature #-}
 
-{-# INLINABLE schnorrG2VerifyScript #-}
 schnorrG2VerifyScript ::
      BuiltinByteString
   -> BuiltinByteString
@@ -882,6 +881,7 @@ schnorrG2VerifyScript message pubKey signature bs16Null =
     (rDeser `Tx.bls12_381_G2_scalarMul` g2generator)
     `Tx.bls12_381_G2_add` (Tx.bls12_381_G2_neg aDeser)
          == c `Tx.bls12_381_G2_scalarMul` pkDeser
+{-# INLINABLE schnorrG2VerifyScript #-}
 
 checkSchnorrG2VerifyScript :: Bool
 checkSchnorrG2VerifyScript = schnorrG2VerifyScript schnorrG2VerifyMessage schnorrG2VerifyPubKey

--- a/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
+++ b/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
@@ -309,7 +309,6 @@ simpleVerifyMessage  = "I am a message"
 verifyBlsSimpleScript :: Integer -> BuiltinByteString -> Bool
 verifyBlsSimpleScript privKey message =
   let g1generator = Tx.bls12_381_G1_uncompress Tx.bls12_381_G1_compressed_generator
-{-# INLINABLE verifyBlsSimpleScript #-}
 
       -- calculate public key
       pubKey = Tx.bls12_381_G1_scalarMul privKey g1generator
@@ -322,6 +321,7 @@ verifyBlsSimpleScript privKey message =
 
   -- verify the msg with signature sigma with the check e(g1,sigma)=e(pub,msgToG2)
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop g1generator sigma) (Tx.bls12_381_millerLoop pubKey msgToG2)
+{-# INLINABLE verifyBlsSimpleScript #-}
 
 checkVerifyBlsSimpleScript :: Bool
 checkVerifyBlsSimpleScript = verifyBlsSimpleScript simpleVerifyPrivKey simpleVerifyMessage
@@ -367,7 +367,6 @@ vrfBlsScript message pubKey (VrfProofWithOutput beta (VrfProof gamma c s)) =
   let
       -- cofactor of G2
       f = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041692990889188039904403802465579155252111 :: Integer
-{-# INLINABLE vrfBlsScript #-}
 
       -- The proof of that the VRF hash of input alpha under our priv key is beta
       -- To verify a VRF hash given an
@@ -386,6 +385,7 @@ vrfBlsScript message pubKey (VrfProofWithOutput beta (VrfProof gamma c s)) =
   in c == (sha2_256 . mconcat $ Tx.bls12_381_G2_compress <$> [g2generator, h, pubKey', Tx.bls12_381_G2_uncompress gamma, u, v])
          &&
          beta == (sha2_256 . Tx.bls12_381_G2_compress $ Tx.bls12_381_G2_scalarMul f (Tx.bls12_381_G2_uncompress gamma))
+{-# INLINABLE vrfBlsScript #-}
 
 -- used offchain to generate the vrf proof output
 generateVrfProof :: Integer -> BuiltinByteString -> VrfProofWithOutput
@@ -476,10 +476,10 @@ g1VerifyScript message pubKey signature dst =
       pkDeser = Tx.bls12_381_G1_uncompress pubKey
       sigDeser = Tx.bls12_381_G2_uncompress signature
       hashedMsg = Tx.bls12_381_G2_hashToGroup message dst
-{-# INLINABLE g1VerifyScript #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop pkDeser hashedMsg)
          (Tx.bls12_381_millerLoop g1generator sigDeser)
+{-# INLINABLE g1VerifyScript #-}
 
 checkG1VerifyScript :: Bool
 checkG1VerifyScript = g1VerifyScript g1VerifyMessage g1VerifyPubKey g1VerifySignature blsSigBls12381G2XmdSha256SswuRoNul
@@ -528,9 +528,9 @@ g2VerifyScript message pubKey signature dst =
       pkDeser = Tx.bls12_381_G2_uncompress pubKey
       sigDeser = Tx.bls12_381_G1_uncompress signature
       hashedMsg = Tx.bls12_381_G1_hashToGroup message dst
-{-# INLINABLE g2VerifyScript #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop hashedMsg pkDeser) (Tx.bls12_381_millerLoop sigDeser g2generator)
+{-# INLINABLE g2VerifyScript #-}
 
 checkG2VerifyScript :: Bool
 checkG2VerifyScript =
@@ -597,7 +597,6 @@ aggregateSingleKeyG1Script messages pubKey aggregateSignature dst =
       pkDeser = Tx.bls12_381_G1_uncompress pubKey
       aggrSigDeser = Tx.bls12_381_G2_uncompress aggregateSignature
       aggrMsg = foldl1 Tx.bls12_381_G2_add hashedMsgs
-{-# INLINABLE aggregateSingleKeyG1Script #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop pkDeser aggrMsg) (Tx.bls12_381_millerLoop g1generator aggrSigDeser)
     where
@@ -606,6 +605,7 @@ aggregateSingleKeyG1Script messages pubKey aggregateSignature dst =
       foldl1 _ []     = traceError "foldr1: empty list"
       foldl1 _ [_]    = traceError "foldr1: only one element in list"
       foldl1 f (x:xs) = Tx.foldl f x xs
+{-# INLINABLE aggregateSingleKeyG1Script #-}
 
 
 checkAggregateSingleKeyG1Script :: Bool
@@ -699,7 +699,6 @@ aggregateMultiKeyG2Script message pubKeys aggregateSignature bs16Null dst =
                     (Tx.sha2_256 (foldl1 Tx.appendByteString pubKeys)) `Tx.appendByteString` bs16Null)
       aggrSigDeser = Tx.bls12_381_G1_uncompress aggregateSignature
       aggrPk = calcAggregatedPubkeys dsScalar pksDeser
-{-# INLINABLE aggregateMultiKeyG2Script #-}
 
   in Tx.bls12_381_finalVerify (Tx.bls12_381_millerLoop hashedMsg aggrPk) (Tx.bls12_381_millerLoop aggrSigDeser g2generator)
     where
@@ -727,6 +726,7 @@ aggregateMultiKeyG2Script message pubKeys aggregateSignature bs16Null dst =
 
       calcAggregatedPubkey :: BuiltinBLS12_381_G2_Element -> Integer -> BuiltinBLS12_381_G2_Element
       calcAggregatedPubkey pk ds = ds `Tx.bls12_381_G2_scalarMul` pk
+{-# INLINABLE aggregateMultiKeyG2Script #-}
 
 {- An alternative implementation of calcAggregatedPubkeys which uses a different
 -- means of scalar exponentiation. It results in a slightly smaller script using less CPU but

--- a/plutus-benchmark/cek-calibration/Main.hs
+++ b/plutus-benchmark/cek-calibration/Main.hs
@@ -34,31 +34,31 @@ import Criterion.Types qualified as C
 
 type PlainTerm = UPLC.Term Name DefaultUni DefaultFun ()
 
-{-# INLINABLE rev #-}
 rev :: [()] -> [()]
 rev l0 = rev' l0 []
     where rev' l acc =
               case l of
                 []   -> acc
                 x:xs -> rev' xs (x:acc)
+{-# INLINABLE rev #-}
 
-{-# INLINABLE mkList #-}
 mkList :: Integer -> [()]
 mkList m = mkList' m []
     where mkList' n acc =
               if n == 0 then acc
               else mkList' (n-1) (():acc)
+{-# INLINABLE mkList #-}
 
-{-# INLINABLE zipl #-}
 zipl :: [()] -> [()] -> [()]
 zipl [] []         = []
 zipl l []          = l
 zipl [] l          = l
 zipl (x:xs) (y:ys) = x:y:(zipl xs ys)
+{-# INLINABLE zipl #-}
 
-{-# INLINABLE go #-}
 go :: Integer -> [()]
 go n = zipl (mkList n) (rev $ mkList n)
+{-# INLINABLE go #-}
 
 
 mkListProg :: Integer -> UPLC.Program NamedDeBruijn DefaultUni DefaultFun ()

--- a/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
+++ b/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
@@ -66,16 +66,16 @@ unstableMakeIsData ''Inputs
 haskellHash :: HashFun
 haskellHash = Hash.sha2_256
 
-{-# INLINEABLE builtinHash #-}
 builtinHash :: BuiltinHashFun
 builtinHash = Tx.sha2_256
+{-# INLINEABLE builtinHash #-}
 
 -- Create a list containing n bytestrings of length l.  This could be better.
-{-# OPAQUE listOfByteStringsOfLength #-}
 listOfByteStringsOfLength :: Integer -> Integer -> [ByteString]
 listOfByteStringsOfLength n l = unsafePerformIO . G.sample $
                              G.list (R.singleton $ fromIntegral n)
                                   (G.bytes (R.singleton $ fromIntegral l))
+{-# OPAQUE listOfByteStringsOfLength #-}
 
 {- | Create a list of valid (verification key, message, signature, data key)
    quadruples.  The DSIGN infrastructure lets us do this in a fairly generic
@@ -118,7 +118,6 @@ mkInputsAsData n hash = Tx.dataToBuiltinData $ toData (mkInputs @Ed25519DSIGN n 
 -- whether verification succeeds or fails.  If the inputs are generated
 -- correctly (which is checked by testHaskell when we run `main`) then
 -- verification always succeeds, but let's be careful just in case.
-{-# INLINEABLE verifyInputs #-}
 verifyInputs :: BuiltinHashFun -> BuiltinData -> Bool
 verifyInputs hash d =
     case Tx.fromBuiltinData d of
@@ -130,6 +129,7 @@ verifyInputs hash d =
                     let dkhash' = hash dk
                         hashesEq = dkhash == dkhash'
                     in Tx.verifyEd25519Signature vk dkhash sg && hashesEq
+{-# INLINEABLE verifyInputs #-}
 
 -- | Create the input data, convert it to BuiltinData, and apply the
 -- verification script to that.

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/GhcSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/GhcSort.hs
@@ -16,7 +16,6 @@ import PlutusTx.Prelude as Tx
 {- | GHC's 'sort' algorithm specialised to Integer.
    See https://hackage.haskell.org/package/base-4.15.0.0/docs/src/Data-OldList.html#sortBy
 -}
-{-# INLINABLE ghcSort #-}
 ghcSort :: [Integer] -> [Integer]
 ghcSort = mergeAll . sequences
   where
@@ -27,6 +26,7 @@ ghcSort = mergeAll . sequences
     {- This detects ascending and descending subsequences of a list, reverses
        the descending ones, and accumulates the results in a list.
        For example, [1,2,9,5,4,7,2,8] -> [[1,2,9],[4,5],[2,7],[8]]. -}
+{-# INLINABLE ghcSort #-}
 
     descending a as (b:bs)
       | a > b = descending b (a:as) bs

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/GhcSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/GhcSort.hs
@@ -26,7 +26,6 @@ ghcSort = mergeAll . sequences
     {- This detects ascending and descending subsequences of a list, reverses
        the descending ones, and accumulates the results in a list.
        For example, [1,2,9,5,4,7,2,8] -> [[1,2,9],[4,5],[2,7],[8]]. -}
-{-# INLINABLE ghcSort #-}
 
     descending a as (b:bs)
       | a > b = descending b (a:as) bs
@@ -55,6 +54,7 @@ ghcSort = mergeAll . sequences
         else b:(merge as bs')
     merge [] bs = bs
     merge as [] = as
+{-# INLINABLE ghcSort #-}
 
 {- I think the worst case input should be about the same as for mergesort.  The
    worst case for 'sequences' is when we start with a list of alternately

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/InsertionSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/InsertionSort.hs
@@ -11,7 +11,6 @@ import PlutusTx qualified as Tx
 import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx hiding (sort)
 
-{-# INLINABLE insertionSort #-}
 insertionSort :: [Integer] -> [Integer]
 insertionSort l0 = sort l0 []
     where sort [] r     = r
@@ -22,6 +21,7 @@ insertionSort l0 = sort l0 []
                 m:ms -> if n <= m
                         then n:acc
                         else m:(insert n ms)
+{-# INLINABLE insertionSort #-}
 
 {- The worst case should be when the list is already sorted, since then whenever
    we insert a new element in the accumulator it'll have to go at the very end. -}

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/MergeSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/MergeSort.hs
@@ -13,7 +13,6 @@ import PlutusTx qualified as Tx
 import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 
-{-# INLINABLE merge #-}
 merge :: [Integer] -> [Integer] -> [Integer]
 merge as@(a:as') bs@(b:bs') =
     if a <= b
@@ -21,8 +20,8 @@ merge as@(a:as') bs@(b:bs') =
     else b:(merge as bs')
 merge [] bs = bs
 merge as [] = as
+{-# INLINABLE merge #-}
 
-{-# INLINABLE mergeSort #-}
 mergeSort :: [Integer] -> [Integer]
 mergeSort xs =
     let n = length xs
@@ -30,6 +29,7 @@ mergeSort xs =
        then let n2 = n `divide` 2
             in merge (mergeSort (take n2 xs)) (mergeSort (drop n2 xs))
        else xs
+{-# INLINABLE mergeSort #-}
 
 {- I think this is approximately the worst case.  A lot of the work happens in
    merge and this should make sure that the maximal amount of interleaving is

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/QuickSort.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sort/QuickSort.hs
@@ -11,7 +11,6 @@ import PlutusTx qualified as Tx
 import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 
-{-# INLINABLE quickSort #-}
 quickSort :: [Integer] -> [Integer]
 quickSort []     = []
 quickSort (n:ns) = (quickSort $ before n ns []) ++ (n:(quickSort $ after n ns []))
@@ -23,6 +22,7 @@ quickSort (n:ns) = (quickSort $ before n ns []) ++ (n:(quickSort $ after n ns []
            after x (y:ys) r = if y >= x  -- Elements >= x
                            then after x ys (y:r)
                            else after x ys r
+{-# INLINABLE quickSort #-}
 
 {- The worst case is when the list is already sorted (or reverse sorted) because
    then if the list has n elements you have to recurse n times, scanning a list

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/Compiled.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/Compiled.hs
@@ -17,23 +17,23 @@ import Prelude (($!))
 
 ---------------- Folding over Scott lists ----------------
 
-{-# INLINABLE foldLeftScott #-}
 foldLeftScott :: (b -> a -> b) -> b -> [a] -> b
 foldLeftScott _ z []     = z
 foldLeftScott f z (x:xs) = foldLeftScott f (f z x) xs
+{-# INLINABLE foldLeftScott #-}
 
-{-# INLINABLE sumLeftScott #-}
 sumLeftScott :: [Integer] -> Integer
 sumLeftScott l = foldLeftScott (+) 0 l
+{-# INLINABLE sumLeftScott #-}
 
-{-# INLINABLE foldRightScott #-}
 foldRightScott :: (a -> b -> b) -> b -> [a] -> b
 foldRightScott _ z []     = z
 foldRightScott f z (x:xs) = f x $! (foldRightScott f z xs)
+{-# INLINABLE foldRightScott #-}
 
-{-# INLINABLE sumRightScott #-}
 sumRightScott :: [Integer] -> Integer
 sumRightScott l = foldRightScott (+) 0 l
+{-# INLINABLE sumRightScott #-}
 
 -- Compiling to PLC terms
 
@@ -51,21 +51,21 @@ mkSumRightScottTerm l = compiledCodeToTerm $ mkSumRightScottCode l
 
 ---------------- Folding over built-in lists ----------------
 
-{-# INLINABLE foldLeftBuiltin #-}
 foldLeftBuiltin :: (b -> a -> b) -> b -> BI.BuiltinList a -> b
 foldLeftBuiltin f z l = B.matchList' l z (\x xs -> (foldLeftBuiltin f (f z x) xs))
+{-# INLINABLE foldLeftBuiltin #-}
 
-{-# INLINABLE sumLeftBuiltin #-}
 sumLeftBuiltin :: BI.BuiltinList Integer -> Integer
 sumLeftBuiltin l = foldLeftBuiltin B.addInteger 0 l
+{-# INLINABLE sumLeftBuiltin #-}
 
-{-# INLINABLE foldRightBuiltin #-}
 foldRightBuiltin :: (a -> b -> b) -> b -> BI.BuiltinList a -> b
 foldRightBuiltin f z l = B.matchList' l z (\x xs -> f x $! (foldRightBuiltin f z xs))
+{-# INLINABLE foldRightBuiltin #-}
 
-{-# INLINABLE sumRightBuiltin #-}
 sumRightBuiltin :: BI.BuiltinList Integer -> Integer
 sumRightBuiltin l = foldRightBuiltin B.addInteger 0 l
+{-# INLINABLE sumRightBuiltin #-}
 
 -- Compiling to PLC terms
 
@@ -113,21 +113,21 @@ matchDataList l nilCase consCase =
       else if tag == 1 then B.matchList values error (\h t -> consCase h (BI.head t))
       else error ()
 
-{-# INLINABLE foldLeftData #-}
 foldLeftData :: (b -> BuiltinData -> b) -> b -> DataList -> b
 foldLeftData f z l = matchDataList l z (\x xs -> (foldLeftData f (f z x) xs))
+{-# INLINABLE foldLeftData #-}
 
-{-# INLINABLE sumLeftData #-}
 sumLeftData :: DataList -> Integer
 sumLeftData l = foldLeftData (\acc d -> B.addInteger acc (BI.unsafeDataAsI d)) 0 l
+{-# INLINABLE sumLeftData #-}
 
-{-# INLINABLE foldRightData #-}
 foldRightData :: (BuiltinData -> b -> b) -> b -> DataList -> b
 foldRightData f z l = matchDataList l z (\x xs -> f x $! (foldRightData f z xs))
+{-# INLINABLE foldRightData #-}
 
-{-# INLINABLE sumRightData #-}
 sumRightData :: DataList -> Integer
 sumRightData l = foldRightData (\d acc -> B.addInteger (BI.unsafeDataAsI d) acc) 0 l
+{-# INLINABLE sumRightData #-}
 
 -- Compiling to PLC terms
 

--- a/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Core/V1/Semantics.hs
+++ b/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Core/V1/Semantics.hs
@@ -722,7 +722,6 @@ instance Eq ReduceEffect where
 
 -- Functions that used in Plutus Core must be inlineable,
 -- so their code is available for PlutusTx compiler.
-{-# INLINABLE fixInterval #-}
 {-# INLINABLE evalValue #-}
 {-# INLINABLE evalObservation #-}
 {-# INLINABLE refundOne #-}
@@ -743,6 +742,7 @@ instance Eq ReduceEffect where
 {-# INLINABLE computeTransaction #-}
 {-# INLINABLE contractLifespanUpperBound #-}
 {-# INLINABLE totalBalance #-}
+{-# INLINABLE fixInterval #-}
 
 
 -- Lifting data types to Plutus Core

--- a/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Scripts/Semantics.hs
+++ b/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Scripts/Semantics.hs
@@ -100,7 +100,6 @@ data MarloweTxInput = Input InputContent
   deriving stock (Haskell.Show,Haskell.Eq,Generic)
 
 
-{-# INLINABLE closeInterval #-}
 -- | Convert a Plutus POSIX time range into the closed interval needed by Marlowe semantics.
 closeInterval :: POSIXTimeRange -> Maybe (POSIXTime, POSIXTime)
 closeInterval (Interval (LowerBound (Finite (POSIXTime l)) lc) (UpperBound (Finite (POSIXTime h)) hc)) =
@@ -110,9 +109,9 @@ closeInterval (Interval (LowerBound (Finite (POSIXTime l)) lc) (UpperBound (Fini
     , POSIXTime $ h - 1 + fromEnum hc  -- Subtract one millisecond if the interval was open.
     )
 closeInterval _ = Nothing
+{-# INLINABLE closeInterval #-}
 
 
-{-# INLINABLE mkMarloweValidator #-}
 -- | The Marlowe semantics validator.
 mkMarloweValidator
     :: ScriptHash     -- ^ The hash of the corresponding Marlowe payout validator.
@@ -125,6 +124,7 @@ mkMarloweValidator
     MarloweData{..}
     marloweTxInputs
     ctx@ScriptContext{scriptContextTxInfo} = do
+{-# INLINABLE mkMarloweValidator #-}
 
     let scriptInValue = txOutValue $ txInInfoResolved ownInput
     let interval =

--- a/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Scripts/Semantics.hs
+++ b/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Scripts/Semantics.hs
@@ -124,7 +124,6 @@ mkMarloweValidator
     MarloweData{..}
     marloweTxInputs
     ctx@ScriptContext{scriptContextTxInfo} = do
-{-# INLINABLE mkMarloweValidator #-}
 
     let scriptInValue = txOutValue $ txInInfoResolved ownInput
     let interval =
@@ -387,6 +386,7 @@ mkMarloweValidator
     -- Tally the value paid to an address.
     valuePaidToAddress :: Ledger.Address -> Val.Value
     valuePaidToAddress address = foldMap txOutValue $ filter ((== address) . txOutAddress) allOutputs
+{-# INLINABLE mkMarloweValidator #-}
 
 
 -- | Convert semantics input to transaction input.

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
@@ -126,40 +126,46 @@ formula1 = Eqv (Eqv (Sym 1) (Sym 1))
                     (Eqv (Sym 1) (Sym 1)))
 {-# INLINABLE formula1 #-}
 
+-- % One execution takes about 0.35s and 300 MB
 formula2 :: Formula  -- (a = a = a) = (a = a = a)
 formula2 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
-{-# INLINABLE formula2 #-} -- % One execution takes about 0.35s and 300 MB
+{-# INLINABLE formula2 #-}
 
+-- % One execution takes about 1.5s and 660 MB
 formula3 :: Formula  -- (a = a = a) = (a = a) = (a = a)
 formula3 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Eqv (Sym 1) (Sym 1))
                     (Eqv (Sym 1) (Sym 1)))
-{-# INLINABLE formula3 #-}  -- % One execution takes about 1.5s and 660 MB
+{-# INLINABLE formula3 #-}
 
+-- % One execution takes about 2s and 1 GB
 formula4 :: Formula  -- (a = b = c) = (d = e) = (f = g)
 formula4 = Eqv (Eqv (Sym 1) (Eqv (Sym 2) (Sym 3)))
                (Eqv (Eqv (Sym 4) (Sym 5))
                     (Eqv (Sym 6) (Sym 7)))
-{-# INLINABLE formula4 #-}  -- % One execution takes about 2s and 1 GB
+{-# INLINABLE formula4 #-}
 
+-- % One execution takes about 11s and 5 GB
 formula5 :: Formula  -- (a = a = a) = (a = a = a) = (a = a)
 formula5 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                     (Eqv (Sym 1) (Sym 1)))
-{-# INLINABLE formula5 #-}  -- % One execution takes about 11s and 5 GB
+{-# INLINABLE formula5 #-}
 
+-- % Overflow
 formula6 :: Formula  -- (a = a = a) = (a = a = a) = (a = a = a)
 formula6 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                     (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1))))
-{-# INLINABLE formula6 #-}  -- % Overflow
+{-# INLINABLE formula6 #-}
 
+-- % Overflow
 formula7 :: Formula -- (a = b = c) = (d = e = f) = (g = h = i)
 formula7 = Eqv (Eqv (Sym 1) (Eqv (Sym 2) (Sym 3)))
                (Eqv (Eqv (Sym 4) (Eqv (Sym 5) (Sym 6)))
                     (Eqv (Sym 7) (Eqv (Sym 8) (Sym 9))))
-{-# INLINABLE formula7 #-} -- % Overflow
+{-# INLINABLE formula7 #-}
 
 data StaticFormula = F1 | F2 | F3 | F4 | F5 | F6 | F7
 Tx.makeLift ''StaticFormula

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Clausify.hs
@@ -32,26 +32,25 @@ data Formula =
 Tx.makeLift ''Formula
 
 -- separate positive and negative literals, eliminating duplicates
-{-# INLINABLE clause #-}
 clause :: Formula -> LRVars
 clause p = clause' p ([] , [])
            where
            clause' (Dis p q)       x   = clause' p (clause' q x)
            clause' (Sym s)       (c,a) = (insert s c , a)
            clause' (Not (Sym s)) (c,a) = (c , insert s a)
+{-# INLINABLE clause #-}
 
 -- the main pipeline from propositional formulae to a list of clauses
-{-# INLINABLE clauses #-}
 clauses :: Formula -> [LRVars]
 clauses = unicl . split . disin . negin . elim
+{-# INLINABLE clauses #-}
 
-{-# INLINABLE conjunct #-}
 conjunct :: Formula -> Bool
 conjunct (Con _ _) = True
 conjunct _         = False
+{-# INLINABLE conjunct #-}
 
 -- shift disjunction within conjunction
-{-# INLINABLE disin #-}
 disin :: Formula -> Formula
 disin (Dis p (Con q r)) = Con (disin (Dis p q)) (disin (Dis p r))
 disin (Dis (Con p q) r) = Con (disin (Dis p r)) (disin (Dis q r))
@@ -63,17 +62,17 @@ disin (Dis p q) =
   dq = disin q
 disin (Con p q) = Con (disin p) (disin q)
 disin p = p
+{-# INLINABLE disin #-}
 
 -- split conjunctive proposition into a list of conjuncts
-{-# INLINABLE split #-}
 split :: Formula -> [Formula]
 split p = split' p []
           where
           split' (Con p q) a = split' p (split' q a)
           split' p a         = p : a
+{-# INLINABLE split #-}
 
 -- eliminate connectives other than not, disjunction and conjunction
-{-# INLINABLE elim #-}
 elim :: Formula -> Formula
 elim (Sym s)    = Sym s
 elim (Not p)    = Not (elim p)
@@ -81,19 +80,19 @@ elim (Dis p q)  = Dis (elim p) (elim q)
 elim (Con p q)  = Con (elim p) (elim q)
 elim (Imp p q)  = Dis (Not (elim p)) (elim q)
 elim (Eqv f f') = Con (elim (Imp f f')) (elim (Imp f' f))
+{-# INLINABLE elim #-}
 
 -- insertion of an item into an ordered list
 -- Note: this is a corrected version from Colin (94/05/03 WDP)
-{-# INLINABLE insert #-}
 insert :: (Ord t) => t -> [t] -> [t]
 insert x [] = [x]
 insert x p@(y:ys) =
   if x < y then x : p
   else if x > y then y : insert x ys
   else p
+{-# INLINABLE insert #-}
 
 -- shift negation to innermost positions
-{-# INLINABLE negin #-}
 negin :: Formula -> Formula
 negin (Not (Not p))   = negin p
 negin (Not (Con p q)) = Dis (negin (Not p)) (negin (Not q))
@@ -101,70 +100,70 @@ negin (Not (Dis p q)) = Con (negin (Not p)) (negin (Not q))
 negin (Dis p q)       = Dis (negin p) (negin q)
 negin (Con p q)       = Con (negin p) (negin q)
 negin p               = p
+{-# INLINABLE negin #-}
 
 -- does any symbol appear in both consequent and antecedent of clause
-{-# INLINABLE tautclause #-}
 tautclause :: LRVars -> Bool
 tautclause (c,a) = [x | x <- c, x `elem` a] /= []
+{-# INLINABLE tautclause #-}
 
 -- form unique clausal axioms excluding tautologies
-{-# INLINABLE unicl #-}
 unicl :: [Formula] -> [LRVars]
 unicl a = foldr unicl' [] a
           where
           unicl' p x = if tautclause cp then x else insert cp x
                        where
                        cp = clause p :: LRVars
+{-# INLINABLE unicl #-}
 
-{-# INLINABLE while #-}
 while :: (t -> Bool) -> (t -> t) -> t -> t
 while p f x = if p x then while p f (f x) else x
+{-# INLINABLE while #-}
 
-{-# INLINABLE formula1 #-}
 formula1 :: Formula  -- % (a = a) = (a = a) = (a = a)
 formula1 = Eqv (Eqv (Sym 1) (Sym 1))
                (Eqv (Eqv (Sym 1) (Sym 1))
                     (Eqv (Sym 1) (Sym 1)))
+{-# INLINABLE formula1 #-}
 
-{-# INLINABLE formula2 #-} -- % One execution takes about 0.35s and 300 MB
 formula2 :: Formula  -- (a = a = a) = (a = a = a)
 formula2 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
+{-# INLINABLE formula2 #-} -- % One execution takes about 0.35s and 300 MB
 
-{-# INLINABLE formula3 #-}  -- % One execution takes about 1.5s and 660 MB
 formula3 :: Formula  -- (a = a = a) = (a = a) = (a = a)
 formula3 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Eqv (Sym 1) (Sym 1))
                     (Eqv (Sym 1) (Sym 1)))
+{-# INLINABLE formula3 #-}  -- % One execution takes about 1.5s and 660 MB
 
-{-# INLINABLE formula4 #-}  -- % One execution takes about 2s and 1 GB
 formula4 :: Formula  -- (a = b = c) = (d = e) = (f = g)
 formula4 = Eqv (Eqv (Sym 1) (Eqv (Sym 2) (Sym 3)))
                (Eqv (Eqv (Sym 4) (Sym 5))
                     (Eqv (Sym 6) (Sym 7)))
+{-# INLINABLE formula4 #-}  -- % One execution takes about 2s and 1 GB
 
-{-# INLINABLE formula5 #-}  -- % One execution takes about 11s and 5 GB
 formula5 :: Formula  -- (a = a = a) = (a = a = a) = (a = a)
 formula5 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                     (Eqv (Sym 1) (Sym 1)))
+{-# INLINABLE formula5 #-}  -- % One execution takes about 11s and 5 GB
 
-{-# INLINABLE formula6 #-}  -- % Overflow
 formula6 :: Formula  -- (a = a = a) = (a = a = a) = (a = a = a)
 formula6 = Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                (Eqv (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1)))
                     (Eqv (Sym 1) (Eqv (Sym 1) (Sym 1))))
+{-# INLINABLE formula6 #-}  -- % Overflow
 
-{-# INLINABLE formula7 #-} -- % Overflow
 formula7 :: Formula -- (a = b = c) = (d = e = f) = (g = h = i)
 formula7 = Eqv (Eqv (Sym 1) (Eqv (Sym 2) (Sym 3)))
                (Eqv (Eqv (Sym 4) (Eqv (Sym 5) (Sym 6)))
                     (Eqv (Sym 7) (Eqv (Sym 8) (Sym 9))))
+{-# INLINABLE formula7 #-} -- % Overflow
 
 data StaticFormula = F1 | F2 | F3 | F4 | F5 | F6 | F7
 Tx.makeLift ''StaticFormula
 
-{-# INLINABLE getFormula #-}
 getFormula :: StaticFormula -> Formula
 getFormula =
     \case
@@ -175,11 +174,12 @@ getFormula =
      F5 -> formula5
      F6 -> formula6
      F7 -> formula7
+{-# INLINABLE getFormula #-}
 
 -- % Haskell entry point for testing
-{-# INLINABLE runClausify #-}
 runClausify :: StaticFormula -> [LRVars]
 runClausify = clauses . getFormula
+{-# INLINABLE runClausify #-}
 
 mkClausifyCode :: StaticFormula -> Tx.CompiledCode [LRVars]
 mkClausifyCode formula =

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights.hs
@@ -21,34 +21,34 @@ import PlutusTx.Plugin ()
 import PlutusTx.Prelude as Tx
 import Prelude qualified as Haskell
 
-{-# INLINABLE zipConst #-}
 zipConst :: a -> [b] -> [(a,b)]
 zipConst a = map ((,) a)
+{-# INLINABLE zipConst #-}
 
-{-# INLINABLE grow #-}
 grow :: (Integer,ChessSet) -> [(Integer,ChessSet)]
 grow (x,y) = zipConst (x+1) (descendents y)
+{-# INLINABLE grow #-}
 
-{-# INLINABLE isFinished #-}
 isFinished :: (Integer,ChessSet) -> Bool
 isFinished (_,y) = tourFinished y
+{-# INLINABLE isFinished #-}
 
-{-# INLINABLE interval #-}
 interval :: Integer -> Integer -> [Integer]
 interval a0 b = go a0 where
     go a = if a > b then [] else a : go (a + 1)
+{-# INLINABLE interval #-}
 
 -- % Original version used infinite lists.
-{-# INLINABLE mkStarts #-}
 mkStarts :: Integer -> [(Integer, ChessSet)]
 mkStarts sze =
     let l = [startTour (x,y) sze | x <- interval 1 sze, y <- interval 1 sze]
         numStarts = Tx.length l  -- = sze*sze
     in Tx.zip (replicate numStarts (1-numStarts)) l
+{-# INLINABLE mkStarts #-}
 
-{-# INLINABLE root #-}
 root :: Integer -> Queue (Integer, ChessSet)
 root sze = addAllFront (mkStarts sze) createQueue
+{-# INLINABLE root #-}
 
 {-% Original version
 root sze = addAllFront
@@ -62,7 +62,6 @@ root sze = addAllFront
 
 type Solution = (Integer, ChessSet)
 
-{-# INLINABLE depthSearch #-}
 -- % Added a depth parameter to stop things getting out of hand in the strict world.
 depthSearch :: (Eq a) => Integer -> Queue a -> (a -> [a]) -> (a -> Bool) -> Queue a
 depthSearch depth q growFn finFn
@@ -75,6 +74,7 @@ depthSearch depth q growFn finFn
                                               (removeFront q))
                                  growFn
                                  finFn
+{-# INLINABLE depthSearch #-}
 
 -- % Only for textual output of PLC scripts
 unindent :: PLC.Doc ann -> [Haskell.String]
@@ -82,9 +82,9 @@ unindent d = map (Haskell.dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d
 
 
 -- % Haskell entry point for testing
-{-# INLINABLE runKnights #-}
 runKnights :: Integer -> Integer -> [Solution]
 runKnights depth boardSize = depthSearch depth (root boardSize) grow isFinished
+{-# INLINABLE runKnights #-}
 
 mkKnightsCode :: Integer -> Integer -> Tx.CompiledCode [Solution]
 mkKnightsCode depth boardSize =

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/ChessSetList.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/ChessSetList.hs
@@ -46,36 +46,36 @@ instance Tx.Eq ChessSet where
 instance Tx.Ord ChessSet where
     _ <= _ = True
 
-{-# INLINABLE createBoard #-}
 createBoard :: Integer -> Tile -> ChessSet
 createBoard x t = Board x 1 (Just t) [t]
+{-# INLINABLE createBoard #-}
 
-{-# INLINABLE sizeBoard #-}
 sizeBoard :: ChessSet -> Integer
 sizeBoard (Board s _ _ _) = s
+{-# INLINABLE sizeBoard #-}
 
-{-# INLINABLE noPieces #-}
 noPieces :: ChessSet -> Integer
 noPieces (Board _ n _ _) = n
+{-# INLINABLE noPieces #-}
 
-{-# INLINABLE addPiece #-}
 addPiece :: Tile -> ChessSet -> ChessSet
 addPiece t (Board s n f ts) = Board s (n+1) f (t:ts)
+{-# INLINABLE addPiece #-}
 
 -- % Remove the last element from a list
-{-# INLINABLE init #-}
 init :: [a] -> [a]
 init l = case reverse l of
            _:as -> reverse as
            []   -> Tx.error ()
+{-# INLINABLE init #-}
 
-{-# INLINABLE secondLast #-}
 secondLast :: [a] -> Maybe a
 secondLast l =
     case reverse l of
       []    -> Tx.error ()
       [_]   -> Nothing
       _:a:_ -> Just a
+{-# INLINABLE secondLast #-}
 
 
 {-%  Note (deleteFirst).
@@ -90,29 +90,28 @@ secondLast l =
     look at it.
 %-}
 
-{-# INLINABLE deleteFirst #-}
 deleteFirst :: ChessSet -> ChessSet
 deleteFirst (Board s n _ ts) =
     Board s (n-1) f' ts'
         where ts' = init ts
               f' = secondLast ts
+{-# INLINABLE deleteFirst #-}
 
-{-# INLINABLE positionPiece #-}
 positionPiece :: Integer -> ChessSet -> Tile
 positionPiece x (Board _ n _ ts) = ts Tx.!! (n - x)
+{-# INLINABLE positionPiece #-}
 
-{-# INLINABLE lastPiece #-}
 lastPiece :: ChessSet -> Tile
 lastPiece (Board _ _ _ (t:_)) = t
 lastPiece _                   = Tx.error ()
+{-# INLINABLE lastPiece #-}
 
-{-# INLINABLE firstPiece #-}
 firstPiece :: ChessSet -> Tile
 firstPiece (Board _ _ f _) =
     case f of Just tile -> tile
               Nothing   -> Tx.error ()
+{-# INLINABLE firstPiece #-}
 
-{-# INLINABLE pieceAtTile #-}
 pieceAtTile :: Tile -> ChessSet -> Integer
 pieceAtTile x0 (Board _ _ _ ts)
    = findPiece x0 ts
@@ -121,16 +120,17 @@ pieceAtTile x0 (Board _ _ _ ts)
         findPiece x (y:xs)
            | x == y    = 1 + Tx.length xs
            | otherwise = findPiece x xs
+{-# INLINABLE pieceAtTile #-}
 
 
-{-# INLINABLE notIn #-}
 notIn :: Eq a => a  -> [a] -> Bool
 notIn _ []     = True
 notIn x (a:as) = (x /= a) && (notIn x as)
+{-# INLINABLE notIn #-}
 
-{-# INLINABLE isSquareFree #-}
 isSquareFree :: Tile -> ChessSet -> Bool
 isSquareFree x (Board _ _ _ ts) = notIn x ts
+{-# INLINABLE isSquareFree #-}
 
 
 -- % Everything below here is only needed for printing boards.

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/KnightHeuristic.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/KnightHeuristic.hs
@@ -14,7 +14,6 @@ import PlutusTx.Prelude as Tx
 
 data Direction = UL | UR | DL |DR | LU | LD | RU | RD
 
-{-# INLINABLE move #-}
 move :: Direction -> Tile -> Tile
 move UL (x,y) = (x-1,y-2)
 move UR (x,y) = (x+1,y-2)
@@ -24,24 +23,24 @@ move LU (x,y) = (x-2,y-1)
 move LD (x,y) = (x-2,y+1)
 move RU (x,y) = (x+2,y-1)
 move RD (x,y) = (x+2,y+1)
+{-# INLINABLE move #-}
 
-{-# INLINABLE startTour #-}
 startTour :: Tile -> Integer -> ChessSet
 startTour st size
    | (size `Tx.remainder` 2) == 0 = createBoard size st
    | otherwise           = {-Tx.trace "startTour" $ -} Tx.error ()
+{-# INLINABLE startTour #-}
 
-{-# INLINABLE moveKnight #-}
 moveKnight :: ChessSet -> Direction -> ChessSet
 moveKnight board dir
    = addPiece (move dir (lastPiece board)) board
+{-# INLINABLE moveKnight #-}
 
-{-# INLINABLE canMove #-}
 canMove :: ChessSet -> Direction -> Bool
 canMove board dir
    = canMoveTo (move dir (lastPiece board)) board
+{-# INLINABLE canMove #-}
 
-{-# INLINABLE canMoveTo #-}
 canMoveTo :: Tile -> ChessSet -> Bool
 canMoveTo t@(x,y) board
    = (x Tx.>= 1) && (x Tx.<= sze) &&
@@ -49,8 +48,8 @@ canMoveTo t@(x,y) board
      isSquareFree t board
      where
         sze = sizeBoard board
+{-# INLINABLE canMoveTo #-}
 
-{-# INLINABLE descendents #-}
 descendents :: ChessSet -> [ChessSet]
 descendents board =
   if (canJumpFirst board) && (deadEnd (addPiece (firstPiece board) board))
@@ -62,39 +61,40 @@ descendents board =
            else []           -- Going to be dead end
                where
                  singles = singleDescend board
+{-# INLINABLE descendents #-}
 
 
-{-# INLINABLE singleDescend #-}
 singleDescend :: ChessSet -> [ChessSet]
 singleDescend board =[x | (y,x) <- descAndNo board, y==1]
+{-# INLINABLE singleDescend #-}
 
-{-# INLINABLE descAndNo #-}
 descAndNo :: ChessSet -> [(Integer,ChessSet)]
 descAndNo board
    = [(Tx.length (possibleMoves (deleteFirst x)),x) | x <- allDescend board]
+{-# INLINABLE descAndNo #-}
 
-{-# INLINABLE allDescend #-}
 allDescend :: ChessSet -> [ChessSet]
 allDescend board
    =  map (moveKnight board) (possibleMoves board)
+{-# INLINABLE allDescend #-}
 
-{-# INLINABLE possibleMoves #-}
 possibleMoves :: ChessSet -> [Direction]
 possibleMoves board
    =[x | x <- [UL,UR,DL,DR,LU,LD,RU,RD], (canMove board x)]
+{-# INLINABLE possibleMoves #-}
 
-{-# INLINABLE deadEnd #-}
 deadEnd :: ChessSet -> Bool
 deadEnd board = (Tx.length (possibleMoves board)) == 0
+{-# INLINABLE deadEnd #-}
 
-{-# INLINABLE canJumpFirst #-}
 canJumpFirst :: ChessSet -> Bool
 canJumpFirst board
   = canMoveTo (firstPiece board) (deleteFirst board)
+{-# INLINABLE canJumpFirst #-}
 
-{-# INLINABLE tourFinished #-}
 tourFinished :: ChessSet -> Bool
 tourFinished board
    = (noPieces board == (sze*sze)) && (canJumpFirst board)
      where
         sze = sizeBoard board
+{-# INLINABLE tourFinished #-}

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Queue.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Queue.hs
@@ -9,57 +9,57 @@ import PlutusTx.Prelude as Tx
 
 type Queue a = [a]
 
-{-# INLINABLE createQueue #-}
 createQueue :: Queue a
 createQueue = []
+{-# INLINABLE createQueue #-}
 
-{-# INLINABLE addFront #-}
 addFront :: a -> Queue a -> Queue a
 addFront x q = x:q
+{-# INLINABLE addFront #-}
 
-{-# INLINABLE addBack #-}
 addBack :: a -> Queue a -> Queue a
 addBack x q = q Tx.++ [x]
+{-# INLINABLE addBack #-}
 
-{-# INLINABLE addAllFront #-}
 addAllFront :: [a] -> Queue a -> Queue a
 addAllFront list q = list Tx.++ q
+{-# INLINABLE addAllFront #-}
 
-{-# INLINABLE addAllBack #-}
 addAllBack :: [a] -> Queue a -> Queue a
 addAllBack list q = q Tx.++ list
+{-# INLINABLE addAllBack #-}
 
-{-# INLINABLE inquireFront #-}
 inquireFront :: Queue a -> a
 inquireFront []    = Tx.error ()
+{-# INLINABLE inquireFront #-}
 
 inquireFront (h:_) = h
 
-{-# INLINABLE inquireBack #-}
 inquireBack :: Queue a -> a
 inquireBack []     = Tx.error ()
 inquireBack [x]    = x
 inquireBack (_:xs) = inquireBack xs
+{-# INLINABLE inquireBack #-}
 
-{-# INLINABLE removeFront #-}
 removeFront :: Queue a -> Queue a
 removeFront []    = Tx.error ()
 removeFront (_:t) = t
+{-# INLINABLE removeFront #-}
 
-{-# INLINABLE removeBack #-}
 removeBack :: Queue a -> Queue a
 removeBack []     = Tx.error ()
 removeBack [_]    =  []
 removeBack (x:xs) = x:(removeBack xs)
+{-# INLINABLE removeBack #-}
 
-{-# INLINABLE emptyQueue #-}
 emptyQueue :: Queue a -> Bool
 emptyQueue [] = True
 emptyQueue _  = False
+{-# INLINABLE emptyQueue #-}
 
 
 {-
-{-# INLINABLE sizeQueue #-}
 sizeQueue :: Queue b -> Integer
 sizeQueue xs = length' xs
 -}
+{-# INLINABLE sizeQueue #-}

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Queue.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Queue.hs
@@ -31,9 +31,8 @@ addAllBack list q = q Tx.++ list
 
 inquireFront :: Queue a -> a
 inquireFront []    = Tx.error ()
-{-# INLINABLE inquireFront #-}
-
 inquireFront (h:_) = h
+{-# INLINABLE inquireFront #-}
 
 inquireBack :: Queue a -> a
 inquireBack []     = Tx.error ()
@@ -57,9 +56,8 @@ emptyQueue [] = True
 emptyQueue _  = False
 {-# INLINABLE emptyQueue #-}
 
-
 {-
 sizeQueue :: Queue b -> Integer
 sizeQueue xs = length' xs
--}
 {-# INLINABLE sizeQueue #-}
+-}

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Sort.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Sort.hs
@@ -89,8 +89,8 @@ rqpart le x (y:ys) rle rgt r =
         rqpart le x ys (y:rle) rgt r
     else
         rqpart le x ys rle (y:rgt) r
-%-}
 {-# INLINABLE rqpart #-}
+%-}
 
 randomIntegers :: Integer -> Integer -> [Integer]
 randomIntegers s1 s2 =
@@ -112,13 +112,13 @@ rands s1 s2
         k    = s1 `div` 53668
         s1'  = 40014 * (s1 - k * 53668) - k * 12211
         s1'' = if s1' < 0 then s1' + 2147483563 else s1'
-{-# INLINABLE rands #-}
 
         k'   = s2 `div` 52774
         s2'  = 40692 * (s2 - k' * 52774) - k' * 3791
         s2'' = if s2' < 0 then s2' + 2147483399 else s2'
 
         z    = s1'' - s2''
+{-# INLINABLE rands #-}
 
 -- % These are from the original program.  That's literate Haskell, and it
 -- % contains the results as latex.

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Sort.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Sort.hs
@@ -8,18 +8,17 @@ module PlutusBenchmark.NoFib.Knights.Sort
 
 import PlutusTx.Prelude qualified as Tx
 
-{-# INLINABLE insertSort #-}
 insertSort :: (Tx.Ord a) => [a] -> [a]
 insertSort xs = foldr insertion [] xs
+{-# INLINABLE insertSort #-}
 
-{-# INLINABLE insertion #-}
 insertion :: (Tx.Ord a) => a -> [a] -> [a]
 insertion x [] = [x]
 insertion x (y:ys)
         | x Tx.<= y    = x:y:ys
         | otherwise = y:insertion x ys
+{-# INLINABLE insertion #-}
 
-{-# INLINABLE mergeSort #-}
 mergeSort :: (Tx.Ord a) => [a] -> [a]
 mergeSort xs
         = if (n <=1 ) then xs
@@ -29,49 +28,49 @@ mergeSort xs
                 ( mergeSort (drop (n `div` 2) xs)))
           where
                 n = length xs
+{-# INLINABLE mergeSort #-}
 
-{-# INLINABLE mergeList #-}
 mergeList :: (Tx.Ord a) => [a] -> [a] -> [a]
 mergeList []   ys = ys
 mergeList xs   [] = xs
 mergeList (x:xs) (y:ys)
         | x Tx.<= y    = x:mergeList xs (y:ys)
         | otherwise = y:mergeList (x:xs) ys
+{-# INLINABLE mergeList #-}
 
-{-# INLINABLE quickSort #-}
 quickSort :: (Tx.Ord a) => [a] -> [a]
 quickSort []     = []
 quickSort (x:xs) = (quickSort [y | y<-xs, y Tx.< x]) ++ [x] ++
                    (quickSort [y | y<-xs, y Tx.>= x])
+{-# INLINABLE quickSort #-}
 
 {-% These don't work in Plutus, and aren't used in the original program.
-{-# INLINABLE lazySortLe #-}
 lazySortLe :: (a -> a -> Bool) -> [a] -> [a]
 lazySortLe le l = lazyQsort le   l []
+{-# INLINABLE lazySortLe #-}
 
-{-# INLINABLE lazySort #-}
 lazySort :: (Tx.Ord a) => [a] -> [a]
 lazySort      l = lazyQsort (<=) l []
+{-# INLINABLE lazySort #-}
 
 -- lazyQsort is stable and does not concatenate.
-{-# INLINABLE lazyQsort #-}
 lazyQsort :: (a -> a -> Bool) -> [a] -> [a] -> [a]
 lazyQsort le []     r = r
 lazyQsort le [x]    r = x:r
 lazyQsort le (x:xs) r = qpart le x xs [] [] r
+{-# INLINABLE lazyQsort #-}
 
 -- rlazyQsort is as lazyQsort but anti-stable,
 -- i.e. reverses equal elements.
-{-# INLINABLE rlazyQsort #-}
 rlazyQsort :: (a -> a -> Bool) -> [a] -> [a] -> [a]
 rlazyQsort  le []     r = r
 rlazyQsort le [x]    r  = x:r
 rlazyQsort  le (x:xs) r = rqpart le x xs [] [] r
+{-# INLINABLE rlazyQsort #-}
 
 -- qpart partitions and sorts the sublists
 -- rlt and rge are in reverse order and must be sorted with an
 -- anti-stable sorting
-{-# INLINABLE qpart #-}
 qpart :: (a -> a -> Bool) -> a -> [a] -> [a] -> [a] -> [a] -> [a]
 qpart le x [] rlt rge r =
     rlazyQsort le rlt (x:rlazyQsort le rge r)
@@ -80,8 +79,8 @@ qpart le x (y:ys) rlt rge r =
         qpart le x ys rlt (y:rge) r
     else
         qpart le x ys (y:rlt) rge r
+{-# INLINABLE qpart #-}
 
-{-# INLINABLE rqpart #-}
 rqpart :: (a -> a -> Bool) -> a -> [a] -> [a] -> [a] -> [a] -> [a]
 rqpart le x [] rle rgt r =
     lazyQsort le rle (x:lazyQsort le rgt r)
@@ -91,8 +90,8 @@ rqpart le x (y:ys) rle rgt r =
     else
         rqpart le x ys rle (y:rgt) r
 %-}
+{-# INLINABLE rqpart #-}
 
-{-# INLINABLE randomIntegers #-}
 randomIntegers :: Integer -> Integer -> [Integer]
 randomIntegers s1 s2 =
     if 1 <= s1 && s1 <= 2147483562 then
@@ -102,8 +101,8 @@ randomIntegers s1 s2 =
             error "randomIntegers: Bad second seed."
     else
         error "randomIntegers: Bad first seed."
+{-# INLINABLE randomIntegers #-}
 
-{-# INLINABLE rands #-}
 rands :: Integer -> Integer -> [Integer]
 rands s1 s2
    = if z < 1 then z + 2147483562 : rands s1'' s2''
@@ -113,6 +112,7 @@ rands s1 s2
         k    = s1 `div` 53668
         s1'  = 40014 * (s1 - k * 53668) - k * 12211
         s1'' = if s1' < 0 then s1' + 2147483563 else s1'
+{-# INLINABLE rands #-}
 
         k'   = s2 `div` 52774
         s2'  = 40692 * (s2 - k' * 52774) - k' * 3791

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Utils.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Utils.hs
@@ -4,7 +4,7 @@ module PlutusBenchmark.NoFib.Knights.Utils where
 
 import PlutusTx.Prelude
 
-{-# INLINABLE take' #-}
 take' :: Integer -> [a] -> [a]
 take' _ []     = []
 take' n (a:as) = if n<=0 then [] else a:(take' (n-1) as)
+{-# INLINABLE take' #-}

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
@@ -140,11 +140,11 @@ next :: Square -> Square
 next (row,col) = (row,col+1)
 {-# INLINABLE next #-}
 
-{-# INLINABLE maxCol #-}
 maxRow,maxCol :: Integer
 maxRow = 8
 maxCol = 8
 {-# INLINABLE maxRow #-}
+{-# INLINABLE maxCol #-}
 
 
 ------------------------

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/LastPiece.hs
@@ -55,30 +55,29 @@ data Solution = Soln Board
 data Sex = Male | Female
 
 
-{-# INLINABLE sumList #-}
 sumList :: [Integer] -> Integer
 sumList []    = 0
 sumList (h:t) = h + sumList t
+{-# INLINABLE sumList #-}
 
-{-# INLINABLE numSolutions #-}
 numSolutions :: Solution -> Integer
 numSolutions (Soln _)   = 1
 numSolutions (Choose l) = sumList . map numSolutions $ l
 numSolutions Fail       = 0
+{-# INLINABLE numSolutions #-}
 
 sizeOfSolution :: Solution -> Integer
 sizeOfSolution (Soln _)   = 1
 sizeOfSolution (Choose l) = sumList . map sizeOfSolution $ l
 sizeOfSolution Fail       = 1
 
-{-# INLINABLE flipSex #-}
 flipSex :: Sex -> Sex
 flipSex Male   = Female
 flipSex Female = Male
+{-# INLINABLE flipSex #-}
 
 --      The main search
 
-{-# INLINABLE search #-}
 search :: Square -> Sex         -- Square we are up to
        -> Board                 -- Current board
        -> [Piece]               -- Remaining pieces
@@ -100,8 +99,8 @@ search square sex board ps
                              Male   -> ms
                              Female -> fs,
                  os <- oss]
+{-# INLINABLE search #-}
 
-{-# INLINABLE prune #-}
 -- % An attempt to cut down on the size of the result (not in the original program)
 prune :: [Solution] -> Solution
 prune ss =
@@ -111,61 +110,61 @@ prune ss =
       l        -> Choose l
       where nonFailure Fail = False
             nonFailure _    = True
+{-# INLINABLE prune #-}
 
-{-# INLINABLE try #-}
 try :: Square -> Sex -> Board -> (PieceId,[Offset],[Piece]) -> Maybe Solution
 try square sex board (pid,os,ps)
   = case fit board square pid os of
         Just board' -> Just (search (next square) (flipSex sex) board' ps)
         Nothing     -> Nothing
+{-# INLINABLE try #-}
 
 
-{-# INLINABLE fit #-}
 fit :: Board -> Square -> PieceId -> [Offset] -> Maybe Board
 fit board square pid []     = Just (extend board square pid)
 fit board square pid (o:os) =
     case extend_maybe board (square `add` o) pid of
       Just board' -> fit board' square pid os
       Nothing     -> Nothing
+{-# INLINABLE fit #-}
 
 
 --------------------------
 --      Offsets and squares
 
-{-# INLINABLE add #-}
 add :: Square -> Offset -> Square
 add (row,col) (orow, ocol) = (row + orow, col + ocol)
+{-# INLINABLE add #-}
 
-{-# INLINABLE next #-}
 next :: Square -> Square
 next (row,col) = (row,col+1)
+{-# INLINABLE next #-}
 
-{-# INLINABLE maxRow #-}
 {-# INLINABLE maxCol #-}
 maxRow,maxCol :: Integer
 maxRow = 8
 maxCol = 8
+{-# INLINABLE maxRow #-}
 
 
 ------------------------
 --      Boards
 
-{-# INLINABLE emptyBoard #-}
 emptyBoard :: Board
 emptyBoard = [] -- Map.empty
+{-# INLINABLE emptyBoard #-}
 
-{-# INLINABLE check #-}
 check :: Board -> Square -> Maybe PieceId
 check board square = -- Map.lookup square board
     case board of
       []                   -> Nothing
       (square',pid):board' -> if square == square' then Just pid else check board' square
+{-# INLINABLE check #-}
 
-{-# INLINABLE extend #-}
 extend :: Board -> Square -> PieceId -> Board
 extend board square pid = (square, pid): board -- Map.insert square pid board
+{-# INLINABLE extend #-}
 
-{-# INLINABLE extend_maybe #-}
 extend_maybe :: Board -> Square -> PieceId -> Maybe Board
 extend_maybe board square@(row,col) pid
   | row > maxRow || col < 1 || col > maxCol
@@ -174,129 +173,130 @@ extend_maybe board square@(row,col) pid
   = case check board square of
         Just _  -> Nothing
         Nothing -> Just (extend board square pid)
+{-# INLINABLE extend_maybe #-}
 
 
 --------------------------
 --      Utility
 
-{-# INLINABLE pickOne #-}
 pickOne :: [a] -> [(a,[a])]
 pickOne = go id
   where
     go _ []     = []
     go f (x:xs) = (x, f xs) : go ((x :) . f) xs
+{-# INLINABLE pickOne #-}
 
 
 -----------------------------------
 --      The initial setup
 
-{-# INLINABLE fromJust #-}
 -- % Library functions is not inlinable
 fromJust :: Maybe a -> a
 fromJust Nothing  = Tx.error ()
 fromJust (Just x) = x
+{-# INLINABLE fromJust #-}
 
-{-# INLINABLE initialBoard #-}
 initialBoard :: Board
 initialBoard = fromJust (fit emptyBoard (1,1) "a" [(1,0),(1,1)])
+{-# INLINABLE initialBoard #-}
 
-{-# INLINABLE initialPieces #-}
 initialPieces :: [Piece]
 initialPieces = [bPiece, cPiece, dPiece, ePiece, fPiece,
                  gPiece, hPiece, iPiece, jPiece, kPiece,
                  lPiece, mPiece, nPiece]
+{-# INLINABLE initialPieces #-}
 
-{-# INLINABLE nPiece #-}
 nPiece :: Piece
 nPiece = P "n" [ [(0,1),(1,1),(2,1),(2,2)],
                  [(1,0),(1,-1),(1,-2),(2,-2)] ]
                []
+{-# INLINABLE nPiece #-}
 
-{-# INLINABLE mPiece #-}
 mPiece :: Piece
 mPiece = P "m" [ [(0,1),(1,0),(2,0),(3,0)] ]
                [ [(0,1),(0,2),(0,3),(1,3)],
                  [(1,0),(2,0),(3,0),(3,-1)] ]
+{-# INLINABLE mPiece #-}
 
-{-# INLINABLE lPiece #-}
 lPiece :: Piece
 lPiece = P "l" [ [(0,1),(0,2),(0,3),(1,2)],
                  [(1,0),(2,0),(3,0),(2,-1)] ]
                [ [(1,-1),(1,0),(1,1),(1,2)],
                  [(1,0),(2,0),(3,0),(1,1)] ]
+{-# INLINABLE lPiece #-}
 
-{-# INLINABLE kPiece #-}
 kPiece :: Piece
 kPiece = P "k" [ [(0,1),(1,0),(2,0),(2,-1)] ]
                [ [(1,0),(1,1),(1,2),(2,2)] ]
+{-# INLINABLE kPiece #-}
 
 
-{-# INLINABLE jPiece #-}
 jPiece :: Piece
 jPiece = P "j" [ [(0,1),(0,2),(0,3),(1,1)],
                  [(1,0),(2,0),(3,0),(1,-1)],
                  [(1,-2),(1,-1),(1,0),(1,1)] ]
                [ [(1,0),(2,0),(3,0),(2,2)] ]
+{-# INLINABLE jPiece #-}
 
-{-# INLINABLE iPiece #-}
 iPiece :: Piece
 iPiece = P "i" [ [(1,0),(2,0),(2,1),(3,1)],
                  [(0,1),(0,2),(1,0),(1,-1)],
                  [(1,0),(1,1),(2,1),(3,1)] ]
                [ [(0,1),(1,0),(1,-1),(1,-2)] ]
+{-# INLINABLE iPiece #-}
 
-{-# INLINABLE hPiece #-}
 hPiece :: Piece
 hPiece = P "h" [ [(0,1),(1,1),(1,2),(2,2)],
                  [(1,0),(1,-1),(2,-1),(2,-2)],
                  [(1,0),(1,1),(2,1),(2,2)] ]
                [ [(0,1),(1,0),(1,-1),(2,-1)] ]
+{-# INLINABLE hPiece #-}
 
 
-{-# INLINABLE gPiece #-}
 gPiece :: Piece
 gPiece = P "g" [ ]
                [ [(0,1),(1,1),(1,2),(1,3)],
                  [(1,0),(1,-1),(2,-1),(3,-1)],
                  [(0,1),(0,2),(1,2),(1,3)],
                  [(1,0),(2,0),(2,-1),(3,-1)] ]
+{-# INLINABLE gPiece #-}
 
-{-# INLINABLE fPiece #-}
 fPiece :: Piece
 fPiece = P "f" [ [(0,1),(1,1),(2,1),(3,1)],
                  [(1,0),(1,-1),(1,-2),(1,-3)],
                  [(1,0),(2,0),(3,0),(3,1)] ]
                [ [(0,1),(0,2),(0,3),(1,0)] ]
+{-# INLINABLE fPiece #-}
 
 
-{-# INLINABLE ePiece #-}
 ePiece :: Piece
 ePiece = P "e" [ [(0,1),(1,1),(1,2)],
                  [(1,0),(1,-1),(2,-1)] ]
                [ [(0,1),(1,1),(1,2)],
                  [(1,0),(1,-1),(2,-1)] ]
+{-# INLINABLE ePiece #-}
 
-{-# INLINABLE dPiece #-}
 dPiece :: Piece
 dPiece = P "d" [ [(0,1),(1,1),(2,1)],
                  [(1,0),(1,-1),(1,-2)] ]
                [ [(1,0),(2,0),(2,1)] ]
+{-# INLINABLE dPiece #-}
 
 
-{-# INLINABLE cPiece #-}
 cPiece :: Piece
 cPiece = P "c" [ ]
                [ [(0,1),(0,2),(1,1)],
                  [(1,0),(1,-1),(2,0)],
                  [(1,-1),(1,0),(1,1)],
                  [(1,0),(1,1),(2,0)] ]
+{-# INLINABLE cPiece #-}
 
-{-# INLINABLE bPiece #-}
 bPiece :: Piece
 bPiece = P "b"  [ [(0,1),(0,2),(1,2)],
                   [(1,0),(2,0),(2,-1)],
                   [(0,1),(1,0),(2,0)] ]
                 [ [(1,0),(1,1),(1,2)] ]
+{-# INLINABLE bPiece #-}
 
 unindent :: PLC.Doc ann -> [Haskell.String]
 unindent d = map (Haskell.dropWhile isSpace) (Haskell.lines . Haskell.show $ d)

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
@@ -45,12 +45,11 @@ even n = (n `modInteger` 2) == 0
 -- This satisfies:
 -- \[@makeNumber@ \, @b@ \, [x_0,\,x_1,\,\ldots,\,x_n]
 --  = x_0.@b@^n + x_1.@b@^{n-1} + \cdots + x_n.@b@^0\]
-{-# INLINABLE makeNumber #-}
 makeNumber :: Integer -> [Integer] -> Integer
 makeNumber b = foldl f 0 where f a x = a * b + x
+{-# INLINABLE makeNumber #-}
 
 -- The (left and right) inverse of @makeNumber@ is @chop@.
-{-# INLINABLE chop #-}
 chop :: Integer -> Integer -> [Integer]
 chop b = chop' []
     where chop' a n =
@@ -58,6 +57,7 @@ chop b = chop' []
               then a
               else chop' (r:a) q
                   where (q,r) = n `divMod` b
+{-# INLINABLE chop #-}
 
 
 {- The following function @powerMod@ calculates @a^b `mod` m@. I suspect
@@ -66,7 +66,6 @@ chop b = chop' []
    storage, it should be a candidate for being a built-in within the
    Haskell library.
 -}
-{-# INLINABLE powerMod #-}
 powerMod :: Integer -> Integer -> Integer -> Integer
 powerMod a b m =
     if b == 0 then 1
@@ -76,6 +75,7 @@ powerMod a b m =
                         else g a b where
                              g a b | even b = g ((a*a) `modInteger` m) (b `divideInteger` 2)
                                    | otherwise = f a (b-1) ((a*c) `modInteger` m)
+{-# INLINABLE powerMod #-}
 
 {- The value $@y@=@cubeRoot x@$ is the integer cube root of @x@, {\it
    i.e.} $@y@ = \lfloor \sqrt[3]{@x@} \, \rfloor$. Given $@x@\geq 0$,
@@ -88,20 +88,20 @@ powerMod a b m =
 
    My implementation uses Newton's method.
 -}
-{-# INLINABLE cubeRoot #-}
 cubeRoot :: Integer -> Integer
 cubeRoot x = until satisfy improve x
              where satisfy y = y*y*y >= x && y'*y'*y' < x where y' = y-1
                    improve y = (2*y*y*y+x) `ddiv` (3*y*y)
                    ddiv a b  = if (r < (b `divideInteger` 2)) then q else q+1
                            where (q, r) = a `divMod` b
+{-# INLINABLE cubeRoot #-}
 
 ---The $@log2@ n$ is the @Integer@ $m$ such that $m = \lfloor\log_2
 -- n\rfloor$.
 
-{-# INLINABLE log2 #-}
 log2 :: Integer -> Integer
 log2 = Haskell.fromIntegral . length . chop 2
+{-# INLINABLE log2 #-}
 
 
 ---------------- Random ----------------
@@ -116,7 +116,6 @@ data RNGstate = RNGstate Integer Integer
    plugin (non-strict let-bindings): to avoid it, use `case` instead:
    `case complicatedFunction m n r of ...` %-}
 
-{-# INLINABLE initRNG #-}
 initRNG :: Integer -> Integer -> RNGstate
 initRNG s1 s2 =
     if 1 <= s1 && s1 <= 2147483562 then
@@ -125,12 +124,12 @@ initRNG s1 s2 =
         else {-Tx.trace "randomInts: Bad second seed." $-} Tx.error ()
     -- error "randomInts: Bad first seed."
     else {-Tx.trace "randomInts: Bad first seed." $-} Tx.error ()
+{-# INLINABLE initRNG #-}
 
 
 -- % Make a single random integer, returning that and the updated state.  In the
 -- original version this was an infinite list of random numbers, but that's not
 -- a good idea in the strict world.
-{-# INLINABLE getRandom #-}
 getRandom :: RNGstate -> (Integer, RNGstate)
 getRandom (RNGstate s1 s2) =
     let
@@ -144,6 +143,7 @@ getRandom (RNGstate s1 s2) =
         newState = RNGstate s1'' s2''
    in  if z < 1 then (z + 2147483562, newState)
        else (z, newState)
+{-# INLINABLE getRandom #-}
 
 -- % Produce a list of n random numbers, also returning the updated RNG state.
 getRandoms :: Integer -> RNGstate -> ([Integer], RNGstate)
@@ -158,7 +158,6 @@ getRandoms n r = getRandoms' n r []
 
 -- Given a value @x@ we can test whether we have a witness to @n@'s
 -- compositeness using @singleTestX@.
-{-# INLINABLE singleTestX #-}
 singleTestX :: Integer -> (Integer, Integer) -> Integer -> Bool
 singleTestX n (k, q) x
  = (t == 1) || (t == (n-1)) || witness ts
@@ -168,18 +167,18 @@ singleTestX n (k, q) x
                           else if t == 1 then False
                                else witness ts
          square x       = (x*x) `modInteger` n
+{-# INLINABLE singleTestX #-}
 
 -- The function @singleTest@ takes an odd, positive, @Integer@ @n@ and a
 -- pair of @Integer@'s derived from @n@ by the @findKQ@ function
-{-# INLINABLE singleTest #-}
 singleTest :: Integer -> (Integer, Integer) -> RNGstate -> (Bool, RNGstate)
 singleTest n kq r =  -- Tx.trace "singleTest" $
     (singleTestX n kq (2+x), r')
         where (x, r') = boundedRandom (n-2) r
+{-# INLINABLE singleTest #-}
 
 --The function @findKQ@ takes an odd integer $n$ and returns the tuple
 -- $(k,q)$ such that $n = q2^k+1$.
-{-# INLINABLE findKQ #-}
 findKQ :: Integer -> (Integer, Integer)
 findKQ n = f (0, (n-1))
     where f (k,q) =
@@ -187,9 +186,9 @@ findKQ n = f (0, (n-1))
               then f (k+1, d)
               else (k, q)
                   where (d,r) = q `divMod` 2
+{-# INLINABLE findKQ #-}
 
 -- % Perform k single tests on the integer n
-{-# INLINABLE multiTest #-}
 multiTest :: Integer -> RNGstate-> Integer -> (Bool, RNGstate)
 multiTest k r n = {-Tx.trace "* multiTest" $-}  -- (True, r)
     if (n <= 1 || even n)
@@ -201,33 +200,34 @@ multiTest k r n = {-Tx.trace "* multiTest" $-}  -- (True, r)
                   else case singleTest n (findKQ n) r
                        of (True, r') -> mTest (k-1) r'
                           x          -> x
+{-# INLINABLE multiTest #-}
 
 -- % Original version used `take k (iterate ...)` which doesn't terminate with strict evaluation.
-{-# INLINABLE iterateN #-}
 iterateN :: Integer -> (a -> a) -> a -> [a]
 iterateN k f x =
     if k == 0 then []
     else x : iterateN (k-1) f (f x)
+{-# INLINABLE iterateN #-}
 
 
 -- % The @boundedRandom@ function takes a number @n@ and the state of a (pseudo-) RNG @r@
 -- and returns a tuple consisting of an @Integer@ $x$ in the range $0 \leq x <
 -- @n@$, and the updated RNG state.
-{-# INLINABLE boundedRandom #-}
 boundedRandom :: Integer -> RNGstate -> (Integer, RNGstate)
 boundedRandom n r = (makeNumber 65536 (uniform ns rs), r')
               where ns        = chop 65536 n
                     (rs,r') = getRandoms (length ns) r
+{-# INLINABLE boundedRandom #-}
 
 -- The @uniform@ function generates a sequence of @Integer@'s such that,
 -- when considered as a sequence of digits, we generate a number uniform
 -- in the range @0..ns@ from the random numbers @rs@.
-{-# INLINABLE uniform #-}
 uniform :: [Integer] -> [Integer] -> [Integer]
 uniform [n]    [r]    = [r `modInteger` n]
 uniform (n:ns) (r:rs) = if t == n then t: uniform ns rs
                                   else t: map ((`modInteger` 65536). Haskell.toInteger) rs
                         where t  = Haskell.toInteger r `modInteger` (n+1)
+{-# INLINABLE uniform #-}
 
 
 ---------------- Main ----------------
@@ -241,7 +241,6 @@ Tx.makeLift ''PrimeID
    https://primes.utm.edu/lists/small/small.html and
    https://primes.utm.edu/lists/small/small2.html -}
 
-{-# INLINABLE getPrime #-}
 getPrime :: PrimeID -> Integer
 getPrime =
     \case
@@ -259,6 +258,7 @@ getPrime =
         533791764536500962982816454877600313815808544134584704665367971790938714376754987723404131641943766815146845004667377003395107827504566198008424339207
      P200 ->
         58021664585639791181184025950440248398226136069516938232493687505822471836536824298822733710342250697739996825938232641940670857624514103125986134050997697160127301547995788468137887651823707102007839
+{-# INLINABLE getPrime #-}
 
 
 -- % Only for textual output of PLC scripts
@@ -267,14 +267,14 @@ unindent d = map (Haskell.dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d
 
 
 -- % Initialise the RNG
-{-# INLINABLE initState #-}
 initState :: RNGstate
 initState = initRNG 111 47
+{-# INLINABLE initState #-}
 
 -- % Parameter for multiTest: how many rounds of the main primality test do we want to perform?
-{-# INLINABLE numTests #-}
 numTests :: Integer
 numTests = 100
+{-# INLINABLE numTests #-}
 
 data Result = Composite | Prime
     deriving stock (Haskell.Show, Haskell.Eq, Generic)
@@ -285,7 +285,6 @@ Tx.makeLift ''Result
 
 -- % The @processList@ function takes a list of input numbers
 -- % and produces a list of output results.
-{-# INLINABLE processList #-}
 processList :: [Integer] -> RNGstate -> [Result]
 processList input r =
     case input of
@@ -293,18 +292,19 @@ processList input r =
       n:ns -> case multiTest numTests r n
               of (True, r')  -> Prime : processList ns r'
                  (False, r') -> Composite : processList ns r'
+{-# INLINABLE processList #-}
 
 -- % The @testInteger@ function takes a single input number and produces a single result.
-{-# INLINABLE testInteger #-}
 testInteger :: Integer -> RNGstate -> Result
 testInteger n state = if fst $ multiTest numTests state n -- Discard the RNG state in the result
                       then Prime
                       else Composite
+{-# INLINABLE testInteger #-}
 
 -- % Haskell entry point for testing
-{-# INLINABLE runPrimalityTest #-}
 runPrimalityTest :: Integer -> Result
 runPrimalityTest n = testInteger n initState
+{-# INLINABLE runPrimalityTest #-}
 
 -- % Run the program on an arbitrary integer, for testing
 mkPrimalityTestTerm :: Integer -> Term

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
@@ -76,22 +76,22 @@ Tx.makeLift ''Algorithm
 allAlgorithms :: [Labeler]
 allAlgorithms = [bt, bm, bjbt, bjbt', fc]
 
-{-# INLINABLE lookupAlgorithm #-}
 lookupAlgorithm :: Algorithm -> Labeler
 lookupAlgorithm Bt    = bt
 lookupAlgorithm Bm    = bm
 lookupAlgorithm Bjbt1 = bjbt
 lookupAlgorithm Bjbt2 = bjbt'  -- bjbt' problematic on command line
 lookupAlgorithm Fc    = fc
+{-# INLINABLE lookupAlgorithm #-}
 
-{-# INLINABLE nqueens #-}
 nqueens :: Integer -> Labeler -> [State]
 nqueens n algorithm = (search algorithm (queens n))
+{-# INLINABLE nqueens #-}
 
 -- % Haskell entry point for testing
-{-# INLINABLE runQueens #-}
 runQueens :: Integer -> Algorithm -> [State]
 runQueens n alg = nqueens n (lookupAlgorithm alg)
+{-# INLINABLE runQueens #-}
 
 -- % Compile a Plutus Core term which runs nqueens on given arguments
 mkQueensCode :: Integer -> Algorithm -> Tx.CompiledCode [State]
@@ -124,39 +124,38 @@ unindent d = map (dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d)
 -----------------------------------------------------------
 
 -- % Replacement for `iterate`, which generates an infinite list
-{-# INLINABLE iterateN #-}
 iterateN :: Integer -> (a -> a) -> a -> [a]
 iterateN k f x =
     if k == 0 then []
     else x : iterateN (k-1) f (f x)
+{-# INLINABLE iterateN #-}
 
 -- % Replacement for [a..b]
-{-# INLINABLE interval #-}
 interval :: Integer -> Integer -> [Integer]
 interval a b =
     if a > b then []
     else a : (interval (a+1) b)
+{-# INLINABLE interval #-}
 
-{-# INLINABLE abs #-}
 abs :: Integer -> Integer
 abs n = if n<0 then 0-n else n
+{-# INLINABLE abs #-}
 
 -- % Things needed for `union`
 
-{-# INLINABLE deleteBy #-}
 deleteBy :: (a -> a -> Bool) -> a -> [a] -> [a]
 deleteBy _  _ []     = []
 deleteBy eq x (y:ys) = if x `eq` y then ys else y : deleteBy eq x ys
+{-# INLINABLE deleteBy #-}
 
-{-# INLINABLE unionBy #-}
 unionBy :: (a -> a -> Bool) -> [a] -> [a] -> [a]
 unionBy eq xs ys =  xs ++ foldl (flip (deleteBy eq)) (TxPrelude.nubBy eq ys) xs
+{-# INLINABLE unionBy #-}
 
-{-# INLINABLE union #-}
 union :: (Eq a) => [a] -> [a] -> [a]
 union                   = unionBy (==)
+{-# INLINABLE union #-}
 
-{-# INLINABLE sortBy #-}
 -- % Stolen from Data.List
 sortBy :: (a -> a -> Ordering) -> [a] -> [a]
 sortBy cmp = mergeAll . sequences
@@ -165,6 +164,7 @@ sortBy cmp = mergeAll . sequences
       | (a `cmp` b) == GT = descending b [a]  xs
       | otherwise       = ascending  b (a:) xs
     sequences xs = [xs]
+{-# INLINABLE sortBy #-}
 
     descending a as (b:bs)
       | (a `cmp` b) == GT = descending b (a:as) bs
@@ -210,51 +210,51 @@ data CSP = CSP { vars, vals :: Integer, rel :: Relation }
 
 type State = [Assign]
 
-{-# INLINABLE level #-}
 level :: Assign -> Var
 level (var := val) = var
+{-# INLINABLE level #-}
 
-{-# INLINABLE value #-}
 value :: Assign -> Value
 value (var := val) = val
+{-# INLINABLE value #-}
 
-{-# INLINABLE maxLevel #-}
 maxLevel :: State -> Var
 maxLevel []               = 0
 maxLevel ((var := val):_) = var
+{-# INLINABLE maxLevel #-}
 
-{-# INLINABLE complete #-}
 complete :: CSP -> State -> Bool
 complete CSP{vars=vars} s = maxLevel s == vars
+{-# INLINABLE complete #-}
 
-{-# INLINABLE generate #-}
 generate :: CSP -> [State]
 generate CSP{vals=vals,vars=vars} = g vars
   where g 0   = [[]]
         g var = [ (var := val):st | val <- interval 1 vals, st <- g (var-1) ]
+{-# INLINABLE generate #-}
 
-{-# INLINABLE inconsistencies #-}
 inconsistencies :: CSP -> State -> [(Var,Var)]
 inconsistencies CSP{rel=rel} as =
   [ (level a, level b) | a <- as, b <- reverse as, a > b, not (rel a b) ]
+{-# INLINABLE inconsistencies #-}
 
-{-# INLINABLE consistent #-}
 consistent :: CSP -> State -> Bool
 consistent csp = null . (inconsistencies csp)
+{-# INLINABLE consistent #-}
 
-{-# INLINABLE test #-}
 test :: CSP -> [State] -> [State]
 test csp = filter (consistent csp)
+{-# INLINABLE test #-}
 
-{-# INLINABLE solver #-}
 solver :: CSP -> [State]
 solver csp  = test csp candidates
   where candidates = generate csp
+{-# INLINABLE solver #-}
 
-{-# INLINABLE queens #-}
 queens :: Integer -> CSP
 queens n = CSP {vars = n, vals = n, rel = safe}
   where safe (i := m) (j := n) = (m /= n) && abs (i - j) /= abs (m - n)
+{-# INLINABLE queens #-}
 
 -------------------------------
 -- Figure 2.  Trees in Haskell.
@@ -267,61 +267,61 @@ label (Node lab _) = lab
 
 type Transform a b = Tree a -> Tree b
 
-{-# INLINABLE mapTree  #-}
 mapTree  :: (a -> b) -> Transform a b
 mapTree f (Node a cs) = Node (f a) (map (mapTree f) cs)
+{-# INLINABLE mapTree  #-}
 
-{-# INLINABLE foldTree #-}
 foldTree :: (a -> [b] -> b) -> Tree a -> b
 foldTree f (Node a cs) = f a (map (foldTree f) cs)
+{-# INLINABLE foldTree #-}
 
-{-# INLINABLE filterTree #-}
 filterTree :: (a -> Bool) -> Transform a a
 filterTree p = foldTree f
   where f a cs = Node a (filter (p . label) cs)
+{-# INLINABLE filterTree #-}
 
-{-# INLINABLE prune #-}
 prune :: (a -> Bool) -> Transform a a
 prune p = filterTree (not . p)
+{-# INLINABLE prune #-}
 
-{-# INLINABLE leaves #-}
 leaves :: Tree a -> [a]
 leaves (Node leaf []) = [leaf]
 leaves (Node _ cs)    = concat (map leaves cs)
+{-# INLINABLE leaves #-}
 
-{-# INLINABLE initTree #-}
 initTree :: (a -> [a]) -> a -> Tree a
 initTree f a = Node a (map (initTree f) (f a))
+{-# INLINABLE initTree #-}
 
 --------------------------------------------------
 -- Figure 3.  Simple backtracking solver for CSPs.
 --------------------------------------------------
 
-{-# INLINABLE mkTree #-}
 mkTree :: CSP -> Tree State
 mkTree CSP{vars=vars,vals=vals} = initTree next []
         -- Removed [1..vals]
   where next ss = [ ((maxLevel ss + 1) := j):ss | maxLevel ss < vars, j <- vallist ]
         vallist = interval 1 vals
+{-# INLINABLE mkTree #-}
 
-{-# INLINABLE earliestInconsistency #-}
 earliestInconsistency :: CSP -> State -> Maybe (Var,Var)
 earliestInconsistency CSP{rel=rel} [] = Nothing
 earliestInconsistency CSP{rel=rel} (a:as) =
         case filter (not . rel a) (reverse as) of
           []    -> Nothing
           (b:_) -> Just (level a, level b)
+{-# INLINABLE earliestInconsistency #-}
 
-{-# INLINABLE labelInconsistencies #-}
 labelInconsistencies :: CSP -> Transform State (State,Maybe (Var,Var))
 labelInconsistencies csp = mapTree f
     where f s = (s,earliestInconsistency csp s)
+{-# INLINABLE labelInconsistencies #-}
 
-{-# INLINABLE btsolver0 #-}
 btsolver0 :: CSP -> [State]
 btsolver0 csp =
   (filter (complete csp) . leaves . (mapTree fst) . prune ((/= Nothing) . snd)
                                             . (labelInconsistencies csp) .  mkTree) csp
+{-# INLINABLE btsolver0 #-}
 
 -----------------------------------------------
 -- Figure 6. Conflict-directed solving of CSPs.
@@ -333,23 +333,22 @@ instance TxPrelude.Eq ConflictSet where
     Unknown == Unknown = True
     _ == _             = False
 
-{-# INLINABLE knownConflict #-}
 knownConflict :: ConflictSet -> Bool
 knownConflict (Known (a:as)) = True
 knownConflict _              = False
+{-# INLINABLE knownConflict #-}
 
-{-# INLINABLE knownSolution #-}
 knownSolution :: ConflictSet -> Bool
 knownSolution (Known []) = True
 knownSolution _          = False
+{-# INLINABLE knownSolution #-}
 
-{-# INLINABLE checkComplete #-}
 checkComplete :: CSP -> State -> ConflictSet
 checkComplete csp s = if complete csp s then Known [] else Unknown
+{-# INLINABLE checkComplete #-}
 
 type Labeler = CSP -> Transform State (State, ConflictSet)
 
-{-# INLINABLE search #-}
 search :: Labeler -> CSP -> [State]
 search labeler csp =
   (map
@@ -357,57 +356,58 @@ search labeler csp =
       filter
         (knownSolution . snd) . leaves . prune (knownConflict . snd) . labeler csp . mkTree)
         csp
+{-# INLINABLE search #-}
 
-{-# INLINABLE bt #-}
 bt :: Labeler
 bt csp = mapTree f
       where f s = (s,
                    case earliestInconsistency csp s of
                      Nothing    -> checkComplete csp s
                      Just (a,b) -> Known [a,b])
+{-# INLINABLE bt #-}
 
-{-# INLINABLE btsolver #-}
 btsolver :: CSP -> [State]
 btsolver = search bt
+{-# INLINABLE btsolver #-}
 
 -------------------------------------
 -- Figure 7. Randomization heuristic.
 -------------------------------------
 
-{-# INLINABLE hrandom #-}
 hrandom :: Integer -> Transform a a
 hrandom seed (Node a cs) =
   Node a (randomList seed' (zipWith hrandom (randoms (length cs) seed') cs))
   where seed' = random seed
+{-# INLINABLE hrandom #-}
 
-{-# INLINABLE btr #-}
 btr :: Integer -> Labeler
 btr seed csp = bt csp . hrandom seed
+{-# INLINABLE btr #-}
 
 ---------------------------------------------
 -- Support for random numbers (not in paper).
 ---------------------------------------------
 
-{-# INLINABLE random2 #-}
 random2 :: Integer -> Integer
 random2 n = if test > 0 then test else test + 2147483647
   where test = 16807 * lo - 2836 * hi
         hi   = n `Haskell.div` 127773
         lo   = n `Haskell.rem` 127773
+{-# INLINABLE random2 #-}
 
-{-# INLINABLE randoms #-}
 randoms :: Integer -> Integer -> [Integer]
 randoms k = iterateN k random2
+{-# INLINABLE randoms #-}
 
-{-# INLINABLE random #-}
 random :: Integer -> Integer
 random n = (a * n + c) -- mod m
   where a = 994108973
         c = a
+{-# INLINABLE random #-}
 
-{-# INLINABLE randomList #-}
 randomList :: Integer -> [a] -> [a]
 randomList i as = map snd (sortBy (\(a,b) (c,d) -> compare a c) (zip (randoms (length as) i) as))
+{-# INLINABLE randomList #-}
 
 -------------------------
 -- Figure 8. Backmarking.
@@ -416,20 +416,19 @@ randomList i as = map snd (sortBy (\(a,b) (c,d) -> compare a c) (zip (randoms (l
 type Table = [Row]       -- indexed by Var
 type Row = [ConflictSet] -- indexed by Value
 
-{-# INLINABLE bm #-}
 bm :: Labeler
 bm csp = mapTree fst . lookupCache csp . cacheChecks csp (emptyTable csp)
+{-# INLINABLE bm #-}
 
-{-# INLINABLE emptyTable #-}
 emptyTable :: CSP -> Table
 emptyTable CSP{vars=vars,vals=vals} = []:[[Unknown | m <- interval 1 vals] | n <- interval 1 vars]
+{-# INLINABLE emptyTable #-}
 
-{-# INLINABLE cacheChecks #-}
 cacheChecks :: CSP -> Table -> Transform State (State, Table)
 cacheChecks csp tbl (Node s cs) =
   Node (s, tbl) (map (cacheChecks csp (fillTable s csp (tail tbl))) cs)
+{-# INLINABLE cacheChecks #-}
 
-{-# INLINABLE fillTable #-}
 fillTable :: State -> CSP -> Table -> Table
 fillTable [] csp tbl = tbl
 fillTable ((var' := val'):as) CSP{vars=vars,vals=vals,rel=rel} tbl =
@@ -437,65 +436,66 @@ fillTable ((var' := val'):as) CSP{vars=vars,vals=vals,rel=rel} tbl =
           where f cs (var,val) = if cs == Unknown && not (rel (var' := val') (var := val)) then
                                    Known [var',var]
                                  else cs
+{-# INLINABLE fillTable #-}
 
-{-# INLINABLE lookupCache #-}
 lookupCache :: CSP -> Transform (State, Table) ((State, ConflictSet), Table)
 lookupCache csp t = mapTree f t
   where f ([], tbl)      = (([], Unknown), tbl)
         f (s@(a:_), tbl) = ((s, cs), tbl)
              where cs = if tableEntry == Unknown then checkComplete csp s else tableEntry
                    tableEntry = (head tbl)!!(value a-1)
+{-# INLINABLE lookupCache #-}
 
 --------------------------------------------
 -- Figure 10. Conflict-directed backjumping.
 --------------------------------------------
 
-{-# INLINABLE bjbt #-}
 bjbt :: Labeler
 bjbt csp = bj csp . bt csp
+{-# INLINABLE bjbt #-}
 
-{-# INLINABLE bjbt' #-}
 bjbt' :: Labeler
 bjbt' csp = bj' csp . bt csp
+{-# INLINABLE bjbt' #-}
 
-{-# INLINABLE bj #-}
 bj :: CSP -> Transform (State, ConflictSet) (State, ConflictSet)
 bj csp = foldTree f
   where f (a, Known cs) chs = Node (a,Known cs) chs
         f (a, Unknown)  chs = Node (a,Known cs') chs
           where cs' = combine (map label chs) []
+{-# INLINABLE bj #-}
 
-{-# INLINABLE combine #-}
 combine :: [(State, ConflictSet)] -> [Var] -> [Var]
 combine []                 acc = acc
 combine ((s, Known cs):css) acc =
   if maxLevel s `notElem` cs then cs else combine css (cs `union` acc)
+{-# INLINABLE combine #-}
 
-{-# INLINABLE bj' #-}
 bj' :: CSP -> Transform (State, ConflictSet) (State, ConflictSet)
 bj' csp = foldTree f
   where f (a, Known cs) chs = Node (a,Known cs) chs
         f (a, Unknown) chs = if knownConflict cs' then Node (a,cs') [] else Node (a,cs') chs
            where cs' = Known (combine (map label chs) [])
+{-# INLINABLE bj' #-}
 
 -------------------------------
 -- Figure 11. Forward checking.
 -------------------------------
 
-{-# INLINABLE fc #-}
 fc :: Labeler
 fc csp = domainWipeOut csp . lookupCache csp . cacheChecks csp (emptyTable csp)
+{-# INLINABLE fc #-}
 
-{-# INLINABLE collect #-}
 collect :: [ConflictSet] -> [Var]
 collect []             = []
 collect (Known cs:css) = cs `union` (collect css)
+{-# INLINABLE collect #-}
 
-{-# INLINABLE domainWipeOut #-}
 domainWipeOut :: CSP -> Transform ((State, ConflictSet), Table) (State, ConflictSet)
 domainWipeOut CSP{vars=vars} t = mapTree f t
   where f ((as, cs), tbl) = (as, cs')
           where wipedDomains = ([vs | vs <- tbl, all (knownConflict) vs])
                 cs' = if null wipedDomains then cs else Known (collect (head wipedDomains))
+{-# INLINABLE domainWipeOut #-}
 
 Tx.makeLift ''Assign

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
@@ -164,7 +164,6 @@ sortBy cmp = mergeAll . sequences
       | (a `cmp` b) == GT = descending b [a]  xs
       | otherwise       = ascending  b (a:) xs
     sequences xs = [xs]
-{-# INLINABLE sortBy #-}
 
     descending a as (b:bs)
       | (a `cmp` b) == GT = descending b (a:as) bs
@@ -187,6 +186,7 @@ sortBy cmp = mergeAll . sequences
       | otherwise       = a:merge as' bs
     merge [] bs         = bs
     merge as []         = as
+{-# INLINABLE sortBy #-}
 
 
 -----------------------------

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/Data/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/Data/ScriptContexts.hs
@@ -62,7 +62,6 @@ mkValue i = assetClassValue (assetClass adaSymbol adaToken) i
 -- does some work that's roughly proportional to the size of the script context (counting the
 -- outputs). This should be a somewhat realistic example where a reasonable chunk of work is
 -- done in addition to decoding.
-{-# INLINABLE checkScriptContext1 #-}
 checkScriptContext1 :: PlutusTx.BuiltinData -> ()
 checkScriptContext1 d =
   -- Bang pattern to ensure this is forced, probably not necesssary
@@ -73,6 +72,7 @@ checkScriptContext1 d =
   if Data.List.length (txInfoOutputs txi) `PlutusTx.modInteger` 2 PlutusTx.== 0
   then ()
   else PlutusTx.traceError "Odd number of outputs"
+{-# INLINABLE checkScriptContext1 #-}
 
 mkCheckScriptContext1Code :: ScriptContext -> PlutusTx.CompiledCode ()
 mkCheckScriptContext1Code sc =
@@ -85,7 +85,6 @@ mkCheckScriptContext1Code sc =
 -- This example aims to *force* the decoding of the script context and then ignore it entirely.
 -- This corresponds to the unfortunate case where the decoding "wrapper" around a script forces
 -- all the decoding work to be done even if it isn't used.
-{-# INLINABLE checkScriptContext2 #-}
 checkScriptContext2 :: PlutusTx.BuiltinData -> ()
 checkScriptContext2 d =
   let (sc :: ScriptContext) = PlutusTx.unsafeFromBuiltinData d
@@ -97,6 +96,7 @@ checkScriptContext2 d =
       if 48 PlutusTx.* 9900 PlutusTx.== (475200 :: Integer)
       then ()
       else PlutusTx.traceError "Got my sums wrong"
+{-# INLINABLE checkScriptContext2 #-}
 
 mkCheckScriptContext2Code :: ScriptContext -> PlutusTx.CompiledCode ()
 mkCheckScriptContext2Code sc =
@@ -120,13 +120,13 @@ for comparison.
 -- This example checks the script context for equality (with itself) when encoded as `Data`.
 -- That means it just takes a single builtin call, which is fast (so long as the builtin is
 -- costed cheaply).
-{-# INLINABLE scriptContextEqualityData #-}
 scriptContextEqualityData :: ScriptContext -> PlutusTx.BuiltinData -> ()
 -- See Note [Redundant arguments to equality benchmarks]
 scriptContextEqualityData _ d =
   if PlutusTx.equalsData d d
   then ()
   else PlutusTx.traceError "The argument is not equal to itself"
+{-# INLINABLE scriptContextEqualityData #-}
 
 mkScriptContextEqualityDataCode :: ScriptContext -> PlutusTx.CompiledCode ()
 mkScriptContextEqualityDataCode sc =
@@ -137,9 +137,9 @@ mkScriptContextEqualityDataCode sc =
 
 -- This example is just the overhead from the previous two
 -- See Note [Redundant arguments to equality benchmarks]
-{-# INLINABLE scriptContextEqualityOverhead #-}
 scriptContextEqualityOverhead :: ScriptContext -> PlutusTx.BuiltinData -> ()
 scriptContextEqualityOverhead _ _ = ()
+{-# INLINABLE scriptContextEqualityOverhead #-}
 
 mkScriptContextEqualityOverheadCode :: ScriptContext -> PlutusTx.CompiledCode ()
 mkScriptContextEqualityOverheadCode sc =

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/ScriptContexts.hs
@@ -61,7 +61,6 @@ mkValue i = assetClassValue (assetClass adaSymbol adaToken) (fromIntegral i)
 -- does some work that's roughly proportional to the size of the script context (counting the
 -- outputs). This should be a somewhat realistic example where a reasonable chunk of work is
 -- done in addition to decoding.
-{-# INLINABLE checkScriptContext1 #-}
 checkScriptContext1 :: PlutusTx.BuiltinData -> ()
 checkScriptContext1 d =
   -- Bang pattern to ensure this is forced, probably not necesssary
@@ -72,6 +71,7 @@ checkScriptContext1 d =
   if PlutusTx.length (txInfoOutputs txi) `PlutusTx.modInteger` 2 PlutusTx.== 0
   then ()
   else PlutusTx.traceError "Odd number of outputs"
+{-# INLINABLE checkScriptContext1 #-}
 
 mkCheckScriptContext1Code :: ScriptContext -> PlutusTx.CompiledCode ()
 mkCheckScriptContext1Code sc =
@@ -84,7 +84,6 @@ mkCheckScriptContext1Code sc =
 -- This example aims to *force* the decoding of the script context and then ignore it entirely.
 -- This corresponds to the unfortunate case where the decoding "wrapper" around a script forces
 -- all the decoding work to be done even if it isn't used.
-{-# INLINABLE checkScriptContext2 #-}
 checkScriptContext2 :: PlutusTx.BuiltinData -> ()
 checkScriptContext2 d =
   let (sc :: ScriptContext) = PlutusTx.unsafeFromBuiltinData d
@@ -96,6 +95,7 @@ checkScriptContext2 d =
       if 48 PlutusTx.* 9900 PlutusTx.== (475200 :: Integer)
       then ()
       else PlutusTx.traceError "Got my sums wrong"
+{-# INLINABLE checkScriptContext2 #-}
 
 mkCheckScriptContext2Code :: ScriptContext -> PlutusTx.CompiledCode ()
 mkCheckScriptContext2Code sc =
@@ -119,13 +119,13 @@ for comparison.
 -- This example checks the script context for equality (with itself) when encoded as `Data`.
 -- That means it just takes a single builtin call, which is fast (so long as the builtin is
 -- costed cheaply).
-{-# INLINABLE scriptContextEqualityData #-}
 scriptContextEqualityData :: ScriptContext -> PlutusTx.BuiltinData -> ()
 -- See Note [Redundant arguments to equality benchmarks]
 scriptContextEqualityData _ d =
   if PlutusTx.equalsData d d
   then ()
   else PlutusTx.traceError "The argument is not equal to itself"
+{-# INLINABLE scriptContextEqualityData #-}
 
 mkScriptContextEqualityDataCode :: ScriptContext -> PlutusTx.CompiledCode ()
 mkScriptContextEqualityDataCode sc =
@@ -136,9 +136,9 @@ mkScriptContextEqualityDataCode sc =
 
 -- This example is just the overhead from the previous two
 -- See Note [Redundant arguments to equality benchmarks]
-{-# INLINABLE scriptContextEqualityOverhead #-}
 scriptContextEqualityOverhead :: ScriptContext -> PlutusTx.BuiltinData -> ()
 scriptContextEqualityOverhead _ _ = ()
+{-# INLINABLE scriptContextEqualityOverhead #-}
 
 mkScriptContextEqualityOverheadCode :: ScriptContext -> PlutusTx.CompiledCode ()
 mkScriptContextEqualityOverheadCode sc =

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -129,7 +129,6 @@ nopCostParameters =
 -- This is just to avoid some deeply nested case expressions for the NopNc
 -- functions below.  There is a Monad instance for EvaluationResult, but that
 -- appears to be a little slower than this.
-{-# INLINE (>:) #-}
 infixr >:
 (>:) :: uni ~ DefaultUni
      => SomeConstant uni Integer
@@ -139,6 +138,7 @@ n >: k =
     case n of
       SomeConstant (Some (ValueOf DefaultUniInteger _)) -> k
       _                                                 -> evaluationFailure
+{-# INLINE (>:) #-}
 
 {- | The meanings of the builtins.  Each one takes a number of arguments and
    returns a result without doing any other work.  A builtin can process its

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -43,23 +43,22 @@ indicate that it does what's required (in fact, `cloneInteger n = (n+1)-1` with
 OPAQUE suffices, but that's perhaps a bit too fragile).
 -}
 
-{-# OPAQUE incInteger #-}
 incInteger :: Integer -> Integer
 incInteger n = n+1
+{-# OPAQUE incInteger #-}
 
-{-# OPAQUE decInteger #-}
 decInteger :: Integer -> Integer
 decInteger n = n-1
+{-# OPAQUE decInteger #-}
 
-{-# OPAQUE copyInteger #-}
 copyInteger :: Integer -> Integer
 copyInteger = decInteger . incInteger
+{-# OPAQUE copyInteger #-}
 
-{-# OPAQUE copyByteString #-}
 copyByteString :: BS.ByteString -> BS.ByteString
 copyByteString = BS.copy
+{-# OPAQUE copyByteString #-}
 
-{-# OPAQUE copyData #-}
 copyData :: Data -> Data
 copyData =
     \case
@@ -68,6 +67,7 @@ copyData =
      List l     -> List (map copyData l)
      I n        -> I $ copyInteger n
      B b        -> B $ copyByteString b
+{-# OPAQUE copyData #-}
 
 pairWith :: (a -> b) -> [a] -> [(a,b)]
 pairWith f = fmap (\a -> (a, f a))

--- a/plutus-core/index-envs/bench/Main.hs
+++ b/plutus-core/index-envs/bench/Main.hs
@@ -59,11 +59,11 @@ consN n = applyN n (cons ())
 consNSlab :: (RandomAccessList e, Element e ~ ()) => Word64 -> e -> e
 consNSlab n = consNSlabM (n `div` 10) 10
 
-{-# INLINE consNSlabM #-}
 -- | Conses on 'n' slabs of size 'm'
 consNSlabM :: (RandomAccessList e, Element e ~ ()) => Word64 -> Word64 -> e -> e
 consNSlabM slabNo slabSize = applyN slabNo (consSlab slab)
    where slab = fromJust $ NEV.replicate (fromIntegral slabSize) ()
+{-# INLINE consNSlabM #-}
 
 -- | Accesses the given indices.
 query :: (RandomAccessList e, Element e ~ ()) => [Word64] -> e -> Element e

--- a/plutus-core/index-envs/src/Data/RandomAccessList/Class.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/Class.hs
@@ -71,15 +71,15 @@ class RandomAccessList e where
     unsafeIndexOne :: e -> Word64 -> Element e
     unsafeIndexOne e = fromJust . indexOne e
 
-{-# INLINABLE head #-}
 -- O(1) worst-case
 head :: (RandomAccessList e, a ~ Element e) => e -> a
 head = fst . fromMaybe (error "empty list") . uncons
+{-# INLINABLE head #-}
 
-{-# INLINABLE tail #-}
 -- O(1) worst-case
 tail :: (RandomAccessList e) => e -> e
 tail = snd . fromMaybe (error "empty list") . uncons
+{-# INLINABLE tail #-}
 
 instance RandomAccessList [a] where
     type Element [a] = a

--- a/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinary.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinary.hs
@@ -41,10 +41,10 @@ data RAList a = BHead
              deriving stock (Eq, Show)
              deriving (IsList) via RAL.AsRAL (RAList a)
 
-{-# INLINABLE null #-}
 null :: RAList a -> Bool
 null Nil = True
 null _   = False
+{-# INLINABLE null #-}
 
 {-# complete Cons, Nil #-}
 {-# complete BHead, Nil #-}

--- a/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinarySlab.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinarySlab.hs
@@ -131,10 +131,10 @@ data RAList a = BHead
 instance Eq a => Eq (RAList a) where
     l == l' = toList l == toList l'
 
-{-# INLINABLE null #-}
 null :: RAList a -> Bool
 null Nil = True
 null _   = False
+{-# INLINABLE null #-}
 
 {-# complete Cons, Nil #-}
 {-# complete BHead, Nil #-}
@@ -154,14 +154,14 @@ consValues x l = case l of
     ts -> BHead 1 (Leaf x) ts
 
 -- O(1) worst-case
-{-# INLINE cons #-}
 cons :: a -> RAList a -> RAList a
 cons x = consValues (One x)
+{-# INLINE cons #-}
 
 -- O(1) worst-case
-{-# INLINE consSlab #-}
 consSlab :: NEV.NonEmptyVector a -> RAList a -> RAList a
 consSlab x = consValues (Many x)
+{-# INLINE consSlab #-}
 
 -- /O(1)/
 -- 'uncons' is a bit funny: if we uncons a vector of values

--- a/plutus-core/plutus-core/src/Data/Either/Extras.hs
+++ b/plutus-core/plutus-core/src/Data/Either/Extras.hs
@@ -5,13 +5,13 @@ module Data.Either.Extras
 
 import Control.Exception
 
-{-# INLINE unsafeFromEither #-}
 -- | If argument is `Left` throw an exception, otherwise return the value inside `Right`.
 unsafeFromEither :: Exception e => Either e a -> a
 unsafeFromEither = either throw id
+{-# INLINE unsafeFromEither #-}
 
-{-# INLINE fromRightM #-}
 -- | If argument is `Right` return its value,
 -- otherwise apply the given action to the value of Left and return its result.
 fromRightM :: Monad m => (a -> m b) -> Either a b -> m b
 fromRightM f = either f pure
+{-# INLINE fromRightM #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
@@ -426,7 +426,6 @@ unsafeByteStringToInteger statedByteOrder input = case statedByteOrder of
   -}
 
 -- | Bitwise logical AND, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122).
-{-# INLINEABLE andByteString #-}
 andByteString :: Bool -> ByteString -> ByteString -> ByteString
 andByteString shouldPad bs1 bs2 =
   let (shorter, longer) = if BS.length bs1 < BS.length bs2 then (bs1, bs2) else (bs2, bs1)
@@ -453,9 +452,9 @@ andByteString shouldPad bs1 bs2 =
               w8_1 <- peekElemOff smallDstPtr i
               w8_2 <- peekElemOff smallTraversePtr i
               pokeElemOff smallDstPtr i $ w8_1 Bits..&. w8_2
+{-# INLINEABLE andByteString #-}
 
 -- | Bitwise logical OR, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122).
-{-# INLINEABLE orByteString #-}
 orByteString :: Bool -> ByteString -> ByteString -> ByteString
 orByteString shouldPad bs1 bs2 =
   let (shorter, longer) = if BS.length bs1 < BS.length bs2 then (bs1, bs2) else (bs2, bs1)
@@ -482,9 +481,9 @@ orByteString shouldPad bs1 bs2 =
               w8_1 <- peekElemOff smallDstPtr i
               w8_2 <- peekElemOff smallTraversePtr i
               pokeElemOff smallDstPtr i $ w8_1 Bits..|. w8_2
+{-# INLINEABLE orByteString #-}
 
 -- | Bitwise logical XOR, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122).
-{-# INLINEABLE xorByteString #-}
 xorByteString :: Bool -> ByteString -> ByteString -> ByteString
 xorByteString shouldPad bs1 bs2 =
   let (shorter, longer) = if BS.length bs1 < BS.length bs2 then (bs1, bs2) else (bs2, bs1)
@@ -511,9 +510,9 @@ xorByteString shouldPad bs1 bs2 =
               w8_1 <- peekElemOff smallDstPtr i
               w8_2 <- peekElemOff smallTraversePtr i
               pokeElemOff smallDstPtr i $ Bits.xor w8_1 w8_2
+{-# INLINEABLE xorByteString #-}
 
 -- | Bitwise logical complement, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122).
-{-# INLINEABLE complementByteString #-}
 complementByteString :: ByteString -> ByteString
 complementByteString bs = unsafeDupablePerformIO . BS.useAsCStringLen bs $ \(srcPtr, len) -> do
   -- We use loop sectioning here; see Note [Loop sectioning] as to why we do this
@@ -530,9 +529,9 @@ complementByteString bs = unsafeDupablePerformIO . BS.useAsCStringLen bs $ \(src
     for_ [0 .. littleStrides - 1] $ \i -> do
       w8 <- peekElemOff smallSrcPtr i
       pokeElemOff smallDstPtr i . Bits.complement $ w8
+{-# INLINEABLE complementByteString #-}
 
 -- | Bit read at index, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122)
-{-# INLINEABLE readBit #-}
 readBit :: ByteString -> Int -> BuiltinResult Bool
 readBit bs ix
   | ix < 0 = do
@@ -550,9 +549,9 @@ readBit bs ix
   where
     len :: Int
     len = BS.length bs
+{-# INLINEABLE readBit #-}
 
 -- | Bulk bit write, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122)
-{-# INLINEABLE writeBits #-}
 writeBits :: ByteString -> [Integer] -> Bool -> BuiltinResult ByteString
 writeBits bs ixs bit = case unsafeDupablePerformIO . try $ go of
   Left (WriteBitsException i) -> do
@@ -589,6 +588,7 @@ writeBits bs ixs bit = case unsafeDupablePerformIO . try $ go of
                         else Bits.clearBit w8 . fromIntegral $ littleIx
           pokeByteOff ptr flipIx toWrite
     {-# INLINEABLE setOrClearAtIx #-}
+{-# INLINEABLE writeBits #-}
 
 -- | Byte replication, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122)
 -- We want to cautious about the allocation of huge amounts of memory so we

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
@@ -43,10 +43,10 @@ kindSubkinds f kind0 = case kind0 of
 kindSubkindsDeep :: Fold (Kind ann) (Kind ann)
 kindSubkindsDeep = cosmosOf kindSubkinds
 
-{-# INLINE tyVarDeclSubkinds #-}
 -- | Get all the direct child 'Kind's of the given 'TyVarDecl'.
 tyVarDeclSubkinds :: Traversal' (TyVarDecl tyname a) (Kind a)
 tyVarDeclSubkinds f (TyVarDecl a ty k) = TyVarDecl a ty <$> f k
+{-# INLINE tyVarDeclSubkinds #-}
 
 -- | Get all the direct child 'tyname a's of the given 'Type' from binders.
 typeTyBinds :: Traversal' (Type tyname uni ann) tyname
@@ -84,7 +84,6 @@ typeUniques f ty0 = case ty0 of
     TyBuiltin{}          -> pure ty0
     TySOP{}              -> pure ty0
 
-{-# INLINE typeSubkinds #-}
 -- | Get all the direct child 'Kind's of the given 'Type'.
 typeSubkinds :: Traversal' (Type tyname uni ann) (Kind ann)
 typeSubkinds f ty0 = case ty0 of
@@ -96,8 +95,8 @@ typeSubkinds f ty0 = case ty0 of
     TyBuiltin{}          -> pure ty0
     TyVar{}              -> pure ty0
     TySOP{}              -> pure ty0
+{-# INLINE typeSubkinds #-}
 
-{-# INLINE typeSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'Type'.
 typeSubtypes :: Traversal' (Type tyname uni ann) (Type tyname uni ann)
 typeSubtypes f ty0 = case ty0 of
@@ -109,15 +108,16 @@ typeSubtypes f ty0 = case ty0 of
     TySOP ann tyls       -> TySOP ann <$> (traverse . traverse) f tyls
     TyBuiltin{}          -> pure ty0
     TyVar{}              -> pure ty0
+{-# INLINE typeSubtypes #-}
 
 -- | Get all the transitive child 'Type's of the given 'Type'.
 typeSubtypesDeep :: Fold (Type tyname uni ann) (Type tyname uni ann)
 typeSubtypesDeep = cosmosOf typeSubtypes
 
-{-# INLINE varDeclSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'VarDecl'.
 varDeclSubtypes :: Traversal' (VarDecl tyname name uni a) (Type tyname uni a)
 varDeclSubtypes f (VarDecl a n ty) = VarDecl a n <$> f ty
+{-# INLINE varDeclSubtypes #-}
 
 -- | Get all the direct constants of the given 'Term' from 'Constant's.
 termConstants :: Traversal' (Term tyname name uni fun ann) (Some (ValueOf uni))
@@ -199,7 +199,6 @@ termUniques f term0 = case term0 of
     Constr{}          -> pure term0
     Case{}            -> pure term0
 
-{-# INLINE termSubkinds #-}
 -- | Get all the direct child 'Kind's of the given 'Term'.
 termSubkinds :: Traversal' (Term tyname name uni fun ann) (Kind ann)
 termSubkinds f term0 = case term0 of
@@ -215,8 +214,8 @@ termSubkinds f term0 = case term0 of
     Builtin{}       -> pure term0
     Constr{}        -> pure term0
     Case{}          -> pure term0
+{-# INLINE termSubkinds #-}
 
-{-# INLINE termSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'Term'.
 termSubtypes :: Traversal' (Term tyname name uni fun ann) (Type tyname uni ann)
 termSubtypes f term0 = case term0 of
@@ -232,6 +231,7 @@ termSubtypes f term0 = case term0 of
     Var{}               -> pure term0
     Constant{}          -> pure term0
     Builtin{}           -> pure term0
+{-# INLINE termSubtypes #-}
 
 -- | Get all the transitive child 'Constant's of the given 'Term'.
 termConstantsDeep :: Fold (Term tyname name uni fun ann) (Some (ValueOf uni))
@@ -241,7 +241,6 @@ termConstantsDeep = termSubtermsDeep . termConstants
 termSubtypesDeep :: Fold (Term tyname name uni fun ann) (Type tyname uni ann)
 termSubtypesDeep = termSubtermsDeep . termSubtypes . typeSubtypesDeep
 
-{-# INLINE termSubterms #-}
 -- | Get all the direct child 'Term's of the given 'Term'.
 termSubterms :: Traversal' (Term tyname name uni fun ann) (Term tyname name uni fun ann)
 termSubterms f term0 = case term0 of
@@ -257,6 +256,7 @@ termSubterms f term0 = case term0 of
     Var{}               -> pure term0
     Constant{}          -> pure term0
     Builtin{}           -> pure term0
+{-# INLINE termSubterms #-}
 
 -- | Get all the transitive child 'Term's of the given 'Term'.
 termSubtermsDeep :: Fold (Term tyname name uni fun ann) (Term tyname name uni fun ann)

--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G1.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G1.hs
@@ -74,21 +74,21 @@ instance Hashable Element where
     hashWithSalt salt = hashWithSalt salt . compress
 
 -- | Add two G1 group elements
-{-# INLINE add #-}
 add :: Element -> Element -> Element
 add = coerce (BlstBindings.blsAddOrDouble @BlstBindings.Curve1)
+{-# INLINE add #-}
 
 -- | Negate a G1 group element
-{-# INLINE neg #-}
 neg :: Element -> Element
 neg = coerce (BlstBindings.blsNeg @BlstBindings.Curve1)
+{-# INLINE neg #-}
 
 -- | Multiplication of group elements by scalars. In the blst library the
 -- arguments are the other way round, but scalars acting on the left is more
 -- consistent with standard mathematical practice.
-{-# INLINE scalarMul #-}
 scalarMul :: Integer -> Element -> Element
 scalarMul = coerce $ flip (BlstBindings.blsMult @BlstBindings.Curve1)
+{-# INLINE scalarMul #-}
 
 {- | Compress a G1 element to a bytestring. This serialises a curve point to its
  x coordinate only.  The compressed bytestring is 48 bytes long, with three
@@ -97,9 +97,9 @@ scalarMul = coerce $ flip (BlstBindings.blsMult @BlstBindings.Curve1)
  point is the point at infinity. See
  https://github.com/supranational/blst#serialization-format
 -}
-{-# INLINE compress #-}
 compress :: Element -> ByteString
 compress = coerce (BlstBindings.blsCompress @BlstBindings.Curve1)
+{-# INLINE compress #-}
 
 {- | Uncompress a bytestring to get a G1 point.  This will fail if any of the
    following are true.
@@ -110,9 +110,9 @@ compress = coerce (BlstBindings.blsCompress @BlstBindings.Curve1)
      * The bytestring does represent a point on the E1 curve, but the
        point is not in the G1 subgroup.
 -}
-{-# INLINE uncompress #-}
 uncompress :: ByteString -> Either BlstBindings.BLSTError Element
 uncompress = coerce (BlstBindings.blsUncompress @BlstBindings.Curve1)
+{-# INLINE uncompress #-}
 
 {-  Note [Hashing and Domain Separation Tags].  The hashToGroup functions take a
    bytestring and hash it to obtain an element in the relevant group, as
@@ -152,9 +152,9 @@ offchain_zero = coerce (BlstBindings.Internal.blsZero @BlstBindings.Curve1)
 
 -- | The zero element of G1 compressed into a bytestring.  This is provided for
 -- convenience in PlutusTx and is not exported as a builtin.
-{-# INLINABLE compressed_zero #-}
 compressed_zero :: ByteString
 compressed_zero = compress $ coerce (BlstBindings.Internal.blsZero @BlstBindings.Curve1)
+{-# INLINABLE compressed_zero #-}
 
 -- | The standard generator of G1 compressed into a bytestring.  This is
 -- provided for convenience in PlutusTx and is not exported as a builtin.

--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G2.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/BLS12_381/G2.hs
@@ -60,27 +60,27 @@ instance Hashable Element where
     hashWithSalt salt = hashWithSalt salt . compress
 
 -- | Add two G2 group elements
-{-# INLINE add #-}
 add :: Element -> Element -> Element
 add = coerce (BlstBindings.blsAddOrDouble @BlstBindings.Curve2)
+{-# INLINE add #-}
 
 -- | Negate a G2 group element
-{-# INLINE neg #-}
 neg :: Element -> Element
 neg = coerce (BlstBindings.blsNeg @BlstBindings.Curve2)
+{-# INLINE neg #-}
 
-{-# INLINE scalarMul #-}
 scalarMul :: Integer -> Element -> Element -- Other way round from library function
 scalarMul = coerce $ flip (BlstBindings.blsMult @BlstBindings.Curve2)
+{-# INLINE scalarMul #-}
 
 {- | Compress a G2 element to a bytestring. This serialises a curve point to its x
  coordinate only, using an extra bit to determine which of two possible y
  coordinates the point has. The compressed bytestring is 96 bytes long. See
  https://github.com/supranational/blst#serialization-format
 -}
-{-# INLINE compress #-}
 compress :: Element -> ByteString
 compress = coerce (BlstBindings.blsCompress @BlstBindings.Curve2)
+{-# INLINE compress #-}
 
 {- | Uncompress a bytestring to get a G2 point.  This will fail if any of the
    following are true:
@@ -91,9 +91,9 @@ compress = coerce (BlstBindings.blsCompress @BlstBindings.Curve2)
      * The bytestring does represent a point on the E2 curve, but the
        point is not in the G2 subgroup
 -}
-{-# INLINE uncompress #-}
 uncompress :: ByteString -> Either BlstBindings.BLSTError Element
 uncompress = coerce (BlstBindings.blsUncompress @BlstBindings.Curve2)
+{-# INLINE uncompress #-}
 
 -- Take an arbitrary bytestring and a Domain Separation Tag and hash them to a
 -- get point in G2.  See Note [Hashing and Domain Separation Tags].

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -340,7 +340,6 @@ data OneVariableQuadraticFunction = OneVariableQuadraticFunction
     } deriving stock (Show, Eq, Generic, Lift)
     deriving anyclass (NFData)
 
-{-# INLINE evaluateOneVariableQuadraticFunction #-}
 evaluateOneVariableQuadraticFunction
   :: OneVariableQuadraticFunction
   -> CostingInteger
@@ -348,6 +347,7 @@ evaluateOneVariableQuadraticFunction
 evaluateOneVariableQuadraticFunction
    (OneVariableQuadraticFunction (Coefficient0 c0) (Coefficient1 c1)  (Coefficient2 c2)) x =
        c0 + c1*x + c2*x*x
+{-# INLINE evaluateOneVariableQuadraticFunction #-}
 
 {- Note [Minimum values for two-variable quadratic costing functions] Unlike most
    of our other costing functions our use cases for two-variable quadratic
@@ -369,7 +369,6 @@ data TwoVariableQuadraticFunction = TwoVariableQuadraticFunction
   } deriving stock (Show, Eq, Generic, Lift)
     deriving anyclass (NFData)
 
-{-# INLINE evaluateTwoVariableQuadraticFunction #-}
 evaluateTwoVariableQuadraticFunction
   :: TwoVariableQuadraticFunction
   -> CostingInteger
@@ -382,6 +381,7 @@ evaluateTwoVariableQuadraticFunction
    ) x y = max minVal (c00 + c10*x + c01*y + c20*x*x + c11*x*y + c02*y*y)
   -- We want to be absolutely sure that we don't get back a negative number
   -- here: see Note [Minimum values for two-variable quadratic costing functions]
+{-# INLINE evaluateTwoVariableQuadraticFunction #-}
 
 -- FIXME: we could use ModelConstantOrOneArgument for
 -- ModelTwoArgumentsSubtractedSizes instead, but that would change the order of

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
@@ -338,25 +338,25 @@ we make sure by defining a top level function for each of the size measures and
 getting the memoryUsage instances to call those.
 -}
 
-{-# OPAQUE g1ElementCost #-}
 g1ElementCost :: CostRose
 g1ElementCost = singletonRose . unsafeToSatInt $ BLS12_381.G1.memSizeBytes `div` 8
+{-# OPAQUE g1ElementCost #-}
 
 instance ExMemoryUsage BLS12_381.G1.Element where
     memoryUsage _ = g1ElementCost
     -- Should be 18
 
-{-# OPAQUE g2ElementCost #-}
 g2ElementCost :: CostRose
 g2ElementCost = singletonRose . unsafeToSatInt $ BLS12_381.G2.memSizeBytes `div` 8
+{-# OPAQUE g2ElementCost #-}
 
 instance ExMemoryUsage BLS12_381.G2.Element where
     memoryUsage _ = g2ElementCost
     -- Should be 36
 
-{-# OPAQUE mlResultElementCost #-}
 mlResultElementCost :: CostRose
 mlResultElementCost = singletonRose . unsafeToSatInt $ BLS12_381.Pairing.mlResultMemSizeBytes `div` 8
+{-# OPAQUE mlResultElementCost #-}
 
 instance ExMemoryUsage BLS12_381.Pairing.MlResult where
     memoryUsage _ = mlResultElementCost

--- a/plutus-core/plutus-core/src/PlutusCore/Subst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Subst.hs
@@ -40,7 +40,6 @@ import PlutusCore.Name.UniqueSet qualified as USet
 purely :: ((a -> Identity b) -> c -> Identity d) -> (a -> b) -> c -> d
 purely = coerce
 
-{-# INLINE substTyVarA #-}
 -- | Applicatively replace a type variable using the given function.
 substTyVarA
     :: Applicative f
@@ -49,6 +48,7 @@ substTyVarA
     -> f (Type tyname uni ann)
 substTyVarA tynameF ty@(TyVar _ tyname) = fromMaybe ty <$> tynameF tyname
 substTyVarA _       ty                  = pure ty
+{-# INLINE substTyVarA #-}
 
 -- | Applicatively replace a variable using the given function.
 substVarA
@@ -73,7 +73,6 @@ substVar
     -> Term tyname name uni fun ann
 substVar = purely substVarA
 
-{-# INLINE typeSubstTyNamesM #-}
 -- | Naively monadically substitute type names (i.e. do not substitute binders).
 -- INLINE is important here because the function is too polymorphic (determined from profiling)
 typeSubstTyNamesM
@@ -82,6 +81,7 @@ typeSubstTyNamesM
     -> Type tyname uni ann
     -> m (Type tyname uni ann)
 typeSubstTyNamesM = transformMOf typeSubtypes . substTyVarA
+{-# INLINE typeSubstTyNamesM #-}
 
 -- | Naively monadically substitute names using the given function (i.e. do not substitute binders).
 termSubstNamesM

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Substitute.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Substitute.hs
@@ -19,7 +19,6 @@ import PlutusPrelude
 
 import Control.Lens
 
-{-# INLINE substVarA #-}
 -- | Applicatively replace a variable using the given function.
 substVarA ::
   (Applicative f) =>
@@ -28,8 +27,8 @@ substVarA ::
   f (Term tyname name uni fun ann)
 substVarA nameF t@(Var _ name) = fromMaybe t <$> nameF name
 substVarA _ t                  = pure t
+{-# INLINE substVarA #-}
 
-{-# INLINE substTyVarA #-}
 -- | Applicatively replace a type variable using the given function.
 substTyVarA ::
   (Applicative f) =>
@@ -38,6 +37,7 @@ substTyVarA ::
   f (Type tyname uni ann)
 substTyVarA tynameF ty@(TyVar _ tyname) = fromMaybe ty <$> tynameF tyname
 substTyVarA _ ty                        = pure ty
+{-# INLINE substTyVarA #-}
 
 -- | Naively substitute names using the given functions (i.e. do not substitute binders).
 termSubstNames ::

--- a/plutus-core/prelude/PlutusPrelude.hs
+++ b/plutus-core/prelude/PlutusPrelude.hs
@@ -262,9 +262,9 @@ timesA = ala Endo . stimes
 -- | A 'MonadError' version of 'try'.
 --
 -- TODO: remove when we switch to mtl>=2.3
-{-# INLINE tryError #-}
 tryError :: MonadError e m => m a -> m (Either e a)
 tryError a = (Right <$> a) `catchError` (pure . Left)
+{-# INLINE tryError #-}
 
 {- A different 'MonadError' analogue to the 'withExceptT' function.
 Modify the value (and possibly the type) of an error in an @ExceptT@-transformed

--- a/plutus-core/satint/src/Data/SatInt.hs
+++ b/plutus-core/satint/src/Data/SatInt.hs
@@ -36,16 +36,16 @@ newtype SatInt = SI { unSatInt :: Int }
     deriving Serialise via Int
     deriving anyclass NoThunks
 
-{-# INLINE unsafeToSatInt #-}
 -- | Wrap an 'Int' as a 'SatInt'. This is unsafe because the 'Int' can be a result of an arbitrary
 -- potentially underflowing/overflowing operation.
 unsafeToSatInt :: Int -> SatInt
 unsafeToSatInt = SI
+{-# INLINE unsafeToSatInt #-}
 
-{-# INLINE fromSatInt #-}
 -- | An optimized version of @fromIntegral . unSatInt@.
 fromSatInt :: forall a. Num a => SatInt -> a
 fromSatInt = coerce (fromIntegral :: Int -> a)
+{-# INLINE fromSatInt #-}
 
 -- | In the `Num' instance, we plug in our own addition, multiplication
 -- and subtraction function that perform overflow-checking.
@@ -78,13 +78,13 @@ instance Num SatInt where
     | x < minBoundInteger  = minBound
     | otherwise            = SI (fromInteger x)
 
-{-# INLINABLE maxBoundInteger #-}
 maxBoundInteger :: Integer
 maxBoundInteger = toInteger maxInt
+{-# INLINABLE maxBoundInteger #-}
 
-{-# INLINABLE minBoundInteger #-}
 minBoundInteger :: Integer
 minBoundInteger = toInteger minInt
+{-# INLINABLE minBoundInteger #-}
 
 {-
 'addIntC#', 'subIntC#', and 'mulIntMayOflow#' have tricky returns:
@@ -97,7 +97,6 @@ So we have to case on the result, and then do some logic to work out what
 kind of overflow we're facing, and pick the correct result accordingly.
 -}
 
-{-# INLINE plusSI #-}
 plusSI :: SatInt -> SatInt -> SatInt
 plusSI (SI (I# x#)) (SI (I# y#)) =
   case addIntC# x# y#  of
@@ -109,8 +108,8 @@ plusSI (SI (I# x#)) (SI (I# y#)) =
       -- x and y have opposite signs, and yet we've overflowed, should
       -- be impossible
       else overflowError
+{-# INLINE plusSI #-}
 
-{-# INLINE minusSI #-}
 minusSI :: SatInt -> SatInt -> SatInt
 minusSI (SI (I# x#)) (SI (I# y#)) =
   case subIntC# x# y# of
@@ -122,8 +121,8 @@ minusSI (SI (I# x#)) (SI (I# y#)) =
       -- x and y have the same sign, and yet we've overflowed, should
       -- be impossible
       else overflowError
+{-# INLINE minusSI #-}
 
-{-# INLINE timesSI #-}
 timesSI :: SatInt -> SatInt -> SatInt
 timesSI (SI (I# x#)) (SI (I# y#)) =
   case mulIntMayOflo# x# y# of
@@ -137,6 +136,7 @@ timesSI (SI (I# x#)) (SI (I# y#)) =
           -- Logically unreachable unless x or y is 0, in which case
           -- it should be impossible to overflow
           else overflowError
+{-# INLINE timesSI #-}
 
 -- Specialized versions of several functions. They're specialized for
 -- Int in the GHC base libraries. We try to get the same effect by

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Scope.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Scope.hs
@@ -26,7 +26,6 @@ Inlining this function makes a big difference,
 since it will usually be called in a context where all the type variables are known.
 That then means that GHC can optimize go locally in a completely monomorphic setting, which helps a lot.
 -}
-{-# INLINE checkScope #-}
 checkScope :: forall e m name uni fun a.
              (HasIndex name, MonadError e m, AsFreeVariableError e)
            => UPLC.Term name uni fun a
@@ -52,3 +51,4 @@ checkScope = go 0
         Force _ t     -> go lvl t
         Delay _ t     -> go lvl t
         _             -> pure ()
+{-# INLINE checkScope #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Plated.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Plated.hs
@@ -52,7 +52,6 @@ termUniques f = \case
     Var ann n      -> theUnique f n <&> Var ann
     x              -> pure x
 
-{-# INLINE termSubterms #-}
 -- | Get all the direct child 'Term's of the given 'Term'.
 termSubterms :: Traversal' (Term name uni fun ann) (Term name uni fun ann)
 termSubterms f = \case
@@ -66,6 +65,7 @@ termSubterms f = \case
     v@Var {}          -> pure v
     c@Constant {}     -> pure c
     b@Builtin {}      -> pure b
+{-# INLINE termSubterms #-}
 
 -- | Get all the transitive child 'Constant's of the given 'Term'.
 termConstantsDeep :: Fold (Term name uni fun ann) (Some (ValueOf uni))

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/StepCounter.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/StepCounter.hs
@@ -73,8 +73,6 @@ modifyCounter i f c = do
   pure modified
 {-# INLINE modifyCounter #-}
 
--- I also tried INLINABLE + SPECIALIZE, which just resulted in it getting inlined, so might
--- as well just go straight for that
 -- | Traverse the counters with an effectful function.
 itraverseCounter_
   :: forall n m
@@ -86,7 +84,6 @@ itraverseCounter_ f (StepCounter arr) = do
   -- The implementation of this function is very performance-sensitive. I believe
   -- it may be possible to do better, but it's time-consuming to experiment more
   -- and unclear what improves things.
-{-# INLINE itraverseCounter_ #-}
 
   -- The safety of this operation is a little subtle. The frozen array is only
   -- safe to use if the underlying mutable array is not mutated 'afterwards'.
@@ -103,6 +100,10 @@ itraverseCounter_ f (StepCounter arr) = do
           go (i+1)
       | otherwise = pure ()
   go 0
+-- I also tried INLINABLE + SPECIALIZE, which just resulted in it getting inlined, so might
+-- as well just go straight for that
+{-# INLINE itraverseCounter_ #-}
+
 
 -- | Traverse the counters with an effectful function.
 iforCounter_

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/FlatNatWord.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/FlatNatWord.hs
@@ -89,9 +89,9 @@ The old implementation relied on this function which is safe
 *only* for 64-bit systems. There were previously safety checks to fail compilation
 on other systems, but we removed them  since we only test on 64-bit systems afterall.
 -}
-{-# INLINABLE naturalToWord64Maybe #-}
 naturalToWord64Maybe :: Natural -> Maybe Word64
 naturalToWord64Maybe n = fromIntegral <$> naturalToWordMaybe n
+{-# INLINABLE naturalToWord64Maybe #-}
 
 newtype OldIndex = OldIndex {unOldIndex :: Word64}
   deriving stock (Generic)

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
@@ -156,49 +156,49 @@ instance Pretty ScriptContext where
             , nest 2 $ vsep ["TxInfo:", pretty scriptContextTxInfo]
             ]
 
-{-# INLINABLE findOwnInput #-}
 -- | Find the input currently being validated.
 findOwnInput :: ScriptContext -> Maybe TxInInfo
 findOwnInput ScriptContext{scriptContextTxInfo=TxInfo{txInfoInputs}, scriptContextPurpose=Spending txOutRef} =
     find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == txOutRef) txInfoInputs
 findOwnInput _ = Nothing
+{-# INLINABLE findOwnInput #-}
 
-{-# INLINABLE findDatum #-}
 -- | Find the data corresponding to a data hash, if there is one
 findDatum :: DatumHash -> TxInfo -> Maybe Datum
 findDatum dsh TxInfo{txInfoData} = snd <$> find f txInfoData
     where
         f (dsh', _) = dsh' == dsh
+{-# INLINABLE findDatum #-}
 
-{-# INLINABLE findDatumHash #-}
 -- | Find the hash of a datum, if it is part of the pending transaction's
 --   hashes
 findDatumHash :: Datum -> TxInfo -> Maybe DatumHash
 findDatumHash ds TxInfo{txInfoData} = fst <$> find f txInfoData
     where
         f (_, ds') = ds' == ds
+{-# INLINABLE findDatumHash #-}
 
-{-# INLINABLE findTxInByTxOutRef #-}
 -- | Given a UTXO reference and a transaction (`TxInfo`), resolve it to one of the transaction's inputs (`TxInInfo`).
 findTxInByTxOutRef :: TxOutRef -> TxInfo -> Maybe TxInInfo
 findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
     find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == outRef) txInfoInputs
+{-# INLINABLE findTxInByTxOutRef #-}
 
-{-# INLINABLE findContinuingOutputs #-}
 -- | Finds all the outputs that pay to the same script address that we are currently spending from, if any.
 findContinuingOutputs :: ScriptContext -> [Integer]
 findContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = findIndices (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
     where
         f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
 findContinuingOutputs _ = traceError "Le" -- "Can't find any continuing outputs"
+{-# INLINABLE findContinuingOutputs #-}
 
-{-# INLINABLE getContinuingOutputs #-}
 -- | Get all the outputs that pay to the same script address we are currently spending from, if any.
 getContinuingOutputs :: ScriptContext -> [TxOut]
 getContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = filter (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
     where
         f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
 getContinuingOutputs _ = traceError "Lf" -- "Can't get any continuing outputs"
+{-# INLINABLE getContinuingOutputs #-}
 
 {- Note [Hashes in validator scripts]
 
@@ -224,43 +224,42 @@ them from the correct types in Haskell, and for comparing them (in
 
 -}
 
-{-# INLINABLE txSignedBy #-}
 -- | Check if a transaction was signed by the given public key.
 txSignedBy :: TxInfo -> PubKeyHash -> Bool
 txSignedBy TxInfo{txInfoSignatories} k = case find ((==) k) txInfoSignatories of
     Just _  -> True
     Nothing -> False
+{-# INLINABLE txSignedBy #-}
 
-{-# INLINABLE pubKeyOutputsAt #-}
 -- | Get the values paid to a public key address by a pending transaction.
 pubKeyOutputsAt :: PubKeyHash -> TxInfo -> [Value]
 pubKeyOutputsAt pk p =
     let flt TxOut{txOutAddress = Address (PubKeyCredential pk') _, txOutValue} | pk == pk' = Just txOutValue
         flt _                             = Nothing
     in mapMaybe flt (txInfoOutputs p)
+{-# INLINABLE pubKeyOutputsAt #-}
 
-{-# INLINABLE valuePaidTo #-}
 -- | Get the total value paid to a public key address by a pending transaction.
 valuePaidTo :: TxInfo -> PubKeyHash -> Value
 valuePaidTo ptx pkh = mconcat (pubKeyOutputsAt pkh ptx)
+{-# INLINABLE valuePaidTo #-}
 
-{-# INLINABLE valueSpent #-}
 -- | Get the total value of inputs spent by this transaction.
 valueSpent :: TxInfo -> Value
 valueSpent = foldMap (txOutValue . txInInfoResolved) . txInfoInputs
+{-# INLINABLE valueSpent #-}
 
-{-# INLINABLE valueProduced #-}
 -- | Get the total value of outputs produced by this transaction.
 valueProduced :: TxInfo -> Value
 valueProduced = foldMap txOutValue . txInfoOutputs
+{-# INLINABLE valueProduced #-}
 
-{-# INLINABLE ownCurrencySymbol #-}
 -- | The 'CurrencySymbol' of the current validator script.
 ownCurrencySymbol :: ScriptContext -> CurrencySymbol
 ownCurrencySymbol ScriptContext{scriptContextPurpose=Minting cs} = cs
 ownCurrencySymbol _                                              = traceError "Lh" -- "Can't get currency symbol of the current validator script"
+{-# INLINABLE ownCurrencySymbol #-}
 
-{-# INLINABLE spendsOutput #-}
 {- | Check if the pending transaction spends a specific transaction output
 (identified by the hash of a transaction and an index into that
 transactions' outputs)
@@ -271,6 +270,7 @@ spendsOutput p h i =
             let outRef = txInInfoOutRef inp
             in h == txOutRefId outRef
                 && i == txOutRefIdx outRef
+{-# INLINABLE spendsOutput #-}
 
     in any spendsOutRef (txInfoInputs p)
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
@@ -270,9 +270,8 @@ spendsOutput p h i =
             let outRef = txInInfoOutRef inp
             in h == txOutRefId outRef
                 && i == txOutRefIdx outRef
-{-# INLINABLE spendsOutput #-}
-
     in any spendsOutRef (txInfoInputs p)
+{-# INLINABLE spendsOutput #-}
 
 ----------------------------------------------------------------------------------------------------
 -- TH Splices --------------------------------------------------------------------------------------

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
@@ -280,6 +280,5 @@ spendsOutput p h i =
             let outRef = txInInfoOutRef inp
             in h == txOutRefId outRef
                 && i == txOutRefIdx outRef
-{-# INLINABLE spendsOutput #-}
-
     in Data.List.any spendsOutRef (txInfoInputs p)
+{-# INLINABLE spendsOutput #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
@@ -166,49 +166,49 @@ instance Pretty ScriptContext where
             , nest 2 $ vsep ["TxInfo:", pretty scriptContextTxInfo]
             ]
 
-{-# INLINABLE findOwnInput #-}
 -- | Find the input currently being validated.
 findOwnInput :: ScriptContext -> Maybe TxInInfo
 findOwnInput ScriptContext{scriptContextTxInfo=TxInfo{txInfoInputs}, scriptContextPurpose=Spending txOutRef} =
     Data.List.find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == txOutRef) txInfoInputs
 findOwnInput _ = Nothing
+{-# INLINABLE findOwnInput #-}
 
-{-# INLINABLE findDatum #-}
 -- | Find the data corresponding to a data hash, if there is one
 findDatum :: DatumHash -> TxInfo -> Maybe Datum
 findDatum dsh TxInfo{txInfoData} = snd <$> find f txInfoData
     where
         f (dsh', _) = dsh' == dsh
+{-# INLINABLE findDatum #-}
 
-{-# INLINABLE findDatumHash #-}
 -- | Find the hash of a datum, if it is part of the pending transaction's
 --   hashes
 findDatumHash :: Datum -> TxInfo -> Maybe DatumHash
 findDatumHash ds TxInfo{txInfoData} = fst <$> find f txInfoData
     where
         f (_, ds') = ds' == ds
+{-# INLINABLE findDatumHash #-}
 
-{-# INLINABLE findTxInByTxOutRef #-}
 -- | Given a UTXO reference and a transaction (`TxInfo`), resolve it to one of the transaction's inputs (`TxInInfo`).
 findTxInByTxOutRef :: TxOutRef -> TxInfo -> Maybe TxInInfo
 findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
     Data.List.find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == outRef) txInfoInputs
+{-# INLINABLE findTxInByTxOutRef #-}
 
-{-# INLINABLE findContinuingOutputs #-}
 -- | Finds all the outputs that pay to the same script address that we are currently spending from, if any.
 findContinuingOutputs :: ScriptContext -> List Integer
 findContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = Data.List.findIndices (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
     where
         f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
 findContinuingOutputs _ = traceError "Le" -- "Can't find any continuing outputs"
+{-# INLINABLE findContinuingOutputs #-}
 
-{-# INLINABLE getContinuingOutputs #-}
 -- | Get all the outputs that pay to the same script address we are currently spending from, if any.
 getContinuingOutputs :: ScriptContext -> List TxOut
 getContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = Data.List.filter (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
     where
         f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
 getContinuingOutputs _ = traceError "Lf" -- "Can't get any continuing outputs"
+{-# INLINABLE getContinuingOutputs #-}
 
 {- Note [Hashes in validator scripts]
 
@@ -234,43 +234,42 @@ them from the correct types in Haskell, and for comparing them (in
 
 -}
 
-{-# INLINABLE txSignedBy #-}
 -- | Check if a transaction was signed by the given public key.
 txSignedBy :: TxInfo -> PubKeyHash -> Bool
 txSignedBy TxInfo{txInfoSignatories} k = case Data.List.find ((==) k) txInfoSignatories of
     Just _  -> True
     Nothing -> False
+{-# INLINABLE txSignedBy #-}
 
-{-# INLINABLE pubKeyOutputsAt #-}
 -- | Get the values paid to a public key address by a pending transaction.
 pubKeyOutputsAt :: PubKeyHash -> TxInfo -> List Value
 pubKeyOutputsAt pk p =
     let flt TxOut{txOutAddress = Address (PubKeyCredential pk') _, txOutValue} | pk == pk' = Just txOutValue
         flt _                             = Nothing
     in Data.List.mapMaybe flt (txInfoOutputs p)
+{-# INLINABLE pubKeyOutputsAt #-}
 
-{-# INLINABLE valuePaidTo #-}
 -- | Get the total value paid to a public key address by a pending transaction.
 valuePaidTo :: TxInfo -> PubKeyHash -> Value
 valuePaidTo ptx pkh = Data.List.mconcat (pubKeyOutputsAt pkh ptx)
+{-# INLINABLE valuePaidTo #-}
 
-{-# INLINABLE valueSpent #-}
 -- | Get the total value of inputs spent by this transaction.
 valueSpent :: TxInfo -> Value
 valueSpent = Data.List.foldMap (txOutValue . txInInfoResolved) . txInfoInputs
+{-# INLINABLE valueSpent #-}
 
-{-# INLINABLE valueProduced #-}
 -- | Get the total value of outputs produced by this transaction.
 valueProduced :: TxInfo -> Value
 valueProduced = Data.List.foldMap txOutValue . txInfoOutputs
+{-# INLINABLE valueProduced #-}
 
-{-# INLINABLE ownCurrencySymbol #-}
 -- | The 'CurrencySymbol' of the current validator script.
 ownCurrencySymbol :: ScriptContext -> CurrencySymbol
 ownCurrencySymbol ScriptContext{scriptContextPurpose=Minting cs} = cs
 ownCurrencySymbol _                                              = traceError "Lh" -- "Can't get currency symbol of the current validator script"
+{-# INLINABLE ownCurrencySymbol #-}
 
-{-# INLINABLE spendsOutput #-}
 {- | Check if the pending transaction spends a specific transaction output
 (identified by the hash of a transaction and an index into that
 transactions' outputs)
@@ -281,5 +280,6 @@ spendsOutput p h i =
             let outRef = txInInfoOutRef inp
             in h == txOutRefId outRef
                 && i == txOutRefIdx outRef
+{-# INLINABLE spendsOutput #-}
 
     in Data.List.any spendsOutRef (txInfoInputs p)

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -454,12 +454,12 @@ flattenValue v = goOuter [] (Map.toList $ getValue v)
   where
     goOuter acc []             = acc
     goOuter acc ((cs, m) : tl) = goOuter (goInner cs acc (Map.toList m)) tl
-{-# INLINABLE flattenValue #-}
 
     goInner _ acc [] = acc
     goInner cs acc ((tn, a) : tl)
         | a /= 0    = goInner cs ((cs, tn, a) : acc) tl
         | otherwise = goInner cs acc tl
+{-# INLINABLE flattenValue #-}
 
 -- Num operations
 
@@ -526,11 +526,11 @@ lt l r = leq l r && not (eq l r)
 split :: Value -> (Value, Value)
 split (Value mp) = (negate (Value neg), Value pos) where
   (neg, pos) = Map.mapThese splitIntl mp
-{-# INLINABLE split #-}
 
   splitIntl :: Map TokenName Integer -> These (Map TokenName Integer) (Map TokenName Integer)
   splitIntl mp' = These l r where
     (l, r) = Map.mapThese (\i -> if i <= 0 then This i else That i) mp'
+{-# INLINABLE split #-}
 
 {- | Check equality of two lists of distinct key-value pairs, each value being uniquely
 identified by a key, given a function checking whether a 'Value' is zero and a function

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -136,10 +136,10 @@ instance HasBlueprintSchema CurrencySymbol referencedTypes where
     & withSchemaInfo \info ->
       info { title = Just "CurrencySymbol" }
 
-{-# INLINABLE currencySymbol #-}
 -- | Creates `CurrencySymbol` from raw `ByteString`.
 currencySymbol :: BS.ByteString -> CurrencySymbol
 currencySymbol = CurrencySymbol . PlutusTx.toBuiltin
+{-# INLINABLE currencySymbol #-}
 
 {- | ByteString of a name of a token.
 Shown as UTF-8 string when possible.
@@ -174,10 +174,10 @@ instance HasBlueprintSchema TokenName referencedTypes where
     & withSchemaInfo \info ->
       info { title = Just "TokenName" }
 
-{-# INLINABLE tokenName #-}
 -- | Creates `TokenName` from raw `BS.ByteString`.
 tokenName :: BS.ByteString -> TokenName
 tokenName = TokenName . PlutusTx.toBuiltin
+{-# INLINABLE tokenName #-}
 
 fromText :: Text -> TokenName
 fromText = tokenName . E.encodeUtf8
@@ -205,15 +205,15 @@ toString = Text.unpack . fromTokenName asBase16 id
 instance Haskell.Show TokenName where
     show = Text.unpack . fromTokenName asBase16 quoted
 
-{-# INLINABLE adaSymbol #-}
 -- | The 'CurrencySymbol' of the 'Ada' currency.
 adaSymbol :: CurrencySymbol
 adaSymbol = CurrencySymbol emptyByteString
+{-# INLINABLE adaSymbol #-}
 
-{-# INLINABLE adaToken #-}
 -- | The 'TokenName' of the 'Ada' currency.
 adaToken :: TokenName
 adaToken = TokenName emptyByteString
+{-# INLINABLE adaToken #-}
 
 -- | An asset class, identified by a `CurrencySymbol` and a `TokenName`.
 newtype AssetClass = AssetClass {unAssetClass :: (CurrencySymbol, TokenName)}
@@ -240,10 +240,10 @@ instance HasBlueprintSchema AssetClass referencedTypes where
         , right = schema @TokenName
         }
 
-{-# INLINABLE assetClass #-}
 -- | The curried version of 'AssetClass' constructor
 assetClass :: CurrencySymbol -> TokenName -> AssetClass
 assetClass s t = AssetClass (s, t)
+{-# INLINABLE assetClass #-}
 
 {- Note [Value vs value]
 We call two completely different things "values": the 'Value' type and a value within a key-value
@@ -354,7 +354,6 @@ instance MeetSemiLattice Value where
     {-# INLINABLE (/\) #-}
     (/\) = unionWith Ord.min
 
-{-# INLINABLE valueOf #-}
 -- | Get the quantity of the given currency in the 'Value'.
 -- Assumes that the underlying map doesn't contain duplicate keys.
 valueOf :: Value -> CurrencySymbol -> TokenName -> Integer
@@ -363,6 +362,7 @@ valueOf value cur tn =
     case Map.lookup tn tokens of
             Nothing -> 0
             Just v  -> v
+{-# INLINABLE valueOf #-}
 
 {-# INLINEABLE withCurrencySymbol #-}
 
@@ -390,37 +390,36 @@ currencySymbolValueOf value cur = withCurrencySymbol cur value 0 \tokens ->
         -- the latter materializes the intermediate result of `Map.elems tokens`.
         Map.foldr (\amt acc -> amt + acc) 0 tokens
 
-{-# INLINABLE symbols #-}
 -- | The list of 'CurrencySymbol's of a 'Value'.
 symbols :: Value -> BuiltinList BuiltinData
 symbols (Value mp) = Map.keys mp
+{-# INLINABLE symbols #-}
 
-{-# INLINABLE singleton #-}
 -- | Make a 'Value' containing only the given quantity of the given currency.
 singleton :: CurrencySymbol -> TokenName -> Integer -> Value
 singleton c tn i = Value (Map.singleton c (Map.singleton tn i))
+{-# INLINABLE singleton #-}
 
-{-# INLINABLE lovelaceValue #-}
 -- | A 'Value' containing the given quantity of Lovelace.
 lovelaceValue :: Lovelace -> Value
 lovelaceValue = singleton adaSymbol adaToken . getLovelace
+{-# INLINABLE lovelaceValue #-}
 
-{-# INLINABLE lovelaceValueOf #-}
 -- | Get the quantity of Lovelace in the 'Value'.
 lovelaceValueOf :: Value -> Lovelace
 lovelaceValueOf v = Lovelace (valueOf v adaSymbol adaToken)
+{-# INLINABLE lovelaceValueOf #-}
 
-{-# INLINABLE assetClassValue #-}
 -- | A 'Value' containing the given amount of the asset class.
 assetClassValue :: AssetClass -> Integer -> Value
 assetClassValue (AssetClass (c, t)) = singleton c t
+{-# INLINABLE assetClassValue #-}
 
-{-# INLINABLE assetClassValueOf #-}
 -- | Get the quantity of the given 'AssetClass' class in the 'Value'.
 assetClassValueOf :: Value -> AssetClass -> Integer
 assetClassValueOf v (AssetClass (c, t)) = valueOf v c t
+{-# INLINABLE assetClassValueOf #-}
 
-{-# INLINABLE unionVal #-}
 -- | Combine two 'Value' maps, assumes the well-definedness of the two maps.
 unionVal :: Value -> Value -> Map CurrencySymbol (Map TokenName (These Integer Integer))
 unionVal (Value l) (Value r) =
@@ -431,8 +430,8 @@ unionVal (Value l) (Value r) =
             That b    -> Map.map That b
             These a b -> Map.union a b
     in Map.map unThese combined
+{-# INLINABLE unionVal #-}
 
-{-# INLINABLE unionWith #-}
 -- | Combine two 'Value' maps with the argument function.
 -- Assumes the well-definedness of the two maps.
 unionWith :: (Integer -> Integer -> Integer) -> Value -> Value -> Value
@@ -444,8 +443,8 @@ unionWith f ls rs =
             That b    -> f 0 b
             These a b -> f a b
     in Value (Map.map (Map.map unThese) combined)
+{-# INLINABLE unionWith #-}
 
-{-# INLINABLE flattenValue #-}
 -- | Convert a 'Value' to a simple list, keeping only the non-zero amounts.
 -- Note that the result isn't sorted, meaning @v1 == v2@ doesn't generally imply
 -- @flattenValue v1 == flattenValue v2@.
@@ -455,6 +454,7 @@ flattenValue v = goOuter [] (Map.toList $ getValue v)
   where
     goOuter acc []             = acc
     goOuter acc ((cs, m) : tl) = goOuter (goInner cs acc (Map.toList m)) tl
+{-# INLINABLE flattenValue #-}
 
     goInner _ acc [] = acc
     goInner cs acc ((tn, a) : tl)
@@ -463,12 +463,11 @@ flattenValue v = goOuter [] (Map.toList $ getValue v)
 
 -- Num operations
 
-{-# INLINABLE isZero #-}
 -- | Check whether a 'Value' is zero.
 isZero :: Value -> Bool
 isZero (Value xs) = Map.all (Map.all (\i -> 0 == i)) xs
+{-# INLINABLE isZero #-}
 
-{-# INLINABLE checkPred #-}
 -- | Checks whether a predicate holds for all the values in a 'Value'
 -- union. Assumes the well-definedness of the two underlying 'Map's.
 checkPred :: (These Integer Integer -> Bool) -> Value -> Value -> Bool
@@ -478,8 +477,8 @@ checkPred f l r =
       inner = Map.all f
     in
       Map.all inner (unionVal l r)
+{-# INLINABLE checkPred #-}
 
-{-# INLINABLE checkBinRel #-}
 -- | Check whether a binary relation holds for value pairs of two 'Value' maps,
 --   supplying 0 where a key is only present in one of them.
 checkBinRel :: (Integer -> Integer -> Bool) -> Value -> Value -> Bool
@@ -490,32 +489,33 @@ checkBinRel f l r =
             That b    -> f 0 b
             These a b -> f a b
     in checkPred unThese l r
+{-# INLINABLE checkBinRel #-}
 
-{-# INLINABLE geq #-}
 -- | Check whether one 'Value' is greater than or equal to another. See 'Value' for an explanation
 -- of how operations on 'Value's work.
 geq :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true, but this is fine.
 geq = checkBinRel (>=)
+{-# INLINABLE geq #-}
 
-{-# INLINABLE leq #-}
 -- | Check whether one 'Value' is less than or equal to another. See 'Value' for an explanation of
 -- how operations on 'Value's work.
 leq :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true, but this is fine.
 leq = checkBinRel (<=)
+{-# INLINABLE leq #-}
 
-{-# INLINABLE gt #-}
 -- | Check whether one 'Value' is strictly greater than another.
 -- This is *not* a pointwise operation. @gt l r@ means @geq l r && not (eq l r)@.
 gt :: Value -> Value -> Bool
 gt l r = geq l r && not (eq l r)
+{-# INLINABLE gt #-}
 
-{-# INLINABLE lt #-}
 -- | Check whether one 'Value' is strictly less than another.
 -- This is *not* a pointwise operation. @lt l r@ means @leq l r && not (eq l r)@.
 lt :: Value -> Value -> Bool
 lt l r = leq l r && not (eq l r)
+{-# INLINABLE lt #-}
 
 -- | Split a 'Value' into its positive and negative parts. The first element of
 --   the tuple contains the negative parts of the 'Value', the second element
@@ -523,21 +523,21 @@ lt l r = leq l r && not (eq l r)
 --
 --   @negate (fst (split a)) `plus` (snd (split a)) == a@
 --
-{-# INLINABLE split #-}
 split :: Value -> (Value, Value)
 split (Value mp) = (negate (Value neg), Value pos) where
   (neg, pos) = Map.mapThese splitIntl mp
+{-# INLINABLE split #-}
 
   splitIntl :: Map TokenName Integer -> These (Map TokenName Integer) (Map TokenName Integer)
   splitIntl mp' = These l r where
     (l, r) = Map.mapThese (\i -> if i <= 0 then This i else That i) mp'
 
-{-# INLINABLE unordEqWith #-}
 {- | Check equality of two lists of distinct key-value pairs, each value being uniquely
 identified by a key, given a function checking whether a 'Value' is zero and a function
 checking equality of values. Note that the caller must ensure that the two lists are
 well-defined in this sense. This is not checked or enforced in `unordEqWith`, and therefore
 it might yield undefined results for ill-defined input.
+{-# INLINABLE unordEqWith #-}
 
 This function recurses on both the lists in parallel and checks whether the key-value pairs are
 equal pointwise. If there is a mismatch, then it tries to find the left key-value pair in the right
@@ -658,7 +658,6 @@ unordEqWith is0 eqV = goBoth where
                 )
 
 
-{-# INLINABLE eqMapOfMapsWith #-}
 -- | Check equality of two maps of maps indexed by 'CurrencySymbol's,
 --- given a function checking whether a value is zero and a function
 -- checking equality of values.
@@ -674,8 +673,8 @@ eqMapOfMapsWith is0 eqV map1 map2 =
         is0' v = is0 (unsafeFromBuiltinData v)
         eqV' v1 v2 = eqV (unsafeFromBuiltinData v1) (unsafeFromBuiltinData v2)
      in unordEqWith is0' eqV' xs1 xs2
+{-# INLINABLE eqMapOfMapsWith #-}
 
-{-# INLINABLE eqMapWith #-}
 -- | Check equality of two 'Map Token Integer's given a function checking whether a value is zero and a function
 -- checking equality of values.
 eqMapWith
@@ -690,8 +689,8 @@ eqMapWith is0 eqV map1 map2 =
         is0' v = is0 (unsafeFromBuiltinData v)
         eqV' v1 v2 = eqV (unsafeFromBuiltinData v1) (unsafeFromBuiltinData v2)
      in unordEqWith is0' eqV' xs1 xs2
+{-# INLINABLE eqMapWith #-}
 
-{-# INLINABLE eq #-}
 -- | Check equality of two 'Value's. Does not assume orderness of lists within a 'Value' or a lack
 -- of empty values (such as a token whose quantity is zero or a currency that has a bunch of such
 -- tokens or no tokens at all), but does assume that no currencies or tokens within a single
@@ -699,6 +698,7 @@ eqMapWith is0 eqV map1 map2 =
 eq :: Value -> Value -> Bool
 eq (Value currs1) (Value currs2) =
     eqMapOfMapsWith (Map.all (0 ==)) (eqMapWith (0 ==) (==)) currs1 currs2
+{-# INLINABLE eq #-}
 
 newtype Lovelace = Lovelace { getLovelace :: Integer }
   deriving stock (Generic, Typeable)

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -232,7 +232,7 @@ newtype AssetClass = AssetClass {unAssetClass :: (CurrencySymbol, TokenName)}
   deriving (Pretty) via (PrettyShow (CurrencySymbol, TokenName))
 
 instance HasBlueprintSchema AssetClass referencedTypes where
-  {-# INLINEABLE schema #-}
+  {-# INLINABLE schema #-}
   schema =
     SchemaBuiltInPair emptySchemaInfo $
       MkPairSchema
@@ -364,8 +364,6 @@ valueOf value cur tn =
             Just v  -> v
 {-# INLINABLE valueOf #-}
 
-{-# INLINEABLE withCurrencySymbol #-}
-
 {- | Apply a continuation function to the token quantities of the given currency
 symbol in the value or return a default value if the currency symbol is not present
 in the value.
@@ -375,8 +373,7 @@ withCurrencySymbol currency value def k =
   case Map.lookup currency (getValue value) of
     Nothing              -> def
     Just tokenQuantities -> k tokenQuantities
-
-{-# INLINEABLE currencySymbolValueOf #-}
+{-# INLINABLE withCurrencySymbol #-}
 
 {- | Get the total value of the currency symbol in the 'Value' map.
 Assumes that the underlying map doesn't contain duplicate keys.
@@ -389,6 +386,7 @@ currencySymbolValueOf value cur = withCurrencySymbol cur value 0 \tokens ->
         -- This is more efficient than `PlutusTx.sum (Map.elems tokens)`, because
         -- the latter materializes the intermediate result of `Map.elems tokens`.
         Map.foldr (\amt acc -> amt + acc) 0 tokens
+{-# INLINABLE currencySymbolValueOf #-}
 
 -- | The list of 'CurrencySymbol's of a 'Value'.
 symbols :: Value -> BuiltinList BuiltinData

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -537,7 +537,6 @@ identified by a key, given a function checking whether a 'Value' is zero and a f
 checking equality of values. Note that the caller must ensure that the two lists are
 well-defined in this sense. This is not checked or enforced in `unordEqWith`, and therefore
 it might yield undefined results for ill-defined input.
-{-# INLINABLE unordEqWith #-}
 
 This function recurses on both the lists in parallel and checks whether the key-value pairs are
 equal pointwise. If there is a mismatch, then it tries to find the left key-value pair in the right
@@ -656,6 +655,7 @@ unordEqWith is0 eqV = goBoth where
                 ( \hd tl ->
                     rev tl (hd `BI.mkCons` acc)
                 )
+{-# INLINABLE unordEqWith #-}
 
 
 -- | Check equality of two maps of maps indexed by 'CurrencySymbol's,

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
@@ -290,36 +290,32 @@ instance (Enum a, Ord a) => Haskell.Ord (LowerBound a) where
     compare = PlutusTx.compare
 
 {- | Construct a strict upper bound from a value.
-{-# INLINABLE strictUpperBound #-}
-
 The resulting bound includes all values that are (strictly) smaller than the input value.
 -}
 strictUpperBound :: a -> UpperBound a
 strictUpperBound a = UpperBound (Finite a) False
+{-# INLINABLE strictUpperBound #-}
 
 {- | Construct a strict lower bound from a value.
-{-# INLINABLE strictLowerBound #-}
-
 The resulting bound includes all values that are (strictly) greater than the input value.
 -}
 strictLowerBound :: a -> LowerBound a
 strictLowerBound a = LowerBound (Finite a) False
+{-# INLINABLE strictLowerBound #-}
 
 {- | Construct a lower bound from a value.
-{-# INLINABLE lowerBound #-}
-
 The resulting bound includes all values that are equal or greater than the input value.
 -}
 lowerBound :: a -> LowerBound a
 lowerBound a = LowerBound (Finite a) True
+{-# INLINABLE lowerBound #-}
 
 {- |  Construct an upper bound from a value.
-{-# INLINABLE upperBound #-}
-
 The resulting bound includes all values that are equal or smaller than the input value.
 -}
 upperBound :: a -> UpperBound a
 upperBound a = UpperBound (Finite a) True
+{-# INLINABLE upperBound #-}
 
 -- See Note [Enumerable Intervals]
 instance (Enum a, Ord a) => JoinSemiLattice (Interval a) where
@@ -384,13 +380,12 @@ always = Interval (LowerBound NegInf True) (UpperBound PosInf True)
 {-# INLINABLE always #-}
 
 {- | An 'Interval' that is empty.
-{-# INLINABLE never #-}
-
 There can be many empty intervals, see `isEmpty`.
 The empty interval `never` is arbitrarily set to [+∞,-∞].
 -}
 never :: Interval a
 never = Interval (LowerBound PosInf True) (UpperBound NegInf True)
+{-# INLINABLE never #-}
 
 -- | Check whether a value is in an interval.
 member :: (Enum a, Ord a) => a -> Interval a -> Bool

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
@@ -289,32 +289,32 @@ instance (Enum a, Ord a) => Ord (LowerBound a) where
 instance (Enum a, Ord a) => Haskell.Ord (LowerBound a) where
     compare = PlutusTx.compare
 
-{-# INLINABLE strictUpperBound #-}
 {- | Construct a strict upper bound from a value.
+{-# INLINABLE strictUpperBound #-}
 
 The resulting bound includes all values that are (strictly) smaller than the input value.
 -}
 strictUpperBound :: a -> UpperBound a
 strictUpperBound a = UpperBound (Finite a) False
 
-{-# INLINABLE strictLowerBound #-}
 {- | Construct a strict lower bound from a value.
+{-# INLINABLE strictLowerBound #-}
 
 The resulting bound includes all values that are (strictly) greater than the input value.
 -}
 strictLowerBound :: a -> LowerBound a
 strictLowerBound a = LowerBound (Finite a) False
 
-{-# INLINABLE lowerBound #-}
 {- | Construct a lower bound from a value.
+{-# INLINABLE lowerBound #-}
 
 The resulting bound includes all values that are equal or greater than the input value.
 -}
 lowerBound :: a -> LowerBound a
 lowerBound a = LowerBound (Finite a) True
 
-{-# INLINABLE upperBound #-}
 {- |  Construct an upper bound from a value.
+{-# INLINABLE upperBound #-}
 
 The resulting bound includes all values that are equal or smaller than the input value.
 -}
@@ -354,37 +354,37 @@ instance (Enum a, Ord a) => Haskell.Eq (Interval a) where
     {-# INLINABLE (==) #-}
     (==) = (PlutusTx.==)
 
-{-# INLINABLE interval #-}
 -- | @interval a b@ includes all values that are greater than or equal to @a@
 -- and smaller than or equal to @b@. Therefore it includes @a@ and @b@. In math. notation: [a,b]
 interval :: a -> a -> Interval a
 interval s s' = Interval (lowerBound s) (upperBound s')
+{-# INLINABLE interval #-}
 
-{-# INLINABLE singleton #-}
 -- | Create an interval that includes just a single concrete point @a@,
 -- i.e. having the same non-strict lower and upper bounds. In math.notation: [a,a]
 singleton :: a -> Interval a
 singleton s = interval s s
+{-# INLINABLE singleton #-}
 
-{-# INLINABLE from #-}
 -- | @from a@ is an 'Interval' that includes all values that are
 --  greater than or equal to @a@. In math. notation: [a,+∞]
 from :: a -> Interval a
 from s = Interval (lowerBound s) (UpperBound PosInf True)
+{-# INLINABLE from #-}
 
-{-# INLINABLE to #-}
 -- | @to a@ is an 'Interval' that includes all values that are
 --  smaller than or equal to @a@. In math. notation: [-∞,a]
 to :: a -> Interval a
 to s = Interval (LowerBound NegInf True) (upperBound s)
+{-# INLINABLE to #-}
 
-{-# INLINABLE always #-}
 -- | An 'Interval' that covers every slot. In math. notation [-∞,+∞]
 always :: Interval a
 always = Interval (LowerBound NegInf True) (UpperBound PosInf True)
+{-# INLINABLE always #-}
 
-{-# INLINABLE never #-}
 {- | An 'Interval' that is empty.
+{-# INLINABLE never #-}
 
 There can be many empty intervals, see `isEmpty`.
 The empty interval `never` is arbitrarily set to [+∞,-∞].
@@ -392,29 +392,28 @@ The empty interval `never` is arbitrarily set to [+∞,-∞].
 never :: Interval a
 never = Interval (LowerBound PosInf True) (UpperBound NegInf True)
 
-{-# INLINABLE member #-}
 -- | Check whether a value is in an interval.
 member :: (Enum a, Ord a) => a -> Interval a -> Bool
 member a i = i `contains` singleton a
+{-# INLINABLE member #-}
 
-{-# INLINABLE overlaps #-}
 -- | Check whether two intervals overlap, that is, whether there is a value that
 --   is a member of both intervals.
 overlaps :: (Enum a, Ord a) => Interval a -> Interval a -> Bool
 overlaps l r = not $ isEmpty (l `intersection` r)
+{-# INLINABLE overlaps #-}
 
-{-# INLINABLE intersection #-}
 -- | 'intersection a b' is the largest interval that is contained in 'a' and in
 --   'b', if it exists.
 intersection :: (Enum a, Ord a) => Interval a -> Interval a -> Interval a
 intersection (Interval l1 h1) (Interval l2 h2) = Interval (max l1 l2) (min h1 h2)
+{-# INLINABLE intersection #-}
 
-{-# INLINABLE hull #-}
 -- | 'hull a b' is the smallest interval containing 'a' and 'b'.
 hull :: (Enum a, Ord a) => Interval a -> Interval a -> Interval a
 hull (Interval l1 h1) (Interval l2 h2) = Interval (min l1 l2) (max h1 h2)
+{-# INLINABLE hull #-}
 
-{-# INLINABLE contains #-}
 {- | @a `contains` b@ is true if the 'Interval' @b@ is entirely contained in
 @a@. That is, @a `contains` b@ if for every entry @s@, if @member s b@ then
 @member s a@.
@@ -428,8 +427,8 @@ contains i1 _ | isEmpty i1 = False
 -- Otherwise we check the endpoints. This doesn't work for empty intervals,
 -- hence the cases above.
 contains (Interval l1 h1) (Interval l2 h2) = l1 <= l2 && h2 <= h1
+{-# INLINABLE contains #-}
 
-{-# INLINABLE isEmpty #-}
 {- | Check if an 'Interval' is empty. -}
 isEmpty :: (Enum a, Ord a) => Interval a -> Bool
 isEmpty (Interval lb ub) = case inclusiveLowerBound lb `compare` inclusiveUpperBound ub of
@@ -439,16 +438,17 @@ isEmpty (Interval lb ub) = case inclusiveLowerBound lb `compare` inclusiveUpperB
     EQ -> False
     -- We have no possible values
     GT -> True
+{-# INLINABLE isEmpty #-}
 
-{-# INLINABLE before #-}
 -- | Check if a value is earlier than the beginning of an 'Interval'.
 before :: (Enum a, Ord a) => a -> Interval a -> Bool
 before h (Interval f _) = lowerBound h < f
+{-# INLINABLE before #-}
 
-{-# INLINABLE after #-}
 -- | Check if a value is later than the end of an 'Interval'.
 after :: (Enum a , Ord a) => a -> Interval a -> Bool
 after h (Interval _ t) = upperBound h > t
+{-# INLINABLE after #-}
 
 {- Note [Enumerable Intervals]
 The 'Interval' type is set up to handle open intervals, where we have non-inclusive

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Time.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Time.hs
@@ -90,9 +90,9 @@ instance Pretty POSIXTime where
 type POSIXTimeRange = Interval POSIXTime
 
 -- | Simple conversion from 'DiffMilliSeconds' to 'POSIXTime'.
-{-# INLINEABLE fromMilliSeconds #-}
 fromMilliSeconds :: DiffMilliSeconds -> POSIXTime
 fromMilliSeconds (DiffMilliSeconds s) = POSIXTime s
+{-# INLINEABLE fromMilliSeconds #-}
 
 ----------------------------------------------------------------------------------------------------
 -- TH Splices --------------------------------------------------------------------------------------

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -129,10 +129,10 @@ instance HasBlueprintSchema CurrencySymbol referencedTypes where
     & withSchemaInfo \info ->
       info { title = Just "CurrencySymbol" }
 
-{-# INLINABLE currencySymbol #-}
 -- | Creates `CurrencySymbol` from raw `ByteString`.
 currencySymbol :: BS.ByteString -> CurrencySymbol
 currencySymbol = CurrencySymbol . PlutusTx.toBuiltin
+{-# INLINABLE currencySymbol #-}
 
 {- | ByteString of a name of a token.
 Shown as UTF-8 string when possible.
@@ -167,10 +167,10 @@ instance HasBlueprintSchema TokenName referencedTypes where
     & withSchemaInfo \info ->
       info { title = Just "TokenName" }
 
-{-# INLINABLE tokenName #-}
 -- | Creates `TokenName` from raw `BS.ByteString`.
 tokenName :: BS.ByteString -> TokenName
 tokenName = TokenName . PlutusTx.toBuiltin
+{-# INLINABLE tokenName #-}
 
 fromText :: Text -> TokenName
 fromText = tokenName . E.encodeUtf8
@@ -196,15 +196,15 @@ toString = Text.unpack . fromTokenName asBase16 id
 instance Haskell.Show TokenName where
     show = Text.unpack . fromTokenName asBase16 quoted
 
-{-# INLINABLE adaSymbol #-}
 -- | The 'CurrencySymbol' of the 'Ada' currency.
 adaSymbol :: CurrencySymbol
 adaSymbol = CurrencySymbol emptyByteString
+{-# INLINABLE adaSymbol #-}
 
-{-# INLINABLE adaToken #-}
 -- | The 'TokenName' of the 'Ada' currency.
 adaToken :: TokenName
 adaToken = TokenName emptyByteString
+{-# INLINABLE adaToken #-}
 
 -- | An asset class, identified by a `CurrencySymbol` and a `TokenName`.
 newtype AssetClass = AssetClass {unAssetClass :: (CurrencySymbol, TokenName)}
@@ -231,10 +231,10 @@ instance HasBlueprintSchema AssetClass referencedTypes where
         , right = schema @TokenName
         }
 
-{-# INLINABLE assetClass #-}
 -- | The curried version of 'AssetClass' constructor
 assetClass :: CurrencySymbol -> TokenName -> AssetClass
 assetClass s t = AssetClass (s, t)
+{-# INLINABLE assetClass #-}
 
 {- Note [Value vs value]
 We call two completely different things "values": the 'Value' type and a value within a key-value
@@ -346,7 +346,6 @@ instance MeetSemiLattice Value where
     {-# INLINABLE (/\) #-}
     (/\) = unionWith Ord.min
 
-{-# INLINABLE valueOf #-}
 -- | Get the quantity of the given currency in the 'Value'.
 -- Assumes that the underlying map doesn't contain duplicate keys.
 valueOf :: Value -> CurrencySymbol -> TokenName -> Integer
@@ -355,6 +354,7 @@ valueOf value cur tn =
     case Map.lookup tn tokens of
       Nothing -> 0
       Just v  -> v
+{-# INLINABLE valueOf #-}
 
 {-# INLINEABLE withCurrencySymbol #-}
 
@@ -382,37 +382,36 @@ currencySymbolValueOf value cur = withCurrencySymbol cur value 0 \tokens ->
   -- the latter materializes the intermediate result of `Map.elems tokens`.
   PlutusTx.List.foldr (\(_, amt) acc -> amt + acc) 0 (Map.toList tokens)
 
-{-# INLINABLE symbols #-}
 -- | The list of 'CurrencySymbol's of a 'Value'.
 symbols :: Value -> [CurrencySymbol]
 symbols (Value mp) = Map.keys mp
+{-# INLINABLE symbols #-}
 
-{-# INLINABLE singleton #-}
 -- | Make a 'Value' containing only the given quantity of the given currency.
 singleton :: CurrencySymbol -> TokenName -> Integer -> Value
 singleton c tn i = Value (Map.singleton c (Map.singleton tn i))
+{-# INLINABLE singleton #-}
 
-{-# INLINABLE lovelaceValue #-}
 -- | A 'Value' containing the given quantity of Lovelace.
 lovelaceValue :: Lovelace -> Value
 lovelaceValue = singleton adaSymbol adaToken . getLovelace
+{-# INLINABLE lovelaceValue #-}
 
-{-# INLINABLE lovelaceValueOf #-}
 -- | Get the quantity of Lovelace in the 'Value'.
 lovelaceValueOf :: Value -> Lovelace
 lovelaceValueOf v = Lovelace (valueOf v adaSymbol adaToken)
+{-# INLINABLE lovelaceValueOf #-}
 
-{-# INLINABLE assetClassValue #-}
 -- | A 'Value' containing the given amount of the asset class.
 assetClassValue :: AssetClass -> Integer -> Value
 assetClassValue (AssetClass (c, t)) = singleton c t
+{-# INLINABLE assetClassValue #-}
 
-{-# INLINABLE assetClassValueOf #-}
 -- | Get the quantity of the given 'AssetClass' class in the 'Value'.
 assetClassValueOf :: Value -> AssetClass -> Integer
 assetClassValueOf v (AssetClass (c, t)) = valueOf v c t
+{-# INLINABLE assetClassValueOf #-}
 
-{-# INLINABLE unionVal #-}
 -- | Combine two 'Value' maps, assumes the well-definedness of the two maps.
 unionVal :: Value -> Value -> Map CurrencySymbol (Map TokenName (These Integer Integer))
 unionVal (Value l) (Value r) =
@@ -423,8 +422,8 @@ unionVal (Value l) (Value r) =
             That b    -> That <$> b
             These a b -> Map.union a b
     in unThese <$> combined
+{-# INLINABLE unionVal #-}
 
-{-# INLINABLE unionWith #-}
 -- | Combine two 'Value' maps with the argument function.
 -- Assumes the well-definedness of the two maps.
 unionWith :: (Integer -> Integer -> Integer) -> Value -> Value -> Value
@@ -436,8 +435,8 @@ unionWith f ls rs =
             That b    -> f 0 b
             These a b -> f a b
     in Value (fmap (fmap unThese) combined)
+{-# INLINABLE unionWith #-}
 
-{-# INLINABLE flattenValue #-}
 -- | Convert a 'Value' to a simple list, keeping only the non-zero amounts.
 -- Note that the result isn't sorted, meaning @v1 == v2@ doesn't generally imply
 -- @flattenValue v1 == flattenValue v2@.
@@ -447,6 +446,7 @@ flattenValue v = goOuter [] (Map.toList $ getValue v)
   where
     goOuter acc []             = acc
     goOuter acc ((cs, m) : tl) = goOuter (goInner cs acc (Map.toList m)) tl
+{-# INLINABLE flattenValue #-}
 
     goInner _ acc [] = acc
     goInner cs acc ((tn, a) : tl)
@@ -455,12 +455,11 @@ flattenValue v = goOuter [] (Map.toList $ getValue v)
 
 -- Num operations
 
-{-# INLINABLE isZero #-}
 -- | Check whether a 'Value' is zero.
 isZero :: Value -> Bool
 isZero (Value xs) = Map.all (Map.all (\i -> 0 == i)) xs
+{-# INLINABLE isZero #-}
 
-{-# INLINABLE checkPred #-}
 -- | Checks whether a predicate holds for all the values in a 'Value'
 -- union. Assumes the well-definedness of the two underlying 'Map's.
 checkPred :: (These Integer Integer -> Bool) -> Value -> Value -> Bool
@@ -470,8 +469,8 @@ checkPred f l r =
       inner = Map.all f
     in
       Map.all inner (unionVal l r)
+{-# INLINABLE checkPred #-}
 
-{-# INLINABLE checkBinRel #-}
 -- | Check whether a binary relation holds for value pairs of two 'Value' maps,
 --   supplying 0 where a key is only present in one of them.
 checkBinRel :: (Integer -> Integer -> Bool) -> Value -> Value -> Bool
@@ -482,32 +481,33 @@ checkBinRel f l r =
             That b    -> f 0 b
             These a b -> f a b
     in checkPred unThese l r
+{-# INLINABLE checkBinRel #-}
 
-{-# INLINABLE geq #-}
 -- | Check whether one 'Value' is greater than or equal to another. See 'Value' for an explanation
 -- of how operations on 'Value's work.
 geq :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true, but this is fine.
 geq = checkBinRel (>=)
+{-# INLINABLE geq #-}
 
-{-# INLINABLE leq #-}
 -- | Check whether one 'Value' is less than or equal to another. See 'Value' for an explanation of
 -- how operations on 'Value's work.
 leq :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true, but this is fine.
 leq = checkBinRel (<=)
+{-# INLINABLE leq #-}
 
-{-# INLINABLE gt #-}
 -- | Check whether one 'Value' is strictly greater than another.
 -- This is *not* a pointwise operation. @gt l r@ means @geq l r && not (eq l r)@.
 gt :: Value -> Value -> Bool
 gt l r = geq l r && not (eq l r)
+{-# INLINABLE gt #-}
 
-{-# INLINABLE lt #-}
 -- | Check whether one 'Value' is strictly less than another.
 -- This is *not* a pointwise operation. @lt l r@ means @leq l r && not (eq l r)@.
 lt :: Value -> Value -> Bool
 lt l r = leq l r && not (eq l r)
+{-# INLINABLE lt #-}
 
 -- | Split a 'Value' into its positive and negative parts. The first element of
 --   the tuple contains the negative parts of the 'Value', the second element
@@ -515,21 +515,21 @@ lt l r = leq l r && not (eq l r)
 --
 --   @negate (fst (split a)) `plus` (snd (split a)) == a@
 --
-{-# INLINABLE split #-}
 split :: Value -> (Value, Value)
 split (Value mp) = (negate (Value neg), Value pos) where
   (neg, pos) = Map.mapThese splitIntl mp
+{-# INLINABLE split #-}
 
   splitIntl :: Map TokenName Integer -> These (Map TokenName Integer) (Map TokenName Integer)
   splitIntl mp' = These l r where
     (l, r) = Map.mapThese (\i -> if i <= 0 then This i else That i) mp'
 
-{-# INLINABLE unordEqWith #-}
 {- | Check equality of two lists of distinct key-value pairs, each value being uniquely
 identified by a key, given a function checking whether a 'Value' is zero and a function
 checking equality of values. Note that the caller must ensure that the two lists are
 well-defined in this sense. This is not checked or enforced in `unordEqWith`, and therefore
 it might yield undefined results for ill-defined input.
+{-# INLINABLE unordEqWith #-}
 
 This function recurses on both the lists in parallel and checks whether the key-value pairs are
 equal pointwise. If there is a mismatch, then it tries to find the left key-value pair in the right
@@ -592,20 +592,20 @@ unordEqWith is0 eqV = goBoth where
                 | kL == kR  = if vL `eqV` vR then goBoth kvsL' (revAppend acc kvsR') else False
                 | otherwise = goRight (kvR : acc) kvsR'
 
-{-# INLINABLE eqMapWith #-}
 -- | Check equality of two 'Map's given a function checking whether a value is zero and a function
 -- checking equality of values.
 eqMapWith ::
     forall k v. Eq k => (v -> Bool) -> (v -> v -> Bool) -> Map k v -> Map k v -> Bool
 eqMapWith is0 eqV (Map.toList -> xs1) (Map.toList -> xs2) = unordEqWith is0 eqV xs1 xs2
+{-# INLINABLE eqMapWith #-}
 
-{-# INLINABLE eq #-}
 -- | Check equality of two 'Value's. Does not assume orderness of lists within a 'Value' or a lack
 -- of empty values (such as a token whose quantity is zero or a currency that has a bunch of such
 -- tokens or no tokens at all), but does assume that no currencies or tokens within a single
 -- currency have multiple entries.
 eq :: Value -> Value -> Bool
 eq (Value currs1) (Value currs2) = eqMapWith (Map.all (0 ==)) (eqMapWith (0 ==) (==)) currs1 currs2
+{-# INLINABLE eq #-}
 
 newtype Lovelace = Lovelace { getLovelace :: Integer }
   deriving stock (Generic, Typeable)

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -529,7 +529,6 @@ identified by a key, given a function checking whether a 'Value' is zero and a f
 checking equality of values. Note that the caller must ensure that the two lists are
 well-defined in this sense. This is not checked or enforced in `unordEqWith`, and therefore
 it might yield undefined results for ill-defined input.
-{-# INLINABLE unordEqWith #-}
 
 This function recurses on both the lists in parallel and checks whether the key-value pairs are
 equal pointwise. If there is a mismatch, then it tries to find the left key-value pair in the right
@@ -591,6 +590,7 @@ unordEqWith is0 eqV = goBoth where
                 -- equals @(kL, vL)@ from the left list, hence we throw both of them away.
                 | kL == kR  = if vL `eqV` vR then goBoth kvsL' (revAppend acc kvsR') else False
                 | otherwise = goRight (kvR : acc) kvsR'
+{-# INLINABLE unordEqWith #-}
 
 -- | Check equality of two 'Map's given a function checking whether a value is zero and a function
 -- checking equality of values.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -446,12 +446,12 @@ flattenValue v = goOuter [] (Map.toList $ getValue v)
   where
     goOuter acc []             = acc
     goOuter acc ((cs, m) : tl) = goOuter (goInner cs acc (Map.toList m)) tl
-{-# INLINABLE flattenValue #-}
 
     goInner _ acc [] = acc
     goInner cs acc ((tn, a) : tl)
         | a /= 0    = goInner cs ((cs, tn, a) : acc) tl
         | otherwise = goInner cs acc tl
+{-# INLINABLE flattenValue #-}
 
 -- Num operations
 
@@ -518,11 +518,11 @@ lt l r = leq l r && not (eq l r)
 split :: Value -> (Value, Value)
 split (Value mp) = (negate (Value neg), Value pos) where
   (neg, pos) = Map.mapThese splitIntl mp
-{-# INLINABLE split #-}
 
   splitIntl :: Map TokenName Integer -> These (Map TokenName Integer) (Map TokenName Integer)
   splitIntl mp' = These l r where
     (l, r) = Map.mapThese (\i -> if i <= 0 then This i else That i) mp'
+{-# INLINABLE split #-}
 
 {- | Check equality of two lists of distinct key-value pairs, each value being uniquely
 identified by a key, given a function checking whether a 'Value' is zero and a function

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -223,7 +223,7 @@ newtype AssetClass = AssetClass {unAssetClass :: (CurrencySymbol, TokenName)}
   deriving (Pretty) via (PrettyShow (CurrencySymbol, TokenName))
 
 instance HasBlueprintSchema AssetClass referencedTypes where
-  {-# INLINEABLE schema #-}
+  {-# INLINABLE schema #-}
   schema =
     SchemaBuiltInPair emptySchemaInfo $
       MkPairSchema
@@ -356,8 +356,6 @@ valueOf value cur tn =
       Just v  -> v
 {-# INLINABLE valueOf #-}
 
-{-# INLINEABLE withCurrencySymbol #-}
-
 {- | Apply a continuation function to the token quantities of the given currency
 symbol in the value or return a default value if the currency symbol is not present
 in the value.
@@ -367,8 +365,7 @@ withCurrencySymbol currency value def k =
   case Map.lookup currency (getValue value) of
     Nothing              -> def
     Just tokenQuantities -> k tokenQuantities
-
-{-# INLINEABLE currencySymbolValueOf #-}
+{-# INLINABLE withCurrencySymbol #-}
 
 {- | Get the total value of the currency symbol in the 'Value' map.
 Assumes that the underlying map doesn't contain duplicate keys.
@@ -381,6 +378,7 @@ currencySymbolValueOf value cur = withCurrencySymbol cur value 0 \tokens ->
   -- This is more efficient than `PlutusTx.sum (Map.elems tokens)`, because
   -- the latter materializes the intermediate result of `Map.elems tokens`.
   PlutusTx.List.foldr (\(_, amt) acc -> amt + acc) 0 (Map.toList tokens)
+{-# INLINABLE currencySymbolValueOf #-}
 
 -- | The list of 'CurrencySymbol's of a 'Value'.
 symbols :: Value -> [CurrencySymbol]

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
@@ -148,13 +148,12 @@ findDatumHash ds TxInfo{txInfoData} = fst <$> find f (toList txInfoData)
 {-# INLINABLE findDatumHash #-}
 
 {-| Given a UTXO reference and a transaction (`TxInfo`), resolve it to one of the transaction's inputs (`TxInInfo`).
-{-# INLINABLE findTxInByTxOutRef #-}
-
 Note: this only searches the true transaction inputs and not the referenced transaction inputs.
 -}
 findTxInByTxOutRef :: TxOutRef -> TxInfo -> Maybe TxInInfo
 findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
     find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == outRef) txInfoInputs
+{-# INLINABLE findTxInByTxOutRef #-}
 
 -- | Find the indices of all the outputs that pay to the same script address we are currently spending from, if any.
 findContinuingOutputs :: ScriptContext -> [Integer]

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
@@ -218,9 +218,9 @@ spendsOutput p h i =
             let outRef = txInInfoOutRef inp
             in h == txOutRefId outRef
                 && i == txOutRefIdx outRef
-{-# INLINABLE spendsOutput #-}
 
     in any spendsOutRef (txInfoInputs p)
+{-# INLINABLE spendsOutput #-}
 
 ----------------------------------------------------------------------------------------------------
 -- TH Splices --------------------------------------------------------------------------------------

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
@@ -128,28 +128,28 @@ instance Pretty ScriptContext where
             , nest 2 $ vsep ["TxInfo:", pretty scriptContextTxInfo]
             ]
 
-{-# INLINABLE findOwnInput #-}
 -- | Find the input currently being validated.
 findOwnInput :: ScriptContext -> Maybe TxInInfo
 findOwnInput ScriptContext{scriptContextTxInfo=TxInfo{txInfoInputs}, scriptContextPurpose=Spending txOutRef} =
     Data.List.find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == txOutRef) txInfoInputs
 findOwnInput _ = Nothing
+{-# INLINABLE findOwnInput #-}
 
-{-# INLINABLE findDatum #-}
 -- | Find the data corresponding to a data hash, if there is one
 findDatum :: DatumHash -> TxInfo -> Maybe Datum
 findDatum dsh TxInfo{txInfoData} = lookup dsh txInfoData
+{-# INLINABLE findDatum #-}
 
-{-# INLINABLE findDatumHash #-}
 -- | Find the hash of a datum, if it is part of the pending transaction's
 -- hashes
 findDatumHash :: Datum -> TxInfo -> Maybe DatumHash
 findDatumHash ds TxInfo{txInfoData} = fst <$> find f (toList txInfoData)
     where
         f (_, ds') = ds' == ds
+{-# INLINABLE findDatumHash #-}
 
-{-# INLINABLE findTxInByTxOutRef #-}
 {-| Given a UTXO reference and a transaction (`TxInfo`), resolve it to one of the transaction's inputs (`TxInInfo`).
+{-# INLINABLE findTxInByTxOutRef #-}
 
 Note: this only searches the true transaction inputs and not the referenced transaction inputs.
 -}
@@ -157,59 +157,58 @@ findTxInByTxOutRef :: TxOutRef -> TxInfo -> Maybe TxInInfo
 findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
     Data.List.find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == outRef) txInfoInputs
 
-{-# INLINABLE findContinuingOutputs #-}
 -- | Find the indices of all the outputs that pay to the same script address we are currently spending from, if any.
 findContinuingOutputs :: ScriptContext -> List Integer
 findContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = Data.List.findIndices (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
     where
         f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
 findContinuingOutputs _ = traceError "Le" -- "Can't find any continuing outputs"
+{-# INLINABLE findContinuingOutputs #-}
 
-{-# INLINABLE getContinuingOutputs #-}
 -- | Get all the outputs that pay to the same script address we are currently spending from, if any.
 getContinuingOutputs :: ScriptContext -> List TxOut
 getContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = Data.List.filter (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
     where
         f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
 getContinuingOutputs _ = traceError "Lf" -- "Can't get any continuing outputs"
+{-# INLINABLE getContinuingOutputs #-}
 
-{-# INLINABLE txSignedBy #-}
 -- | Check if a transaction was signed by the given public key.
 txSignedBy :: TxInfo -> PubKeyHash -> Bool
 txSignedBy TxInfo{txInfoSignatories} k = case Data.List.find ((==) k) txInfoSignatories of
     Just _  -> True
     Nothing -> False
+{-# INLINABLE txSignedBy #-}
 
-{-# INLINABLE pubKeyOutputsAt #-}
 -- | Get the values paid to a public key address by a pending transaction.
 pubKeyOutputsAt :: PubKeyHash -> TxInfo -> List Value
 pubKeyOutputsAt pk p =
     let flt TxOut{txOutAddress = Address (PubKeyCredential pk') _, txOutValue} | pk == pk' = Just txOutValue
         flt _                             = Nothing
     in Data.List.mapMaybe flt (txInfoOutputs p)
+{-# INLINABLE pubKeyOutputsAt #-}
 
-{-# INLINABLE valuePaidTo #-}
 -- | Get the total value paid to a public key address by a pending transaction.
 valuePaidTo :: TxInfo -> PubKeyHash -> Value
 valuePaidTo ptx pkh = Data.List.mconcat (pubKeyOutputsAt pkh ptx)
+{-# INLINABLE valuePaidTo #-}
 
-{-# INLINABLE valueSpent #-}
 -- | Get the total value of inputs spent by this transaction.
 valueSpent :: TxInfo -> Value
 valueSpent = Data.List.foldMap (txOutValue . txInInfoResolved) . txInfoInputs
+{-# INLINABLE valueSpent #-}
 
-{-# INLINABLE valueProduced #-}
 -- | Get the total value of outputs produced by this transaction.
 valueProduced :: TxInfo -> Value
 valueProduced = Data.List.foldMap txOutValue . txInfoOutputs
+{-# INLINABLE valueProduced #-}
 
-{-# INLINABLE ownCurrencySymbol #-}
 -- | The 'CurrencySymbol' of the current validator script.
 ownCurrencySymbol :: ScriptContext -> CurrencySymbol
 ownCurrencySymbol ScriptContext{scriptContextPurpose=Minting cs} = cs
 ownCurrencySymbol _                                              = traceError "Lh" -- "Can't get currency symbol of the current validator script"
+{-# INLINABLE ownCurrencySymbol #-}
 
-{-# INLINABLE spendsOutput #-}
 {- | Check if the pending transaction spends a specific transaction output
 (identified by the hash of a transaction and an index into that
 transactions' outputs)
@@ -220,5 +219,6 @@ spendsOutput p h i =
             let outRef = txInInfoOutRef inp
             in h == txOutRefId outRef
                 && i == txOutRefIdx outRef
+{-# INLINABLE spendsOutput #-}
 
     in Data.List.any spendsOutRef (txInfoInputs p)

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
@@ -149,13 +149,12 @@ findDatumHash ds TxInfo{txInfoData} = fst <$> find f (toList txInfoData)
 {-# INLINABLE findDatumHash #-}
 
 {-| Given a UTXO reference and a transaction (`TxInfo`), resolve it to one of the transaction's inputs (`TxInInfo`).
-{-# INLINABLE findTxInByTxOutRef #-}
-
 Note: this only searches the true transaction inputs and not the referenced transaction inputs.
 -}
 findTxInByTxOutRef :: TxOutRef -> TxInfo -> Maybe TxInInfo
 findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
     Data.List.find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == outRef) txInfoInputs
+{-# INLINABLE findTxInByTxOutRef #-}
 
 -- | Find the indices of all the outputs that pay to the same script address we are currently spending from, if any.
 findContinuingOutputs :: ScriptContext -> List Integer

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
@@ -219,6 +219,5 @@ spendsOutput p h i =
             let outRef = txInInfoOutRef inp
             in h == txOutRefId outRef
                 && i == txOutRefIdx outRef
-{-# INLINABLE spendsOutput #-}
-
     in Data.List.any spendsOutRef (txInfoInputs p)
+{-# INLINABLE spendsOutput #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/Contexts.hs
@@ -542,8 +542,6 @@ instance Pretty ScriptContext where
       , nest 2 (vsep ["Redeemer:", pretty scriptContextRedeemer])
       ]
 
-{-# INLINEABLE findOwnInput #-}
-
 -- | Find the input currently being validated.
 findOwnInput :: ScriptContext -> Haskell.Maybe TxInInfo
 findOwnInput
@@ -555,14 +553,12 @@ findOwnInput
       (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef PlutusTx.== txOutRef)
       txInfoInputs
 findOwnInput _ = Haskell.Nothing
-
-{-# INLINEABLE findDatum #-}
+{-# INLINEABLE findOwnInput #-}
 
 -- | Find the data corresponding to a data hash, if there is one
 findDatum :: V2.DatumHash -> TxInfo -> Haskell.Maybe V2.Datum
 findDatum dsh TxInfo{txInfoData} = lookup dsh txInfoData
-
-{-# INLINEABLE findDatumHash #-}
+{-# INLINEABLE findDatum #-}
 
 {- | Find the hash of a datum, if it is part of the pending transaction's
 hashes
@@ -572,8 +568,7 @@ findDatumHash ds TxInfo{txInfoData} =
   PlutusTx.fst PlutusTx.<$> PlutusTx.find f (toList txInfoData)
  where
   f (_, ds') = ds' PlutusTx.== ds
-
-{-# INLINEABLE findTxInByTxOutRef #-}
+{-# INLINEABLE findDatumHash #-}
 
 {- | Given a UTXO reference and a transaction (`TxInfo`), resolve it to one of the
 transaction's inputs (`TxInInfo`).
@@ -586,7 +581,7 @@ findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
     (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef PlutusTx.== outRef)
     txInfoInputs
 
-{-# INLINEABLE findContinuingOutputs #-}
+{-# INLINEABLE findTxInByTxOutRef #-}
 
 {- | Find the indices of all the outputs that pay to the same script address we are
 currently spending from, if any.
@@ -601,8 +596,7 @@ findContinuingOutputs ctx
  where
   f addr V2.TxOut{txOutAddress = otherAddress} = addr PlutusTx.== otherAddress
 findContinuingOutputs _ = PlutusTx.traceError "Le" -- "Can't find any continuing outputs"
-
-{-# INLINEABLE getContinuingOutputs #-}
+{-# INLINEABLE findContinuingOutputs #-}
 
 {- | Get all the outputs that pay to the same script address we are currently spending
 from, if any.
@@ -615,16 +609,14 @@ getContinuingOutputs ctx
  where
   f addr V2.TxOut{txOutAddress = otherAddress} = addr PlutusTx.== otherAddress
 getContinuingOutputs _ = PlutusTx.traceError "Lf" -- "Can't get any continuing outputs"
-
-{-# INLINEABLE txSignedBy #-}
+{-# INLINEABLE getContinuingOutputs #-}
 
 -- | Check if a transaction was signed by the given public key.
 txSignedBy :: TxInfo -> V2.PubKeyHash -> Haskell.Bool
 txSignedBy TxInfo{txInfoSignatories} k = case PlutusTx.find ((PlutusTx.==) k) txInfoSignatories of
   Haskell.Just _  -> Haskell.True
   Haskell.Nothing -> Haskell.False
-
-{-# INLINEABLE pubKeyOutputsAt #-}
+{-# INLINEABLE txSignedBy #-}
 
 -- | Get the values paid to a public key address by a pending transaction.
 pubKeyOutputsAt :: V2.PubKeyHash -> TxInfo -> [V2.Value]
@@ -633,27 +625,23 @@ pubKeyOutputsAt pk p =
         | pk PlutusTx.== pk' = Haskell.Just txOutValue
       flt _ = Haskell.Nothing
    in PlutusTx.mapMaybe flt (txInfoOutputs p)
-
-{-# INLINEABLE valuePaidTo #-}
+{-# INLINEABLE pubKeyOutputsAt #-}
 
 -- | Get the total value paid to a public key address by a pending transaction.
 valuePaidTo :: TxInfo -> V2.PubKeyHash -> V2.Value
 valuePaidTo ptx pkh = PlutusTx.mconcat (pubKeyOutputsAt pkh ptx)
-
-{-# INLINEABLE valueSpent #-}
+{-# INLINEABLE valuePaidTo #-}
 
 -- | Get the total value of inputs spent by this transaction.
 valueSpent :: TxInfo -> V2.Value
 valueSpent =
   PlutusTx.foldMap (V2.txOutValue PlutusTx.. txInInfoResolved) PlutusTx.. txInfoInputs
-
-{-# INLINEABLE valueProduced #-}
+{-# INLINEABLE valueSpent #-}
 
 -- | Get the total value of outputs produced by this transaction.
 valueProduced :: TxInfo -> V2.Value
 valueProduced = PlutusTx.foldMap V2.txOutValue PlutusTx.. txInfoOutputs
-
-{-# INLINEABLE ownCurrencySymbol #-}
+{-# INLINEABLE valueProduced #-}
 
 -- | The 'CurrencySymbol' of the current validator script.
 ownCurrencySymbol :: ScriptContext -> V2.CurrencySymbol
@@ -661,8 +649,7 @@ ownCurrencySymbol ScriptContext{scriptContextScriptInfo = MintingScript cs} = cs
 ownCurrencySymbol _ =
   -- "Can't get currency symbol of the current validator script"
   PlutusTx.traceError "Lh"
-
-{-# INLINEABLE spendsOutput #-}
+{-# INLINEABLE ownCurrencySymbol #-}
 
 {- | Check if the pending transaction spends a specific transaction output
 (identified by the hash of a transaction and an index into that
@@ -677,6 +664,7 @@ spendsOutput txInfo txId i =
               PlutusTx.&& i
               PlutusTx.== V3.txOutRefIdx outRef
    in PlutusTx.any spendsOutRef (txInfoInputs txInfo)
+{-# INLINEABLE spendsOutput #-}
 
 ----------------------------------------------------------------------------------------------------
 -- TH Splices --------------------------------------------------------------------------------------

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/MintValue.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/MintValue.hs
@@ -90,27 +90,26 @@ instance HasBlueprintSchema MintValue referencedTypes where
         , maxItems = Nothing
         }
 
-{-# INLINEABLE emptyMintValue #-}
 emptyMintValue :: MintValue
 emptyMintValue = UnsafeMintValue Map.empty
+{-# INLINEABLE emptyMintValue #-}
 
-{-# INLINEABLE mintValueToMap #-}
 mintValueToMap :: MintValue -> Map CurrencySymbol (Map TokenName Integer)
 mintValueToMap (UnsafeMintValue m) = m
+{-# INLINEABLE mintValueToMap #-}
 
 -- | Get the 'Value' minted by the 'MintValue'.
-{-# INLINEABLE mintValueMinted #-}
 mintValueMinted :: MintValue -> Value
 mintValueMinted (UnsafeMintValue values) = filterQuantities (\x -> [x | x > 0]) values
+{-# INLINEABLE mintValueMinted #-}
 
 {- | Get the 'Value' burned by the 'MintValue'.
 All the negative quantities in the 'MintValue' become positive in the resulting 'Value'.
 -}
-{-# INLINEABLE mintValueBurned #-}
 mintValueBurned :: MintValue -> Value
 mintValueBurned (UnsafeMintValue values) = filterQuantities (\x -> [abs x | x < 0]) values
+{-# INLINEABLE mintValueBurned #-}
 
-{-# INLINEABLE filterQuantities #-}
 filterQuantities :: (Integer -> [Integer]) -> Map CurrencySymbol (Map TokenName Integer) -> Value
 filterQuantities mapQuantity values =
   Value (Map.unsafeFromList (foldr filterTokenQuantities [] (Map.toList values)))
@@ -124,6 +123,7 @@ filterQuantities mapQuantity values =
       case concatMap (traverse mapQuantity) (Map.toList tokenQuantities) of
         []         -> id
         quantities -> ((currency, Map.unsafeFromList quantities) :)
+{-# INLINEABLE filterQuantities #-}
 
 ----------------------------------------------------------------------------------------------------
 -- TH Splices --------------------------------------------------------------------------------------

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/MintValue.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/MintValue.hs
@@ -71,7 +71,6 @@ instance HasBlueprintDefinition MintValue where
   definitionId = definitionIdFromType @MintValue
 
 instance HasBlueprintSchema MintValue referencedTypes where
-  {-# INLINEABLE schema #-}
   schema =
     SchemaMap
       emptySchemaInfo{title = Just "MintValue"}
@@ -89,6 +88,7 @@ instance HasBlueprintSchema MintValue referencedTypes where
         , minItems = Nothing
         , maxItems = Nothing
         }
+  {-# INLINEABLE schema #-}
 
 emptyMintValue :: MintValue
 emptyMintValue = UnsafeMintValue Map.empty

--- a/plutus-ledger-api/test-plugin/Spec/Data/Value.hs
+++ b/plutus-ledger-api/test-plugin/Spec/Data/Value.hs
@@ -38,11 +38,10 @@ import Prettyprinter qualified as Pretty
 import Test.Tasty
 import Test.Tasty.Extras
 
-{-# INLINEABLE scalingFactor #-}
 scalingFactor :: Integer
 scalingFactor = 4
+{-# INLINEABLE scalingFactor #-}
 
-{-# INLINEABLE patternOptions #-}
 -- | A list of \"patterns\", each of which can be turned into 'Value's.
 --
 -- We use the patterns to construct lists of tokens: the first element of a tuple becomes a
@@ -66,16 +65,16 @@ patternOptions =
     , [(2,2), (2,3), (1,0), (3,5), (3,6), (2,4), (1,1), (2,7)]
     , [(1,9), (2,2), (6,10), (2,3), (1,0), (4,10), (3,5), (5,0), (3,6), (2,4), (1,1), (2,7), (4,8)]
     ]
+{-# INLINEABLE patternOptions #-}
 
-{-# INLINEABLE i2Bs #-}
 i2Bs :: Integer -> BuiltinByteString
 i2Bs n =
     if n < 0
         then "-" `appendByteString` i2Bs (negate n)
         -- @48@ is the ASCII code of @0@.
         else ListTx.foldr (consByteString . (48 +)) emptyByteString $ toDigits n
+{-# INLINEABLE i2Bs #-}
 
-{-# INLINEABLE replicateToByteString #-}
 -- | Like 'i2Bs but generates longer bytestrings, so that repeated recalculations of
 -- currency/token name comparisons get reflected in the budget tests in a visible manner.
 replicateToByteString :: Integer -> BuiltinByteString
@@ -86,15 +85,15 @@ replicateToByteString i =
     iTo2 = i * i
     iTo4 = iTo2 * iTo2
     iTo6 = iTo4 * iTo2
+{-# INLINEABLE replicateToByteString #-}
 
-{-# INLINEABLE tokenListOptions #-}
 tokenListOptions :: [[(TokenName, Integer)]]
 tokenListOptions =
     ListTx.map
         (ListTx.map $ \(i, x) -> (TokenName $ replicateToByteString i, x))
         patternOptions
+{-# INLINEABLE tokenListOptions #-}
 
-{-# INLINEABLE currencyListOptions #-}
 currencyListOptions :: [[(CurrencySymbol, [(TokenName, Integer)])]]
 currencyListOptions =
     ListTx.map
@@ -103,8 +102,8 @@ currencyListOptions =
             , tokenListOptions ListTx.!! x
             ))
         patternOptions
+{-# INLINEABLE currencyListOptions #-}
 
-{-# INLINEABLE longCurrencyChunk #-}
 -- | A \"long\" list of currencies each with a \"long\" list of tokens for stress-testing (one
 -- doesn't need many elements to stress-test Plutus Tx, hence the quotes).
 longCurrencyChunk :: [(CurrencySymbol, [(TokenName, Integer)])]
@@ -112,8 +111,8 @@ longCurrencyChunk
     = ListTx.concatMap Tx.sequence
     . ListTx.zip (ListTx.map (CurrencySymbol . replicateToByteString) [1 .. scalingFactor])
     $ ListTx.replicate scalingFactor tokenListOptions
+{-# INLINEABLE longCurrencyChunk #-}
 
-{-# INLINEABLE insertHooks #-}
 -- | Return a list whose head is the argument list with 'Nothing' inserted at the beginning, the
 -- middle and the end of it (every other element is wrapped with 'Just'). The tail of the resulting
 -- list comprises all possible versions of the head that we get by removing any number of
@@ -137,14 +136,15 @@ insertHooks xs0 = do
             [prefix ++ map Just xsSlow ++ suffix]
     xs0' <- go xs0 xs0
     [Nothing : xs0', xs0']
+{-# INLINEABLE insertHooks #-}
 
-{-# INLINEABLE currencyLongListOptions #-}
 -- | The last and the biggest list of currencies from 'currencyListOptions' with 'longCurrencyChunk'
 -- inserted in it in various ways as per 'insertHooks'.
 currencyLongListOptions :: [[(CurrencySymbol, [(TokenName, Integer)])]]
 currencyLongListOptions =
     insertHooks (ListTx.last currencyListOptions) <&> \currencyListWithHooks ->
     ListTx.concatMap (maybe longCurrencyChunk pure) currencyListWithHooks
+{-# INLINEABLE currencyLongListOptions #-}
 
 listsToValue :: [(CurrencySymbol, [(TokenName, Integer)])] -> Value
 listsToValue = Value . AssocMap.unsafeFromList . ListTx.map (fmap AssocMap.unsafeFromList)

--- a/plutus-ledger-api/test-plugin/Spec/Value.hs
+++ b/plutus-ledger-api/test-plugin/Spec/Value.hs
@@ -38,11 +38,10 @@ import Prettyprinter qualified as Pretty
 import Test.Tasty
 import Test.Tasty.Extras
 
-{-# INLINEABLE scalingFactor #-}
 scalingFactor :: Integer
 scalingFactor = 4
+{-# INLINEABLE scalingFactor #-}
 
-{-# INLINEABLE patternOptions #-}
 -- | A list of \"patterns\", each of which can be turned into 'Value's.
 --
 -- We use the patterns to construct lists of tokens: the first element of a tuple becomes a
@@ -66,16 +65,16 @@ patternOptions =
     , [(2,2), (2,3), (1,0), (3,5), (3,6), (2,4), (1,1), (2,7)]
     , [(1,9), (2,2), (6,10), (2,3), (1,0), (4,10), (3,5), (5,0), (3,6), (2,4), (1,1), (2,7), (4,8)]
     ]
+{-# INLINEABLE patternOptions #-}
 
-{-# INLINEABLE i2Bs #-}
 i2Bs :: Integer -> BuiltinByteString
 i2Bs n =
     if n < 0
         then "-" `appendByteString` i2Bs (negate n)
         -- @48@ is the ASCII code of @0@.
         else ListTx.foldr (consByteString . (48 +)) emptyByteString $ toDigits n
+{-# INLINEABLE i2Bs #-}
 
-{-# INLINEABLE replicateToByteString #-}
 -- | Like 'i2Bs but generates longer bytestrings, so that repeated recalculations of
 -- currency/token name comparisons get reflected in the budget tests in a visible manner.
 replicateToByteString :: Integer -> BuiltinByteString
@@ -86,15 +85,15 @@ replicateToByteString i =
     iTo2 = i * i
     iTo4 = iTo2 * iTo2
     iTo6 = iTo4 * iTo2
+{-# INLINEABLE replicateToByteString #-}
 
-{-# INLINEABLE tokenListOptions #-}
 tokenListOptions :: [[(TokenName, Integer)]]
 tokenListOptions =
     ListTx.map
         (ListTx.map $ \(i, x) -> (TokenName $ replicateToByteString i, x))
         patternOptions
+{-# INLINEABLE tokenListOptions #-}
 
-{-# INLINEABLE currencyListOptions #-}
 currencyListOptions :: [[(CurrencySymbol, [(TokenName, Integer)])]]
 currencyListOptions =
     ListTx.map
@@ -103,8 +102,8 @@ currencyListOptions =
             , tokenListOptions ListTx.!! x
             ))
         patternOptions
+{-# INLINEABLE currencyListOptions #-}
 
-{-# INLINEABLE longCurrencyChunk #-}
 -- | A \"long\" list of currencies each with a \"long\" list of tokens for stress-testing (one
 -- doesn't need many elements to stress-test Plutus Tx, hence the quotes).
 longCurrencyChunk :: [(CurrencySymbol, [(TokenName, Integer)])]
@@ -112,8 +111,8 @@ longCurrencyChunk
     = ListTx.concatMap Tx.sequence
     . ListTx.zip (ListTx.map (CurrencySymbol . replicateToByteString) [1 .. scalingFactor])
     $ ListTx.replicate scalingFactor tokenListOptions
+{-# INLINEABLE longCurrencyChunk #-}
 
-{-# INLINEABLE insertHooks #-}
 -- | Return a list whose head is the argument list with 'Nothing' inserted at the beginning, the
 -- middle and the end of it (every other element is wrapped with 'Just'). The tail of the resulting
 -- list comprises all possible versions of the head that we get by removing any number of
@@ -137,14 +136,15 @@ insertHooks xs0 = do
             [prefix ++ map Just xsSlow ++ suffix]
     xs0' <- go xs0 xs0
     [Nothing : xs0', xs0']
+{-# INLINEABLE insertHooks #-}
 
-{-# INLINEABLE currencyLongListOptions #-}
 -- | The last and the biggest list of currencies from 'currencyListOptions' with 'longCurrencyChunk'
 -- inserted in it in various ways as per 'insertHooks'.
 currencyLongListOptions :: [[(CurrencySymbol, [(TokenName, Integer)])]]
 currencyLongListOptions =
     insertHooks (ListTx.last currencyListOptions) <&> \currencyListWithHooks ->
     ListTx.concatMap (maybe longCurrencyChunk pure) currencyListWithHooks
+{-# INLINEABLE currencyLongListOptions #-}
 
 listsToValue :: [(CurrencySymbol, [(TokenName, Integer)])] -> Value
 listsToValue = Value . AssocMap.unsafeFromList . ListTx.map (fmap AssocMap.unsafeFromList)

--- a/plutus-tx-plugin/test/Blueprint/Tests/Lib.hs
+++ b/plutus-tx-plugin/test/Blueprint/Tests/Lib.hs
@@ -133,9 +133,9 @@ type ScriptContext = ()
 $(makeIsDataSchemaIndexed ''DatumPayload [('MkDatumPayload, 0)])
 $(makeIsDataSchemaIndexed ''Datum [('DatumLeft, 0), ('DatumRight, 1)])
 
-{-# INLINEABLE typedValidator1 #-}
 typedValidator1 :: Params -> Datum -> Redeemer -> ScriptContext -> Bool
 typedValidator1 _params _datum _redeemer _context = False
+{-# INLINEABLE typedValidator1 #-}
 
 validatorScript1 :: PlutusTx.CompiledCode (Datum -> Redeemer -> ScriptContext -> Bool)
 validatorScript1 =
@@ -171,9 +171,9 @@ $(asData datum2)
 
 type Redeemer2 = Integer
 
-{-# INLINEABLE typedValidator2 #-}
 typedValidator2 :: Param2a -> Param2b -> Datum2 -> Redeemer2 -> ScriptContext -> Bool
 typedValidator2 _p1 _p2 _datum _redeemer _context = True
+{-# INLINEABLE typedValidator2 #-}
 
 validatorScript2 :: PlutusTx.CompiledCode (Datum2 -> Redeemer2 -> ScriptContext -> Bool)
 validatorScript2 =

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -421,11 +421,11 @@ compiledGte0 = $$(compile [||
       let ls = PlutusTx.replicate 1000 0 :: [Integer]
        in List.all (PlutusTx.>= 0) ls ||])
 
-{-# INLINABLE recursiveAll #-}
 -- | A version of @all@ that doesn't inline due to being recursive.
 recursiveAll :: forall a. (a -> Bool) -> [a] -> Bool
 recursiveAll _ []     = True
 recursiveAll f (x:xs) = if f x then recursiveAll f xs else False
+{-# INLINABLE recursiveAll #-}
 
 -- | Check @0 <= 0@ a thousand times using @all@ that doesn't inline.
 compiledRecursiveLte0 :: CompiledCode Bool

--- a/plutus-tx-plugin/test/IsData/Spec.hs
+++ b/plutus-tx-plugin/test/IsData/Spec.hs
@@ -64,7 +64,6 @@ deconstructData = plc (Proxy @"deconstructData4") (\(d :: Builtins.BuiltinData) 
 unsafeDeconstructData :: CompiledCode (Builtins.BuiltinData -> Maybe (Integer, Integer))
 unsafeDeconstructData = plc (Proxy @"deconstructData4") (\(d :: Builtins.BuiltinData) -> IsData.unsafeFromBuiltinData d)
 
-{-# INLINABLE isDataRoundtrip #-}
 isDataRoundtrip :: (IsData.FromData a, IsData.UnsafeFromData a, IsData.ToData a, P.Eq a) => a -> Bool
 isDataRoundtrip a =
     let d = IsData.toBuiltinData a
@@ -73,6 +72,7 @@ isDataRoundtrip a =
             Nothing -> False
         unsafeRoundtrip = IsData.unsafeFromBuiltinData d P.== a
     in safeRoundtrip && unsafeRoundtrip
+{-# INLINABLE isDataRoundtrip #-}
 
 AsData.asData [d|
   data SecretlyData = FirstC () | SecondC Integer

--- a/plutus-tx-plugin/test/Plugin/Coverage/9.6/coverageCode.pir.golden
+++ b/plutus-tx-plugin/test/Plugin/Coverage/9.6/coverageCode.pir.golden
@@ -10,11 +10,11 @@ let
     = \(ds : unit) ->
         trace
           {all dead a. Maybe a}
-          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 14, _covLocEndCol = 15})"
+          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 40, _covLocStartCol = 14, _covLocEndCol = 15})"
           (/\dead ->
              trace
                {all dead a. Maybe a}
-               "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 43, _covLocEndLine = 43, _covLocStartCol = 26, _covLocEndCol = 33})"
+               "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 42, _covLocEndLine = 42, _covLocStartCol = 26, _covLocEndCol = 33})"
                (/\dead -> Nothing)
                {all dead. dead})
           {all dead. dead}
@@ -120,11 +120,11 @@ in
     (/\dead ->
        trace
          {all dead. Maybe Bool}
-         "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 43, _covLocStartCol = 1, _covLocEndCol = 33})"
+         "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 42, _covLocStartCol = 1, _covLocEndCol = 33})"
          (/\dead ->
             trace
               {all dead. Maybe Bool}
-              "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 43, _covLocStartCol = 9, _covLocEndCol = 33})"
+              "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 42, _covLocStartCol = 9, _covLocEndCol = 33})"
               (/\dead ->
                  Maybe_match
                    {integer}
@@ -134,26 +134,26 @@ in
                       /\dead ->
                         trace
                           {all dead. Maybe Bool}
-                          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 42, _covLocEndLine = 42, _covLocStartCol = 12, _covLocEndCol = 22})"
+                          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 12, _covLocEndCol = 22})"
                           (/\dead ->
                              Bool_match
                                (otherFun
                                   (trace
                                      {all dead. integer}
-                                     "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 42, _covLocEndLine = 42, _covLocStartCol = 21, _covLocEndCol = 22})"
+                                     "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 21, _covLocEndCol = 22})"
                                      (/\dead -> y)
                                      {all dead. dead}))
                                {all dead. Maybe Bool}
                                (/\dead ->
                                   trace
                                     {all dead. Maybe Bool}
-                                    "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 42, _covLocEndLine = 42, _covLocStartCol = 26, _covLocEndCol = 36})"
+                                    "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 26, _covLocEndCol = 36})"
                                     (/\dead ->
                                        Just
                                          {Bool}
                                          (trace
                                             {all dead. Bool}
-                                            "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 42, _covLocEndLine = 42, _covLocStartCol = 31, _covLocEndCol = 36})"
+                                            "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 31, _covLocEndCol = 36})"
                                             (/\dead -> False)
                                             {all dead. dead}))
                                     {all dead. dead})

--- a/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
@@ -36,11 +36,11 @@ boolTrueFalse = plc (Proxy @"boolTrueFalse") (\() -> True && False)
 boolOtherFunction :: CompiledCode (Maybe Integer -> Maybe Bool)
 boolOtherFunction = plc (Proxy @"boolOtherFunction") fun
 
-{-# INLINEABLE fun #-}
 fun :: Maybe Integer -> Maybe Bool
 fun x = case x of
   Just y | otherFun y -> Just False
   _                   -> Nothing
+{-# INLINEABLE fun #-}
 
 otherFun :: Integer -> Bool
 otherFun x = (x P.== 5) && True

--- a/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
@@ -53,7 +53,7 @@ coverage = testNested "Coverage" . pure $ testNestedGhc
   [ embed $ testGroup "Application heads and line coverage"
          [ mkTests "noBool" noBool Set.empty [31]
          , mkTests "boolTrueFalse" boolTrueFalse (Set.singleton "&&") [34]
-         , mkTests "boolOtherFunction" boolOtherFunction (Set.fromList ["&&", "=="]) [37, 41, 42, 43]
+         , mkTests "boolOtherFunction" boolOtherFunction (Set.fromList ["&&", "=="]) [37, 40, 41, 42]
          , mkTests "boolQualifiedDisappears" boolQualifiedDisappears Set.empty [49]
          ]
  , goldenPirReadable "coverageCode" boolOtherFunction ]

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -384,18 +384,18 @@ associated :: CompiledCode (AType Bool -> AType Bool)
 associated = plc (Proxy @"associated") (\(x :: AType Bool) -> x)
 
 -- Despite the type family being applied to a parameterized type we can still reduce it
-{-# OPAQUE paramId #-}
 paramId :: forall a . Param a -> AType (Param a) -> AType (Param a)
 paramId _ x = x
+{-# OPAQUE paramId #-}
 
 associatedParam :: CompiledCode Integer
 associatedParam = plc (Proxy @"associatedParam") (paramId (Param 1) 1)
 
 -- Here we cannot reduce the type family
-{-# OPAQUE tfId #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 tfId :: forall a . a -> BasicClosed a -> BasicClosed a
 tfId _ x = x
+{-# OPAQUE tfId #-}
 
 irreducible :: CompiledCode Integer
 irreducible = plc (Proxy @"irreducible") (tfId True 1)

--- a/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
@@ -71,13 +71,13 @@ newtype RecursiveNewtype = RecursiveNewtype [RecursiveNewtype]
 recursiveNewtype :: CompiledCode (RecursiveNewtype)
 recursiveNewtype = plc (Proxy @"recursiveNewtype") (RecursiveNewtype [])
 
-{-# INLINABLE evenDirectLocal #-}
 evenDirectLocal :: Integer -> Bool
 evenDirectLocal n = if Builtins.equalsInteger n 0 then True else oddDirectLocal (Builtins.subtractInteger n 1)
+{-# INLINABLE evenDirectLocal #-}
 
-{-# INLINABLE oddDirectLocal #-}
 oddDirectLocal :: Integer -> Bool
 oddDirectLocal n = if Builtins.equalsInteger n 0 then False else evenDirectLocal (Builtins.subtractInteger n 1)
+{-# INLINABLE oddDirectLocal #-}
 
 -- FIXME: these seem to only get unfoldings when they're in a separate module, even with the simplifier pass
 mutualRecursionUnfoldingsLocal :: CompiledCode Bool

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -34,14 +34,14 @@ laziness = testNested "Laziness" . pure $ testNestedGhc
 joinErrorPir :: CompiledCode (Bool -> Bool -> ())
 joinErrorPir = plc (Proxy @"joinError") joinError
 
-{-# OPAQUE monoId #-}
 monoId :: Builtins.BuiltinByteString -> Builtins.BuiltinByteString
 monoId x = x
+{-# OPAQUE monoId #-}
 
 -- This is a non-value let-binding, so will be delayed, and needs a dependency on Unit
-{-# OPAQUE aByteString #-}
 aByteString :: Builtins.BuiltinByteString
 aByteString = monoId Builtins.emptyByteString
+{-# OPAQUE aByteString #-}
 
 lazyDepUnit :: CompiledCode Builtins.BuiltinByteString
 lazyDepUnit = plc (Proxy @"lazyDepUnit") aByteString

--- a/plutus-tx-plugin/test/Plugin/Lib.hs
+++ b/plutus-tx-plugin/test/Plugin/Lib.hs
@@ -18,13 +18,13 @@ andExternal a b = if a then b else False
 
 data MyExternalRecord = MyExternalRecord { myExternal :: Integer }
 
-{-# INLINABLE evenDirect #-}
 evenDirect :: Integer -> Bool
 evenDirect n = if Builtins.equalsInteger n 0 then True else oddDirect (Builtins.subtractInteger n 1)
+{-# INLINABLE evenDirect #-}
 
-{-# INLINABLE oddDirect #-}
 oddDirect :: Integer -> Bool
 oddDirect n = if Builtins.equalsInteger n 0 then False else evenDirect (Builtins.subtractInteger n 1)
+{-# INLINABLE oddDirect #-}
 
 -- GHC will lift out the error call to the top level, which is unsafe unless we bind it lazily.
 -- This is in Lib so we get the fully optimized unfolding with awkward top-level binds and everything.

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -171,17 +171,17 @@ typeclassTest :: CompiledCode (Integer -> Integer -> Integer)
 typeclassTest = plc (Proxy @"typeclass") do
   \(x :: Integer) (y :: Integer) -> useTypeclass x y
 
-{-# INLINEABLE newtypeFunction #-}
 newtypeFunction :: a -> Identity (a -> a)
 newtypeFunction _ = Identity (\a -> a)
+{-# INLINEABLE newtypeFunction #-}
 
 argMismatch1 :: CompiledCode Integer
 argMismatch1 = plc (Proxy @"argMismatch1") do
   runIdentity (newtypeFunction 1) 1
 
-{-# INLINEABLE obscuredFunction #-}
 obscuredFunction :: (a -> a -> a) -> a -> a -> a
 obscuredFunction f a = f a
+{-# INLINEABLE obscuredFunction #-}
 
 argMismatch2 :: CompiledCode Integer
 argMismatch2 = plc (Proxy @"argMismatch2") do

--- a/plutus-tx/src/PlutusTx/Applicative.hs
+++ b/plutus-tx/src/PlutusTx/Applicative.hs
@@ -26,25 +26,25 @@ class Functor f => Applicative f where
     -- | Plutus Tx version of '(Control.Applicative.<*>)'.
     (<*>) :: f (a -> b) -> f a -> f b
 
-{-# INLINABLE liftA2 #-}
 -- | Plutus Tx version of 'Control.Applicative.liftA2'.
 liftA2 :: Applicative f => (a -> b -> c) -> f a -> f b -> f c
 liftA2 f x = (<*>) (fmap f x)
+{-# INLINABLE liftA2 #-}
 
-{-# INLINABLE (*>) #-}
 -- | Plutus Tx version of '(Control.Applicative.*>)'.
 (*>) :: Applicative f => f a -> f b -> f b
 a1 *> a2 = (id <$ a1) <*> a2
+{-# INLINABLE (*>) #-}
 
-{-# INLINABLE (<*) #-}
 -- | Plutus Tx version of '(Control.Applicative.<*)'.
 (<*) :: Applicative f => f a -> f b -> f a
 (<*) = liftA2 const
+{-# INLINABLE (<*) #-}
 
-{-# INLINABLE unless #-}
 -- | Plutus Tx version of 'Control.Monad.unless'.
 unless :: (Applicative f) => Bool -> f () -> f ()
 unless p s = if p then pure () else s
+{-# INLINABLE unless #-}
 
 instance Applicative Maybe where
     {-# INLINABLE pure #-}

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -209,25 +209,24 @@ instance (Eq k, Semigroup v) => Monoid (Map k v) where
 instance (Pretty k, Pretty v) => Pretty (Map k v) where
   pretty (Map mp) = pretty mp
 
-{-# INLINEABLE unsafeFromList #-}
 -- | Unsafely create a 'Map' from a list of pairs. This should _only_ be applied to lists which
 -- have been checked to not contain duplicate keys, otherwise the resulting 'Map' will contain
 -- conflicting entries (two entries sharing the same key).
 -- As usual, the "keys" are considered to be the first element of the pair.
 unsafeFromList :: [(k, v)] -> Map k v
 unsafeFromList = Map
+{-# INLINEABLE unsafeFromList #-}
 
-{-# INLINEABLE safeFromList #-}
 -- | In case of duplicates, this function will keep only one entry (the one that precedes).
 -- In other words, this function de-duplicates the input list.
 safeFromList :: Eq k => [(k, v)] -> Map k v
 safeFromList = foldr (uncurry insert) empty
+{-# INLINEABLE safeFromList #-}
 
-{-# INLINEABLE toList #-}
 toList :: Map k v -> [(k, v)]
 toList (Map l) = l
+{-# INLINEABLE toList #-}
 
-{-# INLINEABLE lookup #-}
 -- | Find an entry in a 'Map'. If the 'Map' is not well-formed (it contains duplicate keys)
 -- then this will return the value of the left-most pair in the underlying list of pairs.
 lookup :: forall k v. (Eq k) => k -> Map k v -> Maybe v
@@ -238,21 +237,21 @@ lookup c (Map xs) =
     go ((c', i) : xs') = if c' == c then Just i else go xs'
    in
     go xs
+{-# INLINEABLE lookup #-}
 
-{-# INLINEABLE member #-}
 -- | Is the key a member of the map?
 member :: forall k v. (Eq k) => k -> Map k v -> Bool
 member k m = isJust (lookup k m)
+{-# INLINEABLE member #-}
 
-{-# INLINEABLE insert #-}
 -- | If a key already exists in the map, its entry will be replaced with the new value.
 insert :: forall k v. (Eq k) => k -> v -> Map k v -> Map k v
 insert k v (Map xs) = Map (go xs)
   where
     go []                = [(k, v)]
     go ((k', v') : rest) = if k == k' then (k, v) : rest else (k', v') : go rest
+{-# INLINEABLE insert #-}
 
-{-# INLINEABLE delete #-}
 -- | Delete an entry from the 'Map'. Assumes that the 'Map' is well-formed, i.e. if the
 -- underlying list of pairs contains pairs with duplicate keys then only the left-most
 -- pair will be removed.
@@ -263,12 +262,13 @@ delete key (Map ls) = Map (go ls)
     go ((k, v) : rest)
       | k == key = rest
       | otherwise = (k, v) : go rest
+{-# INLINEABLE delete #-}
 
-{-# INLINEABLE keys #-}
 -- | The keys of a 'Map'. Semantically, the resulting list is only a set if the 'Map'
 -- didn't contain duplicate keys.
 keys :: Map k v -> [k]
 keys (Map xs) = P.fmap (\(k, _ :: v) -> k) xs
+{-# INLINEABLE keys #-}
 
 -- | Combine two 'Map's. Keeps both values on key collisions.
 -- Note that well-formedness is only preserved if the two input maps
@@ -296,7 +296,6 @@ union (Map ls) (Map rs) =
    in
     Map (ls' ++ rs'')
 
-{-# INLINEABLE unionWith #-}
 -- | Combine two 'Map's with the given combination function.
 -- Note that well-formedness of the resulting map depends on the two input maps
 -- being well-formed.
@@ -310,6 +309,7 @@ unionWith merge (Map ls) (Map rs) =
     f a b' = case b' of
       Nothing -> a
       Just b  -> merge a b
+{-# INLINEABLE unionWith #-}
 
     ls' :: [(k, a)]
     ls' = P.fmap (\(c, i) -> (c, f i (lookup c (Map rs)))) ls
@@ -319,7 +319,6 @@ unionWith merge (Map ls) (Map rs) =
    in
     Map (ls' ++ rs')
 
-{-# INLINEABLE mapThese #-}
 -- | A version of 'Data.Map.Lazy.mapEither' that works with 'These'.
 mapThese :: (v -> These a b) -> Map k v -> (Map k a, Map k b)
 mapThese f mps = (Map mpl, Map mpr)
@@ -330,6 +329,7 @@ mapThese f mps = (Map mpl, Map mpr)
       This a    -> ((k, a) : as, bs)
       That b    -> (as, (k, b) : bs)
       These a b -> ((k, a) : as, (k, b) : bs)
+{-# INLINEABLE mapThese #-}
 
 -- | A singleton map.
 singleton :: k -> v -> Map k v

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -309,7 +309,6 @@ unionWith merge (Map ls) (Map rs) =
     f a b' = case b' of
       Nothing -> a
       Just b  -> merge a b
-{-# INLINEABLE unionWith #-}
 
     ls' :: [(k, a)]
     ls' = P.fmap (\(c, i) -> (c, f i (lookup c (Map rs)))) ls
@@ -318,6 +317,7 @@ unionWith merge (Map ls) (Map rs) =
     rs' = P.filter (\(c, _) -> not (any (\(c', _) -> c' == c) ls)) rs
    in
     Map (ls' ++ rs')
+{-# INLINEABLE unionWith #-}
 
 -- | A version of 'Data.Map.Lazy.mapEither' that works with 'These'.
 mapThese :: (v -> These a b) -> Map k v -> (Map k a, Map k b)
@@ -335,49 +335,41 @@ mapThese f mps = (Map mpl, Map mpr)
 singleton :: k -> v -> Map k v
 singleton c i = Map [(c, i)]
 
-{-# INLINEABLE empty #-}
 
 -- | An empty 'Map'.
 empty :: Map k v
 empty = Map ([] :: [(k, v)])
-
-{-# INLINEABLE null #-}
+{-# INLINEABLE empty #-}
 
 -- | Is the map empty?
 null :: Map k v -> Bool
 null = P.null . unMap
-
-{-# INLINEABLE filter #-}
+{-# INLINEABLE null #-}
 
 -- | Filter all values that satisfy the predicate.
 filter :: (v -> Bool) -> Map k v -> Map k v
 filter f (Map m) = Map $ P.filter (f . snd) m
-
-{-# INLINEABLE elems #-}
+{-# INLINEABLE filter #-}
 
 -- | Return all elements of the map.
 elems :: Map k v -> [v]
 elems (Map xs) = P.fmap (\(_ :: k, v) -> v) xs
-
-{-# INLINEABLE mapWithKey #-}
+{-# INLINEABLE elems #-}
 
 -- | Map a function over all values in the map.
 mapWithKey :: (k -> a -> b) -> Map k a -> Map k b
 mapWithKey f (Map xs) = Map $ fmap (\(k, v) -> (k, f k v)) xs
-
-{-# INLINEABLE mapMaybe #-}
+{-# INLINEABLE mapWithKey #-}
 
 -- | Map keys\/values and collect the 'Just' results.
 mapMaybe :: (a -> Maybe b) -> Map k a -> Map k b
 mapMaybe f (Map xs) = Map $ P.mapMaybe (\(k, v) -> (k,) <$> f v) xs
-
-{-# INLINEABLE mapMaybeWithKey #-}
+{-# INLINEABLE mapMaybe #-}
 
 -- | Map keys\/values and collect the 'Just' results.
 mapMaybeWithKey :: (k -> a -> Maybe b) -> Map k a -> Map k b
 mapMaybeWithKey f (Map xs) = Map $ P.mapMaybe (\(k, v) -> (k,) <$> f k v) xs
-
-{-# INLINEABLE all #-}
+{-# INLINEABLE mapMaybeWithKey #-}
 
 -- | Determines whether all elements in the map satisfy the predicate.
 all :: (a -> Bool) -> Map k a -> Bool
@@ -386,6 +378,7 @@ all f (Map m) = go m
     go = \case
       []          -> True
       (_, x) : xs -> if f x then go xs else False
+{-# INLINEABLE all #-}
 
 ----------------------------------------------------------------------------------------------------
 -- TH Splices --------------------------------------------------------------------------------------

--- a/plutus-tx/src/PlutusTx/Base.hs
+++ b/plutus-tx/src/PlutusTx/Base.hs
@@ -3,57 +3,57 @@ module PlutusTx.Base (fst, snd, curry, uncurry, ($), flip, until, (.), const, id
 
 import PlutusTx.Bool
 
-{-# INLINABLE fst #-}
 -- | Plutus Tx version of 'Data.Tuple.fst'
 fst :: (a, b) -> a
 fst (a, _) = a
+{-# INLINABLE fst #-}
 
-{-# INLINABLE snd #-}
 -- | Plutus Tx version of 'Data.Tuple.snd'
 snd :: (a, b) -> b
 snd (_, b) = b
+{-# INLINABLE snd #-}
 
-{-# INLINABLE curry #-}
 curry :: ((a, b) -> c) -> a -> b -> c
 curry f a b = f (a, b)
+{-# INLINABLE curry #-}
 
-{-# INLINABLE uncurry #-}
 uncurry :: (a -> b -> c) -> (a, b) -> c
 uncurry f (a, b) = f a b
+{-# INLINABLE uncurry #-}
 
 infixr 0 $
 -- Normal $ is levity-polymorphic, which we can't handle.
-{-# INLINABLE ($) #-}
 -- | Plutus Tx version of 'Data.Function.($)'.
 ($) :: (a -> b) -> a -> b
 f $ a = f a
+{-# INLINABLE ($) #-}
 
-{-# INLINABLE flip #-}
 -- | Plutus Tx version of 'Prelude.flip'.
 flip                    :: (a -> b -> c) -> b -> a -> c
 flip f x y              =  f y x
+{-# INLINABLE flip #-}
 
-{-# INLINABLE until #-}
 -- | Plutus Tx version of 'Prelude.until'.
 until                   :: (a -> Bool) -> (a -> a) -> a -> a
 until p f = go
   where
     go x | p x          = x
          | otherwise    = go (f x)
+{-# INLINABLE until #-}
 
 infixr 9 .
-{-# INLINABLE (.) #-}
 -- | Plutus Tx version of 'Prelude.(.)'.
 (.)    :: (b -> c) -> (a -> b) -> a -> c
 (.) f g = \x -> f (g x)
+{-# INLINABLE (.) #-}
 
 
-{-# INLINABLE const #-}
 -- | Plutus Tx version of 'Prelude.const'.
 const :: a -> b -> a
 const x _ =  x
+{-# INLINABLE const #-}
 
-{-# INLINABLE id #-}
 -- | Plutus Tx version of 'Prelude.id'.
 id :: a -> a
 id x = x
+{-# INLINABLE id #-}

--- a/plutus-tx/src/PlutusTx/Bool.hs
+++ b/plutus-tx/src/PlutusTx/Bool.hs
@@ -11,7 +11,6 @@ import Prelude (Bool (..), otherwise)
 -- `(&&)` and `(||)` are handled specially in the plugin to make sure they can short-circuit.
 -- See Note [Lazy boolean operators] in the plugin.
 
-{-# OPAQUE (&&) #-}
 -- | Logical AND. Short-circuits if the first argument evaluates to `False`.
 --
 --   >>> True && False
@@ -20,8 +19,8 @@ import Prelude (Bool (..), otherwise)
 infixr 3 &&
 (&&) :: Bool -> Bool -> Bool
 (&&) l r = if l then r else False
+{-# OPAQUE (&&) #-}
 
-{-# OPAQUE (||) #-}
 -- | Logical OR. Short-circuits if the first argument evaluates to `True`.
 --
 --   >>> True || False
@@ -30,8 +29,8 @@ infixr 3 &&
 infixr 2 ||
 (||) :: Bool -> Bool -> Bool
 (||) l r = if l then True else r
+{-# OPAQUE (||) #-}
 
-{-# INLINABLE not #-}
 -- | Logical negation
 --
 --   >>> not True
@@ -39,3 +38,4 @@ infixr 2 ||
 --
 not :: Bool -> Bool
 not a = if a then False else True
+{-# INLINABLE not #-}

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -148,67 +148,66 @@ import PlutusTx.Integer (Integer)
 
 import GHC.ByteOrder (ByteOrder (BigEndian, LittleEndian))
 
-{-# INLINABLE appendByteString #-}
 -- | Concatenates two 'ByteString's.
 appendByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString
 appendByteString = BI.appendByteString
+{-# INLINABLE appendByteString #-}
 
-{-# INLINABLE consByteString #-}
 -- | Adds a byte to the front of a 'ByteString'.
 consByteString :: Integer -> BuiltinByteString -> BuiltinByteString
 consByteString n bs = BI.consByteString (toOpaque n) bs
+{-# INLINABLE consByteString #-}
 
-{-# INLINABLE sliceByteString #-}
 -- | Returns the substring of a 'ByteString' from index 'start' of length 'n'.
 sliceByteString :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
 sliceByteString start n bs = BI.sliceByteString (toOpaque start) (toOpaque n) bs
+{-# INLINABLE sliceByteString #-}
 
-{-# INLINABLE lengthOfByteString #-}
 -- | Returns the length of a 'ByteString'.
 lengthOfByteString :: BuiltinByteString -> Integer
 lengthOfByteString = BI.lengthOfByteString
+{-# INLINABLE lengthOfByteString #-}
 
-{-# INLINABLE indexByteString #-}
 -- | Returns the byte of a 'ByteString' at index.
 indexByteString :: BuiltinByteString -> Integer -> Integer
 indexByteString b n = BI.indexByteString b (toOpaque n)
+{-# INLINABLE indexByteString #-}
 
-{-# INLINABLE emptyByteString #-}
 -- | An empty 'ByteString'.
 emptyByteString :: BuiltinByteString
 emptyByteString = BI.emptyByteString
+{-# INLINABLE emptyByteString #-}
 
-{-# INLINABLE sha2_256 #-}
 -- | The SHA2-256 hash of a 'ByteString'
 sha2_256 :: BuiltinByteString -> BuiltinByteString
 sha2_256 = BI.sha2_256
+{-# INLINABLE sha2_256 #-}
 
-{-# INLINABLE sha3_256 #-}
 -- | The SHA3-256 hash of a 'ByteString'
 sha3_256 :: BuiltinByteString -> BuiltinByteString
 sha3_256 = BI.sha3_256
+{-# INLINABLE sha3_256 #-}
 
-{-# INLINABLE blake2b_224 #-}
 -- | The BLAKE2B-224 hash of a 'ByteString'
 blake2b_224 :: BuiltinByteString -> BuiltinByteString
 blake2b_224 = BI.blake2b_224
+{-# INLINABLE blake2b_224 #-}
 
-{-# INLINABLE blake2b_256 #-}
 -- | The BLAKE2B-256 hash of a 'ByteString'
 blake2b_256 :: BuiltinByteString -> BuiltinByteString
 blake2b_256 = BI.blake2b_256
+{-# INLINABLE blake2b_256 #-}
 
-{-# INLINABLE keccak_256 #-}
 -- | The KECCAK-256 hash of a 'ByteString'
 keccak_256 :: BuiltinByteString -> BuiltinByteString
 keccak_256 = BI.keccak_256
+{-# INLINABLE keccak_256 #-}
 
-{-# INLINABLE ripemd_160 #-}
 -- | The RIPEMD-160 hash of a 'ByteString'
 ripemd_160 :: BuiltinByteString -> BuiltinByteString
 ripemd_160 = BI.ripemd_160
+{-# INLINABLE ripemd_160 #-}
 
-{-# INLINABLE verifyEd25519Signature #-}
 -- | Ed25519 signature verification. Verify that the signature is a signature of
 -- the message by the public key. This will fail if key or the signature are not
 -- of the expected length.
@@ -219,38 +218,38 @@ verifyEd25519Signature
     -> Bool
 verifyEd25519Signature pubKey message signature =
     fromOpaque (BI.verifyEd25519Signature pubKey message signature)
+{-# INLINABLE verifyEd25519Signature #-}
 
-{-# INLINABLE equalsByteString #-}
 -- | Check if two 'ByteString's are equal.
 equalsByteString :: BuiltinByteString -> BuiltinByteString -> Bool
 equalsByteString x y = fromOpaque (BI.equalsByteString x y)
+{-# INLINABLE equalsByteString #-}
 
-{-# INLINABLE lessThanByteString #-}
 -- | Check if one 'ByteString' is less than another.
 lessThanByteString :: BuiltinByteString -> BuiltinByteString -> Bool
 lessThanByteString x y = fromOpaque (BI.lessThanByteString x y)
+{-# INLINABLE lessThanByteString #-}
 
-{-# INLINABLE lessThanEqualsByteString #-}
 -- | Check if one 'ByteString' is less than or equal to another.
 lessThanEqualsByteString :: BuiltinByteString -> BuiltinByteString -> Bool
 lessThanEqualsByteString x y = fromOpaque (BI.lessThanEqualsByteString x y)
+{-# INLINABLE lessThanEqualsByteString #-}
 
-{-# INLINABLE greaterThanByteString #-}
 -- | Check if one 'ByteString' is greater than another.
 greaterThanByteString :: BuiltinByteString -> BuiltinByteString -> Bool
 greaterThanByteString x y = BI.ifThenElse (BI.lessThanEqualsByteString x y) False True
+{-# INLINABLE greaterThanByteString #-}
 
-{-# INLINABLE greaterThanEqualsByteString #-}
 -- | Check if one 'ByteString' is greater than another.
 greaterThanEqualsByteString :: BuiltinByteString -> BuiltinByteString -> Bool
 greaterThanEqualsByteString x y = BI.ifThenElse (BI.lessThanByteString x y) False True
+{-# INLINABLE greaterThanEqualsByteString #-}
 
-{-# INLINABLE decodeUtf8 #-}
 -- | Converts a ByteString to a String.
 decodeUtf8 :: BuiltinByteString -> BuiltinString
 decodeUtf8 = BI.decodeUtf8
+{-# INLINABLE decodeUtf8 #-}
 
-{-# INLINEABLE verifyEcdsaSecp256k1Signature #-}
 -- | Given an ECDSA SECP256k1 verification key, an ECDSA SECP256k1 signature,
 -- and an ECDSA SECP256k1 message hash (all as 'BuiltinByteString's), verify the
 -- hash with that key and signature.
@@ -292,8 +291,8 @@ verifyEcdsaSecp256k1Signature
   -> Bool
 verifyEcdsaSecp256k1Signature vk msg sig =
   fromOpaque (BI.verifyEcdsaSecp256k1Signature vk msg sig)
+{-# INLINEABLE verifyEcdsaSecp256k1Signature #-}
 
-{-# INLINEABLE verifySchnorrSecp256k1Signature #-}
 -- | Given a Schnorr SECP256k1 verification key, a Schnorr SECP256k1 signature,
 -- and a message (all as 'BuiltinByteString's), verify the message with that key
 -- and signature.
@@ -326,199 +325,199 @@ verifySchnorrSecp256k1Signature
   -> Bool
 verifySchnorrSecp256k1Signature vk msg sig =
   fromOpaque (BI.verifySchnorrSecp256k1Signature vk msg sig)
+{-# INLINEABLE verifySchnorrSecp256k1Signature #-}
 
-{-# INLINABLE addInteger #-}
 -- | Add two 'Integer's.
 addInteger :: Integer -> Integer -> Integer
 addInteger x y = fromOpaque (BI.addInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE addInteger #-}
 
-{-# INLINABLE subtractInteger #-}
 -- | Subtract two 'Integer's.
 subtractInteger :: Integer -> Integer -> Integer
 subtractInteger x y = fromOpaque (BI.subtractInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE subtractInteger #-}
 
-{-# INLINABLE multiplyInteger #-}
 -- | Multiply two 'Integer's.
 multiplyInteger :: Integer -> Integer -> Integer
 multiplyInteger x y = fromOpaque (BI.multiplyInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE multiplyInteger #-}
 
-{-# INLINABLE divideInteger #-}
 -- | Divide two integers.
 divideInteger :: Integer -> Integer -> Integer
 divideInteger x y = fromOpaque (BI.divideInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE divideInteger #-}
 
-{-# INLINABLE modInteger #-}
 -- | Integer modulo operation.
 modInteger :: Integer -> Integer -> Integer
 modInteger x y = fromOpaque (BI.modInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE modInteger #-}
 
-{-# INLINABLE quotientInteger #-}
 -- | Quotient of two integers.
 quotientInteger :: Integer -> Integer -> Integer
 quotientInteger x y = fromOpaque (BI.quotientInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE quotientInteger #-}
 
-{-# INLINABLE remainderInteger #-}
 -- | Take the remainder of dividing two 'Integer's.
 remainderInteger :: Integer -> Integer -> Integer
 remainderInteger x y = fromOpaque (BI.remainderInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE remainderInteger #-}
 
-{-# INLINABLE greaterThanInteger #-}
 -- | Check whether one 'Integer' is greater than another.
 greaterThanInteger :: Integer -> Integer -> Bool
 greaterThanInteger x y = BI.ifThenElse (BI.lessThanEqualsInteger x y) False True
+{-# INLINABLE greaterThanInteger #-}
 
-{-# INLINABLE greaterThanEqualsInteger #-}
 -- | Check whether one 'Integer' is greater than or equal to another.
 greaterThanEqualsInteger :: Integer -> Integer -> Bool
 greaterThanEqualsInteger x y = BI.ifThenElse (BI.lessThanInteger x y) False True
+{-# INLINABLE greaterThanEqualsInteger #-}
 
-{-# INLINABLE lessThanInteger #-}
 -- | Check whether one 'Integer' is less than another.
 lessThanInteger :: Integer -> Integer -> Bool
 lessThanInteger x y = fromOpaque (BI.lessThanInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE lessThanInteger #-}
 
-{-# INLINABLE lessThanEqualsInteger #-}
 -- | Check whether one 'Integer' is less than or equal to another.
 lessThanEqualsInteger :: Integer -> Integer -> Bool
 lessThanEqualsInteger x y = fromOpaque (BI.lessThanEqualsInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE lessThanEqualsInteger #-}
 
-{-# INLINABLE equalsInteger #-}
 -- | Check if two 'Integer's are equal.
 equalsInteger :: Integer -> Integer -> Bool
 equalsInteger x y = fromOpaque (BI.equalsInteger (toOpaque x) (toOpaque y))
+{-# INLINABLE equalsInteger #-}
 
-{-# INLINABLE error #-}
 -- | Aborts evaluation with an error.
 error :: () -> a
 error x = BI.error (toOpaque x)
+{-# INLINABLE error #-}
 
-{-# INLINABLE appendString #-}
 -- | Append two 'String's.
 appendString :: BuiltinString -> BuiltinString -> BuiltinString
 appendString = BI.appendString
+{-# INLINABLE appendString #-}
 
-{-# INLINABLE emptyString #-}
 -- | An empty 'String'.
 emptyString :: BuiltinString
 emptyString = BI.emptyString
+{-# INLINABLE emptyString #-}
 
-{-# INLINABLE equalsString #-}
 -- | Check if two strings are equal
 equalsString :: BuiltinString -> BuiltinString -> Bool
 equalsString x y = fromOpaque (BI.equalsString x y)
+{-# INLINABLE equalsString #-}
 
-{-# INLINABLE trace #-}
 -- | Emit the given string as a trace message before evaluating the argument.
 trace :: BuiltinString -> a -> a
 trace = BI.trace
+{-# INLINABLE trace #-}
 
-{-# INLINABLE encodeUtf8 #-}
 -- | Convert a String into a ByteString.
 encodeUtf8 :: BuiltinString -> BuiltinByteString
 encodeUtf8 = BI.encodeUtf8
+{-# INLINABLE encodeUtf8 #-}
 
-{-# INLINABLE null #-}
 null :: forall a. BI.BuiltinList a -> Bool
 null l = fromOpaque (BI.null l)
+{-# INLINABLE null #-}
 
-{-# INLINABLE caseList #-}
 caseList :: forall a r . (() -> r) -> (a -> BI.BuiltinList a -> r) -> BI.BuiltinList a -> r
 caseList nilCase consCase l = BI.caseList' nilCase (\x xs _ -> consCase x xs) l ()
+{-# INLINABLE caseList #-}
 
-{-# INLINABLE matchList #-}
 matchList :: forall a r . BI.BuiltinList a -> (() -> r) -> (a -> BI.BuiltinList a -> r) -> r
 matchList l nilCase consCase = caseList nilCase consCase l
+{-# INLINABLE matchList #-}
 
-{-# INLINABLE matchList' #-}
 matchList' :: forall a r . BI.BuiltinList a -> r -> (a -> BI.BuiltinList a -> r) -> r
 matchList' l nilCase consCase = BI.caseList' nilCase consCase l
+{-# INLINABLE matchList' #-}
 
-{-# INLINE headMaybe #-}
 headMaybe :: BI.BuiltinList a -> Maybe a
 headMaybe = BI.caseList' Nothing (\h _ -> Just h)
+{-# INLINE headMaybe #-}
 
-{-# INLINE uncons #-}
 -- | Uncons a builtin list, failing if the list is empty, useful in patterns.
 uncons :: BI.BuiltinList a -> Maybe (a, BI.BuiltinList a)
 uncons = BI.caseList' Nothing (\h t -> Just (h, t))
+{-# INLINE uncons #-}
 
-{-# INLINE unsafeUncons #-}
 -- | Uncons a builtin list, failing if the list is empty, useful in patterns.
 unsafeUncons :: BI.BuiltinList a -> (a, BI.BuiltinList a)
 unsafeUncons l = (BI.head l, BI.tail l)
+{-# INLINE unsafeUncons #-}
 
-{-# INLINE pairToPair #-}
 -- | Turn a builtin pair into a normal pair, useful in patterns.
 pairToPair :: BI.BuiltinPair a b -> (a, b)
 pairToPair tup = (BI.fst tup, BI.snd tup)
+{-# INLINE pairToPair #-}
 
-{-# INLINABLE chooseData #-}
 -- | Given five values for the five different constructors of 'BuiltinData', selects
 -- one depending on which corresponds to the actual constructor of the given value.
 chooseData :: forall a . BuiltinData -> a -> a -> a -> a -> a -> a
 chooseData = BI.chooseData
+{-# INLINABLE chooseData #-}
 
-{-# INLINABLE serialiseData #-}
 -- | Convert a String into a ByteString.
 serialiseData :: BuiltinData -> BuiltinByteString
 serialiseData = BI.serialiseData
+{-# INLINABLE serialiseData #-}
 
-{-# INLINABLE mkConstr #-}
 -- | Constructs a 'BuiltinData' value with the @Constr@ constructor.
 mkConstr :: Integer -> [BuiltinData] -> BuiltinData
 mkConstr i args = BI.mkConstr (toOpaque i) (toOpaque args)
+{-# INLINABLE mkConstr #-}
 
-{-# INLINABLE mkMap #-}
 -- | Constructs a 'BuiltinData' value with the @Map@ constructor.
 mkMap :: [(BuiltinData, BuiltinData)] -> BuiltinData
 mkMap es = BI.mkMap (toOpaque es)
+{-# INLINABLE mkMap #-}
 
-{-# INLINABLE mkList #-}
 -- | Constructs a 'BuiltinData' value with the @List@ constructor.
 mkList :: [BuiltinData] -> BuiltinData
 mkList l = BI.mkList (toOpaque l)
+{-# INLINABLE mkList #-}
 
-{-# INLINABLE mkI #-}
 -- | Constructs a 'BuiltinData' value with the @I@ constructor.
 mkI :: Integer -> BuiltinData
 mkI = BI.mkI
+{-# INLINABLE mkI #-}
 
-{-# INLINABLE mkB #-}
 -- | Constructs a 'BuiltinData' value with the @B@ constructor.
 mkB :: BuiltinByteString -> BuiltinData
 mkB = BI.mkB
+{-# INLINABLE mkB #-}
 
-{-# INLINABLE unsafeDataAsConstr #-}
 -- | Deconstructs a 'BuiltinData' as a @Constr@, or fails if it is not one.
 unsafeDataAsConstr :: BuiltinData -> (Integer, [BuiltinData])
 unsafeDataAsConstr d = fromOpaque (BI.unsafeDataAsConstr d)
+{-# INLINABLE unsafeDataAsConstr #-}
 
-{-# INLINABLE unsafeDataAsMap #-}
 -- | Deconstructs a 'BuiltinData' as a @Map@, or fails if it is not one.
 unsafeDataAsMap :: BuiltinData -> [(BuiltinData, BuiltinData)]
 unsafeDataAsMap d = fromOpaque (BI.unsafeDataAsMap d)
+{-# INLINABLE unsafeDataAsMap #-}
 
-{-# INLINABLE unsafeDataAsList #-}
 -- | Deconstructs a 'BuiltinData' as a @List@, or fails if it is not one.
 unsafeDataAsList :: BuiltinData -> [BuiltinData]
 unsafeDataAsList d = fromOpaque (BI.unsafeDataAsList d)
+{-# INLINABLE unsafeDataAsList #-}
 
-{-# INLINABLE unsafeDataAsI #-}
 -- | Deconstructs a 'BuiltinData' as an @I@, or fails if it is not one.
 unsafeDataAsI :: BuiltinData -> Integer
 unsafeDataAsI d = fromOpaque (BI.unsafeDataAsI d)
+{-# INLINABLE unsafeDataAsI #-}
 
-{-# INLINABLE unsafeDataAsB #-}
 -- | Deconstructs a 'BuiltinData' as a @B@, or fails if it is not one.
 unsafeDataAsB :: BuiltinData -> BuiltinByteString
 unsafeDataAsB = BI.unsafeDataAsB
+{-# INLINABLE unsafeDataAsB #-}
 
-{-# INLINABLE equalsData #-}
 -- | Check if two 'BuiltinData's are equal.
 equalsData :: BuiltinData -> BuiltinData -> Bool
 equalsData d1 d2 = fromOpaque (BI.equalsData d1 d2)
+{-# INLINABLE equalsData #-}
 
-{-# INLINABLE caseData #-}
 caseData
     :: (Integer -> [BuiltinData] -> r)
     -> ([(BuiltinData, BuiltinData)] -> r)
@@ -534,8 +533,8 @@ caseData constrCase mapCase listCase iCase bCase =
      (\ds -> listCase (fromOpaque ds))
      iCase
      bCase
+{-# INLINABLE caseData #-}
 
-{-# INLINABLE matchData' #-}
 matchData'
     :: BuiltinData
     -> (Integer -> BI.BuiltinList BuiltinData -> r)
@@ -546,8 +545,8 @@ matchData'
     -> r
 matchData' d constrCase mapCase listCase iCase bCase =
     BI.caseData' constrCase mapCase listCase iCase bCase d
+{-# INLINABLE matchData' #-}
 
-{-# INLINABLE matchData #-}
 -- | Given a 'BuiltinData' value and matching functions for the five constructors,
 -- applies the appropriate matcher to the arguments of the constructor and returns the result.
 matchData
@@ -560,93 +559,94 @@ matchData
     -> r
 matchData d constrCase mapCase listCase iCase bCase =
    caseData constrCase mapCase listCase iCase bCase d
+{-# INLINABLE matchData #-}
 
 -- G1 --
-{-# INLINABLE bls12_381_G1_equals #-}
 bls12_381_G1_equals :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element -> Bool
 bls12_381_G1_equals a b = fromOpaque (BI.bls12_381_G1_equals a b)
+{-# INLINABLE bls12_381_G1_equals #-}
 
-{-# INLINABLE bls12_381_G1_add #-}
 bls12_381_G1_add :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_add = BI.bls12_381_G1_add
+{-# INLINABLE bls12_381_G1_add #-}
 
-{-# INLINABLE bls12_381_G1_scalarMul #-}
 bls12_381_G1_scalarMul :: Integer -> BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_scalarMul = BI.bls12_381_G1_scalarMul
+{-# INLINABLE bls12_381_G1_scalarMul #-}
 
-{-# INLINABLE bls12_381_G1_neg #-}
 bls12_381_G1_neg :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_neg = BI.bls12_381_G1_neg
+{-# INLINABLE bls12_381_G1_neg #-}
 
-{-# INLINABLE bls12_381_G1_compress #-}
 bls12_381_G1_compress :: BuiltinBLS12_381_G1_Element -> BuiltinByteString
 bls12_381_G1_compress = BI.bls12_381_G1_compress
+{-# INLINABLE bls12_381_G1_compress #-}
 
-{-# INLINABLE bls12_381_G1_uncompress #-}
 bls12_381_G1_uncompress :: BuiltinByteString -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_uncompress = BI.bls12_381_G1_uncompress
+{-# INLINABLE bls12_381_G1_uncompress #-}
 
-{-# INLINABLE bls12_381_G1_hashToGroup #-}
 bls12_381_G1_hashToGroup :: BuiltinByteString -> BuiltinByteString -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_hashToGroup = BI.bls12_381_G1_hashToGroup
+{-# INLINABLE bls12_381_G1_hashToGroup #-}
 
-{-# INLINABLE bls12_381_G1_compressed_zero #-}
 bls12_381_G1_compressed_zero :: BuiltinByteString
 bls12_381_G1_compressed_zero = BI.bls12_381_G1_compressed_zero
+{-# INLINABLE bls12_381_G1_compressed_zero #-}
 
-{-# INLINABLE bls12_381_G1_compressed_generator #-}
 bls12_381_G1_compressed_generator :: BuiltinByteString
 bls12_381_G1_compressed_generator = BI.bls12_381_G1_compressed_generator
+{-# INLINABLE bls12_381_G1_compressed_generator #-}
 
 -- G2 --
-{-# INLINABLE bls12_381_G2_equals #-}
 bls12_381_G2_equals :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element -> Bool
 bls12_381_G2_equals a b = fromOpaque (BI.bls12_381_G2_equals a b)
+{-# INLINABLE bls12_381_G2_equals #-}
 
-{-# INLINABLE bls12_381_G2_add #-}
 bls12_381_G2_add :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_add = BI.bls12_381_G2_add
+{-# INLINABLE bls12_381_G2_add #-}
 
-{-# INLINABLE bls12_381_G2_scalarMul #-}
 bls12_381_G2_scalarMul :: Integer -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_scalarMul = BI.bls12_381_G2_scalarMul
+{-# INLINABLE bls12_381_G2_scalarMul #-}
 
-{-# INLINABLE bls12_381_G2_neg #-}
 bls12_381_G2_neg :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_neg = BI.bls12_381_G2_neg
+{-# INLINABLE bls12_381_G2_neg #-}
 
-{-# INLINABLE bls12_381_G2_compress #-}
 bls12_381_G2_compress :: BuiltinBLS12_381_G2_Element -> BuiltinByteString
 bls12_381_G2_compress = BI.bls12_381_G2_compress
+{-# INLINABLE bls12_381_G2_compress #-}
 
-{-# INLINABLE bls12_381_G2_uncompress #-}
 bls12_381_G2_uncompress :: BuiltinByteString -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_uncompress = BI.bls12_381_G2_uncompress
+{-# INLINABLE bls12_381_G2_uncompress #-}
 
-{-# INLINABLE bls12_381_G2_hashToGroup #-}
 bls12_381_G2_hashToGroup :: BuiltinByteString -> BuiltinByteString -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_hashToGroup = BI.bls12_381_G2_hashToGroup
+{-# INLINABLE bls12_381_G2_hashToGroup #-}
 
-{-# INLINABLE bls12_381_G2_compressed_zero #-}
 bls12_381_G2_compressed_zero :: BuiltinByteString
 bls12_381_G2_compressed_zero = BI.bls12_381_G2_compressed_zero
+{-# INLINABLE bls12_381_G2_compressed_zero #-}
 
-{-# INLINABLE bls12_381_G2_compressed_generator #-}
 bls12_381_G2_compressed_generator :: BuiltinByteString
 bls12_381_G2_compressed_generator = BI.bls12_381_G2_compressed_generator
+{-# INLINABLE bls12_381_G2_compressed_generator #-}
 
 -- Pairing --
-{-# INLINABLE bls12_381_millerLoop #-}
 bls12_381_millerLoop :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_MlResult
 bls12_381_millerLoop = BI.bls12_381_millerLoop
+{-# INLINABLE bls12_381_millerLoop #-}
 
-{-# INLINABLE bls12_381_mulMlResult #-}
 bls12_381_mulMlResult ::  BuiltinBLS12_381_MlResult -> BuiltinBLS12_381_MlResult -> BuiltinBLS12_381_MlResult
 bls12_381_mulMlResult = BI.bls12_381_mulMlResult
+{-# INLINABLE bls12_381_mulMlResult #-}
 
-{-# INLINABLE bls12_381_finalVerify #-}
 bls12_381_finalVerify :: BuiltinBLS12_381_MlResult -> BuiltinBLS12_381_MlResult -> Bool
 bls12_381_finalVerify a b = fromOpaque (BI.bls12_381_finalVerify a b)
+{-# INLINABLE bls12_381_finalVerify #-}
 
 -- Bitwise conversions
 
@@ -671,48 +671,48 @@ byteOrderToBool LittleEndian = False
 -- specified width then the conversion will fail.  Conversion will also fail if
 -- the specified width is greater than 8192 or the input integer is too big to
 -- fit into a bytestring of length 8192.
-{-# INLINABLE integerToByteString #-}
 integerToByteString :: ByteOrder -> Integer -> Integer -> BuiltinByteString
 integerToByteString endianness = BI.integerToByteString (toOpaque (byteOrderToBool endianness))
+{-# INLINABLE integerToByteString #-}
 
 -- | Convert a 'BuiltinByteString' to a 'BuiltinInteger', as described in
 -- [CIP-121](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0121).
 -- The first argument indicates the endianness of the conversion and the second
 -- is the bytestring to be converted.  There is no limitation on the size of
 -- the bytestring.  The empty bytestring is converted to the integer 0.
-{-# INLINABLE byteStringToInteger #-}
 byteStringToInteger :: ByteOrder -> BuiltinByteString -> Integer
 byteStringToInteger endianness =
   BI.byteStringToInteger (toOpaque (byteOrderToBool endianness))
+{-# INLINABLE byteStringToInteger #-}
 
 -- Bitwise operations
 
 -- | Shift a 'BuiltinByteString', as per
 -- [CIP-123](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0123).
-{-# INLINEABLE shiftByteString #-}
 shiftByteString :: BuiltinByteString -> Integer -> BuiltinByteString
 shiftByteString = BI.shiftByteString
+{-# INLINEABLE shiftByteString #-}
 
 -- | Rotate a 'BuiltinByteString', as per
 -- [CIP-123](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0123).
-{-# INLINEABLE rotateByteString #-}
 rotateByteString :: BuiltinByteString -> Integer -> BuiltinByteString
 rotateByteString = BI.rotateByteString
+{-# INLINEABLE rotateByteString #-}
 
 -- | Count the set bits in a 'BuiltinByteString', as per
 -- [CIP-123](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0123).
-{-# INLINEABLE countSetBits #-}
 countSetBits :: BuiltinByteString -> Integer
 countSetBits = BI.countSetBits
+{-# INLINEABLE countSetBits #-}
 
 -- | Find the lowest index of a set bit in a 'BuiltinByteString', as per
 -- [CIP-123](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0123).
 --
 -- If given a 'BuiltinByteString' which consists only of zero bytes (including the empty
 -- 'BuiltinByteString', this returns @-1@.
-{-# INLINEABLE findFirstSetBit #-}
 findFirstSetBit :: BuiltinByteString -> Integer
 findFirstSetBit = BI.findFirstSetBit
+{-# INLINEABLE findFirstSetBit #-}
 
 -- Logical operations
 
@@ -728,13 +728,13 @@ findFirstSetBit = BI.findFirstSetBit
 -- semantics](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#padding-versus-truncation-semantics)
 -- * [Bit indexing
 -- scheme](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bit-indexing-scheme)
-{-# INLINEABLE andByteString #-}
 andByteString ::
   Bool ->
   BuiltinByteString ->
   BuiltinByteString ->
   BuiltinByteString
 andByteString b = BI.andByteString (toOpaque b)
+{-# INLINEABLE andByteString #-}
 
 -- | Perform logical OR on two 'BuiltinByteString' arguments, as described
 -- [here](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bitwiselogicalor).
@@ -748,13 +748,13 @@ andByteString b = BI.andByteString (toOpaque b)
 -- semantics](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#padding-versus-truncation-semantics)
 -- * [Bit indexing
 -- scheme](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bit-indexing-scheme)
-{-# INLINEABLE orByteString #-}
 orByteString ::
   Bool ->
   BuiltinByteString ->
   BuiltinByteString ->
   BuiltinByteString
 orByteString b = BI.orByteString (toOpaque b)
+{-# INLINEABLE orByteString #-}
 
 -- | Perform logical XOR on two 'BuiltinByteString' arguments, as described
 -- [here](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bitwiselogicalxor).
@@ -768,13 +768,13 @@ orByteString b = BI.orByteString (toOpaque b)
 -- semantics](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#padding-versus-truncation-semantics)
 -- * [Bit indexing
 -- scheme](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bit-indexing-scheme)
-{-# INLINEABLE xorByteString #-}
 xorByteString ::
   Bool ->
   BuiltinByteString ->
   BuiltinByteString ->
   BuiltinByteString
 xorByteString b = BI.xorByteString (toOpaque b)
+{-# INLINEABLE xorByteString #-}
 
 -- | Perform logical complement on a 'BuiltinByteString', as described
 -- [here](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bitwiselogicalcomplement).
@@ -783,11 +783,11 @@ xorByteString b = BI.xorByteString (toOpaque b)
 --
 -- * [Bit indexing
 -- scheme](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bit-indexing-scheme)
-{-# INLINEABLE complementByteString #-}
 complementByteString ::
   BuiltinByteString ->
   BuiltinByteString
 complementByteString = BI.complementByteString
+{-# INLINEABLE complementByteString #-}
 
 -- | Read a bit at the _bit_ index given by the 'Integer' argument in the
 -- 'BuiltinByteString' argument. The result will be 'True' if the corresponding bit is set, and
@@ -801,12 +801,12 @@ complementByteString = BI.complementByteString
 -- scheme](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bit-indexing-scheme)
 -- * [Operation
 -- description](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#readbit)
-{-# INLINEABLE readBit #-}
 readBit ::
   BuiltinByteString ->
   Integer ->
   Bool
 readBit bs i = fromOpaque (BI.readBit bs i)
+{-# INLINEABLE readBit #-}
 
 -- | Given a 'BuiltinByteString', a list of indexes to change, and a boolean
 -- value 'b' to change those indexes to, set the /bit/ at each of the specified
@@ -836,13 +836,13 @@ readBit bs i = fromOpaque (BI.readBit bs i)
 -- scheme](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#bit-indexing-scheme)
 -- * [Operation
 -- description](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#writebits)
-{-# INLINEABLE writeBits #-}
 writeBits ::
   BuiltinByteString ->
   [Integer] ->
   Bool ->
   BuiltinByteString
 writeBits bs ixes bit = BI.writeBits bs (toOpaque ixes) (toOpaque bit)
+{-# INLINEABLE writeBits #-}
 
 -- | Given a length (first argument) and a byte (second argument), produce a 'BuiltinByteString' of
 -- that length, with that byte in every position. Will error if given a negative length, or a second
@@ -852,12 +852,12 @@ writeBits bs ixes bit = BI.writeBits bs (toOpaque ixes) (toOpaque bit)
 --
 -- * [Operation
 -- description](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#replicateByteString)
-{-# INLINEABLE replicateByte #-}
 replicateByte ::
   Integer ->
   Integer ->
   BuiltinByteString
 replicateByte = BI.replicateByte
+{-# INLINEABLE replicateByte #-}
 
 
 -- | FIXME
@@ -866,10 +866,10 @@ replicateByte = BI.replicateByte
 --
 -- * [Operation
 -- description](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0109)
-{-# INLINEABLE expModInteger #-}
 expModInteger ::
   Integer ->
   Integer ->
   Integer ->
   Integer
 expModInteger = BI.expModInteger
+{-# INLINEABLE expModInteger #-}

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -90,9 +90,9 @@ otherwise GHC gets very keen to optimize through the newtype and e.g. our users
 see 'Addr#' popping up everywhere.
 -}
 
-{-# OPAQUE error #-}
 error :: BuiltinUnit -> a
 error = Haskell.error "PlutusTx.Builtins.Internal.error"
+{-# OPAQUE error #-}
 
 {-
 BOOL
@@ -101,17 +101,17 @@ BOOL
 -- See Note [Opaque builtin types]
 data BuiltinBool = BuiltinBool ~Bool deriving stock Data
 
-{-# OPAQUE true #-}
 true :: BuiltinBool
 true = BuiltinBool True
+{-# OPAQUE true #-}
 
-{-# OPAQUE false #-}
 false :: BuiltinBool
 false = BuiltinBool False
+{-# OPAQUE false #-}
 
-{-# OPAQUE ifThenElse #-}
 ifThenElse :: BuiltinBool -> a -> a -> a
 ifThenElse (BuiltinBool b) x y = if b then x else y
+{-# OPAQUE ifThenElse #-}
 
 {-
 UNIT
@@ -120,13 +120,13 @@ UNIT
 -- See Note [Opaque builtin types]
 data BuiltinUnit = BuiltinUnit ~() deriving stock Data
 
-{-# OPAQUE unitval #-}
 unitval :: BuiltinUnit
 unitval = BuiltinUnit ()
+{-# OPAQUE unitval #-}
 
-{-# OPAQUE chooseUnit #-}
 chooseUnit :: BuiltinUnit -> a -> a
 chooseUnit (BuiltinUnit ()) a = a
+{-# OPAQUE chooseUnit #-}
 
 {-
 INTEGER
@@ -137,45 +137,45 @@ INTEGER
 -- opaque, but that's going to really mess with our users' code...
 type BuiltinInteger = Integer
 
-{-# OPAQUE addInteger #-}
 addInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 addInteger = coerce ((+) @Integer)
+{-# OPAQUE addInteger #-}
 
-{-# OPAQUE subtractInteger #-}
 subtractInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 subtractInteger = coerce ((-) @Integer)
+{-# OPAQUE subtractInteger #-}
 
-{-# OPAQUE multiplyInteger #-}
 multiplyInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 multiplyInteger = coerce ((*) @Integer)
+{-# OPAQUE multiplyInteger #-}
 
-{-# OPAQUE divideInteger #-}
 divideInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 divideInteger = coerce (div @Integer)
+{-# OPAQUE divideInteger #-}
 
-{-# OPAQUE modInteger #-}
 modInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 modInteger = coerce (mod @Integer)
+{-# OPAQUE modInteger #-}
 
-{-# OPAQUE quotientInteger #-}
 quotientInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 quotientInteger = coerce (quot @Integer)
+{-# OPAQUE quotientInteger #-}
 
-{-# OPAQUE remainderInteger #-}
 remainderInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 remainderInteger = coerce (rem @Integer)
+{-# OPAQUE remainderInteger #-}
 
-{-# OPAQUE lessThanInteger #-}
 lessThanInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
 lessThanInteger x y = BuiltinBool $ coerce ((<) @Integer) x  y
+{-# OPAQUE lessThanInteger #-}
 
-{-# OPAQUE lessThanEqualsInteger #-}
 lessThanEqualsInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
 lessThanEqualsInteger x y = BuiltinBool $ coerce ((<=) @Integer) x y
+{-# OPAQUE lessThanEqualsInteger #-}
 
-{-# OPAQUE equalsInteger #-}
 equalsInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
 equalsInteger x y = BuiltinBool $ coerce ((==) @Integer) x y
+{-# OPAQUE equalsInteger #-}
 
 {-
 BYTESTRING
@@ -211,55 +211,54 @@ instance BA.ByteArray BuiltinByteString where
 instance Pretty BuiltinByteString where
     pretty = viaShow
 
-{-# OPAQUE appendByteString #-}
 appendByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString
 appendByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinByteString $ BS.append b1 b2
+{-# OPAQUE appendByteString #-}
 
-{-# OPAQUE consByteString #-}
 consByteString :: BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegral n) b
+{-# OPAQUE consByteString #-}
 
-{-# OPAQUE sliceByteString #-}
 sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 sliceByteString start n (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral n) (BS.drop (fromIntegral start) b)
+{-# OPAQUE sliceByteString #-}
 
-{-# OPAQUE lengthOfByteString #-}
 lengthOfByteString :: BuiltinByteString -> BuiltinInteger
 lengthOfByteString (BuiltinByteString b) = toInteger $ BS.length b
+{-# OPAQUE lengthOfByteString #-}
 
-{-# OPAQUE indexByteString #-}
 indexByteString :: BuiltinByteString -> BuiltinInteger -> BuiltinInteger
 indexByteString (BuiltinByteString b) i = toInteger $ BS.index b (fromInteger i)
+{-# OPAQUE indexByteString #-}
 
-{-# OPAQUE emptyByteString #-}
 emptyByteString :: BuiltinByteString
 emptyByteString = BuiltinByteString BS.empty
+{-# OPAQUE emptyByteString #-}
 
-{-# OPAQUE sha2_256 #-}
 sha2_256 :: BuiltinByteString -> BuiltinByteString
 sha2_256 (BuiltinByteString b) = BuiltinByteString $ Hash.sha2_256 b
+{-# OPAQUE sha2_256 #-}
 
-{-# OPAQUE sha3_256 #-}
 sha3_256 :: BuiltinByteString -> BuiltinByteString
 sha3_256 (BuiltinByteString b) = BuiltinByteString $ Hash.sha3_256 b
+{-# OPAQUE sha3_256 #-}
 
-{-# OPAQUE blake2b_224 #-}
 blake2b_224 :: BuiltinByteString -> BuiltinByteString
 blake2b_224 (BuiltinByteString b) = BuiltinByteString $ Hash.blake2b_224 b
+{-# OPAQUE blake2b_224 #-}
 
-{-# OPAQUE blake2b_256 #-}
 blake2b_256 :: BuiltinByteString -> BuiltinByteString
 blake2b_256 (BuiltinByteString b) = BuiltinByteString $ Hash.blake2b_256 b
+{-# OPAQUE blake2b_256 #-}
 
-{-# OPAQUE keccak_256 #-}
 keccak_256 :: BuiltinByteString -> BuiltinByteString
 keccak_256 (BuiltinByteString b) = BuiltinByteString $ Hash.keccak_256 b
+{-# OPAQUE keccak_256 #-}
 
-{-# OPAQUE ripemd_160 #-}
 ripemd_160 :: BuiltinByteString -> BuiltinByteString
 ripemd_160 (BuiltinByteString b) = BuiltinByteString $ Hash.ripemd_160 b
+{-# OPAQUE ripemd_160 #-}
 
-{-# OPAQUE verifyEd25519Signature #-}
 verifyEd25519Signature :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString -> BuiltinBool
 verifyEd25519Signature (BuiltinByteString vk) (BuiltinByteString msg) (BuiltinByteString sig) =
   case PlutusCore.Crypto.Ed25519.verifyEd25519Signature_V1 vk msg sig of
@@ -267,8 +266,8 @@ verifyEd25519Signature (BuiltinByteString vk) (BuiltinByteString msg) (BuiltinBy
     BuiltinSuccessWithLogs logs b -> traceAll logs $ BuiltinBool b
     BuiltinFailure logs err       -> traceAll (logs <> pure (display err)) $
         Haskell.error "Ed25519 signature verification errored."
+{-# OPAQUE verifyEd25519Signature #-}
 
-{-# OPAQUE verifyEcdsaSecp256k1Signature #-}
 verifyEcdsaSecp256k1Signature ::
   BuiltinByteString ->
   BuiltinByteString ->
@@ -280,8 +279,8 @@ verifyEcdsaSecp256k1Signature (BuiltinByteString vk) (BuiltinByteString msg) (Bu
     BuiltinSuccessWithLogs logs b -> traceAll logs $ BuiltinBool b
     BuiltinFailure logs err       -> traceAll (logs <> pure (display err)) $
         Haskell.error "ECDSA SECP256k1 signature verification errored."
+{-# OPAQUE verifyEcdsaSecp256k1Signature #-}
 
-{-# OPAQUE verifySchnorrSecp256k1Signature #-}
 verifySchnorrSecp256k1Signature ::
   BuiltinByteString ->
   BuiltinByteString ->
@@ -293,26 +292,27 @@ verifySchnorrSecp256k1Signature (BuiltinByteString vk) (BuiltinByteString msg) (
     BuiltinSuccessWithLogs logs b -> traceAll logs $ BuiltinBool b
     BuiltinFailure logs err       -> traceAll (logs <> pure (display err)) $
         Haskell.error "Schnorr SECP256k1 signature verification errored."
+{-# OPAQUE verifySchnorrSecp256k1Signature #-}
 
 traceAll :: forall (a :: Type) (f :: Type -> Type) .
   (Foldable f) => f Text -> a -> a
 traceAll logs x = Foldable.foldl' (\acc t -> trace (BuiltinString t) acc) x logs
 
-{-# OPAQUE equalsByteString #-}
 equalsByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
 equalsByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 == b2
+{-# OPAQUE equalsByteString #-}
 
-{-# OPAQUE lessThanByteString #-}
 lessThanByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
 lessThanByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 < b2
+{-# OPAQUE lessThanByteString #-}
 
-{-# OPAQUE lessThanEqualsByteString #-}
 lessThanEqualsByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
 lessThanEqualsByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 <= b2
+{-# OPAQUE lessThanEqualsByteString #-}
 
-{-# OPAQUE decodeUtf8 #-}
 decodeUtf8 :: BuiltinByteString -> BuiltinString
 decodeUtf8 (BuiltinByteString b) = BuiltinString $ Text.decodeUtf8 b
+{-# OPAQUE decodeUtf8 #-}
 
 {-
 STRING
@@ -328,25 +328,25 @@ instance Haskell.Eq BuiltinString where
 instance Haskell.Ord BuiltinString where
     compare (BuiltinString t) (BuiltinString t') = compare t t'
 
-{-# OPAQUE appendString #-}
 appendString :: BuiltinString -> BuiltinString -> BuiltinString
 appendString (BuiltinString s1) (BuiltinString s2) = BuiltinString (s1 <> s2)
+{-# OPAQUE appendString #-}
 
-{-# OPAQUE emptyString #-}
 emptyString :: BuiltinString
 emptyString = BuiltinString Text.empty
+{-# OPAQUE emptyString #-}
 
-{-# OPAQUE equalsString #-}
 equalsString :: BuiltinString -> BuiltinString -> BuiltinBool
 equalsString (BuiltinString s1) (BuiltinString s2) = BuiltinBool $ s1 == s2
+{-# OPAQUE equalsString #-}
 
-{-# OPAQUE trace #-}
 trace :: BuiltinString -> a -> a
 trace _ x = x
+{-# OPAQUE trace #-}
 
-{-# OPAQUE encodeUtf8 #-}
 encodeUtf8 :: BuiltinString -> BuiltinByteString
 encodeUtf8 (BuiltinString s) = BuiltinByteString $ Text.encodeUtf8 s
+{-# OPAQUE encodeUtf8 #-}
 
 {-
 PAIR
@@ -362,17 +362,17 @@ instance (Haskell.Eq a, Haskell.Eq b) => Haskell.Eq (BuiltinPair a b) where
 instance (Haskell.Ord a, Haskell.Ord b) => Haskell.Ord (BuiltinPair a b) where
     compare (BuiltinPair p) (BuiltinPair p') = compare p p'
 
-{-# OPAQUE fst #-}
 fst :: BuiltinPair a b -> a
 fst (BuiltinPair (a, _)) = a
+{-# OPAQUE fst #-}
 
-{-# OPAQUE snd #-}
 snd :: BuiltinPair a b -> b
 snd (BuiltinPair (_, b)) = b
+{-# OPAQUE snd #-}
 
-{-# OPAQUE mkPairData #-}
 mkPairData :: BuiltinData -> BuiltinData -> BuiltinPair BuiltinData BuiltinData
 mkPairData d1 d2 = BuiltinPair (d1, d2)
+{-# OPAQUE mkPairData #-}
 
 {-
 LIST
@@ -388,42 +388,42 @@ instance Haskell.Eq a => Haskell.Eq (BuiltinList a) where
 instance Haskell.Ord a => Haskell.Ord (BuiltinList a) where
     compare (BuiltinList l) (BuiltinList l') = compare l l'
 
-{-# OPAQUE null #-}
 null :: BuiltinList a -> BuiltinBool
 null (BuiltinList (_:_)) = BuiltinBool False
 null (BuiltinList [])    = BuiltinBool True
+{-# OPAQUE null #-}
 
-{-# OPAQUE head #-}
 head :: BuiltinList a -> a
 head (BuiltinList (x:_)) = x
 head (BuiltinList [])    = Haskell.error "empty list"
+{-# OPAQUE head #-}
 
-{-# OPAQUE tail #-}
 tail :: BuiltinList a -> BuiltinList a
 tail (BuiltinList (_:xs)) = BuiltinList xs
 tail (BuiltinList [])     = Haskell.error "empty list"
+{-# OPAQUE tail #-}
 
-{-# OPAQUE chooseList #-}
 chooseList :: BuiltinList a -> b -> b -> b
 chooseList (BuiltinList [])    b1 _ = b1
 chooseList (BuiltinList (_:_)) _ b2 = b2
+{-# OPAQUE chooseList #-}
 
-{-# OPAQUE caseList' #-}
 caseList' :: forall a r . r -> (a -> BuiltinList a -> r) -> BuiltinList a -> r
 caseList' nilCase _        (BuiltinList [])       = nilCase
 caseList' _       consCase (BuiltinList (x : xs)) = consCase x (BuiltinList xs)
+{-# OPAQUE caseList' #-}
 
-{-# OPAQUE mkNilData #-}
 mkNilData :: BuiltinUnit -> BuiltinList BuiltinData
 mkNilData _ = BuiltinList []
+{-# OPAQUE mkNilData #-}
 
-{-# OPAQUE mkNilPairData #-}
 mkNilPairData :: BuiltinUnit -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
 mkNilPairData _ = BuiltinList []
+{-# OPAQUE mkNilPairData #-}
 
-{-# OPAQUE mkCons #-}
 mkCons :: a -> BuiltinList a -> BuiltinList a
 mkCons a (BuiltinList as) = BuiltinList (a:as)
+{-# OPAQUE mkCons #-}
 
 {-
 DATA
@@ -456,18 +456,17 @@ instance Pretty BuiltinData where
     pretty (BuiltinData d) = pretty d
 
 -- NOT a builtin, only safe off-chain, hence the OPAQUE
-{-# OPAQUE builtinDataToData #-}
 -- | Convert a 'BuiltinData' into a 'PLC.Data'. Only works off-chain.
 builtinDataToData :: BuiltinData -> PLC.Data
 builtinDataToData (BuiltinData d) = d
+{-# OPAQUE builtinDataToData #-}
 
 -- NOT a builtin, only safe off-chain, hence the OPAQUE
-{-# OPAQUE dataToBuiltinData #-}
 -- | Convert a 'PLC.Data' into a 'BuiltinData'. Only works off-chain.
 dataToBuiltinData :: PLC.Data -> BuiltinData
 dataToBuiltinData = BuiltinData
+{-# OPAQUE dataToBuiltinData #-}
 
-{-# OPAQUE chooseData #-}
 chooseData :: forall a . BuiltinData -> a -> a -> a -> a -> a -> a
 chooseData (BuiltinData d) constrCase mapCase listCase iCase bCase = case d of
     PLC.Constr{} -> constrCase
@@ -475,8 +474,8 @@ chooseData (BuiltinData d) constrCase mapCase listCase iCase bCase = case d of
     PLC.List{}   -> listCase
     PLC.I{}      -> iCase
     PLC.B{}      -> bCase
+{-# OPAQUE chooseData #-}
 
-{-# OPAQUE caseData' #-}
 caseData'
     :: (Integer -> BuiltinList BuiltinData -> r)
     -> (BuiltinList (BuiltinPair BuiltinData BuiltinData) -> r)
@@ -493,63 +492,64 @@ caseData' constrCase mapCase listCase iCase bCase (BuiltinData d) = case d of
     PLC.B b         -> bCase (BuiltinByteString b)
   where
     p2p (d1, d2) = BuiltinPair (dataToBuiltinData d1, dataToBuiltinData d2)
+{-# OPAQUE caseData' #-}
 
-{-# OPAQUE mkConstr #-}
 mkConstr :: BuiltinInteger -> BuiltinList BuiltinData -> BuiltinData
 mkConstr i (BuiltinList args) = BuiltinData (PLC.Constr i (fmap builtinDataToData args))
+{-# OPAQUE mkConstr #-}
 
-{-# OPAQUE mkMap #-}
 mkMap :: BuiltinList (BuiltinPair BuiltinData BuiltinData) -> BuiltinData
 mkMap (BuiltinList es) = BuiltinData (PLC.Map (fmap p2p es))
   where
       p2p (BuiltinPair (d, d')) = (builtinDataToData d, builtinDataToData d')
+{-# OPAQUE mkMap #-}
 
-{-# OPAQUE mkList #-}
 mkList :: BuiltinList BuiltinData -> BuiltinData
 mkList (BuiltinList l) = BuiltinData (PLC.List (fmap builtinDataToData l))
+{-# OPAQUE mkList #-}
 
-{-# OPAQUE mkI #-}
 mkI :: BuiltinInteger -> BuiltinData
 mkI i = BuiltinData (PLC.I i)
+{-# OPAQUE mkI #-}
 
-{-# OPAQUE mkB #-}
 mkB :: BuiltinByteString -> BuiltinData
 mkB (BuiltinByteString b) = BuiltinData (PLC.B b)
+{-# OPAQUE mkB #-}
 
-{-# OPAQUE unsafeDataAsConstr #-}
 unsafeDataAsConstr :: BuiltinData -> BuiltinPair BuiltinInteger (BuiltinList BuiltinData)
 unsafeDataAsConstr (BuiltinData (PLC.Constr i args)) = BuiltinPair (i, BuiltinList $ fmap dataToBuiltinData args)
 unsafeDataAsConstr _                                 = Haskell.error "not a Constr"
+{-# OPAQUE unsafeDataAsConstr #-}
 
-{-# OPAQUE unsafeDataAsMap #-}
 unsafeDataAsMap :: BuiltinData -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
 unsafeDataAsMap (BuiltinData (PLC.Map m)) = BuiltinList (fmap p2p m)
   where
       p2p (d, d') = BuiltinPair (dataToBuiltinData d, dataToBuiltinData d')
 unsafeDataAsMap _                         = Haskell.error "not a Map"
+{-# OPAQUE unsafeDataAsMap #-}
 
-{-# OPAQUE unsafeDataAsList #-}
 unsafeDataAsList :: BuiltinData -> BuiltinList BuiltinData
 unsafeDataAsList (BuiltinData (PLC.List l)) = BuiltinList (fmap dataToBuiltinData l)
 unsafeDataAsList _                          = Haskell.error "not a List"
+{-# OPAQUE unsafeDataAsList #-}
 
-{-# OPAQUE unsafeDataAsI #-}
 unsafeDataAsI :: BuiltinData -> BuiltinInteger
 unsafeDataAsI (BuiltinData (PLC.I i)) = i
 unsafeDataAsI _                       = Haskell.error "not an I"
+{-# OPAQUE unsafeDataAsI #-}
 
-{-# OPAQUE unsafeDataAsB #-}
 unsafeDataAsB :: BuiltinData -> BuiltinByteString
 unsafeDataAsB (BuiltinData (PLC.B b)) = BuiltinByteString b
 unsafeDataAsB _                       = Haskell.error "not a B"
+{-# OPAQUE unsafeDataAsB #-}
 
-{-# OPAQUE equalsData #-}
 equalsData :: BuiltinData -> BuiltinData -> BuiltinBool
 equalsData (BuiltinData b1) (BuiltinData b2) = BuiltinBool $ b1 Haskell.== b2
+{-# OPAQUE equalsData #-}
 
-{-# OPAQUE serialiseData #-}
 serialiseData :: BuiltinData -> BuiltinByteString
 serialiseData (BuiltinData b) = BuiltinByteString $ BSL.toStrict $ serialise b
+{-# OPAQUE serialiseData #-}
 
 
 {-
@@ -584,47 +584,47 @@ instance NFData BuiltinBLS12_381_G1_Element where
 instance Pretty BuiltinBLS12_381_G1_Element where
     pretty (BuiltinBLS12_381_G1_Element a) = pretty a
 
-{-# OPAQUE bls12_381_G1_equals #-}
 bls12_381_G1_equals :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element -> BuiltinBool
 bls12_381_G1_equals a b = BuiltinBool $ coerce ((==) @BuiltinBLS12_381_G1_Element) a b
+{-# OPAQUE bls12_381_G1_equals #-}
 
-{-# OPAQUE bls12_381_G1_add #-}
 bls12_381_G1_add :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_add (BuiltinBLS12_381_G1_Element a) (BuiltinBLS12_381_G1_Element b) = BuiltinBLS12_381_G1_Element (BLS12_381.G1.add a b)
+{-# OPAQUE bls12_381_G1_add #-}
 
-{-# OPAQUE bls12_381_G1_neg #-}
 bls12_381_G1_neg :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_neg (BuiltinBLS12_381_G1_Element a) = BuiltinBLS12_381_G1_Element (BLS12_381.G1.neg a)
+{-# OPAQUE bls12_381_G1_neg #-}
 
-{-# OPAQUE bls12_381_G1_scalarMul #-}
 bls12_381_G1_scalarMul :: BuiltinInteger -> BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_scalarMul n (BuiltinBLS12_381_G1_Element a) = BuiltinBLS12_381_G1_Element (BLS12_381.G1.scalarMul n a)
+{-# OPAQUE bls12_381_G1_scalarMul #-}
 
-{-# OPAQUE bls12_381_G1_compress #-}
 bls12_381_G1_compress :: BuiltinBLS12_381_G1_Element -> BuiltinByteString
 bls12_381_G1_compress (BuiltinBLS12_381_G1_Element a) = BuiltinByteString (BLS12_381.G1.compress a)
+{-# OPAQUE bls12_381_G1_compress #-}
 
-{-# OPAQUE bls12_381_G1_uncompress #-}
 bls12_381_G1_uncompress :: BuiltinByteString -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_uncompress (BuiltinByteString b) =
     case BLS12_381.G1.uncompress b of
       Left err -> Haskell.error $ "BSL12_381 G1 uncompression error: " ++ show err
       Right a  -> BuiltinBLS12_381_G1_Element a
+{-# OPAQUE bls12_381_G1_uncompress #-}
 
-{-# OPAQUE bls12_381_G1_hashToGroup #-}
 bls12_381_G1_hashToGroup ::  BuiltinByteString -> BuiltinByteString -> BuiltinBLS12_381_G1_Element
 bls12_381_G1_hashToGroup (BuiltinByteString msg) (BuiltinByteString dst) =
     case BLS12_381.G1.hashToGroup msg dst of
       Left err -> Haskell.error $ show err
       Right p  -> BuiltinBLS12_381_G1_Element p
+{-# OPAQUE bls12_381_G1_hashToGroup #-}
 
-{-# OPAQUE bls12_381_G1_compressed_zero #-}
 bls12_381_G1_compressed_zero :: BuiltinByteString
 bls12_381_G1_compressed_zero = BuiltinByteString BLS12_381.G1.compressed_zero
+{-# OPAQUE bls12_381_G1_compressed_zero #-}
 
-{-# OPAQUE bls12_381_G1_compressed_generator #-}
 bls12_381_G1_compressed_generator :: BuiltinByteString
 bls12_381_G1_compressed_generator = BuiltinByteString BLS12_381.G1.compressed_generator
+{-# OPAQUE bls12_381_G1_compressed_generator #-}
 
 ---------------- G2 ----------------
 
@@ -639,47 +639,47 @@ instance NFData BuiltinBLS12_381_G2_Element where
 instance Pretty BuiltinBLS12_381_G2_Element where
     pretty (BuiltinBLS12_381_G2_Element a) = pretty a
 
-{-# OPAQUE bls12_381_G2_equals #-}
 bls12_381_G2_equals :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBool
 bls12_381_G2_equals a b = BuiltinBool $ coerce ((==) @BuiltinBLS12_381_G2_Element) a b
+{-# OPAQUE bls12_381_G2_equals #-}
 
-{-# OPAQUE bls12_381_G2_add #-}
 bls12_381_G2_add :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_add (BuiltinBLS12_381_G2_Element a) (BuiltinBLS12_381_G2_Element b) = BuiltinBLS12_381_G2_Element (BLS12_381.G2.add a b)
+{-# OPAQUE bls12_381_G2_add #-}
 
-{-# OPAQUE bls12_381_G2_neg #-}
 bls12_381_G2_neg :: BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_neg (BuiltinBLS12_381_G2_Element a) = BuiltinBLS12_381_G2_Element (BLS12_381.G2.neg a)
+{-# OPAQUE bls12_381_G2_neg #-}
 
-{-# OPAQUE bls12_381_G2_scalarMul #-}
 bls12_381_G2_scalarMul :: BuiltinInteger -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_scalarMul n (BuiltinBLS12_381_G2_Element a) = BuiltinBLS12_381_G2_Element (BLS12_381.G2.scalarMul n a)
+{-# OPAQUE bls12_381_G2_scalarMul #-}
 
-{-# OPAQUE bls12_381_G2_compress #-}
 bls12_381_G2_compress :: BuiltinBLS12_381_G2_Element -> BuiltinByteString
 bls12_381_G2_compress (BuiltinBLS12_381_G2_Element a) = BuiltinByteString (BLS12_381.G2.compress a)
+{-# OPAQUE bls12_381_G2_compress #-}
 
-{-# OPAQUE bls12_381_G2_uncompress #-}
 bls12_381_G2_uncompress :: BuiltinByteString -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_uncompress (BuiltinByteString b) =
     case BLS12_381.G2.uncompress b of
       Left err -> Haskell.error $ "BSL12_381 G2 uncompression error: " ++ show err
       Right a  -> BuiltinBLS12_381_G2_Element a
+{-# OPAQUE bls12_381_G2_uncompress #-}
 
-{-# OPAQUE bls12_381_G2_hashToGroup #-}
 bls12_381_G2_hashToGroup ::  BuiltinByteString -> BuiltinByteString -> BuiltinBLS12_381_G2_Element
 bls12_381_G2_hashToGroup (BuiltinByteString msg) (BuiltinByteString dst) =
     case BLS12_381.G2.hashToGroup msg dst of
       Left err -> Haskell.error $ show err
       Right p  -> BuiltinBLS12_381_G2_Element p
+{-# OPAQUE bls12_381_G2_hashToGroup #-}
 
-{-# OPAQUE bls12_381_G2_compressed_zero #-}
 bls12_381_G2_compressed_zero :: BuiltinByteString
 bls12_381_G2_compressed_zero = BuiltinByteString BLS12_381.G2.compressed_zero
+{-# OPAQUE bls12_381_G2_compressed_zero #-}
 
-{-# OPAQUE bls12_381_G2_compressed_generator #-}
 bls12_381_G2_compressed_generator :: BuiltinByteString
 bls12_381_G2_compressed_generator = BuiltinByteString BLS12_381.G2.compressed_generator
+{-# OPAQUE bls12_381_G2_compressed_generator #-}
 
 
 ---------------- Pairing ----------------
@@ -695,26 +695,25 @@ instance NFData BuiltinBLS12_381_MlResult where
 instance Pretty BuiltinBLS12_381_MlResult where
     pretty (BuiltinBLS12_381_MlResult a) = pretty a
 
-{-# OPAQUE bls12_381_millerLoop #-}
 bls12_381_millerLoop :: BuiltinBLS12_381_G1_Element -> BuiltinBLS12_381_G2_Element -> BuiltinBLS12_381_MlResult
 bls12_381_millerLoop (BuiltinBLS12_381_G1_Element a) (BuiltinBLS12_381_G2_Element b) =
     BuiltinBLS12_381_MlResult $ BLS12_381.Pairing.millerLoop a b
+{-# OPAQUE bls12_381_millerLoop #-}
 
-{-# OPAQUE bls12_381_mulMlResult #-}
 bls12_381_mulMlResult :: BuiltinBLS12_381_MlResult -> BuiltinBLS12_381_MlResult -> BuiltinBLS12_381_MlResult
 bls12_381_mulMlResult (BuiltinBLS12_381_MlResult a) (BuiltinBLS12_381_MlResult b)
     = BuiltinBLS12_381_MlResult $ BLS12_381.Pairing.mulMlResult a b
+{-# OPAQUE bls12_381_mulMlResult #-}
 
-{-# OPAQUE bls12_381_finalVerify #-}
 bls12_381_finalVerify ::  BuiltinBLS12_381_MlResult ->  BuiltinBLS12_381_MlResult -> BuiltinBool
 bls12_381_finalVerify (BuiltinBLS12_381_MlResult a) (BuiltinBLS12_381_MlResult b)
     = BuiltinBool $ BLS12_381.Pairing.finalVerify a b
+{-# OPAQUE bls12_381_finalVerify #-}
 
 {-
 CONVERSION
 -}
 
-{-# OPAQUE integerToByteString #-}
 integerToByteString
     :: BuiltinBool
     -> BuiltinInteger
@@ -726,53 +725,53 @@ integerToByteString (BuiltinBool endiannessArg) paddingArg input =
     BuiltinSuccessWithLogs logs bs -> traceAll logs $ BuiltinByteString bs
     BuiltinFailure logs err        -> traceAll (logs <> pure (display err)) $
         Haskell.error "Integer to ByteString conversion errored."
+{-# OPAQUE integerToByteString #-}
 
-{-# OPAQUE byteStringToInteger #-}
 byteStringToInteger
     :: BuiltinBool
     -> BuiltinByteString
     -> BuiltinInteger
 byteStringToInteger (BuiltinBool statedEndianness) (BuiltinByteString input) =
   Bitwise.byteStringToInteger statedEndianness input
+{-# OPAQUE byteStringToInteger #-}
 
 {-
 BITWISE
 -}
 
-{-# OPAQUE shiftByteString #-}
 shiftByteString ::
   BuiltinByteString ->
   BuiltinInteger ->
   BuiltinByteString
 shiftByteString (BuiltinByteString bs) =
   BuiltinByteString . Bitwise.shiftByteString bs
+{-# OPAQUE shiftByteString #-}
 
-{-# OPAQUE rotateByteString #-}
 rotateByteString ::
   BuiltinByteString ->
   BuiltinInteger ->
   BuiltinByteString
 rotateByteString (BuiltinByteString bs) =
   BuiltinByteString . Bitwise.rotateByteString bs
+{-# OPAQUE rotateByteString #-}
 
-{-# OPAQUE countSetBits #-}
 countSetBits ::
   BuiltinByteString ->
   BuiltinInteger
 countSetBits (BuiltinByteString bs) = fromIntegral . Bitwise.countSetBits $ bs
+{-# OPAQUE countSetBits #-}
 
-{-# OPAQUE findFirstSetBit #-}
 findFirstSetBit ::
   BuiltinByteString ->
   BuiltinInteger
 findFirstSetBit (BuiltinByteString bs) =
   fromIntegral . Bitwise.findFirstSetBit $ bs
+{-# OPAQUE findFirstSetBit #-}
 
 {-
 LOGICAL
 -}
 
-{-# OPAQUE andByteString #-}
 andByteString ::
   BuiltinBool ->
   BuiltinByteString ->
@@ -780,8 +779,8 @@ andByteString ::
   BuiltinByteString
 andByteString (BuiltinBool isPaddingSemantics) (BuiltinByteString data1) (BuiltinByteString data2) =
   BuiltinByteString . Bitwise.andByteString isPaddingSemantics data1 $ data2
+{-# OPAQUE andByteString #-}
 
-{-# OPAQUE orByteString #-}
 orByteString ::
   BuiltinBool ->
   BuiltinByteString ->
@@ -789,8 +788,8 @@ orByteString ::
   BuiltinByteString
 orByteString (BuiltinBool isPaddingSemantics) (BuiltinByteString data1) (BuiltinByteString data2) =
   BuiltinByteString . Bitwise.orByteString isPaddingSemantics data1 $ data2
+{-# OPAQUE orByteString #-}
 
-{-# OPAQUE xorByteString #-}
 xorByteString ::
   BuiltinBool ->
   BuiltinByteString ->
@@ -798,15 +797,15 @@ xorByteString ::
   BuiltinByteString
 xorByteString (BuiltinBool isPaddingSemantics) (BuiltinByteString data1) (BuiltinByteString data2) =
   BuiltinByteString . Bitwise.xorByteString isPaddingSemantics data1 $ data2
+{-# OPAQUE xorByteString #-}
 
-{-# OPAQUE complementByteString #-}
 complementByteString ::
   BuiltinByteString ->
   BuiltinByteString
 complementByteString (BuiltinByteString bs) =
   BuiltinByteString . Bitwise.complementByteString $ bs
+{-# OPAQUE complementByteString #-}
 
-{-# OPAQUE readBit #-}
 readBit ::
   BuiltinByteString ->
   BuiltinInteger ->
@@ -817,8 +816,8 @@ readBit (BuiltinByteString bs) i =
       Haskell.error "readBit errored."
     BuiltinSuccess b -> BuiltinBool b
     BuiltinSuccessWithLogs logs b -> traceAll logs $ BuiltinBool b
+{-# OPAQUE readBit #-}
 
-{-# OPAQUE writeBits #-}
 writeBits ::
   BuiltinByteString ->
   BuiltinList BuiltinInteger ->
@@ -830,8 +829,8 @@ writeBits (BuiltinByteString bs) (BuiltinList ixes) (BuiltinBool bit) =
       Haskell.error "writeBits errored."
     BuiltinSuccess bs' -> BuiltinByteString bs'
     BuiltinSuccessWithLogs logs bs' -> traceAll logs $ BuiltinByteString bs'
+{-# OPAQUE writeBits #-}
 
-{-# OPAQUE replicateByte #-}
 replicateByte ::
   BuiltinInteger ->
   BuiltinInteger ->
@@ -842,8 +841,8 @@ replicateByte n w8 =
       Haskell.error "byteStringReplicate errored."
     BuiltinSuccess bs -> BuiltinByteString bs
     BuiltinSuccessWithLogs logs bs -> traceAll logs $ BuiltinByteString bs
+{-# OPAQUE replicateByte #-}
 
-{-# OPAQUE expModInteger #-}
 expModInteger ::
   BuiltinInteger ->
   BuiltinInteger ->
@@ -857,3 +856,4 @@ expModInteger b e m =
       Haskell.error "expModInteger errored."
     BuiltinSuccess bs -> toInteger bs
     BuiltinSuccessWithLogs logs bs -> traceAll logs $ toInteger bs
+{-# OPAQUE expModInteger #-}

--- a/plutus-tx/src/PlutusTx/Data/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/Data/AssocMap.hs
@@ -266,8 +266,6 @@ any p (Map m) = go m
         )
 {-# INLINEABLE any #-}
 
-{-# INLINEABLE union #-}
-
 -- | Combine two 'Map's into one. It saves both values if the key is present in both maps.
 union ::
   forall k a b.
@@ -326,6 +324,7 @@ union (Map ls) (Map rs) = Map res
                 v = BI.snd hd
              in insert' k v (safeAppend tl xs2)
         )
+{-# INLINEABLE union #-}
 
 -- | Combine two 'Map's with the given combination function.
 unionWith ::
@@ -354,7 +353,6 @@ unionWith f (Map ls) (Map rs) =
                       Nothing -> v'
                  in BI.mkCons (BI.mkPairData k' v'') (go tl)
             )
-{-# INLINEABLE unionWith #-}
 
     rs' :: BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData)
     rs' = go rs
@@ -377,6 +375,7 @@ unionWith f (Map ls) (Map rs) =
           P.caseList'
             acc
             (\hd -> go (BI.mkCons hd acc))
+{-# INLINEABLE unionWith #-}
 
 -- | Convert the `Map` to a list of key-value pairs. This operation is O(n).
 -- See 'toBuiltinList' for a more efficient alternative.

--- a/plutus-tx/src/PlutusTx/Data/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/Data/AssocMap.hs
@@ -84,13 +84,13 @@ instance
   ) => Pretty (Map k a) where
   pretty = pretty . toList
 
-{-# INLINEABLE lookup #-}
 -- | Look up the value corresponding to the key.
 -- If the `Map` is not well-defined, the result is the value associated with
 -- the left-most occurrence of the key in the list.
 -- This operation is O(n).
 lookup :: forall k a. (P.ToData k, P.UnsafeFromData a) => k -> Map k a -> Maybe a
 lookup (P.toBuiltinData -> k) (Map m) = P.unsafeFromBuiltinData <$> lookup' k m
+{-# INLINEABLE lookup #-}
 
 lookup'
   :: BuiltinData
@@ -108,10 +108,10 @@ lookup' k m = go m
                   else go
         )
 
-{-# INLINEABLE member #-}
 -- | Check if the key is in the `Map`.
 member :: forall k a. (P.ToData k) => k -> Map k a -> Bool
 member (P.toBuiltinData -> k) (Map m) = member' k m
+{-# INLINEABLE member #-}
 
 member' :: BuiltinData -> BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData) -> Bool
 member' k = go
@@ -127,11 +127,11 @@ member' k = go
                   else go
         )
 
-{-# INLINEABLE insert #-}
 -- | Insert a key-value pair into the `Map`. If the key is already present,
 -- the value is updated.
 insert :: forall k a. (P.ToData k, P.ToData a) => k -> a -> Map k a -> Map k a
 insert (P.toBuiltinData -> k) (P.toBuiltinData -> a) (Map m) = Map $ insert' k a m
+{-# INLINEABLE insert #-}
 
 insert'
   :: BuiltinData
@@ -154,12 +154,12 @@ insert' k a = go
                   else BI.mkCons hd (go tl)
         )
 
-{-# INLINEABLE delete #-}
 -- | Delete a key value pair from the `Map`.
 -- If the `Map` is not well-defined, it deletes the pair associated with the
 -- left-most occurrence of the key in the list.
 delete :: forall k a. (P.ToData k) => k -> Map k a -> Map k a
 delete (P.toBuiltinData -> k) (Map m) = Map $ delete' k m
+{-# INLINEABLE delete #-}
 
 delete' ::
   BuiltinData ->
@@ -180,23 +180,22 @@ delete' k = go
                   else BI.mkCons hd (go tl)
         )
 
-{-# INLINEABLE singleton #-}
 -- | Create an `Map` with a single key-value pair.
 singleton :: forall k a. (P.ToData k, P.ToData a) => k -> a -> Map k a
 singleton (P.toBuiltinData -> k) (P.toBuiltinData -> a) =
   Map $ BI.mkCons (BI.mkPairData k a) nil
+{-# INLINEABLE singleton #-}
 
-{-# INLINEABLE empty #-}
 -- | An empty `Map`.
 empty :: forall k a. Map k a
 empty = Map nil
+{-# INLINEABLE empty #-}
 
-{-# INLINEABLE null #-}
 -- | Check if the `Map` is empty.
 null :: forall k a. Map k a -> Bool
 null (Map m) = P.null m
+{-# INLINEABLE null #-}
 
-{-# INLINEABLE safeFromList #-}
 -- | Create an `Map` from a list of key-value pairs.
 -- In case of duplicates, this function will keep only one entry (the one that precedes).
 -- In other words, this function de-duplicates the input list.
@@ -212,8 +211,8 @@ safeFromList =
       if P.toBuiltinData k == k'
         then (P.toBuiltinData k, P.toBuiltinData v) : go k v rest
         else (k', v') : go k v rest
+{-# INLINEABLE safeFromList #-}
 
-{-# INLINEABLE unsafeFromList #-}
 -- | Unsafely create an 'Map' from a list of pairs.
 -- This should _only_ be applied to lists which have been checked to not
 -- contain duplicate keys, otherwise the resulting 'Map' will contain
@@ -223,8 +222,8 @@ unsafeFromList =
   Map
     . toOpaque
     . PlutusTx.Prelude.map (\(k, a) -> (P.toBuiltinData k, P.toBuiltinData a))
+{-# INLINEABLE unsafeFromList #-}
 
-{-# INLINEABLE noDuplicateKeys #-}
 -- | Check if the `Map` is well-defined. Warning: this operation is O(n^2).
 noDuplicateKeys :: forall k a. Map k a -> Bool
 noDuplicateKeys (Map m) = go m
@@ -237,8 +236,8 @@ noDuplicateKeys (Map m) = go m
             let k = BI.fst hd
              in if member' k tl then False else go tl
         )
+{-# INLINEABLE noDuplicateKeys #-}
 
-{-# INLINEABLE all #-}
 --- | Check if all values in the `Map` satisfy the predicate.
 all :: forall k a. (P.UnsafeFromData a) => (a -> Bool) -> Map k a -> Bool
 all p (Map m) = go m
@@ -251,8 +250,8 @@ all p (Map m) = go m
             let a = P.unsafeFromBuiltinData (BI.snd hd)
              in if p a then go else \_ -> False
         )
+{-# INLINEABLE all #-}
 
-{-# INLINEABLE any #-}
 -- | Check if any value in the `Map` satisfies the predicate.
 any :: forall k a. (P.UnsafeFromData a) => (a -> Bool) -> Map k a -> Bool
 any p (Map m) = go m
@@ -265,6 +264,7 @@ any p (Map m) = go m
             let a = P.unsafeFromBuiltinData (BI.snd hd)
              in if p a then \_ -> True else go
         )
+{-# INLINEABLE any #-}
 
 {-# INLINEABLE union #-}
 
@@ -327,7 +327,6 @@ union (Map ls) (Map rs) = Map res
              in insert' k v (safeAppend tl xs2)
         )
 
-{-# INLINEABLE unionWith #-}
 -- | Combine two 'Map's with the given combination function.
 unionWith ::
   forall k a.
@@ -355,6 +354,7 @@ unionWith f (Map ls) (Map rs) =
                       Nothing -> v'
                  in BI.mkCons (BI.mkPairData k' v'') (go tl)
             )
+{-# INLINEABLE unionWith #-}
 
     rs' :: BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData)
     rs' = go rs
@@ -378,7 +378,6 @@ unionWith f (Map ls) (Map rs) =
             acc
             (\hd -> go (BI.mkCons hd acc))
 
-{-# INLINEABLE toList #-}
 -- | Convert the `Map` to a list of key-value pairs. This operation is O(n).
 -- See 'toBuiltinList' for a more efficient alternative.
 toList :: (P.UnsafeFromData k, P.UnsafeFromData a) => Map k a -> [(k, a)]
@@ -391,13 +390,13 @@ toList d = go (toBuiltinList d)
             (P.unsafeFromBuiltinData (BI.fst hd), P.unsafeFromBuiltinData (BI.snd hd))
               : go tl
         )
+{-# INLINEABLE toList #-}
 
-{-# INLINEABLE toBuiltinList #-}
 -- | Convert the `Map` to a `P.BuiltinList` of key-value pairs. This operation is O(1).
 toBuiltinList :: Map k a -> BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData)
 toBuiltinList (Map d) = d
+{-# INLINEABLE toBuiltinList #-}
 
-{-# INLINEABLE unsafeFromBuiltinList #-}
 -- | Unsafely create an 'Map' from a `P.BuiltinList` of key-value pairs.
 -- This function is unsafe because it assumes that the elements of the list can be safely
 -- decoded from their 'BuiltinData' representation.
@@ -406,11 +405,12 @@ unsafeFromBuiltinList ::
   BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData) ->
   Map k a
 unsafeFromBuiltinList = Map
+{-# INLINEABLE unsafeFromBuiltinList #-}
 
-{-# INLINEABLE nil #-}
 -- | An empty `P.BuiltinList` of key-value pairs.
 nil :: BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData)
 nil = P.mkNil
+{-# INLINEABLE nil #-}
 
 keys'
   :: BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData)
@@ -425,11 +425,10 @@ keys' = go
              in BI.mkCons k (go tl)
         )
 
-{-# INLINEABLE keys #-}
 keys :: forall k a. Map k a -> BI.BuiltinList BuiltinData
 keys (Map m) = keys' m
+{-# INLINEABLE keys #-}
 
-{-# INLINEABLE mapThese #-}
 mapThese
   :: forall v k a b
   . ( P.ToData a, P.ToData b, P.UnsafeFromData v)
@@ -461,8 +460,8 @@ mapThese f (Map m) = (Map ls, Map rs)
         )
     f' :: BuiltinData -> These a b
     f' = f . P.unsafeFromBuiltinData
+{-# INLINEABLE mapThese #-}
 
-{-# INLINEABLE map #-}
 map :: forall k a b. (P.UnsafeFromData a, P.ToData b) => (a -> b) -> Map k a -> Map k b
 map f (Map m) = Map $ go m
   where
@@ -477,8 +476,8 @@ map f (Map m) = Map $ go m
                 (BI.mkPairData k (P.toBuiltinData (f (P.unsafeFromBuiltinData v))))
                 (go tl)
         )
+{-# INLINEABLE map #-}
 
-{-# INLINEABLE foldr #-}
 foldr :: forall a b k. (P.UnsafeFromData a) => (a -> b -> b) -> b -> Map k a -> b
 foldr f z (Map m) = go m
   where
@@ -489,5 +488,6 @@ foldr f z (Map m) = go m
             let v = BI.snd hd
              in f (P.unsafeFromBuiltinData v) (go tl)
         )
+{-# INLINEABLE foldr #-}
 
 makeLift ''Map

--- a/plutus-tx/src/PlutusTx/Data/List.hs
+++ b/plutus-tx/src/PlutusTx/Data/List.hs
@@ -60,9 +60,9 @@ instance (UnsafeFromData a, Pretty a) => Pretty (List a) where
     {-# INLINEABLE pretty #-}
     pretty = pretty . toSOP
 
-{-# INLINEABLE cons #-}
 cons :: (ToData a) => a -> List a -> List a
 cons h (List t) = List (BI.mkCons (toBuiltinData h) t)
+{-# INLINEABLE cons #-}
 
 {-# INLINEABLE append #-}
 
@@ -86,17 +86,16 @@ instance Haskell.Semigroup  (List a) where
 instance Haskell.Monoid (List a) where
     mempty = List B.mkNil
 
-{-# INLINEABLE toSOP #-}
 toSOP :: (UnsafeFromData a) => List a -> [a]
 toSOP (List l) = go l
   where
     go = B.caseList' [] (\h t -> unsafeFromBuiltinData h : go t)
+{-# INLINEABLE toSOP #-}
 
-{-# INLINEABLE fromSOP #-}
 fromSOP :: (ToData a) => [a] -> List a
 fromSOP = List . BI.unsafeDataAsList . B.mkList . fmap toBuiltinData
+{-# INLINEABLE fromSOP #-}
 
-{-# INLINEABLE find #-}
 find :: (UnsafeFromData a) => (a -> Bool) -> List a -> Maybe a
 find pred' (List l) = go l
   where
@@ -110,8 +109,8 @@ find pred' (List l) = go l
                         then Just h'
                         else go t
             )
+{-# INLINEABLE find #-}
 
-{-# INLINEABLE findIndices #-}
 findIndices :: (UnsafeFromData a) => (a -> Bool) -> List a -> List Integer
 findIndices pred' (List l) = go 0 l
   where
@@ -126,8 +125,8 @@ findIndices pred' (List l) = go 0 l
                         then i `cons` indices
                         else indices
             )
+{-# INLINEABLE findIndices #-}
 
-{-# INLINEABLE filter #-}
 filter :: (UnsafeFromData a, ToData a) => (a -> Bool) -> List a -> List a
 filter pred (List l) = go l
   where
@@ -138,8 +137,8 @@ filter pred (List l) = go l
                 let h' = unsafeFromBuiltinData h
                 in if pred h' then h' `cons` go t else go t
             )
+{-# INLINEABLE filter #-}
 
-{-# INLINEABLE mapMaybe #-}
 mapMaybe :: (UnsafeFromData a, ToData b) => (a -> Maybe b) -> List a -> List b
 mapMaybe f (List l) = go l
   where
@@ -152,8 +151,8 @@ mapMaybe f (List l) = go l
                     Just b  -> b `cons` go t
                     Nothing -> go t
             )
+{-# INLINEABLE mapMaybe #-}
 
-{-# INLINEABLE any #-}
 any :: (UnsafeFromData a) => (a -> Bool) -> List a -> Bool
 any pred (List l) = go l
   where
@@ -164,8 +163,8 @@ any pred (List l) = go l
                 let h' = unsafeFromBuiltinData h
                 in pred h' || go t
             )
+{-# INLINEABLE any #-}
 
-{-# INLINEABLE foldMap #-}
 foldMap :: (UnsafeFromData a, Monoid m) => (a -> m) -> List a -> m
 foldMap f (List l) = go l
   where
@@ -184,8 +183,8 @@ map f (List l) = List (go l)
         B.caseList'
             B.mkNil
             (\h t -> BI.mkCons (toBuiltinData $ f $ unsafeFromBuiltinData h) (go t))
+{-# INLINEABLE foldMap #-}
 
-{-# INLINEABLE length #-}
 length :: List a -> Integer
 length (List l) = go l 0
   where
@@ -193,8 +192,8 @@ length (List l) = go l 0
         B.caseList'
             id
             (\_ t -> B.addInteger 1 . go t)
+{-# INLINEABLE length #-}
 
-{-# INLINABLE mconcat #-}
 -- | Plutus Tx version of 'Data.Monoid.mconcat'.
 mconcat :: (Monoid a, UnsafeFromData a) => List a -> a
 mconcat (List l) = go l
@@ -206,5 +205,6 @@ mconcat (List l) = go l
                 let h' = unsafeFromBuiltinData h
                 in h' <> go t
             )
+{-# INLINABLE mconcat #-}
 
 makeLift ''List

--- a/plutus-tx/src/PlutusTx/Either.hs
+++ b/plutus-tx/src/PlutusTx/Either.hs
@@ -11,20 +11,20 @@ import Prelude (Either (..))
 
 {- HLINT ignore -}
 
-{-# INLINABLE isLeft #-}
 -- | Return `True` if the given value is a `Left`-value, `False` otherwise.
 isLeft :: Either a b -> Bool
 isLeft (Left _)  = True
 isLeft (Right _) = False
+{-# INLINABLE isLeft #-}
 
-{-# INLINABLE isRight #-}
 -- | Return `True` if the given value is a `Right`-value, `False` otherwise.
 isRight :: Either a b -> Bool
 isRight (Left _)  = False
 isRight (Right _) = True
+{-# INLINABLE isRight #-}
 
-{-# INLINABLE either #-}
 -- | Plutus Tx version of 'Prelude.either'
 either :: (a -> c) -> (b -> c) -> Either a b -> c
 either f _ (Left x)  = f x
 either _ g (Right y) = g y
+{-# INLINABLE either #-}

--- a/plutus-tx/src/PlutusTx/Eq.hs
+++ b/plutus-tx/src/PlutusTx/Eq.hs
@@ -19,9 +19,9 @@ class Eq a where
     -- (/=) deliberately omitted, to make this a one-method class which has a
     -- simpler representation
 
-{-# INLINABLE (/=) #-}
 (/=) :: Eq a => a -> a -> Bool
 x /= y = not (x == y)
+{-# INLINABLE (/=) #-}
 
 instance Eq Builtins.Integer where
     {-# INLINABLE (==) #-}

--- a/plutus-tx/src/PlutusTx/ErrorCodes.hs
+++ b/plutus-tx/src/PlutusTx/ErrorCodes.hs
@@ -60,106 +60,106 @@ plutusPreludeErrorCodes = Map.fromList
   ]
 
 -- | The error happens in TH generation of indexed data
-{-# INLINABLE reconstructCaseError #-}
 reconstructCaseError :: Builtins.BuiltinString
 reconstructCaseError = "PT1"
+{-# INLINABLE reconstructCaseError #-}
 
 -- | Error case of 'unsafeFromBuiltinData'
-{-# INLINABLE voidIsNotSupportedError #-}
 voidIsNotSupportedError :: Builtins.BuiltinString
 voidIsNotSupportedError = "PT2"
+{-# INLINABLE voidIsNotSupportedError #-}
 
 -- | Ratio number can't have a zero denominator
-{-# INLINABLE ratioHasZeroDenominatorError #-}
 ratioHasZeroDenominatorError :: Builtins.BuiltinString
 ratioHasZeroDenominatorError = "PT3"
+{-# INLINABLE ratioHasZeroDenominatorError #-}
 
 -- | 'check' input is 'False'
-{-# INLINABLE checkHasFailedError #-}
 checkHasFailedError :: Builtins.BuiltinString
 checkHasFailedError = "PT5"
+{-# INLINABLE checkHasFailedError #-}
 
 -- | PlutusTx.List.!!: negative index
-{-# INLINABLE negativeIndexError #-}
 negativeIndexError :: Builtins.BuiltinString
 negativeIndexError = "PT6"
+{-# INLINABLE negativeIndexError #-}
 
 -- | PlutusTx.List.!!: index too large
-{-# INLINABLE indexTooLargeError #-}
 indexTooLargeError :: Builtins.BuiltinString
 indexTooLargeError = "PT7"
+{-# INLINABLE indexTooLargeError #-}
 
 -- | PlutusTx.List.head: empty list
-{-# INLINABLE headEmptyListError #-}
 headEmptyListError :: Builtins.BuiltinString
 headEmptyListError = "PT8"
+{-# INLINABLE headEmptyListError #-}
 
 -- | PlutusTx.List.tail: empty list
-{-# INLINABLE tailEmptyListError #-}
 tailEmptyListError :: Builtins.BuiltinString
 tailEmptyListError = "PT9"
+{-# INLINABLE tailEmptyListError #-}
 
 -- | PlutusTx.Enum.().succ: bad argument
-{-# INLINABLE succVoidBadArgumentError #-}
 succVoidBadArgumentError :: Builtins.BuiltinString
 succVoidBadArgumentError = "PT10"
+{-# INLINABLE succVoidBadArgumentError #-}
 
 -- | PlutusTx.Enum.().pred: bad argument
-{-# INLINABLE predVoidBadArgumentError #-}
 predVoidBadArgumentError :: Builtins.BuiltinString
 predVoidBadArgumentError = "PT11"
+{-# INLINABLE predVoidBadArgumentError #-}
 
 -- | PlutusTx.Enum.().toEnum: bad argument
-{-# INLINABLE toEnumVoidBadArgumentError #-}
 toEnumVoidBadArgumentError :: Builtins.BuiltinString
 toEnumVoidBadArgumentError = "PT12"
+{-# INLINABLE toEnumVoidBadArgumentError #-}
 
 -- | PlutusTx.Enum.Bool.succ: bad argument
-{-# INLINABLE succBoolBadArgumentError #-}
 succBoolBadArgumentError :: Builtins.BuiltinString
 succBoolBadArgumentError = "PT13"
+{-# INLINABLE succBoolBadArgumentError #-}
 
 -- | PlutusTx.Enum.Bool.pred: bad argument
-{-# INLINABLE predBoolBadArgumentError #-}
 predBoolBadArgumentError :: Builtins.BuiltinString
 predBoolBadArgumentError = "PT14"
+{-# INLINABLE predBoolBadArgumentError #-}
 
 -- | PlutusTx.Enum.Bool.toEnum: bad argument
-{-# INLINABLE toEnumBoolBadArgumentError #-}
 toEnumBoolBadArgumentError :: Builtins.BuiltinString
 toEnumBoolBadArgumentError = "PT15"
+{-# INLINABLE toEnumBoolBadArgumentError #-}
 
 -- | PlutusTx.Enum.Ordering.succ: bad argument
-{-# INLINABLE succOrderingBadArgumentError #-}
 succOrderingBadArgumentError :: Builtins.BuiltinString
 succOrderingBadArgumentError = "PT16"
+{-# INLINABLE succOrderingBadArgumentError #-}
 
 -- | PlutusTx.Enum.Ordering.pred: bad argument
-{-# INLINABLE predOrderingBadArgumentError #-}
 predOrderingBadArgumentError :: Builtins.BuiltinString
 predOrderingBadArgumentError = "PT17"
+{-# INLINABLE predOrderingBadArgumentError #-}
 
 -- | PlutusTx.Enum.Ordering.toEnum: bad argument
-{-# INLINABLE toEnumOrderingBadArgumentError #-}
 toEnumOrderingBadArgumentError :: Builtins.BuiltinString
 toEnumOrderingBadArgumentError = "PT18"
+{-# INLINABLE toEnumOrderingBadArgumentError #-}
 
 -- | PlutusTx.List.last: empty list
-{-# INLINABLE lastEmptyListError #-}
 lastEmptyListError :: Builtins.BuiltinString
 lastEmptyListError = "PT19"
+{-# INLINABLE lastEmptyListError #-}
 
 -- | PlutusTx.Ratio.recip: reciprocal of zero
-{-# INLINABLE reciprocalOfZeroError #-}
 reciprocalOfZeroError :: Builtins.BuiltinString
 reciprocalOfZeroError = "PT20"
+{-# INLINABLE reciprocalOfZeroError #-}
 
 -- | PlutusTx.List.indexBuiltinList: negative index
-{-# INLINABLE builtinListNegativeIndexError #-}
 builtinListNegativeIndexError :: Builtins.BuiltinString
 builtinListNegativeIndexError = "PT21"
+{-# INLINABLE builtinListNegativeIndexError #-}
 
 -- | PlutusTx.List.indexBuiltinList: index too large
-{-# INLINABLE builtinListIndexTooLargeError #-}
 builtinListIndexTooLargeError :: Builtins.BuiltinString
 builtinListIndexTooLargeError = "PT22"
+{-# INLINABLE builtinListIndexTooLargeError #-}

--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -74,38 +74,38 @@ instance Foldable (Const c) where
     foldr _ z _ = z
 
 -- | Plutus Tx version of 'Data.Foldable.fold'.
-{-# INLINABLE fold #-}
 fold :: (Foldable t, Monoid m) => t m -> m
 fold = foldMap id
+{-# INLINABLE fold #-}
 
 -- | Plutus Tx version of 'Data.Foldable.foldMap'.
 foldMap :: (Foldable t, Monoid m) => (a -> m) -> t a -> m
 foldMap f = foldr ((<>) . f) mempty
 
 -- | Plutus Tx version of 'Data.Foldable.foldl'.
-{-# INLINABLE foldl #-}
 foldl :: Foldable t => (b -> a -> b) -> b -> t a -> b
 foldl f z t = foldr (\a g b -> g (f b a)) id t z
+{-# INLINABLE foldl #-}
 
 -- | Plutus Tx version of 'Data.Foldable.toList'.
 toList :: Foldable t => t a -> [a]
-{-# INLINE toList #-}
 toList t = build (\ c n -> foldr c n t)
+{-# INLINE toList #-}
 
 -- | Plutus Tx version of 'Data.Foldable.length'.
-{-# INLINABLE length #-}
 length :: Foldable t => t a -> Integer
 length = foldr (\_ acc -> acc + 1) 0
+{-# INLINABLE length #-}
 
 -- | Plutus Tx version of 'Data.Foldable.sum'.
-{-# INLINEABLE sum #-}
 sum :: (Foldable t, AdditiveMonoid a) => t a -> a
 sum = foldr (+) zero
+{-# INLINEABLE sum #-}
 
 -- | Plutus Tx version of 'Data.Foldable.product'.
-{-# INLINABLE product #-}
 product :: (Foldable t, MultiplicativeMonoid a) => t a -> a
 product = foldr (*) one
+{-# INLINABLE product #-}
 
 -- | Plutus Tx version of 'Data.Foldable.traverse_'.
 traverse_ :: (Foldable t, Applicative f) => (a -> f b) -> t a -> f ()
@@ -115,8 +115,8 @@ traverse_ f = foldr c (pure ())
 
 -- | Plutus Tx version of 'Data.Foldable.for_'.
 for_ :: (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
-{-# INLINE for_ #-}
 for_ = flip traverse_
+{-# INLINE for_ #-}
 
 -- | Plutus Tx version of 'Data.Foldable.sequenceA_'.
 sequenceA_ :: (Foldable t, Applicative f) => t (f a) -> f ()
@@ -126,8 +126,8 @@ sequenceA_ = foldr c (pure ())
 
 -- | Plutus Tx version of 'Data.Foldable.asum'.
 asum :: (Foldable t, Alternative f) => t (f a) -> f a
-{-# INLINE asum #-}
 asum = foldr (<|>) empty
+{-# INLINE asum #-}
 
 -- | Plutus Tx version of 'Data.Foldable.concat'.
 concat :: Foldable t => t [a] -> [a]

--- a/plutus-tx/src/PlutusTx/Functor.hs
+++ b/plutus-tx/src/PlutusTx/Functor.hs
@@ -23,21 +23,21 @@ class Functor f where
 
 infixl 4 <$>
 -- | Plutus Tx version of '(Data.Functor.<$>)'.
-{-# INLINABLE (<$>) #-}
 (<$>) :: Functor f => (a -> b) -> f a -> f b
 (<$>) = fmap
+{-# INLINABLE (<$>) #-}
 
 infixl 1 <&>
 -- | Plutus Tx version of '(Data.Functor.<&>)'.
-{-# INLINABLE (<&>) #-}
 (<&>) :: Functor f => f a -> (a -> b) -> f b
 as <&> f = f <$> as
+{-# INLINABLE (<&>) #-}
 
 infixl 4 <$
-{-# INLINABLE (<$) #-}
 -- | Plutus Tx version of '(Data.Functor.<$)'.
 (<$) :: Functor f => a -> f b -> f a
 (<$) a = fmap (const a)
+{-# INLINABLE (<$) #-}
 
 instance Functor [] where
     {-# INLINABLE fmap #-}

--- a/plutus-tx/src/PlutusTx/List.hs
+++ b/plutus-tx/src/PlutusTx/List.hs
@@ -424,7 +424,6 @@ sortBy cmp l = mergeAll (sequences l)
       | a `cmp` b == GT = descending b [a]  xs
       | otherwise       = ascending  b (a:) xs
     sequences xs = [xs]
-{-# INLINABLE sortBy #-}
 
     descending a as (b:bs)
       | a `cmp` b == GT = descending b (a:as) bs
@@ -447,3 +446,4 @@ sortBy cmp l = mergeAll (sequences l)
       | otherwise       = a:merge as' bs
     merge [] bs         = bs
     merge as []         = as
+{-# INLINABLE sortBy #-}

--- a/plutus-tx/src/PlutusTx/List.hs
+++ b/plutus-tx/src/PlutusTx/List.hs
@@ -57,21 +57,20 @@ import Prelude (Maybe (..), (.))
 
 {- HLINT ignore -}
 
-{-# INLINABLE uncons #-}
 -- | Plutus Tx version of 'Data.List.uncons'.
 uncons :: [a] -> Maybe (a, [a])
 uncons = \case
     []   -> Nothing
     x:xs -> Just (x, xs)
+{-# INLINABLE uncons #-}
 
-{-# INLINABLE null #-}
 -- | Test whether a list is empty.
 null :: [a] -> Bool
 null = \case
     [] -> True
     _  -> False
+{-# INLINABLE null #-}
 
-{-# INLINABLE map #-}
 -- | Plutus Tx version of 'Data.List.map'.
 --
 --   >>> map (\i -> i + 1) [1, 2, 3]
@@ -84,22 +83,22 @@ map f = go
     go = \case
         []   -> []
         x:xs -> f x : go xs
+{-# INLINABLE map #-}
 
-{-# INLINABLE and #-}
 -- | Returns the conjunction of a list of Bools.
 and :: [Bool] -> Bool
 and = \case
     []     -> True
     x : xs -> if x then and xs else False
+{-# INLINABLE and #-}
 
-{-# INLINABLE or #-}
 -- | Returns the disjunction of a list of Bools.
 or :: [Bool] -> Bool
 or = \case
     []     -> False
     x : xs -> if x then True else or xs
+{-# INLINABLE or #-}
 
-{-# INLINABLE any #-}
 -- | Determines whether any element of the structure satisfies the predicate.
 any :: forall a. (a -> Bool) -> [a] -> Bool
 any f = go
@@ -108,9 +107,9 @@ any f = go
     go = \case
         []     -> False
         x : xs -> if f x then True else go xs
+{-# INLINABLE any #-}
 
 -- The pragma improves some of the budget tests.
-{-# INLINABLE all #-}
 -- | Determines whether all elements of the list satisfy the predicate.
 all :: forall a. (a -> Bool) -> [a] -> Bool
 all f = go
@@ -119,18 +118,18 @@ all f = go
     go = \case
         []     -> True
         x : xs -> if f x then go xs else False
+{-# INLINABLE all #-}
 
-{-# INLINABLE elem #-}
 -- | Does the element occur in the list?
 elem :: Eq a => a -> [a] -> Bool
 elem = any . (==)
+{-# INLINABLE elem #-}
 
-{-# INLINABLE notElem #-}
 -- | The negation of `elem`.
 notElem :: Eq a => a -> [a] -> Bool
 notElem a = not . elem a
+{-# INLINABLE notElem #-}
 
-{-# INLINABLE find #-}
 -- | Returns the leftmost element matching the predicate, or `Nothing` if there's no such element.
 find :: forall a. (a -> Bool) -> [a] -> Maybe a
 find f = go
@@ -139,8 +138,8 @@ find f = go
     go = \case
         []     -> Nothing
         x : xs -> if f x then Just x else go xs
+{-# INLINABLE find #-}
 
-{-# INLINABLE foldr #-}
 -- | Plutus Tx version of 'Data.List.foldr'.
 --
 --   >>> foldr (\i s -> s + i) 0 [1, 2, 3, 4]
@@ -153,8 +152,8 @@ foldr f acc = go
     go = \case
         []   -> acc
         x:xs -> f x (go xs)
+{-# INLINABLE foldr #-}
 
-{-# INLINABLE foldl #-}
 -- | Plutus Tx velsion of 'Data.List.foldl'.
 --
 --   >>> foldl (\s i -> s + i) 0 [1, 2, 3, 4]
@@ -167,8 +166,8 @@ foldl f = go
     go acc = \case
         []   -> acc
         x:xs -> go (f acc x) xs
+{-# INLINABLE foldl #-}
 
-{-# INLINABLE (++) #-}
 -- | Plutus Tx version of '(Data.List.++)'.
 --
 --   >>> [0, 1, 2] ++ [1, 2, 3, 4]
@@ -177,21 +176,21 @@ foldl f = go
 infixr 5 ++
 (++) :: [a] -> [a] -> [a]
 (++) l r = foldr (:) r l
+{-# INLINABLE (++) #-}
 
-{-# INLINABLE concat #-}
 -- | Plutus Tx version of 'Data.List.concat'.
 --
 --   >>> concat [[1, 2], [3], [4, 5]]
 --   [1,2,3,4,5]
 concat :: [[a]] -> [a]
 concat = foldr (++) []
+{-# INLINABLE concat #-}
 
-{-# INLINABLE concatMap #-}
 -- | Plutus Tx version of 'Data.List.concatMap'.
 concatMap :: (a -> [b]) -> [a] -> [b]
 concatMap f = foldr (\x ys -> f x ++ ys) []
+{-# INLINABLE concatMap #-}
 
-{-# INLINABLE filter #-}
 -- | Plutus Tx version of 'Data.List.filter'.
 --
 --   >>> filter (> 1) [1, 2, 3, 4]
@@ -199,20 +198,20 @@ concatMap f = foldr (\x ys -> f x ++ ys) []
 --
 filter :: (a -> Bool) -> [a] -> [a]
 filter p = foldr (\e xs -> if p e then e:xs else xs) []
+{-# INLINABLE filter #-}
 
-{-# INLINABLE listToMaybe #-}
 -- | Plutus Tx version of 'Data.List.listToMaybe'.
 listToMaybe :: [a] -> Maybe a
 listToMaybe []    = Nothing
 listToMaybe (x:_) = Just x
+{-# INLINABLE listToMaybe #-}
 
-{-# INLINABLE uniqueElement #-}
 -- | Return the element in the list, if there is precisely one.
 uniqueElement :: [a] -> Maybe a
 uniqueElement [x] = Just x
 uniqueElement _   = Nothing
+{-# INLINABLE uniqueElement #-}
 
-{-# INLINABLE findIndices #-}
 -- | Plutus Tx version of 'Data.List.findIndices'.
 findIndices :: (a -> Bool) -> [a] -> [Integer]
 findIndices p = go 0
@@ -220,8 +219,8 @@ findIndices p = go 0
         go i l = case l of
             []     -> []
             (x:xs) -> let indices = go (Builtins.addInteger i 1) xs in if p x then i:indices else indices
+{-# INLINABLE findIndices #-}
 
-{-# INLINABLE findIndex #-}
 -- | Plutus Tx version of 'Data.List.findIndex'.
 findIndex :: (a -> Bool) -> [a] -> Maybe Integer
 findIndex f = go 0
@@ -229,8 +228,8 @@ findIndex f = go 0
     go i = \case
         []     -> Nothing
         x : xs -> if f x then Just i else go (Builtins.addInteger i 1) xs
+{-# INLINABLE findIndex #-}
 
-{-# INLINABLE (!!) #-}
 -- | Plutus Tx version of '(GHC.List.!!)'.
 --
 --   >>> [10, 11, 12] !! 2
@@ -247,6 +246,7 @@ xs0 !! n0 = go n0 xs0
         if Builtins.equalsInteger n 0
             then x
             else go (Builtins.subtractInteger n 1) xs
+{-# INLINABLE (!!) #-}
 
 -- | Index operator for builtin lists.
 --
@@ -270,7 +270,6 @@ indexBuiltinList xs0 i0
         )
         ()
 
-{-# INLINABLE revAppend #-}
 -- | Cons each element of the first list to the second one in reverse order (i.e. the last element
 -- of the first list is the head of the result).
 --
@@ -283,60 +282,60 @@ revAppend = rev where
     rev :: [a] -> [a] -> [a]
     rev []     a = a
     rev (x:xs) a = rev xs (x:a)
+{-# INLINABLE revAppend #-}
 
-{-# INLINABLE reverse #-}
 -- | Plutus Tx version of 'Data.List.reverse'.
 reverse :: [a] -> [a]
 reverse l = revAppend l []
+{-# INLINABLE reverse #-}
 
-{-# INLINABLE zip #-}
 -- | Plutus Tx version of 'Data.List.zip'.
 zip :: [a] -> [b] -> [(a,b)]
 zip []     _bs    = []
 zip _as    []     = []
 zip (a:as) (b:bs) = (a,b) : zip as bs
+{-# INLINABLE zip #-}
 
-{-# INLINABLE unzip #-}
 -- | Plutus Tx version of 'Data.List.unzip'.
 unzip :: [(a,b)] -> ([a], [b])
 unzip []             = ([], [])
 unzip ((x, y) : xys) = case unzip xys of
     (xs, ys) -> (x : xs, y : ys)
+{-# INLINABLE unzip #-}
 
-{-# INLINABLE head #-}
 -- | Plutus Tx version of 'Data.List.head'.
 head :: [a] -> a
 head []      = traceError headEmptyListError
 head (x : _) = x
+{-# INLINABLE head #-}
 
-{-# INLINABLE last #-}
 -- | Plutus Tx version of 'Data.List.last'.
 last :: [a] -> a
 last []     = traceError lastEmptyListError
 last [x]    = x
 last (_:xs) = last xs
+{-# INLINABLE last #-}
 
-{-# INLINABLE tail #-}
 -- | Plutus Tx version of 'Data.List.tail'.
 tail :: [a] -> [a]
 tail (_:as) =  as
 tail []     =  traceError tailEmptyListError
+{-# INLINABLE tail #-}
 
-{-# INLINABLE take #-}
 -- | Plutus Tx version of 'Data.List.take'.
 take :: Integer -> [a] -> [a]
 take n _      | n <= 0 =  []
 take _ []              =  []
 take n (x:xs)          =  x : take (Builtins.subtractInteger n 1) xs
+{-# INLINABLE take #-}
 
-{-# INLINABLE drop #-}
 -- | Plutus Tx version of 'Data.List.drop'.
 drop :: Integer -> [a] -> [a]
 drop n xs     | n <= 0 = xs
 drop _ []              = []
 drop n (_:xs)          = drop (Builtins.subtractInteger n 1) xs
+{-# INLINABLE drop #-}
 
-{-# INLINABLE splitAt #-}
 -- | Plutus Tx version of 'Data.List.splitAt'.
 splitAt :: Integer -> [a] -> ([a], [a])
 splitAt n xs
@@ -349,13 +348,13 @@ splitAt n xs
       | m == 1 = ([y], ys)
       | otherwise = case go (Builtins.subtractInteger m 1) ys of
           (zs, ws) -> (y:zs, ws)
+{-# INLINABLE splitAt #-}
 
-{-# INLINABLE nub #-}
 -- | Plutus Tx version of 'Data.List.nub'.
 nub :: (Eq a) => [a] -> [a]
 nub = nubBy (==)
+{-# INLINABLE nub #-}
 
-{-# INLINABLE elemBy #-}
 -- | Plutus Tx version of 'Data.List.elemBy'.
 elemBy :: forall a. (a -> a -> Bool) -> a -> [a] -> Bool
 elemBy eq y = go
@@ -363,8 +362,8 @@ elemBy eq y = go
     go :: [a] -> Bool
     go []     = False
     go (x:xs) =  x `eq` y || go xs
+{-# INLINABLE elemBy #-}
 
-{-# INLINABLE nubBy #-}
 -- | Plutus Tx version of 'Data.List.nubBy'.
 nubBy :: (a -> a -> Bool) -> [a] -> [a]
 nubBy eq l = nubBy' l []
@@ -373,8 +372,8 @@ nubBy eq l = nubBy' l []
     nubBy' (y:ys) xs
        | elemBy eq y xs = nubBy' ys xs
        | otherwise      = y : nubBy' ys (y:xs)
+{-# INLINABLE nubBy #-}
 
-{-# INLINABLE zipWith #-}
 -- | Plutus Tx version of 'Data.List.zipWith'.
 zipWith :: forall a b c. (a -> b -> c) -> [a] -> [b] -> [c]
 zipWith f = go
@@ -383,8 +382,8 @@ zipWith f = go
     go [] _          = []
     go _ []          = []
     go (x:xs) (y:ys) = f x y : go xs ys
+{-# INLINABLE zipWith #-}
 
-{-# INLINABLE dropWhile #-}
 -- | Plutus Tx version of 'Data.List.dropWhile'.
 dropWhile :: forall a. (a -> Bool) -> [a] -> [a]
 dropWhile p = go
@@ -394,29 +393,29 @@ dropWhile p = go
     go xs@(x:xs')
         | p x       = go xs'
         | otherwise = xs
+{-# INLINABLE dropWhile #-}
 
-{-# INLINABLE replicate #-}
 -- | Plutus Tx version of 'Data.List.replicate'.
 replicate :: forall a. Integer -> a -> [a]
 replicate n0 x = go n0 where
     go n | n <= 0 = []
     go n          = x : go (Builtins.subtractInteger n 1)
+{-# INLINABLE replicate #-}
 
-{-# INLINABLE partition #-}
 -- | Plutus Tx version of 'Data.List.partition'.
 partition :: (a -> Bool) -> [a] -> ([a],[a])
 partition p xs = foldr (select p) ([],[]) xs
+{-# INLINABLE partition #-}
 
 select :: (a -> Bool) -> a -> ([a], [a]) -> ([a], [a])
 select p x ~(ts,fs) | p x       = (x:ts,fs)
                     | otherwise = (ts, x:fs)
 
-{-# INLINABLE sort #-}
 -- | Plutus Tx version of 'Data.List.sort'.
 sort :: Ord a => [a] -> [a]
 sort = sortBy compare
+{-# INLINABLE sort #-}
 
-{-# INLINABLE sortBy #-}
 -- | Plutus Tx version of 'Data.List.sortBy'.
 sortBy :: (a -> a -> Ordering) -> [a] -> [a]
 sortBy cmp l = mergeAll (sequences l)
@@ -425,6 +424,7 @@ sortBy cmp l = mergeAll (sequences l)
       | a `cmp` b == GT = descending b [a]  xs
       | otherwise       = ascending  b (a:) xs
     sequences xs = [xs]
+{-# INLINABLE sortBy #-}
 
     descending a as (b:bs)
       | a `cmp` b == GT = descending b (a:as) bs

--- a/plutus-tx/src/PlutusTx/Maybe.hs
+++ b/plutus-tx/src/PlutusTx/Maybe.hs
@@ -12,7 +12,6 @@ import Prelude (Maybe (..))
 
 {- HLINT ignore -}
 
-{-# INLINABLE isJust #-}
 -- | Check if a 'Maybe' @a@ is @Just a@
 --
 --   >>> isJust Nothing
@@ -22,8 +21,8 @@ import Prelude (Maybe (..))
 --
 isJust :: Maybe a -> Bool
 isJust m = case m of { Just _ -> True; _ -> False; }
+{-# INLINABLE isJust #-}
 
-{-# INLINABLE isNothing #-}
 -- | Check if a 'Maybe' @a@ is @Nothing@
 --
 --   >>> isNothing Nothing
@@ -33,8 +32,8 @@ isJust m = case m of { Just _ -> True; _ -> False; }
 --
 isNothing :: Maybe a -> Bool
 isNothing m = case m of { Just _ -> False; _ -> True; }
+{-# INLINABLE isNothing #-}
 
-{-# INLINABLE maybe #-}
 -- | Plutus Tx version of 'Prelude.maybe'.
 --
 --   >>> maybe "platypus" (\s -> s) (Just "plutus")
@@ -46,13 +45,13 @@ maybe :: b -> (a -> b) -> Maybe a -> b
 maybe b f m = case m of
     Nothing -> b
     Just a  -> f a
+{-# INLINABLE maybe #-}
 
-{-# INLINABLE fromMaybe #-}
 -- | Plutus Tx version of 'Data.Maybe.fromMaybe'
 fromMaybe :: a -> Maybe a -> a
 fromMaybe a = maybe a id
+{-# INLINABLE fromMaybe #-}
 
-{-# INLINABLE mapMaybe #-}
 -- | Plutus Tx version of 'Data.Maybe.mapMaybe'.
 --
 --   >>> mapMaybe (\i -> if i == 2 then Just '2' else Nothing) [1, 2, 3, 4]
@@ -60,3 +59,4 @@ fromMaybe a = maybe a id
 --
 mapMaybe :: (a -> Maybe b) -> [a] -> [b]
 mapMaybe p = foldr (\e xs -> maybe xs (:xs) (p e)) []
+{-# INLINABLE mapMaybe #-}

--- a/plutus-tx/src/PlutusTx/Monoid.hs
+++ b/plutus-tx/src/PlutusTx/Monoid.hs
@@ -20,15 +20,15 @@ class Semigroup a => Monoid a where
     -- mappend and mconcat deliberately omitted, to make this a one-method class which has a
     -- simpler representation
 
-{-# INLINABLE mappend #-}
 -- | Plutus Tx version of 'Data.Monoid.mappend'.
 mappend :: Monoid a => a -> a -> a
 mappend = (<>)
+{-# INLINABLE mappend #-}
 
-{-# INLINABLE mconcat #-}
 -- | Plutus Tx version of 'Data.Monoid.mconcat'.
 mconcat :: Monoid a => [a] -> a
 mconcat = foldr mappend mempty
+{-# INLINABLE mconcat #-}
 
 instance Monoid Builtins.BuiltinByteString where
     {-# INLINABLE mempty #-}
@@ -69,6 +69,6 @@ instance Monoid (First a) where
 class Monoid a => Group a where
     inv :: a -> a
 
-{-# INLINABLE gsub #-}
 gsub :: Group a => a -> a -> a
 gsub x y = x <> inv y
+{-# INLINABLE gsub #-}

--- a/plutus-tx/src/PlutusTx/Numeric.hs
+++ b/plutus-tx/src/PlutusTx/Numeric.hs
@@ -47,9 +47,9 @@ class AdditiveSemigroup a => AdditiveMonoid a where
 class AdditiveMonoid a => AdditiveGroup a where
     (-) :: a -> a -> a
 
-{-# INLINABLE negate #-}
 negate :: AdditiveGroup a => a -> a
 negate x = zero - x
+{-# INLINABLE negate #-}
 
 -- | A newtype wrapper to derive 'Additive' classes via.
 newtype Additive a = Additive a
@@ -150,16 +150,16 @@ instance MultiplicativeMonoid a => Monoid (Product a) where
     mempty = Product one
 
 -- | Simultaneous div and mod.
-{-# INLINABLE divMod #-}
 divMod :: Integer -> Integer -> (Integer, Integer)
 divMod x y = ( x `divideInteger` y, x `modInteger` y)
+{-# INLINABLE divMod #-}
 
 -- | Simultaneous quot and rem.
-{-# INLINABLE quotRem #-}
 quotRem :: Integer -> Integer -> (Integer, Integer)
 quotRem x y = ( x `quotientInteger` y, x `remainderInteger` y)
+{-# INLINABLE quotRem #-}
 
 -- | Absolute value for any 'AdditiveGroup'.
-{-# INLINABLE abs #-}
 abs :: (Ord n, AdditiveGroup n) => n -> n
 abs x = if x < zero then negate x else x
+{-# INLINABLE abs #-}

--- a/plutus-tx/src/PlutusTx/Plugin/Utils.hs
+++ b/plutus-tx/src/PlutusTx/Plugin/Utils.hs
@@ -24,8 +24,8 @@ a Proxy to avoid this.
 
 -- This needs to be defined here so we can reference it in the TH functions.
 -- If we inline this then we won't be able to find it later!
-{-# OPAQUE plc #-}
 -- | Marks the given expression for compilation to PLC.
 plc :: forall (loc::Symbol) a . Proxy loc -> a -> CompiledCode a
 -- this constructor is only really there to get rid of the unused warning
 plc _ _ = SerializedCode (mustBeReplaced "plc") (mustBeReplaced "pir") (mustBeReplaced "covidx")
+{-# OPAQUE plc #-}

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -186,12 +186,11 @@ import Prelude qualified as Haskell (return, (=<<), (>>), (>>=))
 --     import PlutusTx.Prelude
 -- @
 
-{-# INLINABLE check #-}
 -- | Checks a 'Bool' and aborts if it is false.
 check :: Bool -> BI.BuiltinUnit
 check b = if b then BI.unitval else traceError checkHasFailedError
+{-# INLINABLE check #-}
 
-{-# INLINABLE divide #-}
 -- | Integer division, rounding downwards
 --
 --   >>> divide (-41) 5
@@ -199,8 +198,8 @@ check b = if b then BI.unitval else traceError checkHasFailedError
 --
 divide :: Integer -> Integer -> Integer
 divide = Builtins.divideInteger
+{-# INLINABLE divide #-}
 
-{-# INLINABLE modulo #-}
 -- | Integer remainder, always positive for a positive divisor
 --
 --   >>> modulo (-41) 5
@@ -208,24 +207,24 @@ divide = Builtins.divideInteger
 --
 modulo :: Integer -> Integer -> Integer
 modulo = Builtins.modInteger
+{-# INLINABLE modulo #-}
 
 
-{-# INLINABLE expMod #-}
 -- | FIXME
 expMod :: Integer -> Integer -> Integer -> Integer
 expMod = Builtins.expModInteger
+{-# INLINABLE expMod #-}
 
-{-# INLINABLE quotient #-}
 -- | Integer division, rouding towards zero
 --
 --   >>> quotient (-41) 5
 --   -8
 --
+{-# INLINABLE quotient #-}
 
 quotient :: Integer -> Integer -> Integer
 quotient = Builtins.quotientInteger
 
-{-# INLINABLE remainder #-}
 -- | Integer remainder, same sign as dividend
 --
 --   >>> remainder (-41) 5
@@ -233,24 +232,25 @@ quotient = Builtins.quotientInteger
 --
 remainder :: Integer -> Integer -> Integer
 remainder = Builtins.remainderInteger
+{-# INLINABLE remainder #-}
 
-{-# INLINABLE even #-}
 even :: Integer -> Bool
 even n = if modulo n 2 == 0 then True else False
+{-# INLINABLE even #-}
 
-{-# INLINABLE odd #-}
 odd :: Integer -> Bool
 odd n = if even n then False else True
+{-# INLINABLE odd #-}
 
-{-# INLINABLE takeByteString #-}
 -- | Returns the n length prefix of a 'ByteString'.
 takeByteString :: Integer -> BuiltinByteString -> BuiltinByteString
 takeByteString n bs = Builtins.sliceByteString 0 n bs
+{-# INLINABLE takeByteString #-}
 
-{-# INLINABLE dropByteString #-}
 -- | Returns the suffix of a 'ByteString' after n elements.
 dropByteString :: Integer -> BuiltinByteString -> BuiltinByteString
 dropByteString n bs = Builtins.sliceByteString n (Builtins.lengthOfByteString bs - n) bs
+{-# INLINABLE dropByteString #-}
 
 {- Note [-fno-full-laziness in Plutus Tx]
 GHC's full-laziness optimization moves computations inside a lambda that don't depend on

--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -193,7 +193,6 @@ instance FromJSON Rational where
 --
 -- If given a zero denominator, this function will error. If you don't mind a
 -- size increase, and care about safety, use 'ratio' instead.
-{-# INLINABLE unsafeRatio #-}
 unsafeRatio :: Integer -> Integer -> Rational
 unsafeRatio n d
   | d P.== P.zero = P.traceError P.ratioHasZeroDenominatorError
@@ -202,10 +201,10 @@ unsafeRatio n d
     let gcd' = euclid n d
      in Rational (n `Builtins.quotientInteger` gcd')
                  (d `Builtins.quotientInteger` gcd')
+{-# INLINABLE unsafeRatio #-}
 
 -- | Safely constructs a 'Rational' from a numerator and a denominator. Returns
 -- 'Nothing' if given a zero denominator.
-{-# INLINABLE ratio #-}
 ratio :: Integer -> Integer -> P.Maybe Rational
 ratio n d
   | d P.== P.zero = P.Nothing
@@ -215,6 +214,7 @@ ratio n d
      in P.Just P.$
           Rational (n `Builtins.quotientInteger` gcd')
                    (d `Builtins.quotientInteger` gcd')
+{-# INLINABLE ratio #-}
 
 -- | Converts a 'Rational' to a GHC 'Ratio.Rational', preserving value. Does not
 -- work on-chain.
@@ -228,9 +228,9 @@ toGHC (Rational n d) = n Ratio.% d
 -- It is /not/ true in general that @'numerator' '<$>' 'ratio' x y = x@; this
 -- will only hold if @x@ and @y@ are coprime. This is due to 'Rational'
 -- normalizing the numerator and denominator.
-{-# INLINABLE numerator #-}
 numerator :: Rational -> Integer
 numerator (Rational n _) = n
+{-# INLINABLE numerator #-}
 
 -- | Returns the denominator of its argument. This will always be greater than,
 -- or equal to, 1, although the type does not describe this.
@@ -240,19 +240,19 @@ numerator (Rational n _) = n
 -- It is /not/ true in general that @'denominator' '<$>' 'ratio' x y = y@; this
 -- will only hold if @x@ and @y@ are coprime. This is due to 'Rational'
 -- normalizing the numerator and denominator.
-{-# INLINABLE denominator #-}
 denominator :: Rational -> Integer
 denominator (Rational _ d) = d
+{-# INLINABLE denominator #-}
 
 -- | 0.5
-{-# INLINABLE half #-}
 half :: Rational
 half = Rational 1 2
+{-# INLINABLE half #-}
 
 -- | Converts an 'Integer' into the equivalent 'Rational'.
-{-# INLINABLE fromInteger #-}
 fromInteger :: Integer -> Rational
 fromInteger num = Rational num P.one
+{-# INLINABLE fromInteger #-}
 
 -- | Converts a GHC 'Ratio.Rational', preserving value. Does not work on-chain.
 fromGHC :: Ratio.Rational -> Rational
@@ -264,9 +264,9 @@ fromGHC r = unsafeRatio (Ratio.numerator r) (Ratio.denominator r)
 --
 -- This is specialized for 'Rational'; use this instead of the generic version
 -- of this function, as it is significantly smaller on-chain.
-{-# INLINABLE negate #-}
 negate :: Rational -> Rational
 negate (Rational n d) = Rational (P.negate n) d
+{-# INLINABLE negate #-}
 
 -- | Returns the absolute value of its argument.
 --
@@ -275,11 +275,11 @@ negate (Rational n d) = Rational (P.negate n) d
 -- This is specialized for 'Rational'; use this instead of the generic version
 -- in @PlutusTx.Numeric@, as said generic version produces much larger on-chain
 -- code than the specialized version here.
-{-# INLINABLE abs #-}
 abs :: Rational -> Rational
 abs rat@(Rational n d)
   | n P.< P.zero = Rational (P.negate n) d
   | P.True = rat
+{-# INLINABLE abs #-}
 
 -- | @'properFraction' r@ returns the pair @(n, f)@, such that all of the
 -- following hold:
@@ -287,11 +287,11 @@ abs rat@(Rational n d)
 -- * @'fromInteger' n 'P.+' f = r@;
 -- * @n@ and @f@ both have the same sign as @r@; and
 -- * @'abs' f 'P.<' 'P.one'@.
-{-# INLINABLE properFraction #-}
 properFraction :: Rational -> (Integer, Rational)
 properFraction (Rational n d) =
   (n `Builtins.quotientInteger` d,
    Rational (n `Builtins.remainderInteger` d) d)
+{-# INLINABLE properFraction #-}
 
 -- | Gives the reciprocal of the argument; specifically, for @r 'P./='
 -- 'P.zero'@, @r 'P.*' 'recip' r = 'P.one'@.
@@ -300,23 +300,22 @@ properFraction (Rational n d) =
 --
 -- The reciprocal of zero is mathematically undefined; thus, @'recip' 'P.zero'@
 -- will error. Use with care.
-{-# INLINABLE recip #-}
 recip :: Rational -> Rational
 recip (Rational n d)
   | n P.== P.zero = P.traceError P.reciprocalOfZeroError
   | n P.< P.zero = Rational (P.negate d) (P.negate n)
   | P.True = Rational d n
+{-# INLINABLE recip #-}
 
 -- | Returns the whole-number part of its argument, dropping any leftover
 -- fractional part. More precisely, @'truncate' r = n@ where @(n, _) =
 -- 'properFraction' r@, but is much more efficient.
-{-# INLINABLE truncate #-}
 truncate :: Rational -> Integer
 truncate (Rational n d) = n `Builtins.quotientInteger` d
+{-# INLINABLE truncate #-}
 
 -- | @'round' r@ returns the nearest 'Integer' value to @r@. If @r@ is
 -- equidistant between two values, the even value will be given.
-{-# INLINABLE round #-}
 round :: Rational -> Integer
 round x =
   let (n, r) = properFraction x
@@ -328,26 +327,27 @@ round x =
                                 then n
                                 else m
           | P.True -> m
+{-# INLINABLE round #-}
 
 -- From GHC.Real
 -- | @'gcd' x y@ is the non-negative factor of both @x@ and @y@ of which
 -- every common factor of @x@ and @y@ is also a factor; for example
 -- @'gcd' 4 2 = 2@, @'gcd' (-4) 6 = 2@, @'gcd' 0 4@ = @4@. @'gcd' 0 0@ = @0@.
-{-# INLINABLE gcd #-}
 gcd :: Integer -> Integer -> Integer
 gcd a b = gcd' (P.abs a) (P.abs b) where
     gcd' a' b'
         | b' P.== P.zero = a'
         | P.True         = gcd' b' (a' `Builtins.remainderInteger` b')
+{-# INLINABLE gcd #-}
 
 -- Helpers
 
 -- Euclid's algorithm
-{-# INLINABLE euclid #-}
 euclid :: Integer -> Integer -> Integer
 euclid x y
   | y P.== P.zero = x
   | P.True = euclid y (x `Builtins.modInteger` y)
+{-# INLINABLE euclid #-}
 
 $(makeLift ''Rational)
 

--- a/plutus-tx/src/PlutusTx/Show.hs
+++ b/plutus-tx/src/PlutusTx/Show.hs
@@ -52,7 +52,6 @@ instance Show Builtins.Integer where
                 )
                 . acc
 
-{-# INLINEABLE toDigits #-}
 -- | Convert a non-negative integer to individual digits.
 toDigits :: Builtins.Integer -> [Builtins.Integer]
 toDigits = go []
@@ -62,6 +61,7 @@ toDigits = go []
             if q == 0
                 then r : acc
                 else go (r : acc) q
+{-# INLINEABLE toDigits #-}
 
 instance Show Builtins.BuiltinByteString where
     {-# INLINEABLE showsPrec #-}
@@ -120,7 +120,6 @@ instance Show a => Show [a] where
     {-# INLINEABLE showsPrec #-}
     showsPrec _ = showList (showsPrec 0)
 
-{-# INLINEABLE showList #-}
 showList :: forall a. (a -> ShowS) -> [a] -> ShowS
 showList showElem = \case
     [] -> showString "[]"
@@ -132,6 +131,7 @@ showList showElem = \case
       where
         alg :: a -> ShowS -> ShowS
         alg a acc = showString "," . showElem a . acc
+{-# INLINEABLE showList #-}
 
 deriveShow ''(,)
 deriveShow ''(,,)

--- a/plutus-tx/src/PlutusTx/Show/TH.hs
+++ b/plutus-tx/src/PlutusTx/Show/TH.hs
@@ -45,31 +45,30 @@ class Show a where
 -}
 type ShowS = [BuiltinString] -> [BuiltinString]
 
-{-# INLINEABLE showString #-}
 showString :: BuiltinString -> ShowS
 showString = (:)
+{-# INLINEABLE showString #-}
 
-{-# INLINEABLE showSpace #-}
 showSpace :: ShowS
 showSpace = showString " "
+{-# INLINEABLE showSpace #-}
 
-{-# INLINEABLE showCommaSpace #-}
 showCommaSpace :: ShowS
 showCommaSpace = showString ", "
+{-# INLINEABLE showCommaSpace #-}
 
-{-# INLINEABLE showParen #-}
 showParen :: Bool -> ShowS -> ShowS
 showParen b p = if b then showString "(" . p . showString ")" else p
+{-# INLINEABLE showParen #-}
 
-{-# INLINEABLE appPrec #-}
 appPrec :: Integer
 appPrec = 10
+{-# INLINEABLE appPrec #-}
 
-{-# INLINEABLE appPrec1 #-}
 appPrec1 :: Integer
 appPrec1 = 11
+{-# INLINEABLE appPrec1 #-}
 
-{-# INLINEABLE concatBuiltinStrings #-}
 concatBuiltinStrings :: [BuiltinString] -> BuiltinString
 concatBuiltinStrings = \case
     [] -> ""
@@ -77,6 +76,7 @@ concatBuiltinStrings = \case
     xs ->
         let (ys, zs) = splitAt (length xs `divideInteger` 2) xs
          in concatBuiltinStrings ys `appendString` concatBuiltinStrings zs
+{-# INLINEABLE concatBuiltinStrings #-}
 
 -- | Derive `Show` instance. Adapted from @Text.Show.Deriving.deriveShow@.
 deriveShow :: TH.Name -> TH.Q [TH.Dec]

--- a/plutus-tx/src/PlutusTx/Sqrt.hs
+++ b/plutus-tx/src/PlutusTx/Sqrt.hs
@@ -33,7 +33,6 @@ data Sqrt
   | Approximately Integer
   deriving stock (Haskell.Show, Haskell.Eq)
 
-{-# INLINABLE rsqrt #-}
 -- | Calculates the sqrt of a ratio of integers. As x / 0 is undefined,
 -- calling this function with `d=0` results in an error.
 rsqrt :: Rational -> Sqrt
@@ -57,11 +56,12 @@ rsqrt r
               in
                 if m * m * d <= n then go m u
                                   else go l m
+{-# INLINABLE rsqrt #-}
 
-{-# INLINABLE isqrt #-}
 -- | Calculates the integer-component of the sqrt of 'n'.
 isqrt :: Integer -> Sqrt
 isqrt n = rsqrt (unsafeRatio n 1)
+{-# INLINABLE isqrt #-}
 
 makeLift ''Sqrt
 makeIsDataIndexed ''Sqrt [ ('Imaginary,     0)

--- a/plutus-tx/src/PlutusTx/These.hs
+++ b/plutus-tx/src/PlutusTx/These.hs
@@ -30,9 +30,9 @@ theseWithDefault a' b' f = \case
   That b -> f a' b
   These a b -> f a b
 
-{-# INLINEABLE these #-}
 these :: (a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c
 these f g h = \case
   This a -> f a
   That b -> g b
   These a b -> h a b
+{-# INLINEABLE these #-}

--- a/plutus-tx/src/PlutusTx/Trace.hs
+++ b/plutus-tx/src/PlutusTx/Trace.hs
@@ -10,23 +10,23 @@ module PlutusTx.Trace (
 import PlutusTx.Bool
 import PlutusTx.Builtins as Builtins
 
-{-# INLINABLE traceError #-}
 -- | Log a message and then terminate the evaluation with an error.
 traceError :: Builtins.BuiltinString -> a
 traceError str = error (trace str ())
+{-# INLINABLE traceError #-}
 
-{-# INLINABLE traceIfFalse #-}
 -- | Emit the given 'BuiltinString' only if the argument evaluates to 'False'.
 traceIfFalse :: Builtins.BuiltinString -> Bool -> Bool
 traceIfFalse str a = if a then True else trace str False
+{-# INLINABLE traceIfFalse #-}
 
-{-# INLINABLE traceIfTrue #-}
 -- | Emit the given 'BuiltinString' only if the argument evaluates to 'True'.
 traceIfTrue :: Builtins.BuiltinString -> Bool -> Bool
 traceIfTrue str a = if a then trace str True else False
+{-# INLINABLE traceIfTrue #-}
 
-{-# INLINABLE traceBool #-}
 -- | Emit one of two 'BuiltinString' depending on whether or not the argument
 -- evaluates to 'True' or 'False'.
 traceBool :: BuiltinString -> BuiltinString -> Bool -> Bool
 traceBool trueLabel falseLabel c = if c then trace trueLabel True else trace falseLabel False
+{-# INLINABLE traceBool #-}

--- a/plutus-tx/src/PlutusTx/Traversable.hs
+++ b/plutus-tx/src/PlutusTx/Traversable.hs
@@ -53,32 +53,32 @@ instance Traversable (Const c) where
 
 -- | Plutus Tx version of 'Data.Traversable.sequenceA'.
 sequenceA :: (Traversable t, Applicative f) => t (f a) -> f (t a)
-{-# INLINE sequenceA #-}
 sequenceA = traverse id
+{-# INLINE sequenceA #-}
 
 -- | Plutus Tx version of 'Data.Traversable.sequence'.
 sequence :: (Traversable t, Applicative f) => t (f a) -> f (t a)
-{-# INLINE sequence #-}
 sequence = sequenceA
+{-# INLINE sequence #-}
 
 -- | Plutus Tx version of 'Data.Traversable.mapM'.
 mapM :: (Traversable t, Applicative f) => (a -> f b) -> t a -> f (t b)
-{-# INLINE mapM #-}
 mapM = traverse
+{-# INLINE mapM #-}
 
 -- | Plutus Tx version of 'Data.Traversable.for'.
 for :: (Traversable t, Applicative f) => t a -> (a -> f b) -> f (t b)
-{-# INLINE for #-}
 for = flip traverse
+{-# INLINE for #-}
 
 -- | Plutus Tx version of 'Data.Traversable.fmapDefault'.
 fmapDefault :: forall t a b . Traversable t
             => (a -> b) -> t a -> t b
-{-# INLINE fmapDefault #-}
 fmapDefault = coerce (traverse :: (a -> Identity b) -> t a -> Identity (t b))
+{-# INLINE fmapDefault #-}
 
 -- | Plutus Tx version of 'Data.Traversable.foldMapDefault'.
 foldMapDefault :: forall t m a . (Traversable t, Monoid m)
                => (a -> m) -> t a -> m
-{-# INLINE foldMapDefault #-}
 foldMapDefault = coerce (traverse :: (a -> Const m ()) -> t a -> Const m (t ()))
+{-# INLINE foldMapDefault #-}


### PR DESCRIPTION
With luck, this moves all of the `OPAQUE`, `INLINE`, `INLINABLE`, and `INLINEABLE` pragmas to below the things that they apply to (for the benefit of fourmolu).  I did this using find together with an awk script that says

```
BEGIN {n=1; P="^{-# (OPAQUE|INLINE|INLINABLE|INLINEABLE)" }
$0 ~ P {pragma = $0; while ((n=getline) && NF>0) print; print pragma}
$0 !~ P {if (n) print}
```
[Later: it turns out that if there's a big comment just before the start of a function then that code can sometimes move a pragma inside it, so it probably needs to be improved.]

A few occurrences had to be fixed manually where , eg, `INLINE`  appeared in the middle of a function (I'm not totally sure what to do in this case) or where there were empty lines before or after it (not sure if I got all of these).  

The pragmas mentioned above seem to be the only ones that we use that apply to blocks of code in the body of a file.  I've ignored things like `HLINT`, `ANN`, `MINIMAL`, `COMPLETE` and `RULES`.  I don't guarantee that this has dealt with every single thing that we might care about.