### PR TITLE
Metatheory for dropList

### DIFF
--- a/plutus-metatheory/src/Algorithmic/CEK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CEK.lagda.md
@@ -340,6 +340,7 @@ BUILTIN findFirstSetBit (base $ V-con s) = inj₂ (V-con (findFirstSetBIT s))
 BUILTIN expModInteger (base  $ V-con b $ V-con e $ V-con m) with expModINTEGER b e m
 ... | just r = inj₂ (V-con r)
 ... | nothing  = inj₁ (con (ne (^ (atomic aInteger))))
+BUILTIN dropList (Λ̂ A $ V-con n $ V-con l) = inj₂ (V-con (dropLIST n l))
 
 BUILTIN' : ∀ b {A}
   → ∀{tn} → {pt : tn ∔ 0 ≣ fv (signature b)}

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -156,6 +156,8 @@ data Builtin : Set where
   ripemd-160                      : Builtin
   -- Modular Exponentiation
   expModInteger                   : Builtin
+  -- DropList
+  dropList                        : Builtin
 ```
 
 ## Signatures
@@ -337,7 +339,7 @@ sig n⋆ n♯ (t₃ ∷ t₂ ∷ t₁) tᵣ
     signature countSetBits                    = ∙ [ bytestring ↑ ]⟶  integer ↑
     signature findFirstSetBit                 = ∙ [ bytestring ↑ ]⟶  integer ↑
     signature expModInteger                   = ∙ [ integer ↑ , integer ↑ , integer ↑ ]⟶  integer ↑
-
+    signature dropList                        = ∀a [ integer ↑ , list a ]⟶ list a
 open SugaredSignature using (signature) public
 
 -- The arity of a builtin, according to its signature.
@@ -440,6 +442,7 @@ Each Agda built-in name must be mapped to a Haskell name.
                                           | FindFirstSetBit
                                           | Ripemd_160
                                           | ExpModInteger
+                                          | DropList
                                           ) #-}
 ```
 
@@ -641,6 +644,7 @@ postulate
 
 -- no binding needed for appendStr
 -- no binding needed for traceStr
+-- See Utils.List for the implementation of dropList
 ```
 
 Equality of Builtins is decidable.

--- a/plutus-metatheory/src/Untyped/CEK.lagda.md
+++ b/plutus-metatheory/src/Untyped/CEK.lagda.md
@@ -142,7 +142,6 @@ V-I : ∀ b
 V-I b {tm = zero}   bt = V-I⇒ b bt
 V-I b {tm = suc tm} bt = V-IΠ b bt
 
-
 fullyAppliedBuiltin : ∀ b → Set
 fullyAppliedBuiltin b = BApp b (alldone (fv (signature b))) (alldone (args♯ (signature b)))
 
@@ -572,6 +571,10 @@ BUILTIN expModInteger = λ
      { (just r) -> inj₂ (V-con integer r)
      ; nothing  -> inj₁ userError
      }
+  ; _ -> inj₁ userError
+  }
+BUILTIN dropList = λ
+  { (app (app (app⋆ base) (V-con integer n)) (V-con (list t) l)) → inj₂ (V-con (list t) (dropLIST n l))
   ; _ -> inj₁ userError
   }
 

--- a/plutus-metatheory/src/Utils.lagda.md
+++ b/plutus-metatheory/src/Utils.lagda.md
@@ -20,7 +20,7 @@ import Data.List as L
 open import Data.Sum using (_⊎_;inj₁;inj₂)
 open import Relation.Nullary using (Dec;yes;no;¬_)
 open import Data.Empty using (⊥;⊥-elim)
-open import Data.Integer using (ℤ)
+open import Data.Integer using (ℤ; +_)
 open import Data.String using (String)
 open import Data.Bool using (Bool)
 open import Data.Maybe using (Maybe; just; nothing; maybe)
@@ -218,6 +218,15 @@ toList (x ∷ xs) = x L.∷ toList xs
 fromList : ∀{A} →  L.List A → List A
 fromList L.[] = []
 fromList (x L.∷ xs) = x ∷ fromList xs
+
+-- Implementation of UPLC's dropList builtin
+dropLIST : ∀{A} → ℤ → List A → List A
+dropLIST (+ n) l = drop n l
+  where drop : ∀{A} → ℕ → List A → List A
+        drop zero xs = xs
+        drop (suc n) [] = []
+        drop (suc n) (x ∷ xs) = drop n xs
+dropLIST _ l = l
 
 map-cong : ∀{A B : Set}{xs : L.List A}{f g : A → B}
      → (∀ x → f x ≡ g x)

--- a/plutus-metatheory/src/Utils/List.lagda.md
+++ b/plutus-metatheory/src/Utils/List.lagda.md
@@ -17,6 +17,7 @@ open import Data.List using (List;[];_∷_;_++_;map;foldr;length;head) public
 open import Data.List.Properties using (foldr-++;++-cancelʳ;∷-injective)
 open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;trans;subst;subst-subst)
 open import Data.Empty using (⊥;⊥-elim)
+open import Data.Integer using (ℤ; pos)
 open import Data.Product using (Σ;_×_;_,_;proj₂)
 open import Relation.Nullary using (¬_)
 


### PR DESCRIPTION
This adds the  `dropList` builtin to the Agda metatheory.