### PR TITLE
Remove Data.AssocMap.toDataList

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/Data/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Data/V2.hs
@@ -163,7 +163,6 @@ module PlutusLedgerApi.Data.V2 (
   unsafeFromSOPList,
   safeFromSOPList,
   toSOPList,
-  toDataList,
   toBuiltinList,
 
   -- *** Newtypes and hash types
@@ -198,7 +197,7 @@ import PlutusLedgerApi.V2.Data.Tx qualified as Tx
 import PlutusLedgerApi.V2.EvaluationContext qualified as EvaluationContext
 import PlutusLedgerApi.V2.ParamName qualified as ParamName
 
-import PlutusTx.Data.AssocMap (Map, safeFromSOPList, toBuiltinList, toDataList, toSOPList,
+import PlutusTx.Data.AssocMap (Map, safeFromSOPList, toBuiltinList, toSOPList,
                                unsafeFromBuiltinList, unsafeFromDataList, unsafeFromSOPList)
 
 {-| An alias to the Plutus ledger language this module exposes at runtime.

--- a/plutus-tx/changelog.d/20250320_234602_ana.pantilie95_remove_toDataList.md
+++ b/plutus-tx/changelog.d/20250320_234602_ana.pantilie95_remove_toDataList.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed `Data.AssocMap.toDataList` because it suffers from the bug described in https://github.com/IntersectMBO/plutus/issues/6085.

--- a/plutus-tx/src/PlutusTx/Data/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/Data/AssocMap.hs
@@ -16,7 +16,6 @@ module PlutusTx.Data.AssocMap (
   empty,
   null,
   toSOPList,
-  toDataList,
   toBuiltinList,
   safeFromSOPList,
   unsafeFromSOPList,
@@ -289,22 +288,6 @@ toSOPList d = go (toBuiltinList d)
 toBuiltinList :: Map k a -> BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData)
 toBuiltinList = coerce
 {-# INLINEABLE toBuiltinList #-}
-
--- | Convert the `Map` to a `List` of key-value pairs.
-toDataList :: Map k a -> List (a, k)
-toDataList = Data.List.fromBuiltinList . go . toBuiltinList
-  where
-    go
-      :: BI.BuiltinList (BI.BuiltinPair BuiltinData BuiltinData)
-      -> BI.BuiltinList BuiltinData
-    go =
-      P.caseList'
-        P.mkNil
-        ( \hd tl ->
-            let p = P.toBuiltinData $ P.pairToPair hd
-             in BI.mkCons p (go tl)
-        )
-{-# INLINEABLE toDataList #-}
 
 -- | Check if the `Map` is well-defined. Warning: this operation is O(n^2).
 noDuplicateKeys :: forall k a. Map k a -> Bool


### PR DESCRIPTION
It does not compile because of https://github.com/IntersectMBO/plutus/issues/6085. I have recorded this in https://github.com/IntersectMBO/plutus/issues/6904 so that we do not forget to bring it back once the bug is fixed. 