### PR TITLE
Update the auction example in the user guide to Plutus V3

### DIFF
--- a/doc/docusaurus/docs/auction-smart-contract/end-to-end/mint.md
+++ b/doc/docusaurus/docs/auction-smart-contract/end-to-end/mint.md
@@ -51,9 +51,9 @@ One final step before minting the token: since we want to lock the minted token 
 we must supply the parameters (i.e., `AuctionParams`) to the auction validator, compile the auction validator, and calculate its script address.
 
 Open `GenAuctionValidatorBlueprint.hs` in the `on-chain` directory, and replace all placeholders:
-- Replace `error "Replace with seller pkh"` with the content of `off-chain/seller.pkh`.
-- Replace `error "Replace with currency symbol"` with the minting policy hash, which you can find in the `hash` field in `off-chain/plutus-auction-minting-policy.json`.
-- Replace `error "Replace with the auction's end time"` with a POSIX timestamp for a time in the near future (say 24 hours from now).
+- Replace the `apSeller` value with the content of `off-chain/seller.pkh`.
+- Replace the `apCurrencySymbol` value with the minting policy hash, which you can find in the `hash` field in `off-chain/plutus-auction-minting-policy.json`.
+- Replace the `apEndTime` value with a POSIX timestamp for a time in the near future (say 24 hours from now).
   Note that the POSIX timestamp in Plutus is the number of _milliseconds_, rather than seconds, elapsed since January 1, 1970.
   In other words, add three zeros to the usual POSIX timestamp.
   For instance, the POSIX timestamp of September 1, 2024, 21:44:51 UTC, is 1725227091000.

--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -44,7 +44,7 @@ library docusaurus-code
     , plutus-tx          ^>=1.39
 
   if !(impl(ghcjs) || os(ghcjs))
-    build-depends: plutus-tx-plugin
+    build-depends: plutus-tx-plugin ^>=1.39
 
 executable example-cip57
   import:           lang, ghc-version-support, os-support
@@ -57,3 +57,20 @@ executable example-cip57
     , containers
     , plutus-ledger-api  ^>=1.39
     , plutus-tx          ^>=1.39
+
+executable quickstart
+  import:           lang, ghc-version-support, os-support
+  main-is:          QuickStart.hs
+  hs-source-dirs:   static/code
+  default-language: Haskell2010
+  other-modules:    AuctionValidator
+  build-depends:
+    , base               >=4.9   && <5
+    , base16-bytestring
+    , bytestring
+    , plutus-core        ^>=1.39
+    , plutus-ledger-api  ^>=1.39
+    , plutus-tx          ^>=1.39
+
+  if !(impl(ghcjs) || os(ghcjs))
+    build-depends: plutus-tx-plugin ^>=1.39

--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -68,7 +68,6 @@ executable quickstart
     , base               >=4.9   && <5
     , base16-bytestring
     , bytestring
-    , plutus-core        ^>=1.39
     , plutus-ledger-api  ^>=1.39
     , plutus-tx          ^>=1.39
 

--- a/doc/docusaurus/static/code/AuctionValidator.hs
+++ b/doc/docusaurus/static/code/AuctionValidator.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost        #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
@@ -22,23 +23,30 @@
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fno-unbox-small-strict-fields #-}
 {-# OPTIONS_GHC -fno-unbox-strict-fields #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.0.0 #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.1.0 #-}
 
 module AuctionValidator where
 
 import GHC.Generics (Generic)
 
-import PlutusCore.Version (plcVersion100)
-import PlutusLedgerApi.V1 (Lovelace, POSIXTime, PubKeyHash)
+import PlutusTx.Prelude
+
+import PlutusCore.Version (plcVersion110)
+import PlutusLedgerApi.V1 (lovelaceValueOf, valueOf)
 import PlutusLedgerApi.V1.Address (toPubKeyHash)
 import PlutusLedgerApi.V1.Interval (contains)
-import PlutusLedgerApi.V1.Value (lovelaceValueOf, valueOf)
-import PlutusLedgerApi.V2 (CurrencySymbol, Datum (..), OutputDatum (..), ScriptContext (..),
-                           TokenName, TxInfo (..), TxOut (..), from, to)
-import PlutusLedgerApi.V2.Contexts (getContinuingOutputs)
-import PlutusTx
+import PlutusLedgerApi.V3 (CurrencySymbol, Datum (Datum, getDatum), Lovelace,
+                           OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash), POSIXTime,
+                           PubKeyHash, Redeemer (getRedeemer), ScriptContext (..),
+                           ScriptInfo (SpendingScript), TokenName,
+                           TxInfo (txInfoOutputs, txInfoValidRange),
+                           TxOut (txOutAddress, txOutDatum, txOutValue), from, to)
+import PlutusLedgerApi.V3.Contexts (getContinuingOutputs)
+import PlutusTx (CompiledCode, FromData (..), ToData, UnsafeFromData (..), compile, liftCode,
+                 makeIsDataSchemaIndexed, makeLift, unsafeApplyCode)
 import PlutusTx.AsData qualified as PlutusTx
-import PlutusTx.Blueprint
+import PlutusTx.Blueprint (HasBlueprintDefinition, definitionRef)
 import PlutusTx.Prelude qualified as PlutusTx
 import PlutusTx.Show qualified as PlutusTx
 
@@ -121,8 +129,7 @@ auctionTypedValidator ::
   AuctionRedeemer ->
   ScriptContext ->
   Bool
-auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx@(ScriptContext txInfo _) =
-  PlutusTx.and conditions
+auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx = PlutusTx.and conditions
   where
     conditions :: [Bool]
     conditions = case redeemer of
@@ -154,7 +161,7 @@ auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx@(ScriptConte
 -- BLOCK4
 -- AuctionValidator.hs
     validBidTime :: Bool
-    ~validBidTime = to (apEndTime params) `contains` txInfoValidRange txInfo
+    ~validBidTime = to (apEndTime params) `contains` txInfoValidRange (scriptContextTxInfo ctx)
 -- BLOCK5
 -- AuctionValidator.hs
     refundsPreviousHighestBid :: Bool
@@ -166,7 +173,7 @@ auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx@(ScriptConte
               (toPubKeyHash (txOutAddress o) PlutusTx.== Just bidderPkh)
                 PlutusTx.&& (lovelaceValueOf (txOutValue o) PlutusTx.== amt)
           )
-          (txInfoOutputs txInfo) of
+          (txInfoOutputs (scriptContextTxInfo ctx)) of
           Just _  -> True
           Nothing -> PlutusTx.traceError "Not found: refund output"
 -- BLOCK6
@@ -209,7 +216,7 @@ auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx@(ScriptConte
 -- BLOCK7
 -- AuctionValidator.hs
     validPayoutTime :: Bool
-    ~validPayoutTime = from (apEndTime params) `contains` txInfoValidRange txInfo
+    ~validPayoutTime = from (apEndTime params) `contains` txInfoValidRange (scriptContextTxInfo ctx)
 
     sellerGetsHighestBid :: Bool
     ~sellerGetsHighestBid = case highestBid of
@@ -220,7 +227,7 @@ auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx@(ScriptConte
               (toPubKeyHash (txOutAddress o) PlutusTx.== Just (apSeller params))
                 PlutusTx.&& (lovelaceValueOf (txOutValue o) PlutusTx.== bAmount bid)
           )
-          (txInfoOutputs txInfo) of
+          (txInfoOutputs (scriptContextTxInfo ctx)) of
           Just _  -> True
           Nothing -> PlutusTx.traceError "Not found: Output paid to seller"
 
@@ -235,34 +242,35 @@ auctionTypedValidator params (AuctionDatum highestBid) redeemer ctx@(ScriptConte
                 (toPubKeyHash (txOutAddress o) PlutusTx.== Just highestBidder)
                   PlutusTx.&& (valueOf (txOutValue o) currencySymbol tokenName PlutusTx.== 1)
             )
-            (txInfoOutputs txInfo) of
+            (txInfoOutputs (scriptContextTxInfo ctx)) of
             Just _  -> True
             Nothing -> PlutusTx.traceError "Not found: Output paid to highest bidder"
 
 -- BLOCK8
 -- AuctionValidator.hs
-auctionUntypedValidator ::
-  AuctionParams ->
-  BuiltinData ->
-  BuiltinData ->
-  BuiltinData ->
-  PlutusTx.BuiltinUnit
-auctionUntypedValidator params datum redeemer ctx =
-  PlutusTx.check
-    ( auctionTypedValidator
-        params
-        (PlutusTx.unsafeFromBuiltinData datum)
-        (PlutusTx.unsafeFromBuiltinData redeemer)
-        (PlutusTx.unsafeFromBuiltinData ctx)
-    )
+auctionUntypedValidator :: AuctionParams -> BuiltinData -> BuiltinUnit
+auctionUntypedValidator params ctx =
+  PlutusTx.check (auctionTypedValidator params auctionDatum auctionRedeemer scriptContext)
+  where
+    scriptContext :: ScriptContext
+    scriptContext = PlutusTx.unsafeFromBuiltinData ctx
+
+    auctionDatum :: AuctionDatum
+    auctionDatum =
+      case scriptContextScriptInfo scriptContext of
+        SpendingScript _TxOutRef (Just datum) -> PlutusTx.unsafeFromBuiltinData (getDatum datum)
+        _ -> PlutusTx.traceError "Expected SpendingScript with a datum"
+
+    auctionRedeemer :: AuctionRedeemer
+    auctionRedeemer =
+      PlutusTx.unsafeFromBuiltinData (getRedeemer (scriptContextRedeemer scriptContext))
+
 {-# INLINEABLE auctionUntypedValidator #-}
 
-auctionValidatorScript ::
-  AuctionParams ->
-  CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> PlutusTx.BuiltinUnit)
+auctionValidatorScript :: AuctionParams -> CompiledCode (BuiltinData -> BuiltinUnit)
 auctionValidatorScript params =
   $$(PlutusTx.compile [||auctionUntypedValidator||])
-    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion100 params
+    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 params
 
 -- BLOCK9
 -- AuctionValidator.hs
@@ -277,7 +285,7 @@ PlutusTx.asData
 
       -- We can derive instances with the newtype strategy, and they
       -- will be based on the instances for 'Data'
-      deriving newtype (Eq, Ord, PlutusTx.ToData, FromData, UnsafeFromData)
+      deriving newtype (Eq, ToData, FromData, UnsafeFromData)
 
     -- don't do this for the datum, since it's just a newtype so
     -- simply delegates to the underlying type
@@ -286,7 +294,7 @@ PlutusTx.asData
     -- In this case it is either a new bid, or a request to close the auction
     -- and pay out the seller and the highest bidder.
     data AuctionRedeemer' = NewBid' Bid | Payout'
-      deriving newtype (Eq, Ord, PlutusTx.ToData, FromData, UnsafeFromData)
+      deriving newtype (Eq, ToData, FromData, UnsafeFromData)
     |]
 
 -- BLOCK10

--- a/doc/docusaurus/static/code/AuctionValidator.hs
+++ b/doc/docusaurus/static/code/AuctionValidator.hs
@@ -32,7 +32,6 @@ import GHC.Generics (Generic)
 
 import PlutusTx.Prelude
 
-import PlutusCore.Version (plcVersion110)
 import PlutusLedgerApi.V1 (lovelaceValueOf, valueOf)
 import PlutusLedgerApi.V1.Address (toPubKeyHash)
 import PlutusLedgerApi.V1.Interval (contains)
@@ -43,7 +42,7 @@ import PlutusLedgerApi.V3 (CurrencySymbol, Datum (Datum, getDatum), Lovelace,
                            TxInfo (txInfoOutputs, txInfoValidRange),
                            TxOut (txOutAddress, txOutDatum, txOutValue), from, to)
 import PlutusLedgerApi.V3.Contexts (getContinuingOutputs)
-import PlutusTx (CompiledCode, FromData (..), ToData, UnsafeFromData (..), compile, liftCode,
+import PlutusTx (CompiledCode, FromData (..), ToData, UnsafeFromData (..), compile, liftCodeDef,
                  makeIsDataSchemaIndexed, makeLift, unsafeApplyCode)
 import PlutusTx.AsData qualified as PlutusTx
 import PlutusTx.Blueprint (HasBlueprintDefinition, definitionRef)
@@ -270,7 +269,7 @@ auctionUntypedValidator params ctx =
 auctionValidatorScript :: AuctionParams -> CompiledCode (BuiltinData -> BuiltinUnit)
 auctionValidatorScript params =
   $$(PlutusTx.compile [||auctionUntypedValidator||])
-    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 params
+    `PlutusTx.unsafeApplyCode` liftCodeDef params
 
 -- BLOCK9
 -- AuctionValidator.hs

--- a/doc/docusaurus/static/code/QuickStart.hs
+++ b/doc/docusaurus/static/code/QuickStart.hs
@@ -1,13 +1,19 @@
 -- BLOCK1
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Main where
 
 import AuctionValidator
 import Data.ByteString qualified as B
 import Data.ByteString.Base16 qualified as Base16
-import Data.ByteString.Short qualified as B
-import PlutusLedgerApi.V2 qualified as V2
+import Data.ByteString.Short qualified as BS
+import PlutusLedgerApi.V1.Crypto qualified as Crypto
+import PlutusLedgerApi.V1.Time qualified as Time
+import PlutusLedgerApi.V1.Value qualified as Value
+import PlutusLedgerApi.V3 (serialiseCompiledCode)
+import PlutusTx.Builtins.HasOpaque (stringToBuiltinByteStringHex)
 
 main :: IO ()
 main =

--- a/doc/docusaurus/static/code/QuickStart.hs
+++ b/doc/docusaurus/static/code/QuickStart.hs
@@ -10,17 +10,33 @@ import Data.ByteString.Short qualified as B
 import PlutusLedgerApi.V2 qualified as V2
 
 main :: IO ()
-main = B.writeFile "validator.uplc" . Base16.encode $ B.fromShort serialisedScript
-  where
-    script = auctionValidatorScript params
-    serialisedScript = V2.serialiseCompiledCode script
-    params =
-      AuctionParams
-        { apSeller = error "Replace with seller's wallet address"
-        , -- The asset to be auctioned is 10000 lovelaces
-          apAsset = V2.singleton V2.adaSymbol V2.adaToken 10000
-        , -- The minimum bid is 100 lovelaces
-          apMinBid = 100
-        , apEndTime = error "Replace with your desired end time"
-        }
+main =
+  B.writeFile "validator.uplc.hex"
+    $ Base16.encode
+    $ BS.fromShort
+    $ serialiseCompiledCode
+    $ auctionValidatorScript AuctionParams
+      { apSeller =
+          -- Replace with the hex-encoded seller's public key hash:
+          Crypto.PubKeyHash (
+            stringToBuiltinByteStringHex
+              "0000000000000000000000000000000000000000\
+              \0000000000000000000000000000000000000000"
+            )
+      , apCurrencySymbol =
+          -- Replace with your desired currency symbol (minting policy hash):
+          Value.CurrencySymbol (
+            stringToBuiltinByteStringHex
+              "00000000000000000000000000000000000000000000000000000000"
+            )
+      , apTokenName =
+          -- Replace with your desired token name:
+          Value.tokenName "MY_TOKEN"
+      , apMinBid =
+          -- Minimal bid in lovelace:
+          100
+      , apEndTime =
+          -- Replace with your desired end time in milliseconds:
+          Time.fromMilliSeconds 1_725_227_091_000
+      }
 -- BLOCK2


### PR DESCRIPTION
Closed https://github.com/IntersectMBO/plutus/issues/6519

I've also added existing `QuickStart.hs` module as an `executable` to cabal project. 
It allowed me to `cabal run quickstart`  generating `validator.uplc` from `AuctionValidator.hs`.