### PR TITLE
Fix a bug in PIR's callsite inliner that caused it to skip valid inlining

### DIFF
--- a/plutus-core/changelog.d/20250322_155229_unsafeFixIO_callsite.md
+++ b/plutus-core/changelog.d/20250322_155229_unsafeFixIO_callsite.md
@@ -1,0 +1,4 @@
+
+### Fixed
+
+- Fixed a bug in PIR's callsite inliner that caused it to skip valid inlining in certain cases.

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/CallSiteInline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/CallSiteInline.hs
@@ -72,7 +72,7 @@ applyAndBetaReduce rhs args0 = do
         InlineM tyname name uni fun ann (Maybe (Term tyname name uni fun ann))
       go acc args = case (acc, args) of
         (LamAbs _ann n _ty tm, TermAppContext arg _ args') -> do
-          safe <- safeToBetaReduce n arg acc
+          safe <- safeToBetaReduce n arg tm
           if safe -- we only do substitution if it is safe to beta reduce
             then do
               acc' <- do

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/Tests.hs
@@ -21,6 +21,7 @@ test_inline =
             (runTest withConstantInlining)
             [ "var"
             , "builtin"
+            , "callsite-6970"
             , "callsite-non-trivial-body"
             , "constant"
             , "transitive"

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/callsite-6970
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/callsite-6970
@@ -1,0 +1,51 @@
+{-
+let
+  !f : all a. list integer -> list integer
+    = /\a -> \(xs : list integer) -> tailList {integer} xs
+in
+\(xs : list integer) ->
+  headList
+    {integer}
+    (tailList {integer} (f {integer} (f {integer} xs)))
+-}
+
+(let
+  (nonrec)
+  (termbind
+    (strict)
+    (vardecl
+      f
+      (all
+        a
+        (type)
+        (fun
+          [ (con list) (con integer) ]
+          [ (con list) (con integer) ]
+        )
+      )
+    )
+    (abs
+      a
+      (type)
+      (lam
+        xs
+        [ (con list) (con integer) ]
+        [ { (builtin tailList) (con integer) } xs ]
+      )
+    )
+  )
+  (lam
+    xs
+    [ (con list) (con integer) ]
+    [
+      { (builtin headList) (con integer) }
+      [
+        { f (con integer) }
+        [
+          { f (con integer) }
+          [ { (builtin tailList) (con integer) } xs ]
+        ]
+      ]
+    ]
+  )
+)

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/callsite-6970.golden
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/callsite-6970.golden
@@ -1,0 +1,8 @@
+let
+  !f : all a. list integer -> list integer
+    = /\a -> \(xs : list integer) -> tailList {integer} xs
+in
+\(xs : list integer) ->
+  headList
+    {integer}
+    (tailList {integer} (tailList {integer} (tailList {integer} xs)))

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/letTypeApp2.golden
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/Inline/letTypeApp2.golden
@@ -1,4 +1,4 @@
 let
   !idFun : all a. a -> a = /\a -> \(x : a) -> x
 in
-(\(x : integer) -> x) ((\(x : integer) -> x) ((\(x : integer) -> x) 3))
+(\(x : integer) -> x) 3

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/destructSum-manual.pir.golden
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/destructSum-manual.pir.golden
@@ -3,8 +3,6 @@ let
     Unit : Unit
   !fail : unit -> data
     = \(ds : unit) -> Unit_match (error {Unit}) {data} (error {data})
-  !`$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData` : data -> data
-    = \(d : data) -> d
   !`$mInts` :
      all r.
        data ->
@@ -40,9 +38,7 @@ in
        True
        False)
     {all dead. data}
-    (/\dead ->
-       `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-         (headList {data} (sndPair {integer} {list data} tup)))
+    (/\dead -> headList {data} (sndPair {integer} {list data} tup))
     (/\dead ->
        let
          !tup : pair integer (list data) = unConstrData d
@@ -54,9 +50,7 @@ in
             True
             False)
          {all dead. data}
-         (/\dead ->
-            `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-              (headList {data} (sndPair {integer} {list data} tup)))
+         (/\dead -> headList {data} (sndPair {integer} {list data} tup))
          (/\dead ->
             let
               !tup : pair integer (list data) = unConstrData d
@@ -71,12 +65,8 @@ in
               (/\dead ->
                  let
                    !args : list data = sndPair {integer} {list data} tup
-                   !y : data
-                     = `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-                         (headList {data} (tailList {data} args))
-                   !ds : data
-                     = `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-                         (headList {data} args)
+                   !y : data = headList {data} (tailList {data} args)
+                   !ds : data = headList {data} args
                  in
                  `$mInts`
                    {data}

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/destructSum.pir.golden
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/destructSum.pir.golden
@@ -3,8 +3,6 @@ let
     Unit : Unit
   !fail : unit -> data
     = \(ds : unit) -> Unit_match (error {Unit}) {data} (error {data})
-  !`$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData` : data -> data
-    = \(d : data) -> d
   !`$mInts` :
      all r.
        data ->
@@ -40,9 +38,7 @@ in
        True
        False)
     {all dead. data}
-    (/\dead ->
-       `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-         (headList {data} (sndPair {integer} {list data} tup)))
+    (/\dead -> headList {data} (sndPair {integer} {list data} tup))
     (/\dead ->
        let
          !tup : pair integer (list data) = unConstrData d
@@ -54,9 +50,7 @@ in
             True
             False)
          {all dead. data}
-         (/\dead ->
-            `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-              (headList {data} (sndPair {integer} {list data} tup)))
+         (/\dead -> headList {data} (sndPair {integer} {list data} tup))
          (/\dead ->
             let
               !tup : pair integer (list data) = unConstrData d
@@ -74,13 +68,11 @@ in
                  in
                  `$mInts`
                    {data}
-                   (`$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-                      (headList {data} l))
+                   (headList {data} l)
                    (\(x : integer) (y : integer) (z : integer) (w : integer) ->
                       `$mInts`
                         {data}
-                        (`$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`
-                           (headList {data} (tailList {data} l)))
+                        (headList {data} (tailList {data} l))
                         (\(x : integer)
                           (y : integer)
                           (z : integer)


### PR DESCRIPTION
Fixes #6970

The third argument to `safeToBetaReduce` should be the body of the `LamAbs`, not the `LamAbs` itself!