### PR TITLE
[Evaluation] [Performance] Strictify 'spend'

### DIFF
--- a/plutus-core/changelog.d/20241126_024818_effectfully_strictify_spend.md
+++ b/plutus-core/changelog.d/20241126_024818_effectfully_strictify_spend.md
@@ -1,0 +1,3 @@
+### Changed
+
+- In #6705 made the local `spend` function faster increasing overall performance of the evaluator by 1.8%.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -1,4 +1,5 @@
 -- editorconfig-checker-disable-file
+{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -142,7 +143,11 @@ restricting (ExRestrictingBudget initB@(ExBudget cpuInit memInit)) = ExBudgetMod
             CekM $ writeCpu cpuLeft'
             CekM $ writeMem memLeft'
             when (cpuLeft' < 0 || memLeft' < 0) $ do
-                let budgetLeft = ExBudget cpuLeft' memLeft'
+                let -- You'd think whether the budget is computed strictly or not before throwing
+                    -- an error isn't important, but GHC refuses to unbox the second argument of
+                    -- @spend@ without this bang. Bangs on @cpuLeft'@ and @memLeft'@ don't help
+                    -- either as those are forced by 'writeCpu' and 'writeMem' anyway. Go figure.
+                    !budgetLeft = ExBudget cpuLeft' memLeft'
                 throwingWithCause _EvaluationError
                     (OperationalEvaluationError . CekOutOfExError $ ExRestrictingBudget budgetLeft)
                     Nothing


### PR DESCRIPTION
I used to see this:

```haskell
              $j_sXeb (x#_aWMv :: Int#) (wild1_aWMu :: Int)
                = let! { I# ipv6_sXec ~ wild3_X8 <- wild1_aWMu } in
```

and now I see this:

```haskell
              $w$j_sum7 :: Int# -> Int# -> (# State# s_sumh, () #)
              $w$j_sum7 (x#_sum1 :: Int#) (ww2_sum4 :: Int#)
```

in the GHC Core of the `spend` local function in `UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode`. It's a tiny but welcome improvement.