### PR TITLE
Fix an error related to mesh wallet

### DIFF
--- a/doc/docusaurus/static/code/generate-keys.mjs
+++ b/doc/docusaurus/static/code/generate-keys.mjs
@@ -14,7 +14,7 @@ const wallet = new MeshWallet({
 })
 
 // obtain the address associated with the secret key
-const address = wallet.getUnusedAddresses()[0]
+const address = (await wallet.getUnusedAddresses())[0]
 
 // derive PubKeyHash from the address
 const pubKeyHash = deserializeAddress(address).pubKeyHash

--- a/doc/docusaurus/static/code/mint-token-for-auction.mjs
+++ b/doc/docusaurus/static/code/mint-token-for-auction.mjs
@@ -65,7 +65,7 @@ const token = {
   }
 }
 
-const walletAddress = wallet.getUsedAddresses()[0]
+const walletAddress = (await wallet.getUsedAddresses())[0]
 
 // The redeemer for the minting policy, corresponding to `()`.
 const redeemer = {


### PR DESCRIPTION
In the latest version of mesh, `getUnusedAddresses` and `getUsedAddresses` return `Promise`, necessitating `await`.