### PR TITLE
Doc-fix, Add required dependency for the off-chain example code 

### DIFF
--- a/doc/docusaurus/docs/auction-smart-contract/end-to-end/generating-keys.md
+++ b/doc/docusaurus/docs/auction-smart-contract/end-to-end/generating-keys.md
@@ -14,6 +14,7 @@ git clone git@github.com:IntersectMBO/plinth-template.git on-chain
 mkdir off-chain && cd $_
 yarn init -y
 yarn add @meshsdk/core
+yarn add @harmoniclabs/pair
 yarn add cbor
 ```
 


### PR DESCRIPTION
off-chain project fails to build as it is missing a dependency.
## To verify the need for fix:
Follow the instruction in **[Generating Keys and Addresses](https://plutus.cardano.intersectmbo.org/docs/auction-smart-contract/end-to-end/generating-keys)**
This will give an error that you're missing the `@harmoniclabs/pair` dependency

## To verify the fix:
Follow the same instruction from the patch branch

