### PR TITLE
Fix typos in Plutus Core Spec of Batch 5 builtins

### DIFF
--- a/doc/plutus-core-spec/cardano/builtins5.tex
+++ b/doc/plutus-core-spec/cardano/builtins5.tex
@@ -67,7 +67,7 @@ $\bar{\bitone} = \bitzero$.
     \TT{countSetBits} & $[\ty{bytestring}] \to \ty{integer}$
     & $b_{n-1}{\cdots}b_0 $ \text{$\mapsto \left|\{i: b_i =1\}\right|$} & No & \\[2mm]
     \TT{findFirstSetBit} & $[\ty{bytestring}] \to \ty{integer}$ & $\mathsf{ffs}$ & No & \ref{note:ffs}\\[2mm]
-    \TT{readBit} & $[\ty{bytestring}, \ty{integer}] $ \text{$\;\; \to \ty{bytestring}$}
+    \TT{readBit} & $[\ty{bytestring}, \ty{integer}] $ \text{$\;\; \to \ty{bool}$}
                                         & $(b_{n-1}{\cdots}b_0, i) $ \text{$\mapsto \begin{cases}
                                         b_i & \text{if $0 \leq i \leq n-1$}\\
                                         \errorX & \text{otherwise}

--- a/doc/plutus-core-spec/cardano/builtins5.tex
+++ b/doc/plutus-core-spec/cardano/builtins5.tex
@@ -115,7 +115,7 @@ $$
   = \cdots = x_{k-1} = x$}.
 $$
 
-\noindent In both cases, the otuput is the same as the input when $k=0$.
+\noindent In both cases, the output is the same as the input when $k=0$.
 \smallskip
 
 \noindent The denotations of the bitwise logical functions are now defined on bitstring

--- a/doc/plutus-core-spec/cardano/builtins5.tex
+++ b/doc/plutus-core-spec/cardano/builtins5.tex
@@ -97,8 +97,8 @@ same length as the shorter one.
 \item If the first argument is $\true$
 then the shorter bytestring is (conceptually) extended on the right to have the
 same length as the longer one.  In the case of $\Xand$ the shorter bytestring is
-extended with $\bitzero$ bits and in the case of $\Xor$ and $\Xxor$ it is
-extended with $\bitone$ bits.
+extended with $\bitone$ bits and in the case of $\Xor$ and $\Xxor$ it is
+extended with $\bitzero$ bits.
 \end{itemize}
 
 \noindent Formally the truncation operation mentioned above is defined as


### PR DESCRIPTION
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
The plutus core spec Builtins Batch 5 Note 1 mentions that for the extending case of and/xor/orByteString, the bytestrings are extended with 0/1/1 respectively. This contradicts conformance test andByteString/case-06 and the statement a few sentences later that "In both cases, the otuput is the same as the input when 𝑘 = 0". Moreover the formular later also contradicts this. I assume this is a simple case of flipped bit in the first mention.

Further:
- fix typo otuput -> output
- fix typo in return type of readBit: bytestring -> bool
