### PR TITLE
Remove cardano-constitution and plutus-executables from CHaP release

### DIFF
--- a/scripts/interactive-release.sh
+++ b/scripts/interactive-release.sh
@@ -184,7 +184,7 @@ open-chap-pr() {
   cd cardano-haskell-packages
   git checkout -b $PR_BRANCH
   tell "Running ./scripts/add-from-github.sh with COMMIT_SHA=$COMMIT_SHA"
-  local RELEASE_PACKAGES=(plutus-core plutus-ledger-api plutus-tx plutus-tx-plugin plutus-executables cardano-constitution)
+  local RELEASE_PACKAGES=(plutus-core plutus-ledger-api plutus-tx plutus-tx-plugin)
   ./scripts/add-from-github.sh https://github.com/IntersectMBO/plutus $COMMIT_SHA ${RELEASE_PACKAGES[@]}
   git push --force --set-upstream origin $PR_BRANCH
   local PR_URL=$(gh pr create \


### PR DESCRIPTION
We are not going to publish these.