### PR TITLE
[UPLC] [Test] Add scoping tests

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -195,6 +195,7 @@ library
     UntypedPlutusCore.Check.Scope
     UntypedPlutusCore.Check.Uniques
     UntypedPlutusCore.Core
+    UntypedPlutusCore.Core.Instance.Scoping
     UntypedPlutusCore.Core.Plated
     UntypedPlutusCore.Core.Type
     UntypedPlutusCore.Core.Zip
@@ -206,12 +207,19 @@ library
     UntypedPlutusCore.Evaluation.Machine.SteppableCek
     UntypedPlutusCore.Evaluation.Machine.SteppableCek.DebugDriver
     UntypedPlutusCore.Evaluation.Machine.SteppableCek.Internal
+    UntypedPlutusCore.Mark
     UntypedPlutusCore.MkUPlc
     UntypedPlutusCore.Parser
     UntypedPlutusCore.Purity
     UntypedPlutusCore.Rename
+    UntypedPlutusCore.Rename.Internal
     UntypedPlutusCore.Size
     UntypedPlutusCore.Transform.CaseOfCase
+    UntypedPlutusCore.Transform.CaseReduce
+    UntypedPlutusCore.Transform.Cse
+    UntypedPlutusCore.Transform.FloatDelay
+    UntypedPlutusCore.Transform.ForceDelay
+    UntypedPlutusCore.Transform.Inline
     UntypedPlutusCore.Transform.Simplifier
 
   other-modules:
@@ -264,16 +272,9 @@ library
     UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
     UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
     UntypedPlutusCore.Evaluation.Machine.CommonAPI
-    UntypedPlutusCore.Mark
-    UntypedPlutusCore.Rename.Internal
     UntypedPlutusCore.Simplify
     UntypedPlutusCore.Simplify.Opts
     UntypedPlutusCore.Subst
-    UntypedPlutusCore.Transform.CaseReduce
-    UntypedPlutusCore.Transform.Cse
-    UntypedPlutusCore.Transform.FloatDelay
-    UntypedPlutusCore.Transform.ForceDelay
-    UntypedPlutusCore.Transform.Inline
 
   reexported-modules: Data.SatInt
   hs-source-dirs:
@@ -438,6 +439,7 @@ test-suite untyped-plutus-core-test
     Evaluation.Regressions
     Flat.Spec
     Generators
+    Scoping.Spec
     Transform.CaseOfCase.Test
     Transform.Simplify
     Transform.Simplify.Lib

--- a/plutus-core/plutus-ir/test/PlutusIR/Scoping/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Scoping/Tests.hs
@@ -30,7 +30,7 @@ test_names :: TestTree
 test_names = testGroup "names"
     [ T.test_scopingGood "beta-reduction" genTerm T.BindingRemovalNotOk T.PrerenameYes $
         pure . beta
-    , T.test_scopingGood "case-of-known-constructor" genTerm T.BindingRemovalNotOk T.PrerenameYes $
+    , T.test_scopingGood "case-of-known-constructor" genTerm T.BindingRemovalOk T.PrerenameYes $
         pure . caseReduce
     , T.test_scopingGood "commuteFnWithConst" genTerm T.BindingRemovalNotOk T.PrerenameYes $
         pure . commuteFnWithConst

--- a/plutus-core/prelude/PlutusPrelude.hs
+++ b/plutus-core/prelude/PlutusPrelude.hs
@@ -98,6 +98,7 @@ module PlutusPrelude
     , distinct
     , unsafeFromRight
     , tryError
+    , addTheRest
     , modifyError
     , lowerInitialChar
     ) where
@@ -265,6 +266,14 @@ timesA = ala Endo . stimes
 tryError :: MonadError e m => m a -> m (Either e a)
 tryError a = (Right <$> a) `catchError` (pure . Left)
 {-# INLINE tryError #-}
+
+-- | Pair each element of the given list with all the other elements.
+--
+-- >>> addTheRest "abcd"
+-- [('a',"bcd"),('b',"acd"),('c',"abd"),('d',"abc")]
+addTheRest :: [a] -> [(a, [a])]
+addTheRest []     = []
+addTheRest (x:xs) = (x, xs) : map (fmap (x :)) (addTheRest xs)
 
 {- A different 'MonadError' analogue to the 'withExceptT' function.
 Modify the value (and possibly the type) of an error in an @ExceptT@-transformed

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -604,7 +604,8 @@ prop_scopingFor ::
   Property
 prop_scopingFor gen bindRem preren run = withTests 200 . property $ do
   prog <- forAllNoShow $ runAstGen gen
-  let catchEverything = unsafePerformIO . try @SomeException . evaluate
+  let -- TODO: use @enclosed-exceptions@.
+      catchEverything = unsafePerformIO . try @SomeException . evaluate
       prep = runPrerename preren
   case catchEverything $ checkRespectsScoping bindRem prep (TPLC.runQuote . run) prog of
     Left exc         -> fail $ displayException exc

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance.hs
@@ -3,3 +3,4 @@ module UntypedPlutusCore.Core.Instance (module Export) where
 import UntypedPlutusCore.Core.Instance.Eq ()
 import UntypedPlutusCore.Core.Instance.Flat as Export
 import UntypedPlutusCore.Core.Instance.Pretty ()
+import UntypedPlutusCore.Core.Instance.Scoping ()

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Scoping.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Scoping.hs
@@ -1,0 +1,70 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+
+module UntypedPlutusCore.Core.Instance.Scoping () where
+
+import PlutusPrelude
+
+import UntypedPlutusCore.Core.Type
+
+import PlutusCore.Check.Scoping
+import PlutusCore.Name.Unique
+import PlutusCore.Quote
+
+import Data.Proxy
+import Data.Vector qualified as Vector
+
+firstBound :: Term name uni fun ann -> [name]
+firstBound (Apply _ (LamAbs _ name body) _) = name : firstBound body
+firstBound _                                = []
+
+instance name ~ Name => Reference Name (Term name uni fun) where
+    referenceVia reg name term = Apply NotAName term $ Var (reg name) name
+
+instance name ~ Name => EstablishScoping (Term name uni fun) where
+    establishScoping (LamAbs _ nameDup body)  = do
+        name <- freshenName nameDup
+        establishScopingBinder (\ann name' _ -> LamAbs ann name') name Proxy body
+    establishScoping (Delay _ body) = Delay NotAName <$> establishScoping body
+    establishScoping (Apply _ fun arg) =
+        Apply NotAName <$> establishScoping fun <*> establishScoping arg
+    establishScoping (Error _) = pure $ Error NotAName
+    establishScoping (Force _ term) = Force NotAName <$> establishScoping term
+    establishScoping (Var _ nameDup) = do
+        name <- freshenName nameDup
+        pure $ Var (registerFree name) name
+    establishScoping (Constant _ con) = pure $ Constant NotAName con
+    establishScoping (Builtin _ bi) = pure $ Builtin NotAName bi
+    establishScoping (Constr _ i es) = Constr NotAName <$> pure i <*> traverse establishScoping es
+    establishScoping (Case _ a es) = do
+        esScoped <- traverse establishScoping es
+        let esScopedPoked = addTheRest . map (\e -> (e, firstBound e)) $ Vector.toList esScoped
+            branchBounds = map (snd . fst) esScopedPoked
+            referenceInBranch ((branch, _), others) = referenceOutOfScope (map snd others) branch
+        aScoped <- establishScoping a
+        -- For each of the branches reference (as out-of-scope) the variables bound in that branch
+        -- in all the other ones, as well as outside of the whole case-expression. This is to check
+        -- that none of the transformations leak variables outside of the branch they're bound in.
+        pure . referenceOutOfScope branchBounds $
+            Case NotAName aScoped . Vector.fromList $ map referenceInBranch esScopedPoked
+
+instance name ~ Name => EstablishScoping (Program name uni fun) where
+    establishScoping (Program _ ver term) = Program NotAName ver <$> establishScoping term
+
+instance name ~ Name => CollectScopeInfo (Term name uni fun) where
+    collectScopeInfo (LamAbs ann name body) = handleSname ann name <> collectScopeInfo body
+    collectScopeInfo (Delay _ body)         = collectScopeInfo body
+    collectScopeInfo (Apply _ fun arg)      = collectScopeInfo fun <> collectScopeInfo arg
+    collectScopeInfo (Error _)              = mempty
+    collectScopeInfo (Force _ term)         = collectScopeInfo term
+    collectScopeInfo (Var ann name)         = handleSname ann name
+    collectScopeInfo (Constant _ _)         = mempty
+    collectScopeInfo (Builtin _ _)          = mempty
+    collectScopeInfo (Constr _ _ es)        = foldMap collectScopeInfo es
+    collectScopeInfo (Case _ arg cs)        = collectScopeInfo arg <> foldMap collectScopeInfo cs
+
+instance name ~ Name => CollectScopeInfo (Program name uni fun) where
+    collectScopeInfo (Program _ _ term) = collectScopeInfo term

--- a/plutus-core/untyped-plutus-core/test/Generators.hs
+++ b/plutus-core/untyped-plutus-core/test/Generators.hs
@@ -10,7 +10,7 @@ import PlutusPrelude (display, fold, on, void, zipExact, (&&&))
 
 import PlutusCore (Name, _nameText)
 import PlutusCore.Annotation
-import PlutusCore.Compiler.Erase (eraseProgram)
+import PlutusCore.Compiler.Erase (eraseProgram, eraseTerm)
 import PlutusCore.Default (Closed, DefaultFun, DefaultUni, Everywhere, GEq)
 import PlutusCore.Error (ParserErrorBundle)
 import PlutusCore.Generators.Hedgehog (forAllPretty)
@@ -69,6 +69,9 @@ compareProgram
     :: (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, Eq a)
     => Program Name uni fun a -> Program Name uni fun a -> Bool
 compareProgram (Program _ v t) (Program _ v' t') = v == v' && compareTerm t t'
+
+genTerm :: forall fun. (Bounded fun, Enum fun) => AstGen (Term Name DefaultUni fun ())
+genTerm = fmap eraseTerm AST.genTerm
 
 genProgram :: forall fun. (Bounded fun, Enum fun) => AstGen (Program Name DefaultUni fun ())
 genProgram = fmap eraseProgram AST.genProgram

--- a/plutus-core/untyped-plutus-core/test/Scoping/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Scoping/Spec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Scoping.Spec where
+
+import Generators (genProgram, genTerm)
+
+import UntypedPlutusCore (_soInlineHints, defaultSimplifyOpts)
+import UntypedPlutusCore.Mark
+import UntypedPlutusCore.Rename.Internal
+import UntypedPlutusCore.Transform.CaseOfCase (caseOfCase)
+import UntypedPlutusCore.Transform.CaseReduce (caseReduce)
+import UntypedPlutusCore.Transform.Cse (cse)
+import UntypedPlutusCore.Transform.FloatDelay (floatDelay)
+import UntypedPlutusCore.Transform.ForceDelay (forceDelay)
+import UntypedPlutusCore.Transform.Inline (inline)
+import UntypedPlutusCore.Transform.Simplifier (evalSimplifierT)
+
+import PlutusCore.Default.Builtins (DefaultFun)
+import PlutusCore.Rename
+import PlutusCore.Test qualified as T
+
+import Test.Tasty
+
+-- See Note [Scoping tests API].
+test_names :: TestTree
+test_names = testGroup "names"
+    [ T.test_scopingGood "renaming" (genProgram @DefaultFun) T.BindingRemovalNotOk T.PrerenameNo
+        rename
+    , T.test_scopingSpoilRenamer (genProgram @DefaultFun) markNonFreshProgram
+        renameProgramM
+    , T.test_scopingGood "case-of-case" (genTerm @DefaultFun) T.BindingRemovalOk T.PrerenameYes $
+        evalSimplifierT . caseOfCase
+    , -- COKC removes entire branches, some of which are going to contain binders, but we still use
+      -- 'BindingRemovalNotOk', because the 'EstablishScoping' instance does not attempt to
+      -- reference bindings from one branch in another one. We could do that, but then we'd be
+      -- removing not just TODO.
+      T.test_scopingGood "case-of-known-constructor"
+        (genTerm @DefaultFun)
+        T.BindingRemovalOk  -- COKC removes branches, which may (and likely do) contain bindings.
+        T.PrerenameYes
+        (evalSimplifierT . caseReduce)
+    , -- CSE creates entirely new names, which isn't supported by the scoping check machinery.
+      T.test_scopingBad "cse"
+        (genTerm @DefaultFun)
+        T.BindingRemovalOk
+        T.PrerenameYes
+        (evalSimplifierT . cse maxBound)
+    , T.test_scopingGood "float-delay"
+        (genTerm @DefaultFun)
+        T.BindingRemovalNotOk
+        T.PrerenameNo
+        (evalSimplifierT . floatDelay)
+    , T.test_scopingGood "force-delay"
+        (genTerm @DefaultFun)
+        T.BindingRemovalNotOk
+        T.PrerenameYes
+        (evalSimplifierT . forceDelay)
+    , T.test_scopingGood "inline"
+        (genTerm @DefaultFun)
+        T.BindingRemovalOk
+        T.PrerenameYes
+        (evalSimplifierT . inline True (_soInlineHints defaultSimplifyOpts) maxBound)
+    ]

--- a/plutus-core/untyped-plutus-core/test/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Spec.hs
@@ -15,6 +15,7 @@ import Evaluation.Machines (test_budget, test_machines, test_tallying)
 import Evaluation.Regressions (schnorrVerifyRegressions)
 import Flat.Spec (test_flat)
 import Generators (test_parsing)
+import Scoping.Spec (test_names)
 import Transform.CaseOfCase.Test (test_caseOfCase)
 import Transform.Simplify (test_simplify)
 
@@ -40,4 +41,5 @@ main = do
       , test_flat
       , schnorrVerifyRegressions
       , evalOrder
+      , test_names
       ]


### PR DESCRIPTION
This adds scoping tests for UPLC the same way we have them for PIR. It also tweaks the way the scoping machinery handles case-expressions for PIR.

I didn't stumble upon any unexpected behavior.