### PR TITLE
Fix `expModInteger` bug

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/ExpMod.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/ExpMod.hs
@@ -21,7 +21,7 @@ expMod b e m
   -- ^ Just in case: GHC.Num.Integer.integerRecip# gets this wrong.  Note that 0
   -- is invertible modulo 1, with inverse 0.
   | b == 0 && e < 0 = failNonInvertible 0 m
-  -- ^ GHC.Num.Integer.integerPowMod# incorrectly returns 0 in this case.
+  -- ^ integerPowMod# incorrectly returns 0 in this case.
   | otherwise =
       case integerPowMod# b e m of
         (# n | #)  -> pure n

--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/ExpMod.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/ExpMod.hs
@@ -10,16 +10,23 @@ import PlutusCore.Builtin
 import GHC.Natural
 import GHC.Num.Integer
 
--- similar to `Default.Builtins.nonZeroSecondArg`
--- We don't really need it because integerPowMod# returns `()` on zero mod, but we put
--- in case of future implementation changes.
--- TODO https://github.com/IntersectMBO/plutus-private/issues/1474
-expMod _ _ 0 = fail "Cannot divide by zero"
-expMod b e m =
-    case integerPowMod# b e m of
-        (# n | #)  -> pure n
-        (# | () #) -> fail "expMod: failure"
-
-
+-- | Modular exponentiation.  This uses GHC.Num.integerPowMod#, which gives the
+-- wrong answer in some cases.  TODO: we'll be able to remove some of the guards
+-- when/if integerPowMod# gets fixed.
 expMod :: Integer -> Integer -> Natural -> BuiltinResult Natural
+expMod b e m
+  | m <= 0 = fail "expMod: invalid modulus"
+  -- ^ We can't have m<0 when m is a Natural, but we may as well be paranoid.
+  | m == 1 = pure 0
+  -- ^ Just in case: GHC.Num.Integer.integerRecip# gets this wrong.  Note that 0
+  -- is invertible modulo 1, with inverse 0.
+  | b == 0 && e < 0 = failNonInvertible 0 m
+  -- ^ GHC.Num.Integer.integerPowMod# incorrectly returns 0 in this case.
+  | otherwise =
+      case integerPowMod# b e m of
+        (# n | #)  -> pure n
+        (# | () #) -> failNonInvertible b m
+  where failNonInvertible :: Integer -> Natural -> BuiltinResult Natural
+        failNonInvertible b1 m1 =
+          fail ("expMod: " ++ (show b1) ++ " is not invertible modulo " ++ (show m1))
 {-# INLINE expMod #-}

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/Integer/ExpMod/exp-neg-non-inverse1.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/Integer/ExpMod/exp-neg-non-inverse1.err.golden
@@ -2,4 +2,4 @@ An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
 Caused by: expModInteger 2 -3 4
 Logs were:
-expMod: failure
+expMod: 2 is not invertible modulo 4

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/Integer/ExpMod/exp-neg-non-inverse2.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/Integer/ExpMod/exp-neg-non-inverse2.err.golden
@@ -2,4 +2,4 @@ An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
 Caused by: expModInteger 500 -5 5
 Logs were:
-expMod: failure
+expMod: 500 is not invertible modulo 5

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/Integer/ExpMod/mod-zero.err.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Golden/Integer/ExpMod/mod-zero.err.golden
@@ -2,4 +2,4 @@ An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
 Caused by: expModInteger 1 1 0
 Logs were:
-Cannot divide by zero
+expMod: invalid modulus


### PR DESCRIPTION
This fixes #7061 (see that for details).  I'll add the property tests that discovered the problem in a later PR.