### PR TITLE
[Evaluation] [Performance] Remove 'unsafeFreezePrimArray' from 'itrav…

### DIFF
--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/StepCounter.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/StepCounter.hs
@@ -91,12 +91,12 @@ itraverseCounter_ f (StepCounter arr) = do
   -- are done with the frozen version. That ordering is enforced by the fact that
   -- the whole thing runs in 'm': future accesses to the mutable array can't
   -- happen until this whole function is finished.
-  arr' <- P.unsafeFreezePrimArray arr
   let
     sz = fromIntegral $ natVal (Proxy @n)
     go !i
       | i < sz = do
-          f i (P.indexPrimArray arr' i)
+          x <- P.readPrimArray arr i
+          f i x
           go (i+1)
       | otherwise = pure ()
   go 0


### PR DESCRIPTION
`unsafeFreezePrimArray` seems entirely unnecessary there. Let's check if this is the case and if we can save any work by removing it. Quite possible it's the opposite and we'll get a slowdown here.