### PR TITLE
doc: fix missing await on wallet.signTx

### DIFF
--- a/doc/docusaurus/static/code/mint-token-for-auction.mjs
+++ b/doc/docusaurus/static/code/mint-token-for-auction.mjs
@@ -78,7 +78,7 @@ const redeemer = {
 const tx = new Transaction({ initiator: wallet })
 tx.mintAsset(mintingPolicy, token, redeemer)
 const unsignedTx = await tx.setRequiredSigners([walletAddress]).build()
-const signedTx = wallet.signTx(unsignedTx)
+const signedTx = await wallet.signTx(unsignedTx)
 const txHash = await wallet.submitTx(signedTx)
 
 console.log(


### PR DESCRIPTION
Fix missing await in <b>Minting the Token to be Auctioned</b> example doc.
`wallet.signTx` return a Promise, getting `{"code":"ERR_INVALID_ARG_TYPE"}` when calling `wallet.submitTx`