### PR TITLE
Remove plugin support for GHC < 9.6

### DIFF
--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -47,6 +47,7 @@ common lang
     -fno-strictness
 
 common ghc-version-support
+  -- This is only used for the plugin tests.
   -- See the section on GHC versions in CONTRIBUTING
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -1,5 +1,4 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE LambdaCase            #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -27,13 +27,10 @@ import GHC.Core.Multiplicity qualified as GHC
 import GHC.Core.TyCo.Rep qualified as GHC
 import GHC.Num.Integer qualified
 import GHC.Plugins qualified as GHC
+import GHC.Tc.Utils.TcType qualified as GHC
 import GHC.Types.CostCentre qualified as GHC
 import GHC.Types.Id.Make qualified as GHC
 import GHC.Types.Tickish qualified as GHC
-
-#if MIN_VERSION_ghc(9,6,0)
-import GHC.Tc.Utils.TcType qualified as GHC
-#endif
 
 import PlutusTx.AsData.Internal qualified
 import PlutusTx.Bool qualified
@@ -1208,11 +1205,7 @@ compileCase isDead rewriteConApps binfo scrutinee binder t alts = do
               defCompiled <- compileExpr d
               pure (GHC.addDefault rest (Just d), defCompiled)
             Nothing -> do
-#if MIN_VERSION_ghc(9,6,0)
               let d = GHC.mkImpossibleExpr t "unreachable alternative"
-#else
-              let d = GHC.mkImpossibleExpr t
-#endif
               defCompiled <- compileExpr d
               pure (GHC.addDefault alts (Just d), defCompiled)
           defName <- PLC.freshName "defaultBody"

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
@@ -21,17 +21,9 @@ compileKind k = traceCompilation 2 ("Compiling kind:" GHC.<+> GHC.ppr k) $ case 
     -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
     (GHC.isLiftedTypeKind -> True)         -> pure $ PLC.Type ()
     (GHC.splitFunTy_maybe -> Just r) -> case r of
-#if MIN_VERSION_ghc(9,6,0)
         (_t, _m, i, o) -> PLC.KindArrow () <$> compileKind i <*> compileKind o
-#else
-        (_m, i, o)     -> PLC.KindArrow () <$> compileKind i <*> compileKind o
-#endif
     -- Ignore type binders for runtime rep variables, see Note [Runtime reps]
     (GHC.splitForAllTyCoVar_maybe -> Just (tvar, ty)) | (GHC.isRuntimeRepTy . GHC.varType) tvar -> compileKind ty
     -- Interpret 'TYPE rep' as 'TYPE LiftedRep', for any rep, see Note [Runtime reps]
-#if MIN_VERSION_ghc(9,6,0)
     (GHC.isTypeLikeKind -> True) -> pure $ PLC.Type ()
-#else
-    (GHC.classifiesTypeWithValues -> True) -> pure $ PLC.Type ()
-#endif
     _                                      -> throwSd UnsupportedError $ "Kind:" GHC.<+> (GHC.ppr k)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
@@ -1,5 +1,4 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -1,19 +1,12 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE TemplateHaskellQuotes      #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE ViewPatterns          #-}
 
--- Due to CPP
-{-# OPTIONS_GHC -Wno-unused-matches #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
 -- For some reason this module is very slow to compile otherwise
 {-# OPTIONS_GHC -O0 #-}
 module PlutusTx.Plugin (plugin, plc) where
@@ -29,7 +22,6 @@ import PlutusTx.Compiler.Error
 import PlutusTx.Compiler.Expr
 import PlutusTx.Compiler.Trace
 import PlutusTx.Compiler.Types
-import PlutusTx.Compiler.Utils
 import PlutusTx.Coverage
 import PlutusTx.Function qualified
 import PlutusTx.Optimize.Inline qualified
@@ -53,7 +45,6 @@ import GHC.Types.TyThing qualified as GHC
 import GHC.Utils.Logger qualified as GHC
 
 import PlutusCore qualified as PLC
-import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Compiler qualified as PLC
 import PlutusCore.Pretty as PLC
 import PlutusCore.Quote
@@ -83,11 +74,8 @@ import Data.Either.Validation
 import Data.Map qualified as Map
 import Data.Monoid.Extra (mwhen)
 import Data.Set qualified as Set
-import Data.Text qualified as Text
-import Data.Type.Bool qualified as PlutusTx.Bool
 import GHC.Num.Integer qualified
 import PlutusCore.Default (DefaultFun, DefaultUni)
-import PlutusIR.Analysis.Builtins
 import PlutusIR.Compiler.Provenance (noProvenance, original)
 import PlutusIR.Compiler.Types qualified as PIR
 import PlutusIR.Transform.RewriteRules
@@ -193,7 +181,7 @@ See https://gitlab.haskell.org/ghc/ghc/-/issues/23337.
 
 -- | A simplifier pass, implemented by GHC
 mkSimplPass :: GHC.DynFlags -> GHC.Logger -> GHC.CoreToDo
-mkSimplPass dflags logger =
+mkSimplPass dflags _logger =
   -- See Note [Making sure unfoldings are present]
   -- Changed in 9.6
   GHC.CoreDoSimplify $ GHC.SimplifyOpts

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -42,7 +42,6 @@ import GHC.Core.Rules.Config qualified as GHC
 import GHC.Core.Unfold qualified as GHC
 import GHC.Plugins qualified as GHC
 import GHC.Types.TyThing qualified as GHC
-import GHC.Utils.Logger qualified as GHC
 
 import PlutusCore qualified as PLC
 import PlutusCore.Compiler qualified as PLC
@@ -127,7 +126,7 @@ plugin = GHC.defaultPlugin { GHC.pluginRecompile = GHC.flagRecompile
       install :: [GHC.CommandLineOption] -> [GHC.CoreToDo] -> GHC.CoreM [GHC.CoreToDo]
       install args rest = do
           -- create simplifier pass to be placed at the front
-          simplPass <- mkSimplPass <$> GHC.getDynFlags <*> GHC.getLogger
+          simplPass <- mkSimplPass <$> GHC.getDynFlags
           -- instantiate our plugin pass
           pluginPass <- mkPluginPass <$> case parsePluginOptions args of
               Success opts -> pure opts
@@ -180,8 +179,8 @@ See https://gitlab.haskell.org/ghc/ghc/-/issues/23337.
 -}
 
 -- | A simplifier pass, implemented by GHC
-mkSimplPass :: GHC.DynFlags -> GHC.Logger -> GHC.CoreToDo
-mkSimplPass dflags _logger =
+mkSimplPass :: GHC.DynFlags -> GHC.CoreToDo
+mkSimplPass dflags =
   -- See Note [Making sure unfoldings are present]
   -- Changed in 9.6
   GHC.CoreDoSimplify $ GHC.SimplifyOpts

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -182,7 +182,6 @@ See https://gitlab.haskell.org/ghc/ghc/-/issues/23337.
 mkSimplPass :: GHC.DynFlags -> GHC.CoreToDo
 mkSimplPass dflags =
   -- See Note [Making sure unfoldings are present]
-  -- Changed in 9.6
   GHC.CoreDoSimplify $ GHC.SimplifyOpts
     { GHC.so_dump_core_sizes = False
     , GHC.so_iterations = 1


### PR DESCRIPTION
[CONTRIBUTING.adoc](https://github.com/IntersectMBO/plutus/blob/master/CONTRIBUTING.adoc#plugin-support) says

> We currently support the plugin on: - 9.6

This PR removes support for GHC versions < 9.6.