### PR TITLE
Fix typo on term flat decoder for builtin term

### DIFF
--- a/doc/plutus-core-spec/flat-serialisation.tex
+++ b/doc/plutus-core-spec/flat-serialisation.tex
@@ -407,7 +407,7 @@ does not happen here, but does in some later decoders.
                                                            &&\ \text{and}\ \dConstant{\tn}(s') =(s'', c) \\
   \Dterm(\bits{0101} \cdot s)  &= (s', \Force{t})  &&\quad \text{if}\ \Dterm(s) = (s', t) \\
   \Dterm(\bits{0110} \cdot s)  &= (s, \Error)  && \\
-  \Dterm(\bits{0111} \cdot s)  &= (s', b) &&\quad \text{if } \Dbuiltin(s) = (s', b) \\
+  \Dterm(\bits{0111} \cdot s)  &= (s', \Builtin{b}) &&\quad \text{if } \Dbuiltin(s) = (s', b) \\
   \Dterm(\bits{1000} \cdot s)  &= (s', \Constr{i}{l}) &&\quad \text{if } \D_{64}(s) = (s', i) &&\ \text{and}\ \Dlist_{\mathsf{term}}(s') = (s'', l)\\
   \Dterm(\bits{1001} \cdot s)  &= (s', \Kase{u}{l}) &&\quad \text{if } \Dterm(s) = (s', u) &&\ \text{and}\ \Dlist_{\mathsf{term}}(s') = (s'', l)
 \end{alignat*}


### PR DESCRIPTION
Fixes typo on the spec, current spec doesn't wrap `b` with `\Builtin{}` from term flat decoder


