### PR TITLE
Kwxm/crypto/remove ed25519-donna

### DIFF
--- a/doc/notes/model/UTxO.hsproj/Examples/Keys.hs
+++ b/doc/notes/model/UTxO.hsproj/Examples/Keys.hs
@@ -4,10 +4,10 @@
 module Examples.Keys
 where
 
-import "cryptonite" Crypto.PubKey.ECC.ECDSA
+import "crypton" Crypto.PubKey.ECC.ECDSA
 import Crypto.PubKey.ECC.Generate
 import Crypto.PubKey.ECC.Types
-import "cryptonite" Crypto.Random
+import "crypton" Crypto.Random
 
 import Data.Map (Map)
 import Data.Map qualified as Map

--- a/doc/notes/model/UTxO.hsproj/Types.hs
+++ b/doc/notes/model/UTxO.hsproj/Types.hs
@@ -13,7 +13,7 @@
 module Types
 where
 
-import "cryptonite" Crypto.Hash
+import "crypton" Crypto.Hash
 
 
 -- Basic types

--- a/doc/notes/model/UTxO.hsproj/UTxO.cabal
+++ b/doc/notes/model/UTxO.hsproj/UTxO.cabal
@@ -15,7 +15,7 @@ x-ghc-framework-version: 8.0.2-9.6-1
 x-last-ide-version:      HfM1.6.0
 
 executable UTxO
-  main-is:          Main.hs
+  main-is:            Main.hs
   build-depends:
       base
     , bytestring
@@ -26,7 +26,8 @@ executable UTxO
     , memory
     , template-haskell
 
-  default-language: Haskell2010
+  default-language:   Haskell2010
+  default-extensions: ImportQualifiedPost
   other-modules:
     Examples.Keys
     Examples.PubKey

--- a/doc/notes/model/UTxO.hsproj/Witness.hs
+++ b/doc/notes/model/UTxO.hsproj/Witness.hs
@@ -33,8 +33,8 @@ module Witness (
   validate
 ) where
 
-import "cryptonite" Crypto.Hash
-import "cryptonite" Crypto.PubKey.ECC.ECDSA
+import "crypton" Crypto.Hash
+import "crypton" Crypto.PubKey.ECC.ECDSA
 import Data.ByteArray qualified as BA
 import Data.ByteString.Char8 qualified as BS
 import Language.Haskell.TH

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -293,13 +293,11 @@ library
     , bimap
     , bytestring
     , bytestring-strict-builder
-    , cardano-crypto              >=1.2
     , cardano-crypto-class        ^>=2.2
     , cassava
     , cborg
     , composition-prelude         >=1.1.0.1
     , containers
-    , crypton
     , data-default-class
     , deepseq
     , dependent-sum               >=0.7.1.0

--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/Ed25519.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/Ed25519.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
-module PlutusCore.Crypto.Ed25519 (
-   verifyEd25519Signature
-   ) where
+module PlutusCore.Crypto.Ed25519 (verifyEd25519Signature)
+where
 
 import PlutusCore.Builtin.KnownType (BuiltinResult)
 import PlutusCore.Crypto.Utils
@@ -29,9 +28,9 @@ verifyEd25519Signature pk msg sig =
       Nothing -> failWithMessage loc "Invalid signature."
       Just sig' ->
           pure $
-               case DSIGN.verifyDSIGN () pk' msg sig' of
-                 Left _   -> False
-                 Right () -> True
+                case DSIGN.verifyDSIGN () pk' msg sig' of
+                  Left _   -> False
+                  Right () -> True
   where
     loc :: Text
     loc = "Ed25519 signature verification"

--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/Ed25519.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/Ed25519.hs
@@ -2,8 +2,7 @@
 {-# LANGUAGE TypeApplications  #-}
 
 module PlutusCore.Crypto.Ed25519 (
-   verifyEd25519Signature_V1,
-   verifyEd25519Signature_V2
+   verifyEd25519Signature
    ) where
 
 import PlutusCore.Builtin.KnownType (BuiltinResult)
@@ -11,40 +10,19 @@ import PlutusCore.Crypto.Utils
 
 import Cardano.Crypto.DSIGN.Class qualified as DSIGN
 import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
-import Crypto.ECC.Ed25519Donna (publicKey, signature, verify)
-import Crypto.Error (CryptoFailable (..))
 import Data.ByteString qualified as BS
-import Data.Text (Text, pack)
-
--- | Ed25519 signature verification
--- This will fail if the key or the signature are not of the expected length.
--- This version uses the cardano-crypto implementation of the verification function.
-verifyEd25519Signature_V1
-    :: BS.ByteString  -- ^ Public Key (32 bytes)
-    -> BS.ByteString  -- ^ Message    (arbitrary length)
-    -> BS.ByteString  -- ^ Signature  (64 bytes)
-    -> BuiltinResult Bool
-verifyEd25519Signature_V1 pubKey msg sig =
-    case verify
-             <$> publicKey pubKey
-             <*> pure msg
-             <*> signature sig
-    of CryptoPassed r   -> pure r
-       CryptoFailed err -> failWithMessage loc $ pack (show err)
-  where
-    loc :: Text
-    loc = "Ed25519 signature verification"
+import Data.Text (Text)
 
 -- | Ed25519 signature verification
 -- This will fail if the key or the signature are not of the expected length.
 -- This version uses the cardano-crypto-class implementation of the verification
 -- function (using libsodium).
-verifyEd25519Signature_V2
+verifyEd25519Signature
     :: BS.ByteString  -- ^ Public Key (32 bytes)
     -> BS.ByteString  -- ^ Message    (arbitrary length)
     -> BS.ByteString  -- ^ Signature  (64 bytes)
     -> BuiltinResult Bool
-verifyEd25519Signature_V2 pk msg sig =
+verifyEd25519Signature pk msg sig =
   case DSIGN.rawDeserialiseVerKeyDSIGN @Ed25519DSIGN pk of
     Nothing -> failWithMessage loc "Invalid verification key."
     Just pk' -> case DSIGN.rawDeserialiseSigDSIGN @Ed25519DSIGN sig of

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -33,7 +33,7 @@ import PlutusCore.Bitwise qualified as Bitwise
 import PlutusCore.Crypto.BLS12_381.G1 qualified as BLS12_381.G1
 import PlutusCore.Crypto.BLS12_381.G2 qualified as BLS12_381.G2
 import PlutusCore.Crypto.BLS12_381.Pairing qualified as BLS12_381.Pairing
-import PlutusCore.Crypto.Ed25519 (verifyEd25519Signature_V1, verifyEd25519Signature_V2)
+import PlutusCore.Crypto.Ed25519 (verifyEd25519Signature)
 import PlutusCore.Crypto.ExpMod qualified as ExpMod
 import PlutusCore.Crypto.Hash qualified as Hash
 import PlutusCore.Crypto.Secp256k1 (verifyEcdsaSecp256k1Signature, verifySchnorrSecp256k1Signature)
@@ -1334,14 +1334,10 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             blake2b_256Denotation
             (runCostingFunOneArgument . paramBlake2b_256)
 
-    toBuiltinMeaning semvar VerifyEd25519Signature =
+    toBuiltinMeaning _semvar VerifyEd25519Signature =
         let verifyEd25519SignatureDenotation
                 :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BuiltinResult Bool
-            verifyEd25519SignatureDenotation =
-                case semvar of
-                  DefaultFunSemanticsVariantA -> verifyEd25519Signature_V1
-                  DefaultFunSemanticsVariantB -> verifyEd25519Signature_V2
-                  DefaultFunSemanticsVariantC -> verifyEd25519Signature_V2
+            verifyEd25519SignatureDenotation = verifyEd25519Signature
             {-# INLINE verifyEd25519SignatureDenotation #-}
         in makeBuiltinMeaning
             verifyEd25519SignatureDenotation

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -59,7 +59,6 @@ library
     , base
     , bytestring
     , composition-prelude
-    , crypton
     , extra
     , filepath
     , ghc-prim

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -570,7 +570,7 @@ postulate
 {-# FOREIGN GHC builtinResultToMaybe :: BuiltinResult a -> Maybe a #-}
 {-# FOREIGN GHC builtinResultToMaybe = reoption #-}
 
-{-# COMPILE GHC verifyEd25519Sig = \k m s -> builtinResultToMaybe $ verifyEd25519Signature_V2 k m s #-}
+{-# COMPILE GHC verifyEd25519Sig = \k m s -> builtinResultToMaybe $ verifyEd25519Signature k m s #-}
 {-# COMPILE GHC verifyEcdsaSecp256k1Sig = \k m s -> builtinResultToMaybe $ verifyEcdsaSecp256k1Signature k m s #-}
 {-# COMPILE GHC verifySchnorrSecp256k1Sig = \k m s -> builtinResultToMaybe $ verifySchnorrSecp256k1Signature k m s #-}
 

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -262,7 +262,7 @@ ripemd_160 (BuiltinByteString b) = BuiltinByteString $ Hash.ripemd_160 b
 
 verifyEd25519Signature :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString -> BuiltinBool
 verifyEd25519Signature (BuiltinByteString vk) (BuiltinByteString msg) (BuiltinByteString sig) =
-  case PlutusCore.Crypto.Ed25519.verifyEd25519Signature_V1 vk msg sig of
+  case PlutusCore.Crypto.Ed25519.verifyEd25519Signature vk msg sig of
     BuiltinSuccess b              -> BuiltinBool b
     BuiltinSuccessWithLogs logs b -> traceAll logs $ BuiltinBool b
     BuiltinFailure logs err       -> traceAll (logs <> pure (display err)) $


### PR DESCRIPTION
This removes the `verifyEd25519Signature_V1` builtin variant, which in turn removes our dependency on the `crypton`/`cryptonite` library and the deprecated `cardano-crypto` package.