### PR TITLE
[AST] [Performance] Use 'SmallArray' instead of 'Vector'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Compiler/Erase.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Compiler/Erase.hs
@@ -1,6 +1,6 @@
 module PlutusCore.Compiler.Erase (eraseTerm, eraseProgram) where
 
-import Data.Vector (fromList)
+import GHC.IsList (fromList)
 import PlutusCore.Core
 import PlutusCore.Name.Unique
 import UntypedPlutusCore.Core qualified as UPLC

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
@@ -20,7 +20,7 @@ import PlutusCore.Rename.Monad
 import Universe
 
 import Data.Hashable
-import Data.Vector qualified as V
+import Data.Primitive.SmallArray (SmallArray)
 
 instance (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, Eq ann) =>
             Eq (Term Name uni fun ann) where
@@ -37,7 +37,7 @@ type HashableTermConstraints uni fun ann =
 
 -- This instance is the only logical one, and exists also in the package `vector-instances`.
 -- Since this is the same implementation as that one, there isn't even much risk of incoherence.
-instance Hashable a => Hashable (V.Vector a) where
+instance Hashable a => Hashable (SmallArray a) where
   hashWithSalt s = hashWithSalt s . toList
 
 instance HashableTermConstraints uni fun ann => Hashable (Term Name uni fun ann)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -28,8 +28,9 @@ module UntypedPlutusCore.Core.Type
 import Control.Lens
 import PlutusPrelude
 
-import Data.Vector
+import Data.Primitive.SmallArray (SmallArray)
 import Data.Word
+import GHC.IsList (fromList)
 import PlutusCore.Builtin qualified as TPLC
 import PlutusCore.Core qualified as TPLC
 import PlutusCore.MkPlc
@@ -86,7 +87,7 @@ data Term name uni fun ann
     -- TODO: try spine-strict list or strict list or vector
     -- See Note [Constr tag type]
     | Constr !ann !Word64 ![Term name uni fun ann]
-    | Case !ann !(Term name uni fun ann) !(Vector (Term name uni fun ann))
+    | Case !ann !(Term name uni fun ann) {-# UNPACK #-} !(SmallArray (Term name uni fun ann))
     deriving stock (Functor, Generic)
 
 deriving stock instance (Show name, GShow uni, Everywhere uni Show, Show fun, Show ann, Closed uni)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Zip.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Zip.hs
@@ -10,7 +10,7 @@ module UntypedPlutusCore.Core.Zip
 
 import Control.Monad (void, when)
 import Control.Monad.Except (MonadError, throwError)
-import Data.Vector
+import GHC.IsList (fromList, toList)
 import UntypedPlutusCore.Core.Instance.Eq ()
 import UntypedPlutusCore.Core.Type
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -28,7 +28,7 @@ import UntypedPlutusCore.Core.Type qualified as UPLC
 import UntypedPlutusCore.Rename (Rename (rename))
 
 import Data.Text (Text)
-import Data.Vector qualified as V
+import GHC.IsList (fromList)
 import PlutusCore.Error (AsParserErrorBundle)
 import PlutusCore.MkPlc (mkIterApp)
 import PlutusCore.Parser hiding (parseProgram, parseTerm, program)
@@ -82,7 +82,7 @@ constrTerm = withSpan $ \sp ->
 caseTerm :: Parser PTerm
 caseTerm = withSpan $ \sp ->
     inParens $ do
-      res <- UPLC.Case sp <$> (symbol "case" *> term) <*> (V.fromList <$> many term)
+      res <- UPLC.Case sp <$> (symbol "case" *> term) <*> (fromList <$> many term)
       whenVersion (\v -> v < plcVersion110) $ fail "'case' is not allowed before version 1.1.0"
       pure res
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/CaseReduce.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/CaseReduce.hs
@@ -9,8 +9,8 @@ import UntypedPlutusCore.Core
 import UntypedPlutusCore.Transform.Simplifier (SimplifierStage (CaseReduce), SimplifierT,
                                                recordSimplification)
 
-import Control.Lens (transformOf)
-import Data.Vector qualified as V
+import Control.Lens (ix, transformOf, (^?))
+import Data.Foldable (toList)
 
 caseReduce
     :: Monad m
@@ -23,6 +23,6 @@ caseReduce term = do
 
 processTerm :: Term name uni fun a -> Term name uni fun a
 processTerm = \case
-    Case ann (Constr _ i args) cs | Just c <- (V.!?) cs (fromIntegral i) ->
+    Case ann (Constr _ i args) cs | Just c <- toList cs ^? ix (fromIntegral i) ->
                                     mkIterApp c ((ann,) <$> args)
     t                                                     -> t

--- a/plutus-core/untyped-plutus-core/testlib/Generators.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Generators.hs
@@ -6,7 +6,7 @@
 -- | UPLC property tests (pretty-printing\/parsing and binary encoding\/decoding).
 module Generators where
 
-import PlutusPrelude (display, fold, on, void, zipExact, (&&&))
+import PlutusPrelude (display, fold, on, toList, void, zipExact, (&&&))
 
 import PlutusCore (Name, _nameText)
 import PlutusCore.Annotation
@@ -28,7 +28,6 @@ import UntypedPlutusCore.Parser (parseProgram, parseTerm)
 import Control.Lens (view)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Vector qualified as V
 
 import Hedgehog (annotate, annotateShow, failure, property, tripping, (===))
 import Hedgehog.Gen qualified as Gen
@@ -61,7 +60,7 @@ compareTerm (Delay _ t ) (Delay _ t')         = compareTerm t t'
 compareTerm (Constant _ x) (Constant _ y)     = x == y
 compareTerm (Builtin _ bi) (Builtin _ bi')    = bi == bi'
 compareTerm (Constr _ i es) (Constr _ i' es') = i == i' && maybe False (all (uncurry compareTerm)) (zipExact es es')
-compareTerm (Case _ arg cs) (Case _ arg' cs') = compareTerm arg arg' && maybe False (all (uncurry compareTerm)) (zipExact (V.toList cs) (V.toList cs'))
+compareTerm (Case _ arg cs) (Case _ arg' cs') = compareTerm arg arg' && maybe False (all (uncurry compareTerm)) (zipExact (toList cs) (toList cs'))
 compareTerm (Error _ ) (Error _ )             = True
 compareTerm _ _                               = False
 

--- a/plutus-core/untyped-plutus-core/testlib/Transform/CaseOfCase/Test.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/CaseOfCase/Test.hs
@@ -6,7 +6,7 @@ module Transform.CaseOfCase.Test where
 
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text.Encoding (encodeUtf8)
-import Data.Vector qualified as V
+import GHC.IsList (fromList)
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.BuiltinCostModel (BuiltinCostModel)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultBuiltinCostModelForTesting,
@@ -45,7 +45,7 @@ caseOfCase1 = runQuote do
   let ite = Force () (Builtin () PLC.IfThenElse)
       true = Constr () 0 []
       false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
+      alts = fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
   pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 {- | This should not simplify, because one of the branches of `ifThenElse` is not a `Constr`.
@@ -59,7 +59,7 @@ caseOfCase2 = runQuote do
   let ite = Force () (Builtin () PLC.IfThenElse)
       true = Var () t
       false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
+      alts = fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
   pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 {- | Similar to `caseOfCase1`, but the type of the @true@ and @false@ branches is
@@ -76,7 +76,7 @@ caseOfCase3 = runQuote do
       false = Constr () 1 []
       altTrue = Var () f
       altFalse = mkConstant @Integer () 2
-      alts = V.fromList [altTrue, altFalse]
+      alts = fromList [altTrue, altFalse]
   pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 {- |
@@ -107,7 +107,7 @@ caseOfCaseWithError =
         , ((), Constr () 1 []) -- False
         ]
     )
-    (V.fromList [mkConstant @() () (), Error ()])
+    (fromList [mkConstant @() () (), Error ()])
 
 testCaseOfCaseWithError :: TestTree
 testCaseOfCaseWithError =

--- a/plutus-core/untyped-plutus-core/testlib/Transform/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/Simplify.hs
@@ -4,7 +4,7 @@
 module Transform.Simplify where
 
 import Data.Text (Text)
-import Data.Vector qualified as V
+import GHC.IsList (fromList)
 import PlutusCore qualified as PLC
 import PlutusCore.MkPlc (mkConstant, mkIterApp, mkIterAppNoAnn)
 import PlutusCore.Quote (Quote, freshName, runQuote)
@@ -35,7 +35,7 @@ caseOfCase1 = runQuote $ do
   let ite = Force () (Builtin () PLC.IfThenElse)
       true = Constr () 0 []
       false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
+      alts = fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
   pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 {- | This should not simplify, because one of the branches of `ifThenElse` is not a `Constr`.
@@ -49,7 +49,7 @@ caseOfCase2 = runQuote $ do
   let ite = Force () (Builtin () PLC.IfThenElse)
       true = Var () t
       false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
+      alts = fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
   pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 {- | Similar to `caseOfCase1`, but the type of the @true@ and @false@ branches is
@@ -66,7 +66,7 @@ caseOfCase3 = runQuote $ do
       false = Constr () 1 []
       altTrue = Var () f
       altFalse = mkConstant @Integer () 2
-      alts = V.fromList [altTrue, altFalse]
+      alts = fromList [altTrue, altFalse]
   pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
 
 -- | The `Delay` should be floated into the lambda.
@@ -441,7 +441,7 @@ cse1 = runQuote $ do
       branch1 = plus onePlusTwoPlusX threePlusX
       branch2 = plus twoPlusX threePlusX
       branch3 = fourPlusX
-      caseExpr = Case () (Var () y) (V.fromList [branch1, branch2, branch3])
+      caseExpr = Case () (Var () y) (fromList [branch1, branch2, branch3])
   pure $ LamAbs () x (LamAbs () y body)
 
 -- | This is the second example in Note [CSE].


### PR DESCRIPTION
#6602 will require optimizing `case`, so let's try doing that separately.