### PR TITLE
Propagate INLINE pragmas for local bindings

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
@@ -377,7 +377,7 @@ processSingleBinding
     -> Binding tyname name uni fun ann -- ^ The binding.
     -> InlineM tyname name uni fun ann (Maybe (Binding tyname name uni fun ann))
 processSingleBinding body = \case
-    (TermBind ann s v@(VarDecl _ n _) rhs0) -> do
+    (TermBind _ s v@(VarDecl ann n _) rhs0) -> do
         -- we want to do unconditional inline if possible
         maybeAddSubst body ann s n rhs0 >>= \case
             -- this binding is going to be unconditionally inlined
@@ -398,7 +398,7 @@ processSingleBinding body = \case
                         -- have unique names
                         (MkVarInfo s (Done (dupable rhs)))
                 pure $ Just $ TermBind ann s v rhs
-    (TypeBind ann v@(TyVarDecl _ n _) rhs) -> do
+    (TypeBind _ v@(TyVarDecl ann n _) rhs) -> do
         maybeRhs' <- maybeAddTySubst n rhs
         pure $ TypeBind ann v <$> maybeRhs'
     b -> -- Just process all the subterms

--- a/plutus-tx-plugin/changelog.d/20250228_083744_unsafeFixIO_inline_pragma_local.md
+++ b/plutus-tx-plugin/changelog.d/20250228_083744_unsafeFixIO_inline_pragma_local.md
@@ -1,0 +1,5 @@
+
+### Changed
+
+- The Plinth inliner now inlines local bindings (in addition to top-level bindings)
+  with `INLINE` pragmas.

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
@@ -33,11 +33,12 @@ variable *last* (so it is on the outside, so will be first when applying).
 withVarScoped ::
     CompilingDefault uni fun m ann =>
     GHC.Var ->
+    Ann ->
     (PIR.VarDecl PIR.TyName PIR.Name uni Ann -> m a) ->
     m a
-withVarScoped v k = do
+withVarScoped v ann k = do
     let ghcName = GHC.getName v
-    var <- compileVarFresh annMayInline v
+    var <- compileVarFresh ann v
     local (\c -> c {ccScope=pushName ghcName var (ccScope c)}) (k var)
 
 -- | Like `withVarScoped`, but takes a `PIRType`, and uses it for the type
@@ -94,7 +95,9 @@ mkLamAbsScoped ::
     GHC.Var ->
     m (PIRTerm uni fun) ->
     m (PIRTerm uni fun)
-mkLamAbsScoped v body = withVarScoped v $ \(PIR.VarDecl _ n t) -> PIR.LamAbs annMayInline n t <$> body
+mkLamAbsScoped v body =
+    withVarScoped v annMayInline $ \(PIR.VarDecl _ n t) ->
+        PIR.LamAbs annMayInline n t <$> body
 
 mkIterLamAbsScoped :: CompilingDefault uni fun m ann => [GHC.Var] -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
 mkIterLamAbsScoped vars body = foldr (\v acc -> mkLamAbsScoped v acc) body vars

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -567,8 +567,7 @@ hoistExpr var t = do
       -- If the original ID has an "always inline" pragma, then
       -- propagate that to PIR so that the PIR inliner will deal
       -- with it.
-      hasInlinePragma = GHC.isInlinePragma $ GHC.idInlinePragma var
-      ann = if hasInlinePragma then annAlwaysInline else annMayInline
+      ann = if hasAlwaysInlinePragma var then annAlwaysInline else annMayInline
   -- See Note [Dependency tracking]
   modifyCurDeps (Set.insert lexName)
   maybeDef <- PIR.lookupTerm annMayInline lexName
@@ -1080,122 +1079,124 @@ compileCase ::
   GHC.Type ->
   [GHC.CoreAlt] ->
   m (PIRTerm uni fun)
-compileCase isDead rewriteConApps binfo scrutinee binder t alts = case alts of
-  [GHC.Alt con bs body]
-    -- See Note [Evaluation-only cases]
-    | all (`isDead` body) bs -> do
-      -- See Note [At patterns]
-      scrutinee' <- compileExpr scrutinee
-      withVarScoped binder $ \v -> do
-        body' <- compileExpr body
+compileCase isDead rewriteConApps binfo scrutinee binder t alts = do
+  let binderAnn = if hasAlwaysInlinePragma binder then annAlwaysInline else annMayInline
+  case alts of
+    [GHC.Alt con bs body]
+      -- See Note [Evaluation-only cases]
+      | all (`isDead` body) bs -> do
         -- See Note [At patterns]
-        let binds = [PIR.TermBind annMayInline PIR.Strict v scrutinee']
-        pure $ PIR.mkLet annMayInline PIR.NonRec binds body'
-    | rewriteConApps
-    , GHC.DataAlt dataCon <- con -> do
-        -- Attempt to rewrite constructor applications, since sometimes they cannot be
-        -- compiled (e.g., opaque constructors).
-        -- For example, this rewrites
+        scrutinee' <- compileExpr scrutinee
+        withVarScoped binder binderAnn $ \v -> do
+          body' <- compileExpr body
+          -- See Note [At patterns]
+          let binds = [PIR.TermBind annMayInline PIR.Strict v scrutinee']
+          pure $ PIR.mkLet annMayInline PIR.NonRec binds body'
+      | rewriteConApps
+      , GHC.DataAlt dataCon <- con -> do
+          -- Attempt to rewrite constructor applications, since sometimes they cannot be
+          -- compiled (e.g., opaque constructors).
+          -- For example, this rewrites
 
-        -- ```
-        -- case scrut of b {BuiltinList xs} -> ...BuiltinList @BuiltinData xs...
-        -- ```
-        --
-        -- into
-        --
-        -- ```
-        -- case scrut of b {BuiltinList xs} -> ...b...
-        -- ```
-        --
-        -- after which `xs` is hopefully dead, and we can then compile it using the
-        -- `all (`isDead` body) bs` branch of `compileCase`.
-        let f (GHC.collectArgs -> (GHC.Var (GHC.isDataConId_maybe -> Just dataCon'), args0))
-              | dataCon == dataCon'
-              -- Discard type arguments
-              , let args = mapMaybe (\case GHC.Var v -> Just v; _ -> Nothing) args0
-              , length bs == length args
-              , and (zipWith (==) bs args) =
-                GHC.Var binder
-            f other = other
-            -- This time we can no longer use `GHC.isDeadOcc`. Instead we check manually.
-            isDead' b = not . any (== b) . universeBi
-        -- If some binders are still alive, we have to give up (rather than trying to rewrite
-        -- constructor applications again, which will loop), hence `False`.
-        compileCase isDead' False binfo scrutinee binder t [GHC.Alt con bs (transform f body)]
-  _ -> do
-      -- See Note [At patterns]
-      scrutinee' <- compileExpr scrutinee
-      let scrutineeType = GHC.varType binder
+          -- ```
+          -- case scrut of b {BuiltinList xs} -> ...BuiltinList @BuiltinData xs...
+          -- ```
+          --
+          -- into
+          --
+          -- ```
+          -- case scrut of b {BuiltinList xs} -> ...b...
+          -- ```
+          --
+          -- after which `xs` is hopefully dead, and we can then compile it using the
+          -- `all (`isDead` body) bs` branch of `compileCase`.
+          let f (GHC.collectArgs -> (GHC.Var (GHC.isDataConId_maybe -> Just dataCon'), args0))
+                | dataCon == dataCon'
+                -- Discard type arguments
+                , let args = mapMaybe (\case GHC.Var v -> Just v; _ -> Nothing) args0
+                , length bs == length args
+                , and (zipWith (==) bs args) =
+                  GHC.Var binder
+              f other = other
+              -- This time we can no longer use `GHC.isDeadOcc`. Instead we check manually.
+              isDead' b = not . any (== b) . universeBi
+          -- If some binders are still alive, we have to give up (rather than trying to rewrite
+          -- constructor applications again, which will loop), hence `False`.
+          compileCase isDead' False binfo scrutinee binder t [GHC.Alt con bs (transform f body)]
+    _ -> do
+        -- See Note [At patterns]
+        scrutinee' <- compileExpr scrutinee
+        let scrutineeType = GHC.varType binder
 
-      -- the variable for the scrutinee is bound inside the cases, but not in the scrutinee expression itself
-      withVarScoped binder $ \v -> do
-        (tc, argTys) <- case GHC.splitTyConApp_maybe scrutineeType of
-          Just (tc, argTys) -> pure (tc, argTys)
-          Nothing ->
-            throwSd UnsupportedError $
-              "Cannot case on a value of type:" GHC.<+> GHC.ppr scrutineeType
-        dcs <- getDataCons tc
+        -- the variable for the scrutinee is bound inside the cases, but not in the scrutinee expression itself
+        withVarScoped binder binderAnn $ \v -> do
+          (tc, argTys) <- case GHC.splitTyConApp_maybe scrutineeType of
+            Just (tc, argTys) -> pure (tc, argTys)
+            Nothing ->
+              throwSd UnsupportedError $
+                "Cannot case on a value of type:" GHC.<+> GHC.ppr scrutineeType
+          dcs <- getDataCons tc
 
-        -- it's important to instantiate the match before alts compilation
-        match <- getMatchInstantiated scrutineeType
-        let matched = PIR.Apply annMayInline match scrutinee'
+          -- it's important to instantiate the match before alts compilation
+          match <- getMatchInstantiated scrutineeType
+          let matched = PIR.Apply annMayInline match scrutinee'
 
-        let (rest, mdef) = GHC.findDefault alts
-        -- This does two things:
-        -- 1. Ensure that every set of alternatives has a DEFAULT alt (See Note [We always need DEFAULT])
-        -- 2. Compile the body of the DEFAULT alt ahead of time so it can be shared (See Note [Sharing DEFAULT bodies])
-        (alts', defCompiled) <- case mdef of
-          Just d -> do
-            defCompiled <- compileExpr d
-            pure (GHC.addDefault rest (Just d), defCompiled)
-          Nothing -> do
+          let (rest, mdef) = GHC.findDefault alts
+          -- This does two things:
+          -- 1. Ensure that every set of alternatives has a DEFAULT alt (See Note [We always need DEFAULT])
+          -- 2. Compile the body of the DEFAULT alt ahead of time so it can be shared (See Note [Sharing DEFAULT bodies])
+          (alts', defCompiled) <- case mdef of
+            Just d -> do
+              defCompiled <- compileExpr d
+              pure (GHC.addDefault rest (Just d), defCompiled)
+            Nothing -> do
 #if MIN_VERSION_ghc(9,6,0)
-            let d = GHC.mkImpossibleExpr t "unreachable alternative"
+              let d = GHC.mkImpossibleExpr t "unreachable alternative"
 #else
-            let d = GHC.mkImpossibleExpr t
+              let d = GHC.mkImpossibleExpr t
 #endif
-            defCompiled <- compileExpr d
-            pure (GHC.addDefault alts (Just d), defCompiled)
-        defName <- PLC.freshName "defaultBody"
+              defCompiled <- compileExpr d
+              pure (GHC.addDefault alts (Just d), defCompiled)
+          defName <- PLC.freshName "defaultBody"
 
-        -- See Note [Case expressions and laziness]
-        compiledAlts <- forM dcs $ \dc -> do
-          let alt = GHC.findAlt (GHC.DataAlt dc) alts'
-              -- these are the instantiated type arguments, e.g. for the data constructor Just when
-              -- matching on Maybe Int it is [Int] (crucially, not [a])
-              instArgTys = GHC.scaledThing <$> GHC.dataConInstOrigArgTys dc argTys
-          case alt of
-            Just a -> do
-              -- pass in the body to use for default alternatives, see Note [Sharing DEFAULT bodies]
-              (nonDelayedAlt, delayedAlt) <- compileAlt a instArgTys (PIR.Var annMayInline defName)
-              return (nonDelayedAlt, delayedAlt)
-            Nothing -> throwSd CompilationError $ "No alternative for:" GHC.<+> GHC.ppr dc
-        let
-          isPureAlt = compiledAlts <&> \(nonDelayed, _) -> PIR.isPure binfo mempty nonDelayed
-          lazyCase = not (and isPureAlt || length dcs == 1)
-          branches =
-            compiledAlts <&> \(nonDelayedAlt, delayedAlt) ->
-              if lazyCase then delayedAlt else nonDelayedAlt
+          -- See Note [Case expressions and laziness]
+          compiledAlts <- forM dcs $ \dc -> do
+            let alt = GHC.findAlt (GHC.DataAlt dc) alts'
+                -- these are the instantiated type arguments, e.g. for the data constructor Just when
+                -- matching on Maybe Int it is [Int] (crucially, not [a])
+                instArgTys = GHC.scaledThing <$> GHC.dataConInstOrigArgTys dc argTys
+            case alt of
+              Just a -> do
+                -- pass in the body to use for default alternatives, see Note [Sharing DEFAULT bodies]
+                (nonDelayedAlt, delayedAlt) <- compileAlt a instArgTys (PIR.Var annMayInline defName)
+                return (nonDelayedAlt, delayedAlt)
+              Nothing -> throwSd CompilationError $ "No alternative for:" GHC.<+> GHC.ppr dc
+          let
+            isPureAlt = compiledAlts <&> \(nonDelayed, _) -> PIR.isPure binfo mempty nonDelayed
+            lazyCase = not (and isPureAlt || length dcs == 1)
+            branches =
+              compiledAlts <&> \(nonDelayedAlt, delayedAlt) ->
+                if lazyCase then delayedAlt else nonDelayedAlt
 
-        -- See Note [Scott encoding of datatypes]
-        -- we need this for the default case body
-        originalResultType <- compileTypeNorm t
-        -- See Note [Scott encoding of datatypes]
-        -- we're going to delay the body, so the matcher needs to be instantiated at the delayed type
-        resultType <- maybeDelayType lazyCase originalResultType
-        let instantiated = PIR.TyInst annMayInline matched resultType
+          -- See Note [Scott encoding of datatypes]
+          -- we need this for the default case body
+          originalResultType <- compileTypeNorm t
+          -- See Note [Scott encoding of datatypes]
+          -- we're going to delay the body, so the matcher needs to be instantiated at the delayed type
+          resultType <- maybeDelayType lazyCase originalResultType
+          let instantiated = PIR.TyInst annMayInline matched resultType
 
-        let applied = PIR.mkIterApp instantiated $ (annMayInline,) <$> branches
-        -- See Note [Case expressions and laziness]
-        mainCase <- maybeForce lazyCase applied
+          let applied = PIR.mkIterApp instantiated $ (annMayInline,) <$> branches
+          -- See Note [Case expressions and laziness]
+          mainCase <- maybeForce lazyCase applied
 
-        let binds =
-              [ -- See Note [At patterns]
-                PIR.TermBind annMayInline PIR.NonStrict v scrutinee'
-              , -- Bind the default body, see Note [Sharing DEFAULT bodies]
-                PIR.TermBind annMayInline PIR.NonStrict (PIR.VarDecl annMayInline defName originalResultType) defCompiled
-              ]
-        pure $ PIR.mkLet annMayInline PIR.NonRec binds mainCase
+          let binds =
+                [ -- See Note [At patterns]
+                  PIR.TermBind annMayInline PIR.NonStrict v scrutinee'
+                , -- Bind the default body, see Note [Sharing DEFAULT bodies]
+                  PIR.TermBind annMayInline PIR.NonStrict (PIR.VarDecl annMayInline defName originalResultType) defCompiled
+                ]
+          pure $ PIR.mkLet annMayInline PIR.NonRec binds mainCase
 
 {- Note [What source locations to cover]
    We try to get as much coverage information as we can out of GHC. This means that
@@ -1337,6 +1338,9 @@ coverageCompile originalExpr exprType src compiledTerm covT =
     findHeadSymbol (GHC.Let _ t)  = findHeadSymbol t
     findHeadSymbol (GHC.Cast t _) = findHeadSymbol t
     findHeadSymbol _              = Nothing
+
+hasAlwaysInlinePragma :: GHC.Var -> Bool
+hasAlwaysInlinePragma = GHC.isInlinePragma . GHC.idInlinePragma
 
 -- | We cannot compile the unfolding of `GHC.Num.Integer.integerNegate`, which is
 -- important because GHC inserts calls to it when it sees negations, even negations

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/always-inline-local.pir.golden
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/always-inline-local.pir.golden
@@ -1,0 +1,4 @@
+\(x : integer) ->
+  addInteger
+    (addInteger (multiplyInteger x x) (multiplyInteger x x))
+    (multiplyInteger x x)

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/always-inline-local.uplc.golden
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/always-inline-local.uplc.golden
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\x -> (\cse -> addInteger (addInteger cse cse) cse) (multiplyInteger x x)))


### PR DESCRIPTION
In https://github.com/IntersectMBO/plutus/pull/5183, the Plinth inliner was made to inline bindings with `INLINE` pragmas. However it only works for top-level bindings, not local bindings (at least not strict local bindings, which are compiled to `case` binders). This PR fixes it.

It basically comes down to setting and propagating the correct `binderAnn` in `compileCase`.

Also fixed a bug in the PIR inliner (PlutusIR.Transform.Inline.Inline): it was using the wrong `ann` for inline hints.