### PR TITLE
chore: fourmolize PlutusBenchmark/Marlowe

### DIFF
--- a/plutus-benchmark/marlowe/exe/Main.hs
+++ b/plutus-benchmark/marlowe/exe/Main.hs
@@ -1,27 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
 
-
------------------------------------------------------------------------------
---
--- Module      :  $Headers
--- License     :  Apache 2.0
---
--- Stability   :  Experimental
--- Portability :  Portable
---
--- | Run benchmarks for Marlowe validators.
---
------------------------------------------------------------------------------
-
-
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE OverloadedStrings   #-}
-
-
-module Main (
-  -- * Entry point
-  main
-) where
-
+module Main (main) where
 
 import Cardano.Binary (serialize')
 import Data.ByteString qualified as BS (writeFile)
@@ -29,71 +8,88 @@ import Data.ByteString.Base16 qualified as B16 (encode)
 import Data.List (intercalate)
 import PlutusBenchmark.Common (getDataDir)
 import PlutusBenchmark.Marlowe.BenchUtil (semanticsBenchmarks, tabulateResults, writeFlatUPLCs)
-import PlutusBenchmark.Marlowe.RolePayout qualified as RolePayout (benchmarks, validatorBytes,
-                                                                   validatorHash, writeUPLC)
-import PlutusBenchmark.Marlowe.Semantics qualified as Semantics (validatorBytes, validatorHash,
-                                                                 writeUPLC)
+import PlutusBenchmark.Marlowe.RolePayout qualified as RolePayout
+import PlutusBenchmark.Marlowe.Semantics qualified as Semantics
 import PlutusLedgerApi.V2 (ScriptHash, SerialisedScript)
+import System.FilePath (normalise, (</>))
 
--- | Run the benchmarks and export information about the validators and the benchmarking results.
+{-| Run the benchmarks and export information about
+the validators and the benchmarking results.
+-}
 main :: IO ()
-main =
-  do
-    dir <- getDataDir
+main = do
+  dir <- normalise <$> getDataDir
 
-    -- Read the semantics benchmarks.
-    benchmarks <- either error id <$> semanticsBenchmarks
+  let semanticsUplcDir = dir </> "marlowe/scripts/semantics"
+      semanticsValidatorExportDir = dir </> "marlowe/exe/marlowe-semantics"
+      semanticsValidatorResults = dir </> "marlowe/exe/marlowe-semantics.tsv"
 
-    -- Write the tabulation of semantics benchmark results.
-    writeFile (dir <> "/marlowe/exe/marlowe-semantics.tsv")
-      . unlines . fmap (intercalate "\t")
-      $ tabulateResults "Semantics" Semantics.validatorHash Semantics.validatorBytes benchmarks
+  let rolePayoutUplcDir = dir </> "marlowe/scripts/rolepayout"
+      rolePayoutValidatorExportDir = dir </> "marlowe/exe/marlowe-rolepayout"
+      rolePayoutValidatorResults = dir </> "marlowe/exe/marlowe-rolepayout.tsv"
 
-    -- Write the flat UPLC files for the semantics benchmarks.
-    writeFlatUPLCs Semantics.writeUPLC benchmarks
-      (dir <> "/marlowe/scripts/semantics")
+  -- Read the semantics benchmarks.
+  benchmarks <- either error id <$> semanticsBenchmarks
 
-    -- Print the semantics validator, and write the plutus file.
-    printValidator
+  -- Write the tabulation of semantics benchmark results.
+  writeFile semanticsValidatorResults . unlines . (intercalate "\t" <$>) $
+    tabulateResults
       "Semantics"
-      (dir <> "/marlowe/exe/marlowe-semantics")
       Semantics.validatorHash
       Semantics.validatorBytes
+      benchmarks
 
-    -- Read the role-payout benchmarks.
-    benchmarks' <- either error id <$> RolePayout.benchmarks
+  -- Write the flat UPLC files for the semantics benchmarks.
+  writeFlatUPLCs Semantics.writeUPLC benchmarks semanticsUplcDir
 
-    -- Write the tabulation of role-payout benchmark results.
-    writeFile (dir <> "/marlowe/exe/marlowe-rolepayout.tsv")
-      . unlines . fmap (intercalate "\t")
-      $ tabulateResults "Role Payout" RolePayout.validatorHash RolePayout.validatorBytes benchmarks'
+  -- Print the semantics validator, and write the plutus file.
+  printValidator
+    "Semantics"
+    semanticsValidatorExportDir
+    Semantics.validatorHash
+    Semantics.validatorBytes
 
-    -- Write the flat UPLC files for the role-payout benchmarks.
-    writeFlatUPLCs RolePayout.writeUPLC benchmarks'
-      (dir <> "/marlowe/scripts/rolepayout")
+  -- Read the role-payout benchmarks.
+  benchmarks' <- either error id <$> RolePayout.benchmarks
 
-    -- Print the role-payout validator, and write the plutus file.
-    printValidator
-      "Role payout"
-      (dir <> "/marlowe/exe/marlowe-rolepayout")
+  -- Write the tabulation of role-payout benchmark results.
+  writeFile rolePayoutValidatorResults . unlines . (intercalate "\t" <$>) $
+    tabulateResults
+      "Role Payout"
       RolePayout.validatorHash
       RolePayout.validatorBytes
+      benchmarks'
 
+  -- Write the flat UPLC files for the role-payout benchmarks.
+  writeFlatUPLCs RolePayout.writeUPLC benchmarks' rolePayoutUplcDir
+
+  -- Print the role-payout validator, and write the plutus file.
+  printValidator
+    "Role payout"
+    rolePayoutValidatorExportDir
+    RolePayout.validatorHash
+    RolePayout.validatorBytes
 
 -- | Print information about a validator.
 printValidator
-  :: String  -- ^ The name of the validator.
-  -> FilePath  -- ^ The base file path for exported files.
-  -> ScriptHash  -- ^ The hash of the validator script.
-  -> SerialisedScript  -- ^ The serialised validator.
-  -> IO ()  -- ^ Action to print the information about the benchmarking, and write the files.
-printValidator name file hash validator =
-  do
-    putStrLn $ name <> ":"
-    putStrLn $ "  Validator hash: " <> show hash
-    putStrLn $ "  Validator file: " <> file <> ".plutus"
-    putStrLn $ "  Measurements file: " <> file <> ".tsv"
-    BS.writeFile (file <> ".plutus")
-      $ "{\"type\": \"PlutusScriptV2\", \"description\": \"\", \"cborHex\": \""
-      <> B16.encode (serialize' validator) <> "\"}"
-    putStrLn ""
+  :: String
+  -- ^ The name of the validator.
+  -> FilePath
+  -- ^ The base file path for exported files.
+  -> ScriptHash
+  -- ^ The hash of the validator script.
+  -> SerialisedScript
+  -- ^ The serialised validator.
+  -> IO ()
+  -- ^ Action to print the information about the benchmarking,
+  -- and write the files.
+printValidator name file hash validator = do
+  putStrLn $ name <> ":"
+  putStrLn $ "  Validator hash: " <> show hash
+  putStrLn $ "  Validator file: " <> file <> ".plutus"
+  putStrLn $ "  Measurements file: " <> file <> ".tsv"
+  BS.writeFile (file <> ".plutus") $
+    "{\"type\": \"PlutusScriptV2\", \"description\": \"\", \"cborHex\": \""
+      <> B16.encode (serialize' validator)
+      <> "\"}"
+  putStrLn ""

--- a/plutus-benchmark/marlowe/exe/PlutusBenchmark/Marlowe/RolePayout.hs
+++ b/plutus-benchmark/marlowe/exe/PlutusBenchmark/Marlowe/RolePayout.hs
@@ -1,32 +1,13 @@
-
-
------------------------------------------------------------------------------
---
--- Module      :  $Headers
--- License     :  Apache 2.0
---
--- Stability   :  Experimental
--- Portability :  Portable
---
--- | Benchmarking support for Marlowe's role-payout validator.
---
------------------------------------------------------------------------------
-
-
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
-
+-- editorconfig-checker-disable-file
+{-# LANGUAGE OverloadedStrings #-}
 
 module PlutusBenchmark.Marlowe.RolePayout (
-  -- * Benchmarking
-  benchmarks
-, validatorBytes
-, validatorHash
-, exampleBenchmark
-, writeUPLC
+  benchmarks,
+  validatorBytes,
+  validatorHash,
+  exampleBenchmark,
+  writeUPLC,
 ) where
-
 
 import Data.Bifunctor (second)
 import PlutusBenchmark.Marlowe.BenchUtil (readBenchmarks, updateScriptHash, writeFlatUPLC)
@@ -45,43 +26,33 @@ import PlutusLedgerApi.V2 (Credential (PubKeyCredential, ScriptCredential), Curr
 import PlutusLedgerApi.V1.Value (TokenName (TokenName))
 import PlutusTx.AssocMap qualified as AM (empty)
 
-
 -- | Write a flat UPLC file for a benchmark.
-writeUPLC
-  :: FilePath
-  -> Benchmark
-  -> IO ()
+writeUPLC :: FilePath -> Benchmark -> IO ()
 writeUPLC = writeFlatUPLC rolePayoutValidator
-
 
 -- | The serialised Marlowe role-payout validator.
 validatorBytes :: SerialisedScript
 validatorBytes = rolePayoutValidatorBytes
 
-
 -- | The hash for the Marlowe role-payout validator.
 validatorHash :: ScriptHash
 validatorHash = rolePayoutValidatorHash
 
-
 -- | The benchmark cases for the Marlowe role-payout validator.
 benchmarks :: IO (Either String [Benchmark])
-benchmarks = second (rescript <$>) <$> readBenchmarks "marlowe/scripts/rolepayout"
-
+benchmarks =
+  second (rescript <$>) <$> readBenchmarks "marlowe/scripts/rolepayout"
 
 -- | Revise the validator hashes in the benchmark's script context.
-rescript
-  :: Benchmark
-  -> Benchmark
+rescript :: Benchmark -> Benchmark
 rescript benchmark@Benchmark{..} =
-  benchmark {
-    bScriptContext =
-      updateScriptHash
-        "e165610232235bbbbeff5b998b233daae42979dec92a6722d9cda989"
-        rolePayoutValidatorHash
-        bScriptContext
-  }
-
+  benchmark
+    { bScriptContext =
+        updateScriptHash
+          "e165610232235bbbbeff5b998b233daae42979dec92a6722d9cda989"
+          rolePayoutValidatorHash
+          bScriptContext
+    }
 
 {-# DEPRECATED exampleBenchmark "Experimental, not thoroughly tested." #-}
 
@@ -90,49 +61,56 @@ exampleBenchmark :: Benchmark
 exampleBenchmark =
   let
     txInfoInputs =
-      [
-        makeInput
-          "6ca85e35c485181d54b4092a49ed9fec93a3f21b603c68cbca741ec27de318cf" 0
+      [ makeInput
+          "6ca85e35c485181d54b4092a49ed9fec93a3f21b603c68cbca741ec27de318cf"
+          0
           (PubKeyCredential "5411f58036fcd19b79cc51539233698dd9b86c2e53d132675b152ce8")
           (lovelace 1008173101)
           Nothing
           Nothing
       , makeInput
-          "6ca85e35c485181d54b4092a49ed9fec93a3f21b603c68cbca741ec27de318cf" 1
+          "6ca85e35c485181d54b4092a49ed9fec93a3f21b603c68cbca741ec27de318cf"
+          1
           (PubKeyCredential "5411f58036fcd19b79cc51539233698dd9b86c2e53d132675b152ce8")
-          (singleton
-            (CurrencySymbol "d768a767450e9ffa2d68ae61e8476fb6267884e0477d7fd19703f9d8")
-            (TokenName "Seller") 1 <> lovelace 1034400)
+          ( singleton
+              (CurrencySymbol "d768a767450e9ffa2d68ae61e8476fb6267884e0477d7fd19703f9d8")
+              (TokenName "Seller")
+              1
+              <> lovelace 1034400
+          )
           Nothing
           Nothing
       , makeInput
-          "ef6a9ef1b84bef3dad5e12d9bf128765595be4a92da45bda2599dc7fae7e2397" 1
+          "ef6a9ef1b84bef3dad5e12d9bf128765595be4a92da45bda2599dc7fae7e2397"
+          1
           (ScriptCredential "e165610232235bbbbeff5b998b233daae42979dec92a6722d9cda989")
           (lovelace 75000000)
           (Just "95de9e2c3bface3de5739c0bd5197f0864315c1819c52783afb9b2ce075215f5")
           Nothing
       ]
     txInfoReferenceInputs =
-      [
-        makeInput
-          "9a8a6f387a3330b4141e1cb019380b9ac5c72151c0abc52aa4266245d3c555cd" 1
+      [ makeInput
+          "9a8a6f387a3330b4141e1cb019380b9ac5c72151c0abc52aa4266245d3c555cd"
+          1
           (PubKeyCredential "f685ca45a4c8c07dd592ba1609690b56fdb0b81cef9440345de947f1")
           (lovelace 12899830)
           Nothing
           (Just "e165610232235bbbbeff5b998b233daae42979dec92a6722d9cda989")
       ]
     txInfoOutputs =
-      [
-        makeOutput
+      [ makeOutput
           (PubKeyCredential "5411f58036fcd19b79cc51539233698dd9b86c2e53d132675b152ce8")
           (lovelace 1082841547)
           Nothing
           Nothing
       , makeOutput
           (PubKeyCredential "5411f58036fcd19b79cc51539233698dd9b86c2e53d132675b152ce8")
-          (singleton
-            (CurrencySymbol "d768a767450e9ffa2d68ae61e8476fb6267884e0477d7fd19703f9d8")
-            (TokenName "Seller") 1 <> lovelace 1034400)
+          ( singleton
+              (CurrencySymbol "d768a767450e9ffa2d68ae61e8476fb6267884e0477d7fd19703f9d8")
+              (TokenName "Seller")
+              1
+              <> lovelace 1034400
+          )
           Nothing
           Nothing
       ]
@@ -151,10 +129,9 @@ exampleBenchmark =
     scriptContextTxInfo = TxInfo{..}
     scriptContextPurpose =
       Spending $ TxOutRef "ef6a9ef1b84bef3dad5e12d9bf128765595be4a92da45bda2599dc7fae7e2397" 1
-  in
+   in
     makeBenchmark
-      (
-        makeBuiltinData
+      ( makeBuiltinData
           "d8799f581cd768a767450e9ffa2d68ae61e8476fb6267884e0477d7fd19703f9d84653656c6c6572ff"
       )
       (makeBuiltinData "d87980")

--- a/plutus-benchmark/marlowe/exe/PlutusBenchmark/Marlowe/Semantics.hs
+++ b/plutus-benchmark/marlowe/exe/PlutusBenchmark/Marlowe/Semantics.hs
@@ -1,32 +1,12 @@
-
 -- editorconfig-checker-disable-file
-
-
------------------------------------------------------------------------------
---
--- Module      :  $Headers
--- License     :  Apache 2.0
---
--- Stability   :  Experimental
--- Portability :  Portable
---
--- | Benchmarking support for Marlowe's semantics validator.
---
------------------------------------------------------------------------------
-
-
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
-
+{-# LANGUAGE OverloadedStrings #-}
 
 module PlutusBenchmark.Marlowe.Semantics (
-validatorBytes
-, validatorHash
-, exampleBenchmark
-, writeUPLC
+  validatorBytes,
+  validatorHash,
+  exampleBenchmark,
+  writeUPLC,
 ) where
-
 
 import PlutusBenchmark.Marlowe.BenchUtil (writeFlatUPLC)
 import PlutusBenchmark.Marlowe.Scripts.Semantics (marloweValidator, marloweValidatorBytes,
@@ -45,11 +25,9 @@ import PlutusLedgerApi.V2 (Credential (PubKeyCredential, ScriptCredential), Curr
 import PlutusLedgerApi.V1.Value (TokenName (TokenName))
 import PlutusTx.AssocMap qualified as AM (empty, unionWith)
 
-
 -- | The serialised Marlowe semantics validator.
 validatorBytes :: SerialisedScript
 validatorBytes = marloweValidatorBytes
-
 
 -- | The script hash for the Marlowe semantics validator.
 validatorHash :: ScriptHash
@@ -69,32 +47,36 @@ exampleBenchmark :: Benchmark
 exampleBenchmark =
   let
     txInfoInputs =
-      [
-        makeInput
-          "4a6808d88ffbceadf2bd86897bbacb9ee04131c9ccd56c998bfbcb65c0f3f471" 0
+      [ makeInput
+          "4a6808d88ffbceadf2bd86897bbacb9ee04131c9ccd56c998bfbcb65c0f3f471"
+          0
           (PubKeyCredential "0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07")
           (lovelace 847996471)
           Nothing
           Nothing
       , makeInput
-          "4a6808d88ffbceadf2bd86897bbacb9ee04131c9ccd56c998bfbcb65c0f3f471" 1
+          "4a6808d88ffbceadf2bd86897bbacb9ee04131c9ccd56c998bfbcb65c0f3f471"
+          1
           (ScriptCredential "626424dba5741cb1f0a3cab8643da59ffccba351495c4257f9ec3689")
           (lovelace 75000000)
           (Just "b4c9d042bd5fbb14431ad65769e21ccf132fd57e0c62f776dcb12961c44bd663")
           Nothing
       , makeInput
-          "db85a19c081d0beca1a63399c88fe96e64f1782699461f64e52d4cb2e26a2050" 1
+          "db85a19c081d0beca1a63399c88fe96e64f1782699461f64e52d4cb2e26a2050"
+          1
           (PubKeyCredential "0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07")
-          (singleton
-            (CurrencySymbol "8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338d")
-            (TokenName "Globe") 1 <> lovelace 2000000)
+          ( singleton
+              (CurrencySymbol "8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338d")
+              (TokenName "Globe")
+              1
+              <> lovelace 2000000
+          )
           Nothing
           Nothing
       ]
     txInfoReferenceInputs = []
     txInfoOutputs =
-      [
-        makeOutput
+      [ makeOutput
           (PubKeyCredential "0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07")
           (lovelace 847801537)
           Nothing
@@ -106,9 +88,12 @@ exampleBenchmark =
           Nothing
       , makeOutput
           (PubKeyCredential "0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07")
-          (singleton
-            (CurrencySymbol "8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338d")
-            (TokenName "Globe") 1 <> lovelace 1030090)
+          ( singleton
+              (CurrencySymbol "8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338d")
+              (TokenName "Globe")
+              1
+              <> lovelace 1030090
+          )
           Nothing
           Nothing
       ]
@@ -121,16 +106,18 @@ exampleBenchmark =
         (LowerBound (Finite 1684449918000) True)
         (UpperBound (Finite 1684450278000) False)
     txInfoSignatories = ["0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07"]
-    txInfoRedeemers = makeRedeemerMap scriptContextPurpose "9fd8799fd87a9fd8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff00ffffff"
+    txInfoRedeemers =
+      makeRedeemerMap
+        scriptContextPurpose
+        "9fd8799fd87a9fd8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff00ffffff"
     txInfoData =
-      AM.unionWith const
-        (
-          makeDatumMap
+      AM.unionWith
+        const
+        ( makeDatumMap
             "b4c9d042bd5fbb14431ad65769e21ccf132fd57e0c62f776dcb12961c44bd663"
             "d8799fd8799f581c8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338dffd8799fa1d8799fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd8799f4040ffff1a047868c0a0a001ffd87c9f9fd8799fd87a9fd8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff9fd8799f0000ffffffd87c9f9fd8799fd87a9fd8799f50466f756e64205377616e20546f6b656ed87a9f445377616effff9fd8799f0000ffffffd87c9f9fd8799fd87a9fd8799f56466f756e64204265617247617264656e20546f6b656ed87a9f4a4265617247617264656effff9fd8799f0000ffffffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f45476c6f6265ffffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f445377616effffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f4a4265617247617264656effffd8799f4040ffd87a9f1a017d7840ffd87980ffffffffff1b0000018831ac75f0d87980ffffff1b0000018831758770d87980ffffff1b00000188313e98f0d87980ffff"
         )
-        (
-          makeDatumMap
+        ( makeDatumMap
             "290c87ba567afe9e3eba9309c37ad993d2be7dbcbfcfaeff09f0009b3d5b2ed9"
             "d8799fd8799f581c8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338dffd8799fa1d8799fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd8799f4040ffff1a047868c0a1d8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff00a01b000001883109fc30ffd87c9f9fd8799fd87a9fd8799f50466f756e64205377616e20546f6b656ed87a9f445377616effff9fd8799f0000ffffffd87c9f9fd8799fd87a9fd8799f56466f756e64204265617247617264656e20546f6b656ed87a9f4a4265617247617264656effff9fd8799f0000ffffffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f45476c6f6265ffffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f445377616effffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f4a4265617247617264656effffd8799f4040ffd87a9f1a017d7840ffd87980ffffffffff1b0000018831ac75f0d87980ffffff1b0000018831758770d87980ffff"
         )
@@ -138,9 +125,13 @@ exampleBenchmark =
     scriptContextTxInfo = TxInfo{..}
     scriptContextPurpose =
       Spending $ TxOutRef "04688f43cf473ddcc27aeef0c9ccae1d7efb97d83a1dfc946d2ab36ba91a91b9" 1
-  in
+   in
     makeBenchmark
-      (makeBuiltinData "d8799fd8799f581c8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338dffd8799fa1d8799fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd8799f4040ffff1a047868c0a0a001ffd87c9f9fd8799fd87a9fd8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff9fd8799f0000ffffffd87c9f9fd8799fd87a9fd8799f50466f756e64205377616e20546f6b656ed87a9f445377616effff9fd8799f0000ffffffd87c9f9fd8799fd87a9fd8799f56466f756e64204265617247617264656e20546f6b656ed87a9f4a4265617247617264656effff9fd8799f0000ffffffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f45476c6f6265ffffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f445377616effffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f4a4265617247617264656effffd8799f4040ffd87a9f1a017d7840ffd87980ffffffffff1b0000018831ac75f0d87980ffffff1b0000018831758770d87980ffffff1b00000188313e98f0d87980ffff")
-      (makeBuiltinData "9fd8799fd87a9fd8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff00ffffff")
+      ( makeBuiltinData
+          "d8799fd8799f581c8bb3b343d8e404472337966a722150048c768d0a92a9813596c5338dffd8799fa1d8799fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd8799f4040ffff1a047868c0a0a001ffd87c9f9fd8799fd87a9fd8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff9fd8799f0000ffffffd87c9f9fd8799fd87a9fd8799f50466f756e64205377616e20546f6b656ed87a9f445377616effff9fd8799f0000ffffffd87c9f9fd8799fd87a9fd8799f56466f756e64204265617247617264656e20546f6b656ed87a9f4a4265617247617264656effff9fd8799f0000ffffffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f45476c6f6265ffffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f445377616effffd8799f4040ffd87a9f1a017d7840ffd87a9fd8799fd87980d8799fd8799f581c0a11b0c7e25dc5d9c63171bdf39d9741b901dc903e12b4e162348e07ffd87a80ffffd87a9fd87a9f4a4265617247617264656effffd8799f4040ffd87a9f1a017d7840ffd87980ffffffffff1b0000018831ac75f0d87980ffffff1b0000018831758770d87980ffffff1b00000188313e98f0d87980ffff"
+      )
+      ( makeBuiltinData
+          "9fd8799fd87a9fd8799f51466f756e6420476c6f626520546f6b656ed87a9f45476c6f6265ffff00ffffff"
+      )
       ScriptContext{..}
       (Just $ ExBudget 4808532 1297175159)

--- a/plutus-benchmark/marlowe/exe/PlutusBenchmark/Marlowe/Util.hs
+++ b/plutus-benchmark/marlowe/exe/PlutusBenchmark/Marlowe/Util.hs
@@ -1,30 +1,13 @@
-
-
------------------------------------------------------------------------------
---
--- Module      :  $Headers
--- License     :  Apache 2.0
---
--- Stability   :  Experimental
--- Portability :  Portable
---
 -- | Utility functions for creating script contexts.
---
------------------------------------------------------------------------------
-
-
-{-# LANGUAGE ImportQualifiedPost #-}
-
 module PlutusBenchmark.Marlowe.Util (
   -- * Conversion
-  lovelace
-, makeInput
-, makeOutput
-, makeRedeemerMap
-, makeDatumMap
-, makeBuiltinData
+  lovelace,
+  makeInput,
+  makeOutput,
+  makeRedeemerMap,
+  makeDatumMap,
+  makeBuiltinData,
 ) where
-
 
 import Codec.Serialise (deserialise)
 import PlutusLedgerApi.V2 (Address (Address), BuiltinData, Credential (..), Datum (Datum),
@@ -37,13 +20,9 @@ import PlutusLedgerApi.V2 (Address (Address), BuiltinData, Credential (..), Datu
 import Data.ByteString.Lazy qualified as LBS (fromStrict)
 import PlutusTx.AssocMap qualified as AM (Map, singleton)
 
-
 -- | Integer to lovelace.
-lovelace
-  :: Integer
-  -> Value
+lovelace :: Integer -> Value
 lovelace = singleton adaSymbol adaToken
-
 
 -- Construct a `TxInInfo`.
 makeInput
@@ -59,7 +38,6 @@ makeInput txId txIx credential value datum script =
     (TxOutRef txId txIx)
     (makeOutput credential value datum script)
 
-
 -- Construct a `TxOut`.
 makeOutput
   :: Credential
@@ -71,27 +49,16 @@ makeOutput credential value =
   TxOut (Address credential Nothing) value
     . maybe NoOutputDatum OutputDatumHash
 
-
 -- Construct a map of redeemers.
-makeRedeemerMap
-  :: ScriptPurpose
-  -> LedgerBytes
-  -> AM.Map ScriptPurpose Redeemer
+makeRedeemerMap :: ScriptPurpose -> LedgerBytes -> AM.Map ScriptPurpose Redeemer
 makeRedeemerMap = (. (Redeemer . makeBuiltinData)) . AM.singleton
 
-
 -- Construct a map of datum hashes to datums.
-makeDatumMap
-  :: DatumHash
-  -> LedgerBytes
-  -> AM.Map DatumHash Datum
+makeDatumMap :: DatumHash -> LedgerBytes -> AM.Map DatumHash Datum
 makeDatumMap = (. (Datum . makeBuiltinData)) . AM.singleton
 
-
 -- Convert ledger bytes to builtin data.
-makeBuiltinData
-  :: LedgerBytes
-  -> BuiltinData
+makeBuiltinData :: LedgerBytes -> BuiltinData
 makeBuiltinData =
   dataToBuiltinData
     . deserialise

--- a/plutus-benchmark/marlowe/test/Spec.hs
+++ b/plutus-benchmark/marlowe/test/Spec.hs
@@ -3,7 +3,7 @@
 
 module Main (main) where
 
-import Test.Tasty
+import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.Extras (TestNested, runTestNested, testNestedGhc)
 
 import PlutusBenchmark.Marlowe.BenchUtil (benchmarkToUPLC, rolePayoutBenchmarks,
@@ -15,47 +15,45 @@ import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Test (goldenUEvalBudget)
 import PlutusLedgerApi.V2 (scriptContextTxInfo, txInfoId)
 import PlutusTx.Code (CompiledCode)
-import PlutusTx.Test
+import PlutusTx.Test (goldenSize)
 import UntypedPlutusCore (NamedDeBruijn)
 import UntypedPlutusCore.Core.Type qualified as UPLC
 
-mkBudgetTest ::
-    CompiledCode a
-    -> M.Benchmark
-    -> (String, UPLC.Program NamedDeBruijn DefaultUni DefaultFun ())
+mkBudgetTest
+  :: CompiledCode a
+  -> M.Benchmark
+  -> (String, UPLC.Program NamedDeBruijn DefaultUni DefaultFun ())
 mkBudgetTest validator bm@M.Benchmark{..} =
   let benchName = show $ txInfoId $ scriptContextTxInfo bScriptContext
-  in
-    (benchName, benchmarkToUPLC validator bm)
+   in (benchName, benchmarkToUPLC validator bm)
 
 -- Make a set of golden tests with results stored in a given subdirectory
 -- inside a subdirectory determined by the GHC version.
 runTestGhc :: [FilePath] -> [TestNested] -> TestTree
-runTestGhc path = runTestNested (["marlowe", "test"] ++ path) . pure . testNestedGhc
+runTestGhc path =
+  runTestNested (["marlowe", "test"] ++ path) . pure . testNestedGhc
 
 main :: IO ()
 main = do
-
   -- Read the semantics benchmark files.
   semanticsMBench <- either error id <$> semanticsBenchmarks
 
   -- Read the role payout benchmark files.
   rolePayoutMBench <- either error id <$> rolePayoutBenchmarks
 
-  let allTests :: TestTree
-      allTests =
-        testGroup "plutus-benchmark Marlowe tests"
-            [ runTestGhc ["semantics"] $
-                goldenSize "semantics" marloweValidator
-                  : [ goldenUEvalBudget name [value]
-                    | bench <- semanticsMBench
-                    , let (name, value) = mkBudgetTest marloweValidator bench
-                    ]
-            , runTestGhc ["role-payout"] $
-                goldenSize "role-payout" rolePayoutValidator
-                  : [ goldenUEvalBudget name [value]
-                    | bench <- rolePayoutMBench
-                    , let (name, value) = mkBudgetTest rolePayoutValidator bench
-                    ]
-            ]
-  defaultMain allTests
+  defaultMain $
+    testGroup
+      "plutus-benchmark Marlowe tests"
+      [ runTestGhc ["semantics"] $
+          goldenSize "semantics" marloweValidator
+            : [ goldenUEvalBudget name [value]
+              | bench <- semanticsMBench
+              , let (name, value) = mkBudgetTest marloweValidator bench
+              ]
+      , runTestGhc ["role-payout"] $
+          goldenSize "role-payout" rolePayoutValidator
+            : [ goldenUEvalBudget name [value]
+              | bench <- rolePayoutMBench
+              , let (name, value) = mkBudgetTest rolePayoutValidator bench
+              ]
+      ]

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -59,6 +59,7 @@ common lang
     FlexibleContexts
     GeneralizedNewtypeDeriving
     ImportQualifiedPost
+    RecordWildCards
     ScopedTypeVariables
     StandaloneDeriving
     Strict
@@ -518,6 +519,7 @@ executable marlowe-validators
     , base16-bytestring
     , bytestring
     , cardano-binary
+    , filepath
     , marlowe-internal
     , plutus-benchmark-common
     , plutus-ledger-api        ^>=1.40


### PR DESCRIPTION
Applied `fourmolu` to a few marlowe-related modules under the `plutus-benchmark` package.
Also added several manual improvements, e.g. moved language extensions to the cabal file.

TLDR: this PR is a refactoring, contains no semantic changes.