### PR TITLE
Fix .gitignore pattern for flat files generated by exe:marlowe-validators

### DIFF
--- a/plutus-benchmark/.gitignore
+++ b/plutus-benchmark/.gitignore
@@ -3,8 +3,8 @@ flat-sizes.txt
 report.html
 report.json
 PlutusBenchmark.Marlowe.Scripts.*.flat
-marlowe/exe/scripts/rolepayout/*.flat
-marlowe/exe/scripts/semantics/*.flat
+marlowe/scripts/rolepayout/*.flat
+marlowe/scripts/semantics/*.flat
 *.plutus
 *.tsv
 


### PR DESCRIPTION
The .gitignore paths had to be adjusted.