### PR TITLE
Remove taskset usage from ci-plutus-benchmarks.sh

### DIFF
--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -43,12 +43,11 @@ jobs:
         uses: actions/github-script@main
         with:
           script: |
-            const regex = /^\/benchmark\s*([^\s]*)\s*(cap=([0-9]+))?\s*$/;
+            const regex = /^\/benchmark\s*([^\s]*)\s*$/;
             const comment = context.payload.comment.body;
             const match = comment.match(regex)
-            if (match !== null && match.length == 4 && match[1] !== '') {
+            if (match !== null && match.length == 2 && match[1] !== '') {
               core.setOutput('benchmark', match[1]);
-              core.setOutput('capability_num', match[3] || "");
             } else {
               core.setFailed(`Unable to extract benchmark name from comment '${comment}'`);
             }
@@ -118,7 +117,6 @@ jobs:
           nix develop --no-warn-dirty --accept-flake-config --command bash ./scripts/ci-plutus-benchmark.sh 
         env:
           BENCHMARK_NAME: ${{ steps.extract-benchmark.outputs.benchmark }}
-          CAPABILITY_NUM: ${{ steps.extract-benchmark.outputs.capability_num }}
           PR_NUMBER: ${{ github.event.issue.number }}
           PR_BRANCH: ${{ steps.extract-branch.outputs.head_ref }}
 

--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -11,14 +11,12 @@
 # `BENCHMARK_NAME=nofib ./scripts/ci-plutus-benchmark.sh`
 #
 # NOTES:
-# The `cabal update` command below is neccessary because while the whole script is executed inside
+# The `cabal update` command below is necessary because while the whole script is executed inside
 # a nix shell, this environment does not provide the hackage record inside .cabal and we have to 
 # fetch/build this each time since we want to run this in a clean environment.
 # The `jq` invocation below is necessary because we have to POST the PR comment as JSON data 
 # (see the curl command) meaning the script output has to be escaped first before we can insert it.
-# Also note the use of the envvar CAPABILITY_NUM and `taskset -c` to limit 
-# the benchmark to a single core. Experiments have shown that this can lead to more stable results.
-# This is only available on linux.
+# For consistent results, the benchmarks should be run on a CPU with a fixed frequency or a performance governor.
 
 set -e
 
@@ -39,19 +37,12 @@ else
    git checkout "$PR_BRANCH"
 fi
 
-if [ -z "$CAPABILITY_NUM" ] ; then
-   echo "[ci-plutus-benchmark]: 'CAPABILITY_NUM' is not set, will default to 2"
-   CAPABILITY_NUM=2
-else 
-   echo "[ci-plutus-benchmark]: 'CAPABILITY_NUM' set to $CAPABILITY_NUM"
-fi
-
 PR_BRANCH_REF="$(git rev-parse --short HEAD)"
 
 if [ -z "$(git merge-base HEAD origin/master)" ]; then
-    echo "The command 'git merge-base HEAD origin/master' returned an empty string."
-    echo "You probably need to 'git rebase --origin master' from your branch first."
-    exit 1
+   echo "The command 'git merge-base HEAD origin/master' returned an empty string."
+   echo "You probably need to 'git rebase --origin master' from your branch first."
+   exit 1
 fi
 
 echo "[ci-plutus-benchmark]: Processing benchmark comparison for benchmark '$BENCHMARK_NAME' on PR $PR_NUMBER"
@@ -65,18 +56,8 @@ cabal update
 echo "[ci-plutus-benchmark]: Clearing caches with cabal clean ..."
 cabal clean
 
-if [[ -z $(which taskset) ]]; then
-   TASKSET=""
-else
-   echo "[ci-plutus-benchmark]: Setting CPU $CAPABILITY_NUM frequency governor to 'userspace' and frequency to 4.21GHz"
-   # This makes the benchmark reliable on a single core and addresses the issue of large variance in the results.
-   sudo cpufreq-set --cpu $CAPABILITY_NUM --governor userspace
-   sudo cpufreq-set --cpu $CAPABILITY_NUM --related --freq 4.21GHz
-   TASKSET="taskset -c $CAPABILITY_NUM"
-fi
-
 echo "[ci-plutus-benchmark]: Running benchmark for PR branch at $PR_BRANCH_REF ..."
-2>&1 $TASKSET cabal bench "$BENCHMARK_NAME" | tee bench-PR.log
+2>&1 cabal bench "$BENCHMARK_NAME" | tee bench-PR.log
 
 echo "[ci-plutus-benchmark]: Switching branches ..."
 git checkout "$(git merge-base HEAD origin/master)"
@@ -86,7 +67,7 @@ echo "[ci-plutus-benchmark]: Clearing caches with cabal clean ..."
 cabal clean
 
 echo "[ci-plutus-benchmark]: Running benchmark for base branch at $BASE_BRANCH_REF ..."
-2>&1 $TASKSET cabal bench "$BENCHMARK_NAME" | tee bench-base.log 
+2>&1 cabal bench "$BENCHMARK_NAME" | tee bench-base.log 
 git checkout "$PR_BRANCH_REF"  # .. so we use the most recent version of the comparison script
 
 echo "[ci-plutus-benchmark]: Comparing results ..."


### PR DESCRIPTION
The benchmarking machine has been configured to use the "performance" frequency governor on all cores.
This means that we no longer need to specify which core to run on, nor do we need to set the governor each time we run the benchmarks.