### PR TITLE
Add apply-to-cbor-data option to uplc

### DIFF
--- a/plutus-executables/plutus-executables.cabal
+++ b/plutus-executables/plutus-executables.cabal
@@ -116,6 +116,7 @@ executable uplc
     , plutus-executables:lib
     , plutus-metatheory
     , prettyprinter
+    , serialise
     , split
     , text
 


### PR DESCRIPTION
On the chain scripts are encoded using `flat` but `data` objects (in redeemers etc) are encoded using CBOR.  This PR adds an `apply-to-cbor-data` option to the `uplc` command that lets you apply a script to a list of such CBOR-encoded `data` objects.

We should really be using the unified `plutus` command instead, but it was a lot quicker for me to add this to `uplc`.