### PR TITLE
Disable .js file minification in docusaurus build

### DIFF
--- a/doc/docusaurus/package.json
+++ b/doc/docusaurus/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build --no-minify",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
This fixes incorrect rendering of mjs files in the docusaurus build.
This will be reverted once [this PR](https://github.com/IntersectMBO/plutus/pull/6780) is merged
