### PR TITLE
Add nicer changelog to plutus release notes

### DIFF
--- a/scripts/interactive-release.sh
+++ b/scripts/interactive-release.sh
@@ -217,7 +217,7 @@ check-and-publish-gh-release() {
 }
 
 
-collect-release-notes() {
+generate-release-notes() {
   local CHANGELOG_PACKAGES=(
     "plutus-core"
     "plutus-ledger-api"
@@ -232,6 +232,8 @@ collect-release-notes() {
     echo "${CHANGELOG:="No changes."}"
     echo 
   done
+  local PREV_VERSION=$(gh release list --json tagName --jq ".[1].tagName")
+  echo "**Full Changelog**: https://github.com/IntersectMBO/plutus/compare/$PREV_VERSION...$VERSION"
 }
 
 
@@ -241,7 +243,7 @@ publish-gh-release() {
     upx -9 ./result/bin/$EXEC -o $EXEC-x86_64-linux-ghc96 --force-overwrite
   done 
   local NOTES_FILE=$(mktemp)
-  collect-release-notes > $NOTES_FILE
+  generate-release-notes > $NOTES_FILE
   gh release create $VERSION --title $VERSION --notes-file $NOTES_FILE --latest
   gh release upload $VERSION {uplc,plc,pir}-x86_64-linux-ghc96 --clobber
   tell "Published the release"

--- a/scripts/interactive-release.sh
+++ b/scripts/interactive-release.sh
@@ -232,20 +232,20 @@ generate-release-notes() {
     echo "${CHANGELOG:="No changes."}"
     echo 
   done
-  local PREV_VERSION=$(gh release list --json tagName --jq ".[1].tagName")
+  local PREV_VERSION=$(gh release list --json tagName --jq ".[0].tagName")
   echo "**Full Changelog**: https://github.com/IntersectMBO/plutus/compare/$PREV_VERSION...$VERSION"
 }
 
 
 publish-gh-release() {
-  for EXEC in uplc pir plc; do 
-    nix build ".#hydraJobs.x86_64-linux.musl64.ghc96.$EXEC"
-    upx -9 ./result/bin/$EXEC -o $EXEC-x86_64-linux-ghc96 --force-overwrite
-  done 
+  # for EXEC in uplc pir plc; do 
+  #   nix build ".#hydraJobs.x86_64-linux.musl64.ghc96.$EXEC"
+  #   upx -9 ./result/bin/$EXEC -o $EXEC-x86_64-linux-ghc96 --force-overwrite
+  # done 
   local NOTES_FILE=$(mktemp)
   generate-release-notes > $NOTES_FILE
   gh release create $VERSION --title $VERSION --notes-file $NOTES_FILE --latest
-  gh release upload $VERSION {uplc,plc,pir}-x86_64-linux-ghc96 --clobber
+  # gh release upload $VERSION {uplc,plc,pir}-x86_64-linux-ghc96 --clobber
   tell "Published the release"
 }
 

--- a/scripts/interactive-release.sh
+++ b/scripts/interactive-release.sh
@@ -238,14 +238,14 @@ generate-release-notes() {
 
 
 publish-gh-release() {
-  # for EXEC in uplc pir plc; do 
-  #   nix build ".#hydraJobs.x86_64-linux.musl64.ghc96.$EXEC"
-  #   upx -9 ./result/bin/$EXEC -o $EXEC-x86_64-linux-ghc96 --force-overwrite
-  # done 
+  for EXEC in uplc pir plc; do 
+    nix build ".#hydraJobs.x86_64-linux.musl64.ghc96.$EXEC"
+    upx -9 ./result/bin/$EXEC -o $EXEC-x86_64-linux-ghc96 --force-overwrite
+  done 
   local NOTES_FILE=$(mktemp)
   generate-release-notes > $NOTES_FILE
   gh release create $VERSION --title $VERSION --notes-file $NOTES_FILE --latest
-  # gh release upload $VERSION {uplc,plc,pir}-x86_64-linux-ghc96 --clobber
+  gh release upload $VERSION {uplc,plc,pir}-x86_64-linux-ghc96 --clobber
   tell "Published the release"
 }
 


### PR DESCRIPTION
Instead of listing the commits between since the last release, the `interactive-release.sh` script will now collect the changes from the CHANGELOG.md files and use them as release notes.