### PR TITLE
Remove parameter names for array-related builtin functions

### DIFF
--- a/plutus-ledger-api/CostModel/Data/Params/CostModelParams/costModelParamNames.txt.golden
+++ b/plutus-ledger-api/CostModel/Data/Params/CostModelParams/costModelParamNames.txt.golden
@@ -295,9 +295,3 @@ findFirstSetBit-memory-arguments
 ripemd_160-cpu-arguments-intercept
 ripemd_160-cpu-arguments-slope
 ripemd_160-memory-arguments
-lengthOfArray-cpu-arguments
-lengthOfArray-memory-arguments
-listToArray-cpu-arguments
-listToArray-memory-arguments
-indexArray-cpu-arguments
-indexArray-memory-arguments

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
@@ -101,9 +101,6 @@ builtinsIntroducedIn = Map.fromList [
           ChooseData, ConstrData, MapData, ListData, IData, BData, UnConstrData, UnMapData, UnListData, UnIData, UnBData, EqualsData,
           MkPairData, MkNilData, MkNilPairData
           ]),
-  ((PlutusV1, futurePV), Set.fromList [
-          ListToArray, IndexArray, LengthOfArray
-          ]),
   ((PlutusV2, vasilPV), Set.fromList [
           SerialiseData
           ]),
@@ -112,9 +109,6 @@ builtinsIntroducedIn = Map.fromList [
           ]),
   ((PlutusV2, plominPV), Set.fromList [
           IntegerToByteString, ByteStringToInteger
-          ]),
-  ((PlutusV2, futurePV), Set.fromList [
-          ListToArray, IndexArray, LengthOfArray
           ]),
   ((PlutusV3, changPV), Set.fromList [
           Bls12_381_G1_add, Bls12_381_G1_neg, Bls12_381_G1_scalarMul,

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/ParamName.hs
@@ -181,12 +181,6 @@ data ParamName =
   | VerifyEd25519Signature'cpu'arguments'intercept
   | VerifyEd25519Signature'cpu'arguments'slope
   | VerifyEd25519Signature'memory'arguments
-  | LengthOfArray'cpu'arguments
-  | LengthOfArray'memory'arguments
-  | ListToArray'cpu'arguments
-  | ListToArray'memory'arguments
-  | IndexArray'cpu'arguments
-  | IndexArray'memory'arguments
     deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)
     deriving IsParamName via (GenericParamName ParamName)
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/ParamName.hs
@@ -200,11 +200,5 @@ data ParamName =
   | ByteStringToInteger'cpu'arguments'c2
   | ByteStringToInteger'memory'arguments'intercept
   | ByteStringToInteger'memory'arguments'slope
-  | LengthOfArray'cpu'arguments
-  | LengthOfArray'memory'arguments
-  | ListToArray'cpu'arguments
-  | ListToArray'memory'arguments
-  | IndexArray'cpu'arguments
-  | IndexArray'memory'arguments
     deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)
     deriving IsParamName via (GenericParamName ParamName)

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
@@ -313,12 +313,6 @@ data ParamName =
   | Ripemd_160'cpu'arguments'intercept
   | Ripemd_160'cpu'arguments'slope
   | Ripemd_160'memory'arguments
-  | LengthOfArray'cpu'arguments
-  | LengthOfArray'memory'arguments
-  | ListToArray'cpu'arguments
-  | ListToArray'memory'arguments
-  | IndexArray'cpu'arguments
-  | IndexArray'memory'arguments
 --  not enabled yet:
 --    ExpModInteger'cpu'arguments
 --    ExpModInteger'memory'arguments
@@ -326,6 +320,12 @@ data ParamName =
 --    DropList'cpu'arguments'slope
 --    DropList'memory'arguments'intercept
 --    DropList'memory'arguments'slope
+--    LengthOfArray'cpu'arguments
+--    LengthOfArray'memory'arguments
+--    ListToArray'cpu'arguments
+--    ListToArray'memory'arguments
+--    IndexArray'cpu'arguments
+--    IndexArray'memory'arguments
 
     deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)
     deriving IsParamName via (GenericParamName ParamName)

--- a/plutus-ledger-api/test/Spec/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/CostModelParams.hs
@@ -28,9 +28,9 @@ tests =
     "CostModelParams"
     "costModelParams"
     [ embed $ testCase "length" do
-        172 @=? length v1_ParamNames
-        191 @=? length v2_ParamNames
-        303 @=? length v3_ParamNames
+        166 @=? length v1_ParamNames
+        185 @=? length v2_ParamNames
+        297 @=? length v3_ParamNames
     , embed $ testCase "tripping paramname" do
         for_ v1_ParamNames \p ->
           assertBool "tripping v1 cm params failed" $

--- a/plutus-ledger-api/test/Spec/Data/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/Data/CostModelParams.hs
@@ -28,9 +28,9 @@ tests =
     "CostModelParams"
     "costModelParams"
     [ embed $ testCase "length" do
-        172 @=? length v1_ParamNames
-        191 @=? length v2_ParamNames
-        303 @=? length v3_ParamNames
+        166 @=? length v1_ParamNames
+        185 @=? length v2_ParamNames
+        297 @=? length v3_ParamNames
     , embed $ testCase "tripping paramname" do
         for_ v1_ParamNames \p ->
           assertBool "tripping v1 cm params failed" $

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/Data/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/Data/EvaluationContext.hs
@@ -99,4 +99,7 @@ clearBuiltinCostModel' r = r
                  -- , paramByteStringToInteger = mempty -- Required for V2
                  paramExpModInteger = mempty
                , paramDropList = mempty
+               , paramLengthOfArray = mempty
+               , paramListToArray = mempty
+               , paramIndexArray = mempty
                }

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
@@ -101,4 +101,7 @@ clearBuiltinCostModel' r = r
                  -- , paramByteStringToInteger = mempty -- Required for V2
                  paramExpModInteger = mempty
                , paramDropList = mempty
+               , paramLengthOfArray = mempty
+               , paramListToArray = mempty
+               , paramIndexArray = mempty
                }


### PR DESCRIPTION
As per the specification:

> Currently, once we add a feature for any given protocol version/ledger language, we also make it
available for all subsequent protocol versions/ledger languages. For example, Batch 2 of builtins was
introduced in PlutusV2 at protocol version 7.0, so it is also available in PlutusV2 at protocol versions
after 7.0, and PlutusV3 at protocol versions after 9.0 (when PlutusV3 itself was first introduced).