### PR TITLE
Relax upper bound on `cardano-crypto-class`

### DIFF
--- a/plutus-core/changelog.d/20241211_095642_1009751+Unisay_relax_crypto_upper_bound.md
+++ b/plutus-core/changelog.d/20241211_095642_1009751+Unisay_relax_crypto_upper_bound.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Relaxed upper bound for the `cardano-crypto-class` dependency (< 2.3)

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -293,7 +293,7 @@ library
     , bytestring
     , bytestring-strict-builder
     , cardano-crypto
-    , cardano-crypto-class        ^>=2.1.5
+    , cardano-crypto-class        >=2.1.5   && <2.3
     , cassava
     , cborg
     , composition-prelude         >=1.1.0.1


### PR DESCRIPTION
I can confirm that plutus builds just fine with the version of `cardano-crypto-class-2.2` that we are getting to release on CHaP.
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
