### PR TITLE
Fixed 3 broken links  CIP-69,  CIP-117 and UnsafeFromData

### DIFF
--- a/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
+++ b/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
@@ -136,7 +136,7 @@ Additional key differences between Plutus V3 and V1/V2 include:
 4. For now, Plutus V3 supports Plutus Core 1.1.0, a Plutus Core language version that introduced [sums-of-products](https://cips.cardano.org/cip/CIP-0085), as well as more builtin functions than Plutus V2.
    However, we plan to enable all Plutus Core versions and all builtin functions across all ledger language versions in the future.
 
-The first two points above are attributed to [CIP-69](https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069/), whereas the third point is attributed to [CIP-117](https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117/).
+The first two points above are attributed to [CIP-69]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069/](https://cips.cardano.org/cip/CIP-0069)), whereas the third point is attributed to [CIP-117]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117/](https://cips.cardano.org/cip/CIP-0117)).
 
 In other words, all Plutus V3 scripts should have the following type in Plinth:
 

--- a/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
+++ b/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
@@ -136,7 +136,7 @@ Additional key differences between Plutus V3 and V1/V2 include:
 4. For now, Plutus V3 supports Plutus Core 1.1.0, a Plutus Core language version that introduced [sums-of-products](https://cips.cardano.org/cip/CIP-0085), as well as more builtin functions than Plutus V2.
    However, we plan to enable all Plutus Core versions and all builtin functions across all ledger language versions in the future.
 
-The first two points above are attributed to [CIP-69]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069/](https://cips.cardano.org/cip/CIP-0069)), whereas the third point is attributed to [CIP-117]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117/](https://cips.cardano.org/cip/CIP-0117)).
+The first two points above are attributed to [CIP-69]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069/](https://cips.cardano.org/cip/CIP-0069), whereas the third point is attributed to [CIP-117]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117/](https://cips.cardano.org/cip/CIP-0117).
 
 In other words, all Plutus V3 scripts should have the following type in Plinth:
 

--- a/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
+++ b/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
@@ -68,7 +68,7 @@ myV1SpendingScriptCompiled :: CompiledCode (BuiltinData -> BuiltinData -> Builti
 myV1SpendingScriptCompiled = $$(PlutusTx.compile [||myV1SpendingScriptUntyped||])
 ```
 
-`unsafeFromBuiltinData` is a method from the [`UnsafeFromData`](http://localhost:3000/docs/working-with-scripts/ledger-language-version) class.
+`unsafeFromBuiltinData` is a method from the [`UnsafeFromData`](https://plutus.cardano.intersectmbo.org/haddock/master/plutus-ledger-api/PlutusLedgerApi-V1.html#t:UnsafeFromData) class.
 Each call to `unsafeFromBuiltinData` decodes a `BuiltinData` into a value of a Haskell domain type, failing if the conversion fails.
 The `check` function takes a `Bool` and returns a `BuiltinUnit`, throwing an error if the input is `False`.
 It is needed because returning `False` does not cause the validation to fail; to fail the validation, an error needs to be thrown.

--- a/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
+++ b/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
@@ -136,7 +136,7 @@ Additional key differences between Plutus V3 and V1/V2 include:
 4. For now, Plutus V3 supports Plutus Core 1.1.0, a Plutus Core language version that introduced [sums-of-products](https://cips.cardano.org/cip/CIP-0085), as well as more builtin functions than Plutus V2.
    However, we plan to enable all Plutus Core versions and all builtin functions across all ledger language versions in the future.
 
-The first two points above are attributed to [CIP-69]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069/](https://cips.cardano.org/cip/CIP-0069), whereas the third point is attributed to [CIP-117]([https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117/](https://cips.cardano.org/cip/CIP-0117).
+The first two points above are attributed to [CIP-69](https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069), whereas the third point is attributed to [CIP-117](https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117).
 
 In other words, all Plutus V3 scripts should have the following type in Plinth:
 

--- a/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
+++ b/doc/docusaurus/docs/working-with-scripts/ledger-language-version.md
@@ -136,7 +136,7 @@ Additional key differences between Plutus V3 and V1/V2 include:
 4. For now, Plutus V3 supports Plutus Core 1.1.0, a Plutus Core language version that introduced [sums-of-products](https://cips.cardano.org/cip/CIP-0085), as well as more builtin functions than Plutus V2.
    However, we plan to enable all Plutus Core versions and all builtin functions across all ledger language versions in the future.
 
-The first two points above are attributed to [CIP-69](https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069), whereas the third point is attributed to [CIP-117](https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117).
+The first two points above are attributed to [CIP-69](https://cips.cardano.org/cip/CIP-69), whereas the third point is attributed to [CIP-117](https://cips.cardano.org/cip/CIP-0117).
 
 In other words, all Plutus V3 scripts should have the following type in Plinth:
 


### PR DESCRIPTION

Fixed 3 broken links :

a) CIP-69  from  `https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0069/` to `https://cips.cardano.org/cip/CIP-69`

b) CIP-117 from  `https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0117/` to `https://cips.cardano.org/cip/CIP-0117`

c) UnsafeFromData class from `http://localhost:3000/docs/working-with-scripts/ledger-language-version` to `https://plutus.cardano.intersectmbo.org/haddock/master/plutus-ledger-api/PlutusLedgerApi-V1.html#t:UnsafeFromData`
