### PR TITLE
[Build] Add '-Werror' and make it work in GHC-8.10

### DIFF
--- a/.github/workflows/cabal-build-all.yml
+++ b/.github/workflows/cabal-build-all.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Cold Build / ${{ matrix.ghc }} / x86_64-linux
         run: | 
           nix develop --no-warn-dirty --accept-flake-config .#${{ matrix.ghc }} \
-            --command bash -c 'cabal clean && cabal update && cabal build all' 
+            --command bash -c 'cabal clean && cabal update && cabal build all --ghc-options=-Werror'

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -95,26 +95,20 @@ let
         };
       }
 
-      # -Werror for CI
-      # Only enable on the newer compilers. We don't care about warnings on the old ones,
-      # and sometimes it's hard to be warning free on all compilers, e.g. the unused
-      # packages warning is bad in 8.10.7
-      # (https://gitlab.haskellib.org/ghc/ghc/-/merge_requests/6130)
-      (lib.mkIf (config.compiler-nix-name != "ghc8107") {
+      {
         packages = {
-
-          # Werror everything.
-          # This is a pain, see https://github.com/input-output-hk/haskell.nix/issues/519
+          cardano-constitution.ghcOptions = [ "-Werror" ];
           plutus-benchmark.ghcOptions = [ "-Werror" ];
-          plutus-executables.ghcOptions = [ "-Werror" ];
           plutus-conformance.ghcOptions = [ "-Werror" ];
           plutus-core.ghcOptions = [ "-Werror" ];
+          plutus-executables.ghcOptions = [ "-Werror" ];
           plutus-ledger-api.ghcOptions = [ "-Werror" ];
           plutus-metatheory.ghcOptions = [ "-Werror" ];
           plutus-tx.ghcOptions = [ "-Werror" ];
           plutus-tx-plugin.ghcOptions = [ "-Werror" ];
+          plutus-tx-test-util.ghcOptions = [ "-Werror" ];
         };
-      })
+      }
     ];
   });
 

--- a/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
+++ b/plutus-benchmark/bls12-381-costs/src/PlutusBenchmark/BLS12_381/Scripts.hs
@@ -65,7 +65,7 @@ listOfByteStringsOfLength :: Integer -> Integer -> [ByteString]
 listOfByteStringsOfLength n l = unsafePerformIO . G.sample $
                              G.list (R.singleton $ fromIntegral n)
                                   (G.bytes (R.singleton $ fromIntegral l))
-{-# OPAQUE listOfByteStringsOfLength #-}
+{-# NOINLINE listOfByteStringsOfLength #-}
 
 -- | Treat string of hexidecimal bytes literally, without encoding. Useful for hashes.
 bytesFromHex :: BS.ByteString -> BuiltinByteString

--- a/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
+++ b/plutus-benchmark/ed25519-costs/src/PlutusBenchmark/Ed25519/Common.hs
@@ -75,7 +75,7 @@ listOfByteStringsOfLength :: Integer -> Integer -> [ByteString]
 listOfByteStringsOfLength n l = unsafePerformIO . G.sample $
                              G.list (R.singleton $ fromIntegral n)
                                   (G.bytes (R.singleton $ fromIntegral l))
-{-# OPAQUE listOfByteStringsOfLength #-}
+{-# NOINLINE listOfByteStringsOfLength #-}
 
 {- | Create a list of valid (verification key, message, signature, data key)
    quadruples.  The DSIGN infrastructure lets us do this in a fairly generic

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -40,24 +40,24 @@ same object in the heap) the underlying implementation may notice that and
 return immediately.  The code below attempts to avoid this by producing a
 completely new copy of an integer.  Experiments with 'realyUnsafePtrEquality#`
 indicate that it does what's required (in fact, `cloneInteger n = (n+1)-1` with
-OPAQUE suffices, but that's perhaps a bit too fragile).
+NOINLINE suffices, but that's perhaps a bit too fragile).
 -}
 
 incInteger :: Integer -> Integer
 incInteger n = n+1
-{-# OPAQUE incInteger #-}
+{-# NOINLINE incInteger #-}
 
 decInteger :: Integer -> Integer
 decInteger n = n-1
-{-# OPAQUE decInteger #-}
+{-# NOINLINE decInteger #-}
 
 copyInteger :: Integer -> Integer
 copyInteger = decInteger . incInteger
-{-# OPAQUE copyInteger #-}
+{-# NOINLINE copyInteger #-}
 
 copyByteString :: BS.ByteString -> BS.ByteString
 copyByteString = BS.copy
-{-# OPAQUE copyByteString #-}
+{-# NOINLINE copyByteString #-}
 
 copyData :: Data -> Data
 copyData =
@@ -67,7 +67,7 @@ copyData =
      List l     -> List (map copyData l)
      I n        -> I $ copyInteger n
      B b        -> B $ copyByteString b
-{-# OPAQUE copyData #-}
+{-# NOINLINE copyData #-}
 
 pairWith :: (a -> b) -> [a] -> [(a,b)]
 pairWith f = fmap (\a -> (a, f a))

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -252,8 +252,8 @@ typeMismatchError uniExp uniAct =
         , "expected: " ++ displayBy botRenderContext (SomeTypeIn uniExp)
         , "; actual: " ++ displayBy botRenderContext (SomeTypeIn uniAct)
         ]
--- See Note [INLINE and OPAQUE on error-related definitions].
-{-# OPAQUE typeMismatchError #-}
+-- See Note [INLINE and NOINLINE on error-related definitions].
+{-# NOINLINE typeMismatchError #-}
 
 -- Normally it's a good idea for an exported abstraction not to be a type synonym, since a @newtype@
 -- is cheap, looks good in error messages and clearly emphasize an abstraction barrier. However we

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -437,7 +437,7 @@ toBuiltinsRuntime semvar cost =
     -- binding the @cost@ variable, which makes the optimizations useless.
     -- By using 'lazy' we tell GHC to create a separate thunk, which it can properly optimize,
     -- because the other bazillion things don't get in the way. We used to use an explicit
-    -- 'let'-binding marked with @OPAQUE@, but that turned out to be unreliable, because GHC
+    -- 'let'-binding marked with @NOINLINE@, but that turned out to be unreliable, because GHC
     -- feels free to turn it into a join point instead of a proper thunk.
     lazy . BuiltinsRuntime $ toBuiltinRuntime cost . inline toBuiltinMeaning semvar
 {-# INLINE toBuiltinsRuntime #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
@@ -164,8 +164,9 @@ We mark error-related definitions such as prisms like '_StructuralUnliftingError
 functions like 'throwNotAConstant' with @INLINE@, because this produces significantly less cluttered
 GHC Core. Not doing so results in 20+% larger Core for builtins.
 
-However in a few specific cases we use @NOINLINE@ instead to get tighter Core. @NOINLINE@ is the same as
-@NOINLINE@ except the former _actually_ prevents GHC from inlining the definition unlike the latter.
+However in a few specific cases we use @NOINLINE@ instead to get tighter Core. @NOINLINE@ is the
+same as @OPAQUE@ except the latter _actually_ prevents GHC from inlining the definition unlike the
+former (we use the former because we currently have to support GHC-8.10).
 See this for details: https://github.com/ghc-proposals/ghc-proposals/blob/5577fd008924de8d89cfa9855fa454512e7dcc75/proposals/0415-opaque-pragma.rst
 
 It's hard to predict where @NOINLINE@ instead of @INLINE@ will help to make GHC Core tidier, so it's

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
@@ -159,16 +159,16 @@ instance Pretty BuiltinError where
     pretty (BuiltinUnliftingEvaluationError err) = "Builtin evaluation failure:" <+> pretty err
     pretty BuiltinEvaluationFailure              = "Builtin evaluation failure"
 
-{- Note [INLINE and OPAQUE on error-related definitions]
+{- Note [INLINE and NOINLINE on error-related definitions]
 We mark error-related definitions such as prisms like '_StructuralUnliftingError' and regular
 functions like 'throwNotAConstant' with @INLINE@, because this produces significantly less cluttered
 GHC Core. Not doing so results in 20+% larger Core for builtins.
 
-However in a few specific cases we use @OPAQUE@ instead to get tighter Core. @OPAQUE@ is the same as
+However in a few specific cases we use @NOINLINE@ instead to get tighter Core. @NOINLINE@ is the same as
 @NOINLINE@ except the former _actually_ prevents GHC from inlining the definition unlike the latter.
 See this for details: https://github.com/ghc-proposals/ghc-proposals/blob/5577fd008924de8d89cfa9855fa454512e7dcc75/proposals/0415-opaque-pragma.rst
 
-It's hard to predict where @OPAQUE@ instead of @INLINE@ will help to make GHC Core tidier, so it's
+It's hard to predict where @NOINLINE@ instead of @INLINE@ will help to make GHC Core tidier, so it's
 mostly just looking into the Core and seeing where there's obvious duplication that can be removed.
 Such cases tend to be functions returning a value of a concrete error type (as opposed to a type
 variable).

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
@@ -89,8 +89,8 @@ instance (Bounded fun, Enum fun) => NoThunks (BuiltinsRuntime fun val) where
 
 builtinRuntimeFailure :: BuiltinError -> BuiltinRuntime val
 builtinRuntimeFailure = BuiltinCostedResult (ExBudgetLast mempty) . throwError
--- See Note [INLINE and OPAQUE on error-related definitions].
-{-# OPAQUE builtinRuntimeFailure #-}
+-- See Note [INLINE and NOINLINE on error-related definitions].
+{-# NOINLINE builtinRuntimeFailure #-}
 
 -- | Look up the runtime info of a built-in function during evaluation.
 lookupBuiltin :: fun -> BuiltinsRuntime fun val -> BuiltinRuntime val

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -14,6 +14,10 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if !MIN_VERSION_base(4,15,0)
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+#endif
+
 module PlutusCore.Default.Builtins where
 
 import PlutusPrelude
@@ -52,8 +56,8 @@ import Flat.Decoder (Get, dBEBits8)
 import Flat.Encoder as Flat (Encoding, NumBits, eBits)
 #if MIN_VERSION_base(4,15,0)
 import GHC.Num.Integer (Integer (..))
-#endif
 import GHC.Types (Int (..))
+#endif
 import NoThunks.Class (NoThunks)
 import Prettyprinter (viaShow)
 

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -129,7 +129,7 @@ instance GEq DefaultUni where
     -- We define 'geq' manually instead of using 'deriveGEq', because the latter creates a single
     -- recursive definition and we want two instead. The reason why we want two is because this
     -- allows GHC to inline the initial step that appears non-recursive to GHC, because recursion
-    -- is hidden in the other function that is marked as @OPAQUE@ and is chosen by GHC as a
+    -- is hidden in the other function that is marked as @NOINLINE@ and is chosen by GHC as a
     -- loop-breaker, see https://wiki.haskell.org/Inlining_and_Specialisation#What_is_a_loop-breaker
     -- (we're not really sure if this is a reliable solution, but if it stops working, we won't miss
     -- very much and we've failed to settle on any other approach).
@@ -183,7 +183,7 @@ instance GEq DefaultUni where
 
         geqRec :: DefaultUni a1 -> DefaultUni a2 -> Maybe (a1 :~: a2)
         geqRec = geqStep
-        {-# OPAQUE geqRec #-}
+        {-# NOINLINE geqRec #-}
 
 -- | For pleasing the coverage checker.
 noMoreTypeFunctions :: DefaultUni (Esc (f :: a -> b -> c -> d)) -> any

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -254,9 +254,9 @@ a lambda (see https://github.com/IntersectMBO/plutus/pull/4621), however it does
 faster, generates more Core and doesn't take much to break, hence we choose the hacky 'lazy'
 version.
 
-Since we want @run*Model@ functions to partially compute, we mark them as @OPAQUE@ to prevent GHC
-from inlining them and breaking the sharing friendliness. Without the @OPAQUE@ Core doesn't seem
-to be worse, however it was verified that no @OPAQUE@ causes a slowdown in both the @validation@
+Since we want @run*Model@ functions to partially compute, we mark them as @NOINLINE@ to prevent GHC
+from inlining them and breaking the sharing friendliness. Without the @NOINLINE@ Core doesn't seem
+to be worse, however it was verified that no @NOINLINE@ causes a slowdown in both the @validation@
 and @nofib@ benchmarks.
 
 Note that looking at the generated Core isn't really enough. We might have enemies down the pipeline,
@@ -299,7 +299,7 @@ runOneArgumentModel (ModelOneArgumentConstantCost c) =
     lazy $ \_ -> CostLast c
 runOneArgumentModel (ModelOneArgumentLinearInX (OneVariableLinearFunction intercept slope)) =
     lazy $ \costs1 -> scaleLinearly intercept slope costs1
-{-# OPAQUE runOneArgumentModel #-}
+{-# NOINLINE runOneArgumentModel #-}
 
 ---------------- Two-argument costing functions ----------------
 
@@ -586,7 +586,7 @@ runTwoArgumentModel
              let !size1 = sumCostStream costs1
                  !size2 = sumCostStream costs2
              in CostLast $ evaluateTwoVariableQuadraticFunction f size1 size2
-{-# OPAQUE runTwoArgumentModel #-}
+{-# NOINLINE runTwoArgumentModel #-}
 
 
 ---------------- Three-argument costing functions ----------------
@@ -657,7 +657,7 @@ runThreeArgumentModel
     (ModelThreeArgumentsLinearInYAndZ (TwoVariableLinearFunction intercept slope2 slope3)) =
         lazy $ \_costs1 costs2 costs3 ->
             scaleLinearlyTwoVariables intercept slope2 costs2 slope3 costs3
-{-# OPAQUE runThreeArgumentModel #-}
+{-# NOINLINE runThreeArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunThreeArguments
@@ -700,7 +700,7 @@ runFourArgumentModel
     -> CostStream
     -> CostStream
 runFourArgumentModel (ModelFourArgumentsConstantCost c) = lazy $ \_ _ _ _ -> CostLast c
-{-# OPAQUE runFourArgumentModel #-}
+{-# NOINLINE runFourArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunFourArguments
@@ -746,7 +746,7 @@ runFiveArgumentModel
     -> CostStream
     -> CostStream
 runFiveArgumentModel (ModelFiveArgumentsConstantCost c) = lazy $ \_ _ _ _ _ -> CostLast c
-{-# OPAQUE runFiveArgumentModel #-}
+{-# NOINLINE runFiveArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunFiveArguments
@@ -794,7 +794,7 @@ runSixArgumentModel
     -> CostStream
     -> CostStream
 runSixArgumentModel (ModelSixArgumentsConstantCost c) = lazy $ \_ _ _ _ _ _ -> CostLast c
-{-# OPAQUE runSixArgumentModel #-}
+{-# NOINLINE runSixArgumentModel #-}
 
 -- See Note [runCostingFun* API].
 runCostingFunSixArguments

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -67,7 +67,7 @@ builtinCostModelVariantA :: BuiltinCostModel
 builtinCostModelVariantA =
     $$(readJSONFromFile DFP.builtinCostModelFileA)
 -- This is a huge record, inlining it is wasteful.
-{-# OPAQUE builtinCostModelVariantA #-}
+{-# NOINLINE builtinCostModelVariantA #-}
 
 {- Note [No inlining for CekMachineCosts]
 We don't want this to get inlined, as otherwise the default 'CekMachineCosts'
@@ -77,7 +77,7 @@ the costing parameters provided by the ledger. -}
 cekMachineCostsVariantA :: CekMachineCosts
 cekMachineCostsVariantA =
   $$(readJSONFromFile DFP.cekMachineCostsFileA)
-{-# OPAQUE cekMachineCostsVariantA #-}
+{-# NOINLINE cekMachineCostsVariantA #-}
 
 {-| The default cost model, including both builtin costs and machine step costs.
     Note that this is not necessarily the cost model in use on the chain at any
@@ -94,13 +94,13 @@ cekCostModelVariantA = CostModel cekMachineCostsVariantA builtinCostModelVariant
 builtinCostModelVariantB :: BuiltinCostModel
 builtinCostModelVariantB =
     $$(readJSONFromFile DFP.builtinCostModelFileB)
-{-# OPAQUE builtinCostModelVariantB #-}
+{-# NOINLINE builtinCostModelVariantB #-}
 
 -- See Note [No inlining for CekMachineCosts]
 cekMachineCostsVariantB :: CekMachineCosts
 cekMachineCostsVariantB =
   $$(readJSONFromFile DFP.cekMachineCostsFileB)
-{-# OPAQUE cekMachineCostsVariantB #-}
+{-# NOINLINE cekMachineCostsVariantB #-}
 
 cekCostModelVariantB :: CostModel CekMachineCosts BuiltinCostModel
 cekCostModelVariantB = CostModel cekMachineCostsVariantB builtinCostModelVariantB
@@ -108,13 +108,13 @@ cekCostModelVariantB = CostModel cekMachineCostsVariantB builtinCostModelVariant
 builtinCostModelVariantC :: BuiltinCostModel
 builtinCostModelVariantC =
     $$(readJSONFromFile DFP.builtinCostModelFileC)
-{-# OPAQUE builtinCostModelVariantC #-}
+{-# NOINLINE builtinCostModelVariantC #-}
 
 -- See Note [No inlining for CekMachineCosts]
 cekMachineCostsVariantC :: CekMachineCosts
 cekMachineCostsVariantC =
   $$(readJSONFromFile DFP.cekMachineCostsFileC)
-{-# OPAQUE cekMachineCostsVariantC #-}
+{-# NOINLINE cekMachineCostsVariantC #-}
 
 cekCostModelVariantC :: CostModel CekMachineCosts BuiltinCostModel
 cekCostModelVariantC = CostModel cekMachineCostsVariantC builtinCostModelVariantC

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
@@ -240,7 +240,7 @@ memoryUsageInteger 0 = 1
 memoryUsageInteger i = fromIntegral $ I# (integerLog2# (abs i) `quotInt#` integerToInt 64) + 1
 -- So that the produced GHC Core doesn't explode in size, we don't win anything by inlining this
 -- function anyway.
-{-# OPAQUE memoryUsageInteger #-}
+{-# NOINLINE memoryUsageInteger #-}
 
 instance ExMemoryUsage Integer where
     memoryUsage i = singletonRose $ memoryUsageInteger i
@@ -362,7 +362,7 @@ getting the memoryUsage instances to call those.
 
 g1ElementCost :: CostRose
 g1ElementCost = singletonRose . unsafeToSatInt $ BLS12_381.G1.memSizeBytes `div` 8
-{-# OPAQUE g1ElementCost #-}
+{-# NOINLINE g1ElementCost #-}
 
 instance ExMemoryUsage BLS12_381.G1.Element where
     memoryUsage _ = g1ElementCost
@@ -370,7 +370,7 @@ instance ExMemoryUsage BLS12_381.G1.Element where
 
 g2ElementCost :: CostRose
 g2ElementCost = singletonRose . unsafeToSatInt $ BLS12_381.G2.memSizeBytes `div` 8
-{-# OPAQUE g2ElementCost #-}
+{-# NOINLINE g2ElementCost #-}
 
 instance ExMemoryUsage BLS12_381.G2.Element where
     memoryUsage _ = g2ElementCost
@@ -378,7 +378,7 @@ instance ExMemoryUsage BLS12_381.G2.Element where
 
 mlResultElementCost :: CostRose
 mlResultElementCost = singletonRose . unsafeToSatInt $ BLS12_381.Pairing.mlResultMemSizeBytes `div` 8
-{-# OPAQUE mlResultElementCost #-}
+{-# NOINLINE mlResultElementCost #-}
 
 instance ExMemoryUsage BLS12_381.Pairing.MlResult where
     memoryUsage _ = mlResultElementCost

--- a/plutus-core/plutus-ir/src/PlutusIR/Pass.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Pass.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs      #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 
 module PlutusIR.Pass where
@@ -13,7 +12,7 @@ import PlutusCore qualified as PLC
 import PlutusCore.Name.Unique
 
 import Control.Monad (void, when)
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT, MonadError, throwError)
 import Control.Monad.Trans.Class (lift)
 import Data.Foldable
 import Data.Text (Text)

--- a/plutus-core/plutus-ir/test/PlutusIR/Compiler/Let/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Compiler/Let/Tests.hs
@@ -4,11 +4,10 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module PlutusIR.Compiler.Let.Tests where
 
-import Control.Monad (join)
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad (join, void)
+import Control.Monad.Except (ExceptT, runExceptT)
+import Control.Monad.Reader (Reader, runReader)
 import Data.Bifunctor
-import Data.Functor (void)
 import PlutusCore qualified as PLC
 import PlutusIR.Compiler (Provenance (..))
 import PlutusIR.Compiler qualified as PIR

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -862,7 +862,7 @@ enterComputeCek = computeCek
         resetCounter ctr
     -- It's very important for this definition not to get inlined. Inlining it caused performance to
     -- degrade by 16+%: https://github.com/IntersectMBO/plutus/pull/5931
-    {-# OPAQUE spendAccumulatedBudget #-}
+    {-# NOINLINE spendAccumulatedBudget #-}
 
     -- Making this a definition of its own causes it to inline better than actually writing it inline, for
     -- some reason.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -499,6 +499,7 @@ test_TrackCostsRestricting =
 
 test_TrackCostsRetaining :: TestTree
 test_TrackCostsRetaining =
+#if MIN_VERSION_base(4,15,0)
     test_TrackCostsWith "retaining" 10000 $ \term -> do
         let -- An 'ExBudgetMode' that retains all the individual budgets by sticking them into a
             -- 'DList'.
@@ -522,6 +523,19 @@ test_TrackCostsRetaining =
                         , "The result was: " ++ show res
                         ]
                 assertBool err $ expected > actual
+#else
+    -- FIXME: @effectfully
+    -- broken only for darwin :x86_64-darwin.ghc810 <https://ci.iog.io/build/5076829/nixlog/1>
+    -- TrackCosts: retaining:                                                             FAIL (0.51s)
+    -- untyped-plutus-core/test/Evaluation/Builtins/Definition.hs:482:
+    -- Too many elements picked up by GC
+    -- Expected at most: 5
+    -- But got: 6
+    -- The result was: [6829,0,0,0,0,3173]
+    -- Use -p '/TrackCosts: retaining/' to rerun this test only.
+    testCase "TrackCosts: retaining" $ do
+        assertBool "dummy" $ not . null $ DList.singleton 'x' -- Avoid 'redundant-imports' warning
+#endif
 
 typecheckAndEvalToOutOfEx :: Term TyName Name DefaultUni DefaultFun () -> Assertion
 typecheckAndEvalToOutOfEx term =
@@ -1234,18 +1248,7 @@ test_definition =
         , test_SwapEls
         , test_IdBuiltinData
         , test_TrackCostsRestricting
-#if MIN_VERSION_base(4,15,0)
-        -- FIXME: @effectfully
-        -- broken only for darwin :x86_64-darwin.ghc810 <https://ci.iog.io/build/5076829/nixlog/1>
-        -- TrackCosts: retaining:                                                             FAIL (0.51s)
-        -- untyped-plutus-core/test/Evaluation/Builtins/Definition.hs:482:
-        -- Too many elements picked up by GC
-        -- Expected at most: 5
-        -- But got: 6
-        -- The result was: [6829,0,0,0,0,3173]
-        -- Use -p '/TrackCosts: retaining/' to rerun this test only.
         , test_TrackCostsRetaining
-#endif
         , test_SerialiseDataImpossible
         , test_fixId
         , runTestNestedHere

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -9,6 +10,9 @@
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-} -- needed for asData pattern synonyms
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-specialise #-}
+#if !MIN_VERSION_base(4,15,0)
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+#endif
 
 module PlutusLedgerApi.V1.Data.Contexts (
   -- * Pending transactions and related types

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Tx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE LambdaCase        #-}
@@ -10,6 +11,9 @@
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-} -- needed for asData pattern synonyms
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+#if !MIN_VERSION_base(4,15,0)
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+#endif
 
 module PlutusLedgerApi.V1.Data.Tx (
   -- * Transactions

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Contexts.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -10,6 +11,9 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-strictness #-}
+#if !MIN_VERSION_base(4,15,0)
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+#endif
 
 module PlutusLedgerApi.V2.Data.Contexts (
   -- * Pending transactions and related types

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Tx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE LambdaCase        #-}
@@ -10,6 +11,9 @@
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-} -- needed for asData pattern synonyms
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+#if !MIN_VERSION_base(4,15,0)
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+#endif
 
 module PlutusLedgerApi.V2.Data.Tx (
   -- * Transactions

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/Data/Contexts.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NamedFieldPuns    #-}
@@ -12,6 +13,9 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-strictness #-}
+#if !MIN_VERSION_base(4,15,0)
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+#endif
 
 module PlutusLedgerApi.V3.Data.Contexts (
   ColdCommitteeCredential (..),

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/Data/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/Data/Tx.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments       #-}
+{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DerivingVia          #-}
 {-# LANGUAGE FlexibleInstances    #-}
@@ -11,6 +12,9 @@
 {-# LANGUAGE ViewPatterns         #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-specialise #-}
+#if !MIN_VERSION_base(4,15,0)
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+#endif
 
 module PlutusLedgerApi.V3.Data.Tx (
   TxId (..),

--- a/plutus-metatheory/Setup.hs
+++ b/plutus-metatheory/Setup.hs
@@ -70,7 +70,7 @@ data AgdaProgramStatus
 
 agdaProgramStatus :: IORef AgdaProgramStatus
 agdaProgramStatus = unsafePerformIO (newIORef NotRun)
-{-# OPAQUE agdaProgramStatus #-}
+{-# NOINLINE agdaProgramStatus #-}
 
 
 main :: IO ()

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
+
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
@@ -15,6 +16,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
 
 module Plugin.Data.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -1,5 +1,6 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE NegativeLiterals    #-}
 {-# LANGUAGE OverloadedStrings   #-}
@@ -16,7 +17,9 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module Plugin.Data.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -3,12 +3,14 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-cse-iterations=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
 
 module Plugin.Laziness.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -1,4 +1,5 @@
 -- editorconfig-checker-disable-file
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -10,7 +11,9 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-cse-iterations=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module Plugin.Laziness.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -11,7 +12,9 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-cse-iterations=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-typecheck #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module Plugin.Typeclasses.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
@@ -10,6 +11,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-cse-iterations=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-typecheck #-}
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
 
 module Plugin.Typeclasses.Spec where
 

--- a/plutus-tx/src/PlutusTx/Bool.hs
+++ b/plutus-tx/src/PlutusTx/Bool.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+
 module PlutusTx.Bool (Bool(..), (&&), (||), not, otherwise) where
 
 {-

--- a/plutus-tx/src/PlutusTx/Bool.hs
+++ b/plutus-tx/src/PlutusTx/Bool.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE CPP #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module PlutusTx.Bool (Bool(..), (&&), (||), not, otherwise) where
 

--- a/plutus-tx/src/PlutusTx/Builtins/HasBuiltin.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/HasBuiltin.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE FlexibleInstances        #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE TypeOperators            #-}
 
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module PlutusTx.Builtins.HasBuiltin where
 

--- a/plutus-tx/src/PlutusTx/Builtins/HasBuiltin.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/HasBuiltin.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE TypeOperators            #-}
 
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+
 module PlutusTx.Builtins.HasBuiltin where
 
 import Prelude

--- a/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
@@ -1,15 +1,17 @@
 {-# LANGUAGE CPP                      #-}
 {-# LANGUAGE DefaultSignatures        #-}
+{-# LANGUAGE DerivingStrategies       #-}
 {-# LANGUAGE FlexibleInstances        #-}
 {-# LANGUAGE FunctionalDependencies   #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE TypeOperators            #-}
 {-# LANGUAGE UndecidableInstances     #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-specialise #-}
-{-# LANGUAGE DerivingStrategies       #-}
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
 
 module PlutusTx.Builtins.HasOpaque where
 

--- a/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/HasOpaque.hs
@@ -11,7 +11,9 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-specialise #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module PlutusTx.Builtins.HasOpaque where
 

--- a/plutus-tx/src/PlutusTx/Function.hs
+++ b/plutus-tx/src/PlutusTx/Function.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE CPP #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module PlutusTx.Function (fix) where
 

--- a/plutus-tx/src/PlutusTx/Function.hs
+++ b/plutus-tx/src/PlutusTx/Function.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+
 module PlutusTx.Function (fix) where
 
 fix :: forall a b. ((a -> b) -> a -> b) -> a -> b

--- a/plutus-tx/src/PlutusTx/Optimize/Inline.hs
+++ b/plutus-tx/src/PlutusTx/Optimize/Inline.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE CPP #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module PlutusTx.Optimize.Inline (inline) where
 

--- a/plutus-tx/src/PlutusTx/Optimize/Inline.hs
+++ b/plutus-tx/src/PlutusTx/Optimize/Inline.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+
 module PlutusTx.Optimize.Inline (inline) where
 
 import Prelude

--- a/plutus-tx/src/PlutusTx/Plugin/Utils.hs
+++ b/plutus-tx/src/PlutusTx/Plugin/Utils.hs
@@ -3,8 +3,11 @@
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE KindSignatures     #-}
 {-# LANGUAGE OverloadedStrings  #-}
+
 {-# OPTIONS_GHC -Wno-unused-foralls #-}
 {-# OPTIONS_GHC -fomit-interface-pragmas #-}
+{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+
 module PlutusTx.Plugin.Utils where
 
 import Data.Proxy

--- a/plutus-tx/src/PlutusTx/Plugin/Utils.hs
+++ b/plutus-tx/src/PlutusTx/Plugin/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
@@ -6,7 +7,9 @@
 
 {-# OPTIONS_GHC -Wno-unused-foralls #-}
 {-# OPTIONS_GHC -fomit-interface-pragmas #-}
+#if !MIN_VERSION_base(4, 15, 0)
 {-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}
+#endif
 
 module PlutusTx.Plugin.Utils where
 


### PR DESCRIPTION
An alternative version of #6952 that replaces `OPAQUE` with `NOINLINE` where it matters and adds `{-# OPTIONS_GHC -Wwarn=unrecognised-pragmas #-}` where it doesn't.

Required for integration into `cardano-node-10`.