### PR TITLE
Replace `clique` with `circuit` in dead code elimination

### DIFF
--- a/plutus-core/changelog.d/20250128_170723_unsafeFixIO_circuit.md
+++ b/plutus-core/changelog.d/20250128_170723_unsafeFixIO_circuit.md
@@ -1,0 +1,5 @@
+
+### Fixed
+
+- Fixed a bug in Plutus IR's dead code elimination pass that could incorrectly remove
+  live data constructors or destructors.

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
@@ -137,7 +137,7 @@ in T1
 Here we need to not delete U, even though T2 is "dead"!
 
 The solution is to focus on the meaning of "dependency": with the pruning that we can do, we *can*
-remove all the term level bits en masse, but only en-mass. So we need to make *them* into a clique,
+remove all the term level bits en masse, but only en-mass. So we need to make *them* into a circuit,
 so that this is visible to the dependency analysis.
 -}
 
@@ -187,8 +187,8 @@ bindingDeps b = case b of
         <$> (withCurrent destr $ traverse (typeDeps . _varDeclType) constrs)
     let tus = fmap (view PLC.theUnique) (destr : fmap _varDeclName constrs)
     -- See Note [Dependencies for datatype bindings, and pruning them]
-    let nonDatatypeClique = G.clique (fmap Variable tus)
-    pure $ G.overlays $ [vDeps] ++ tvDeps ++ cstrDeps ++ [destrDeps] ++ [nonDatatypeClique]
+    let nonDatatypeCircuit = G.circuit (fmap Variable tus)
+    pure $ G.overlays $ [vDeps] ++ tvDeps ++ cstrDeps ++ [destrDeps] ++ [nonDatatypeCircuit]
 
 varDeclDeps ::
   ( DepGraph g

--- a/plutus-core/plutus-ir/test/PlutusIR/Analysis/RetainedSize/datatypeLiveConstr.golden
+++ b/plutus-core/plutus-ir/test/PlutusIR/Analysis/RetainedSize/datatypeLiveConstr.golden
@@ -2,11 +2,11 @@
   (nonrec)
   (datatypebind
     (datatype
-      $0$
+      $1$
       (tyvardecl $4$ Maybe (fun (type) (type)))
       (tyvardecl $2$ a (type))
       match_Maybe
-      (vardecl $16$ Nothing [ Maybe a ]) (vardecl $6$ Just (fun a [ Maybe a ]))
+      (vardecl $17$ Nothing [ Maybe a ]) (vardecl $7$ Just (fun a [ Maybe a ]))
     )
   )
   Nothing

--- a/plutus-core/plutus-ir/test/PlutusIR/Analysis/RetainedSize/datatypeLiveDestr.golden
+++ b/plutus-core/plutus-ir/test/PlutusIR/Analysis/RetainedSize/datatypeLiveDestr.golden
@@ -6,7 +6,7 @@
       (tyvardecl $4$ Maybe (fun (type) (type)))
       (tyvardecl $2$ a (type))
       match_Maybe
-      (vardecl $4$ Nothing [ Maybe a ]) (vardecl $6$ Just (fun a [ Maybe a ]))
+      (vardecl $10$ Nothing [ Maybe a ]) (vardecl $6$ Just (fun a [ Maybe a ]))
     )
   )
   match_Maybe

--- a/plutus-tx-plugin/test/Plugin/Data/9.6/monomorphic/stakingCredential.pir.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/9.6/monomorphic/stakingCredential.pir.golden
@@ -1,0 +1,7 @@
+let
+  Credential = all a. a -> a
+  data StakingCredential | StakingCredential_match where
+    StakingHash : Credential -> StakingCredential
+    StakingPtr : StakingCredential
+in
+StakingPtr

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -56,6 +56,7 @@ monoData = testNested "monomorphic" [
   , goldenPirReadable "recordWithStrictField" recordWithStrictField
   , goldenPirReadable "unusedWrapper" unusedWrapper
   , goldenPirReadable "nonValueCase" nonValueCase
+  , goldenPirReadable "stakingCredential" stakingCredential
   , goldenPirReadable "strictDataMatch" strictDataMatch
   , goldenPirReadable "synonym" synonym
   ]
@@ -156,6 +157,16 @@ unusedWrapper = plc (Proxy @"unusedWrapper") ((\x (y, z) -> x (z, y)) mkT (1, 2)
 -- must be compiled with a lazy case
 nonValueCase :: CompiledCode (MyEnum -> Integer)
 nonValueCase = plc (Proxy @"nonValueCase") (\(x :: MyEnum) -> case x of { Enum1 -> 1::Integer ; Enum2 -> Builtins.error (); })
+
+data Credential
+  = PubKeyCredential
+data StakingCredential
+  = StakingHash Credential
+  | StakingPtr
+
+-- | Check that a data type used in an unused construtor of a used data type doesn't get eliminated.
+stakingCredential :: CompiledCode StakingCredential
+stakingCredential = plc (Proxy @"StakingCredential") StakingPtr
 
 -- Bang patterns on data types do nothing: fields are already strict
 data StrictTy a = StrictTy !a !a


### PR DESCRIPTION
`clique` apparently treats the graph as undirected, as its Haddock says:

> clique [x,y]      == edge x y
> clique [x,y,z]    == edges [(x,y), (x,z), (y,z)]

This is not what we want - we want all pairs of nodes to be mutually reachable. So what we should use is `circuit`.