### PR TITLE
Fix combined-haddock.sh, remove release-1.30.0.0 folder, restore cardano-crypto-class ^>=2.2

### DIFF
--- a/.github/workflows/cabal-build-all.yml
+++ b/.github/workflows/cabal-build-all.yml
@@ -8,7 +8,9 @@ name: "👷 Cabal Build All"
 
 on:
   workflow_dispatch:
-  pull_request: 
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -57,3 +57,19 @@ executable example-cip57
     , containers
     , plutus-ledger-api  ^>=1.40
     , plutus-tx          ^>=1.40
+
+executable quickstart
+  import:           lang, ghc-version-support, os-support
+  main-is:          QuickStart.hs
+  hs-source-dirs:   static/code
+  default-language: Haskell2010
+  other-modules:    AuctionValidator
+  build-depends:
+    , base               >=4.9   && <5
+    , base16-bytestring
+    , bytestring
+    , plutus-ledger-api  ^>=1.40
+    , plutus-tx          ^>=1.40
+
+  if !(impl(ghcjs) || os(ghcjs))
+    build-depends: plutus-tx-plugin ^>=1.40

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -490,7 +490,7 @@ library marlowe-internal
   build-depends:
     , base
     , bytestring
-    , cardano-crypto-class             ^>=2.1.5
+    , cardano-crypto-class
     , directory
     , filepath
     , mtl

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -293,8 +293,8 @@ library
     , bimap
     , bytestring
     , bytestring-strict-builder
-    , cardano-crypto
-    , cardano-crypto-class        ^>=2.1.5
+    , cardano-crypto              >=1.2
+    , cardano-crypto-class        ^>=2.2
     , cassava
     , cborg
     , composition-prelude         >=1.1.0.1

--- a/scripts/combined-haddock.sh
+++ b/scripts/combined-haddock.sh
@@ -195,9 +195,9 @@ EOF
 # Then for each package-version we produce a different sed substitution.
 
 
-NUM_FILES=$(find "${OUTPUT_DIR}" -type f -name "*.html" | wc -l)
+NUM_FILES=$(find "${OUTPUT_DIR}" -type f -name "*.html" -or -name "doc-index.json" | wc -l)
 echo "Applying sed to ${NUM_FILES} files"
-time find "${OUTPUT_DIR}" -name "*.html" | xargs sed -i -E -f "${BUILD_DIR}/sedscript.txt"
+time find "${OUTPUT_DIR}" -name "*.html" -or -name "doc-index.json" | xargs sed -i -E -f "${BUILD_DIR}/sedscript.txt"
 
 
 echo "Checking that all hrefs to /nix/store were replaced"


### PR DESCRIPTION
These changes are needed to account for the exceptional steps needed to publish release 1.40.0.0, which left master in an inconsistent state. 