### PR TITLE
Bump estree-util-value-to-estree to 3.3.3 for docusaurus site

### DIFF
--- a/doc/docusaurus/package.json
+++ b/doc/docusaurus/package.json
@@ -40,7 +40,8 @@
     "@babel/runtime-corejs3": "7.26.10",
     "@babel/runtime": "7.26.10",
     "@babel/helpers": "7.26.10",
-    "image-size": "1.2.1"
+    "image-size": "1.2.1",
+    "estree-util-value-to-estree": "3.3.3"
   },
   "browserslist": {
     "production": [

--- a/doc/docusaurus/yarn.lock
+++ b/doc/docusaurus/yarn.lock
@@ -4623,10 +4623,10 @@ estree-util-to-js@^2.0.0:
     astring "^1.8.0"
     source-map "^0.7.0"
 
-estree-util-value-to-estree@^3.0.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/estree-util-value-to-estree/-/estree-util-value-to-estree-3.2.1.tgz#f8083e56f51efb4889794490730c036ba6167ee6"
-  integrity sha512-Vt2UOjyPbNQQgT5eJh+K5aATti0OjCIAGc9SgMdOFYbohuifsWclR74l0iZTJwePMgWYdX1hlVS+dedH9XV8kw==
+estree-util-value-to-estree@3.3.3, estree-util-value-to-estree@^3.0.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/estree-util-value-to-estree/-/estree-util-value-to-estree-3.3.3.tgz#800b03a551b466dd77ed2c574b042a9992546cf2"
+  integrity sha512-Db+m1WSD4+mUO7UgMeKkAwdbfNWwIxLt48XF2oFU9emPfXkIu+k5/nlOj313v7wqtAPo0f9REhUvznFrPkG8CQ==
   dependencies:
     "@types/estree" "^1.0.0"
 


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/plutus/security/dependabot/45