### PR TITLE
IsString instances to create newtypes wrapping BuiltinByteString

### DIFF
--- a/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Core/V1/Semantics/Types.hs
+++ b/plutus-benchmark/marlowe/src/PlutusBenchmark/Marlowe/Core/V1/Semantics/Types.hs
@@ -53,6 +53,7 @@ import PlutusLedgerApi.V1.Value qualified as Val
 import PlutusLedgerApi.V2 qualified as Ledger (Address (..), Credential (..), PubKeyHash (..),
                                                ScriptHash (..), StakingCredential (..))
 import PlutusTx.AssocMap qualified as Map
+import PlutusTx.Plugin.IsString (Utf8Encoded (..))
 import Prelude qualified as Haskell
 
 deriving stock instance Data POSIXTime
@@ -114,7 +115,8 @@ type Accounts = Map (AccountId, Token) Integer
 -- | Values, as defined using Let ar e identified by name,
 --   and can be used by 'UseValue' construct.
 newtype ValueId = ValueId BuiltinByteString
-  deriving (IsString, Haskell.Show) via TokenName
+  deriving (IsString) via Utf8Encoded BuiltinByteString
+  deriving (Haskell.Show) via TokenName
   deriving stock (Haskell.Eq,Haskell.Ord,Generic,Data)
   deriving anyclass (Newtype)
   deriving newtype (Eq)

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -216,6 +216,7 @@ test-suite plutus-ledger-api-plugin-test
     Spec.ReturnUnit.V3
     Spec.ScriptSize
     Spec.Value
+    Spec.Value.TokenName
     Spec.Value.WithCurrencySymbol
 
   if os(windows)
@@ -240,6 +241,7 @@ test-suite plutus-ledger-api-plugin-test
     , tasty
     , tasty-hunit
     , tasty-quickcheck
+    , text
 
 -- This is a nightly test, so it is an executable instead of test-suite to avoid
 -- running this in CI.

--- a/plutus-ledger-api/test-plugin/Spec.hs
+++ b/plutus-ledger-api/test-plugin/Spec.hs
@@ -9,6 +9,7 @@ import Spec.ReturnUnit.V2 qualified
 import Spec.ReturnUnit.V3 qualified
 import Spec.ScriptSize qualified
 import Spec.Value qualified
+import Spec.Value.TokenName qualified
 import Spec.Value.WithCurrencySymbol qualified
 
 import Test.Tasty
@@ -29,5 +30,6 @@ tests =
     , Spec.MintValue.V3.tests
     , Spec.ScriptSize.tests
     , Spec.Value.test_EqValue
+    , Spec.Value.TokenName.tests
     , Spec.Value.WithCurrencySymbol.tests
     ]

--- a/plutus-ledger-api/test-plugin/Spec/Budget.hs
+++ b/plutus-ledger-api/test-plugin/Spec/Budget.hs
@@ -20,6 +20,7 @@ import Data.Bifunctor
 import Data.String
 import PlutusLedgerApi.V1.Value
 import PlutusTx.AssocMap as Map
+import PlutusTx.Builtins.HasOpaque (stringToBuiltinByteString)
 import PlutusTx.Code
 import PlutusTx.Lift (liftCodeDef)
 import PlutusTx.Test
@@ -56,7 +57,7 @@ toSymbol :: Integer -> CurrencySymbol
 toSymbol = currencySymbol . fromString . show
 
 toToken :: Integer -> TokenName
-toToken = fromString . show
+toToken = TokenName . stringToBuiltinByteString . show
 
 value1 :: Value
 value1 =

--- a/plutus-ledger-api/test-plugin/Spec/Value/TokenName.hs
+++ b/plutus-ledger-api/test-plugin/Spec/Value/TokenName.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE BlockArguments    #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+
+module Spec.Value.TokenName where
+
+import Data.ByteString (ByteString)
+import Data.Text.Encoding as TE
+import PlutusCore (DefaultFun, DefaultUni, NamedDeBruijn, someValue)
+import PlutusLedgerApi.V1.Value (TokenName (..))
+import PlutusTx (CompiledCode, getPlcNoAnn)
+import PlutusTx.Plugin.IsString (RawBytes (..), Utf8Encoded (..))
+import PlutusTx.TH (compile)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+import UntypedPlutusCore (Program (_progTerm), Term (Constant))
+
+tests :: TestTree
+tests =
+  testGroup
+    "IsString TokenName"
+    [ test_TokenName_IsString_Utf8
+    , test_TokenName_IsString_Raw
+    ]
+
+test_TokenName_IsString_Utf8 :: TestTree
+test_TokenName_IsString_Utf8 = testCase "Utf8Encoded" do
+  term $$(compile [||utf8Encoded "Имя Токена" :: TokenName||])
+    @?= Constant () (someValue (TE.encodeUtf8 "Имя Токена"))
+
+test_TokenName_IsString_Raw :: TestTree
+test_TokenName_IsString_Raw = testCase "Raw" do
+  let expectedTerm = Constant () (someValue ("\xBA\xBE" :: ByteString))
+  assertBool "RawBytes TokenName" $
+    term $$(compile [||rawBytes "\xBA\xBE" :: TokenName||]) == expectedTerm
+  assertBool "Utf8Encoded TokenName" $
+    term $$(compile [||utf8Encoded "\xBA\xBE" :: TokenName||]) /= expectedTerm
+
+term :: CompiledCode a -> Term NamedDeBruijn DefaultUni DefaultFun ()
+term = _progTerm . getPlcNoAnn

--- a/plutus-tx-plugin/changelog.d/20241121_161607_Yuriy.Lazaryev_IsString_instances.md
+++ b/plutus-tx-plugin/changelog.d/20241121_161607_Yuriy.Lazaryev_IsString_instances.md
@@ -1,0 +1,4 @@
+### Added
+
+- `instance IsString (Utf8Encoded TokenName)` allows using string literals to construct UTF8-encoded `TokenName` values.
+- `instance IsString (RawBytes TokenName)` allows using string literals to construct `TokenName`s of raw bytes.

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -32,6 +32,7 @@ import PlutusTx.Compiler.Utils
 import PlutusTx.Coverage
 import PlutusTx.PIRTypes
 import PlutusTx.PLCTypes
+import PlutusTx.Plugin.IsString qualified as IsString
 import PlutusTx.Plugin.Utils
 import PlutusTx.Trace
 
@@ -410,6 +411,8 @@ compileMarkedExpr locStr codeTy origE = do
           , 'useToOpaque
           , 'useFromOpaque
           , 'mkNilOpaque
+          , ''IsString.Utf8Encoded
+          , ''IsString.RawBytes
           ]
     modBreaks <- asks pcModuleModBreaks
     let coverage = CoverageOpts . Set.fromList $

--- a/plutus-tx-plugin/test/Plugin/Errors/9.6/literalCaseOther.uplc.golden
+++ b/plutus-tx-plugin/test/Plugin/Errors/9.6/literalCaseOther.uplc.golden
@@ -1,1 +1,8 @@
-Error: Unsupported feature: Use of fromString on type other than builtin strings or bytestrings: Plugin.Errors.Spec.AType
+Error: Unsupported feature: 
+       Use of fromString is only supported for the following types:
+       - PlutusTx.Builtins.Internal.BuiltinString
+       - PlutusTx.Builtins.Internal.BuiltinByteString
+       - PlutusTx.Plugin.IsString.Utf8Encoded
+       - PlutusTx.Plugin.IsString.RawBytes
+
+       Using fromString for Plugin.Errors.Spec.AType is not supported.

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -96,6 +96,7 @@ library
     PlutusTx.Monoid
     PlutusTx.Numeric
     PlutusTx.Ord
+    PlutusTx.Plugin.IsString
     PlutusTx.Plugin.Utils
     PlutusTx.Prelude
     PlutusTx.Ratio

--- a/plutus-tx/src/PlutusTx/Plugin/IsString.hs
+++ b/plutus-tx/src/PlutusTx/Plugin/IsString.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures   #-}
+
+module PlutusTx.Plugin.IsString (
+  Utf8Encoded (..),
+  RawBytes (..),
+  EncodingAction (..),
+) where
+
+import Prelude
+
+import Data.Coerce (Coercible, coerce)
+import Data.Kind (Type)
+import Data.String (IsString (..))
+import GHC.Base qualified as Magic
+import PlutusTx.Builtins (BuiltinByteString)
+import PlutusTx.Builtins.HasOpaque (stringToBuiltinByteString)
+
+{- Note [IsString instances and UTF-8 encoded string literals]
+
+GHC Core encodes string literals in UTF-8 by default.
+Plugin handles GHC Core expressions representing such literals specially:
+in compile type it undoes the UTF-8 encoding when string literal is used to construct
+a value of type 'BuiltinByteString' and preserves the UTF-8 encoding to construct 'BuiltinString'.
+
+The 'EncodingAction' type helps to distinguish between these two cases.
+
+The newtypes 'Utf8Encoded' and 'RawBytes' are used to indirectly provide IsString instances
+for other newtypes that wrap 'BuiltinString' or 'BuiltinByteString' i.e. 'TokenName':
+  - 'utf8Encoded "Мой Токен" :: TokenName'
+  - 'rawBytes "\42\33\255" :: TokenName'
+
+-}
+
+data EncodingAction = UndoUtf8 | PreserveUtf8
+
+newtype Utf8Encoded (a :: Type) = Utf8Encoded {utf8Encoded :: a}
+
+instance (Coercible a BuiltinByteString) => IsString (Utf8Encoded a) where
+  fromString = Magic.noinline (coerce . stringToBuiltinByteString)
+
+newtype RawBytes (a :: Type) = RawBytes {rawBytes :: a}
+
+instance (Coercible a BuiltinByteString) => IsString (RawBytes a) where
+  fromString = Magic.noinline (coerce . stringToBuiltinByteString)


### PR DESCRIPTION
Before: `TokenName` type has no `IsString` instance and expressions like `"MyTok" :: TokenName` won't compile.

After this PR: `TokenName` has 2 instances (indirectly, via newtype-wrappers):

1.  UTF-8 encoded `TokenName` construction with a literal:
     ```haskell
     utf8Encoded "Мой Токен" :: TokenName
     ```
2.  Un-encoded (raw bytes) `TokenName` construction with a literal: 
    ```haskell
    rawBytes "\xDE\xAD\xBE\xEF" :: TokenName
    ```
