### PR TITLE
[Test] Add 'fix id'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -140,6 +140,7 @@ module PlutusCore.Evaluation.Machine.ExBudget
     , ExBudgetBuiltin(..)
     , ExRestrictingBudget(..)
     , LowerInitialCharacter
+    , largeBudget
     , enormousBudget
     ) where
 
@@ -205,6 +206,12 @@ newtype ExRestrictingBudget = ExRestrictingBudget
     } deriving stock (Show, Eq)
       deriving newtype (Semigroup, Monoid)
       deriving newtype (Pretty, PrettyBy config, NFData)
+
+-- | When we want to just evaluate the program that is intended to run out of budget we use the
+-- 'Restricting' mode with this big budget designed to make the CEK machine terminate in a
+-- fraction of a second on the reference machine.
+largeBudget :: ExRestrictingBudget
+largeBudget = ExRestrictingBudget $ ExBudget (2 * 10 ^ (11 :: Int)) (10 ^ (10 :: Int))
 
 -- | When we want to just evaluate the program we use the 'Restricting' mode with an enormous
 -- budget, so that evaluation costs of on-chain budgeting are reflected accurately in benchmarks.

--- a/plutus-core/plutus-ir/test/PlutusIR/Generators/QuickCheck/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Generators/QuickCheck/Tests.hs
@@ -14,7 +14,6 @@ import PlutusIR.Generators.QuickCheck
 
 import PlutusCore.Builtin (fromValue)
 import PlutusCore.Default
-import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekParametersForTesting)
 import PlutusCore.Name.Unique
 import PlutusCore.Pretty
@@ -25,7 +24,7 @@ import PlutusCore.Version (latestVersion)
 import PlutusIR
 import PlutusIR.Test ()
 import UntypedPlutusCore qualified as UPLC
-import UntypedPlutusCore.Evaluation.Machine.Cek (restricting, runCekNoEmit,
+import UntypedPlutusCore.Evaluation.Machine.Cek (restrictingLarge, runCekNoEmit,
                                                  unsafeSplitStructuralOperational)
 
 import Control.Exception
@@ -203,11 +202,10 @@ noStructuralErrors term =
   -- Throw on a structural evaluation error and succeed on both an operational evaluation error and
   -- evaluation success.
   void . evaluate . unsafeSplitStructuralOperational . fst $ do
-    let -- The numbers are picked so that evaluation of the arbitrarily generated term always
-        -- finishes in reasonable time even if evaluation loops (in which case we'll get an
-        -- out-of-budget failure).
-        budgeting = restricting . ExRestrictingBudget $ ExBudget 1000000000 1000000000
-    runCekNoEmit defaultCekParametersForTesting budgeting term
+    -- Using 'restrictingLarge' so that evaluation of the arbitrarily generated term always finishes
+    -- in reasonable time even if evaluation loops (in which case we'll get an out-of-budget
+    -- failure).
+    runCekNoEmit defaultCekParametersForTesting restrictingLarge term
 
 -- | Test that evaluation of well-typed terms doesn't fail with a structural error.
 prop_noStructuralErrors :: Property

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -32,6 +32,7 @@ module UntypedPlutusCore.Evaluation.Machine.Cek
     , counting
     , tallying
     , restricting
+    , restrictingLarge
     , restrictingEnormous
     , enormousBudget
     -- * Emitter modes

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -20,6 +20,7 @@ module UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
     , enormousBudget
     , tallying
     , restricting
+    , restrictingLarge
     , restrictingEnormous
     )
 where
@@ -158,6 +159,10 @@ restricting (ExRestrictingBudget initB@(ExBudget cpuInit memInit)) = ExBudgetMod
             pure $ initB `minusExBudget` r
         final = RestrictingSt . ExRestrictingBudget <$> remaining
     pure $ ExBudgetInfo spender final cumulative
+
+-- | 'restricting' instantiated at 'largeBudget'.
+restrictingLarge :: ThrowableBuiltins uni fun => ExBudgetMode RestrictingSt uni fun
+restrictingLarge = restricting largeBudget
 
 -- | 'restricting' instantiated at 'enormousBudget'.
 restrictingEnormous :: ThrowableBuiltins uni fun => ExBudgetMode RestrictingSt uni fun


### PR DESCRIPTION
We have a test ensuring that running a builtin call forever gonna drain the budget, but we don't have a test that running regular function calls forever will. This adds such a test. It'll also be useful to test #6793.