### PR TITLE
Enable & Publish Project Coverage Reports For plutus-core

### DIFF
--- a/.github/workflows/code-coverage-report.yml
+++ b/.github/workflows/code-coverage-report.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches: 
-      - test-coverage # TODO remove me before merging
+      - coverage-plutus-core # TODO remove me before merging
 
 jobs:
   deploy:

--- a/.github/workflows/code-coverage-report.yml
+++ b/.github/workflows/code-coverage-report.yml
@@ -8,9 +8,6 @@ on:
     branches: 
       - master 
   workflow_dispatch:
-  pull_request:
-    branches: 
-      - coverage-plutus-core # TODO remove me before merging
 
 jobs:
   deploy:

--- a/.github/workflows/code-coverage-report.yml
+++ b/.github/workflows/code-coverage-report.yml
@@ -1,0 +1,36 @@
+# On push to master, this workflow builds and publishes the project's coverage 
+# report to: https://plutus.cardano.intersectmbo.org/dev/coverage
+
+name: "📊 Code Coverage Report"
+
+on:
+  push: 
+    branches: 
+      - master 
+  workflow_dispatch:
+  pull_request:
+    branches: 
+      - test-coverage # TODO remove me before merging
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: [self-hosted, plutus-ci]
+    permissions:
+      contents: write
+    environment:
+      name: github-pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Build Report
+        run: | 
+          nix build --no-warn-dirty --accept-flake-config .#project-coverage-report
+
+      - name: Deploy Report
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
+        with:
+          folder: result/share/hpc/vanilla/html
+          target-folder: dev/coverage
+          single-commit: true

--- a/.github/workflows/slack-message-broker.yml
+++ b/.github/workflows/slack-message-broker.yml
@@ -21,6 +21,7 @@ on:
       - "🌘 Nightly Testsuite"
       - "📝 Papers & Specs"
       - "🏛️ Plinth Template"
+      - "📊 Code Coverage Report"
 
 jobs:
   Send:

--- a/.github/workflows/slack-message-broker.yml
+++ b/.github/workflows/slack-message-broker.yml
@@ -158,7 +158,7 @@ jobs:
 
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.1.0
         if: ${{ steps.prepare-slack-message.outputs.shouldSendMessage == 'true' }}
         env:
             SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }} 

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -58,9 +58,13 @@ let
       [ "devShells" ]; # Won't build on Windows
   };
 
+  project-coverage-report =
+    project.projectVariants.ghc96-coverage.projectCoverageReport;
+
   extra-artifacts =
     { inherit metatheory-site; } //
     { inherit metatheory-agda-library; } //
+    { inherit project-coverage-report; } //
     (latex-documents);
 
   project-variants-hydra-jobs = {
@@ -77,9 +81,6 @@ let
     ghc910.roots = project-variants-hydra-jobs.ghc910.roots;
     ghc910.plan-nix = project-variants-hydra-jobs.ghc910.plan-nix;
   };
-
-  project-coverage-report =
-    project.projectVariants.ghc96-coverage.projectCoverageReport;
 
   packages =
     exposed-haskell-packages //
@@ -102,7 +103,6 @@ let
       (project-variants-hydra-jobs) //
       (windows-packages) //
       (packages) //
-      { inherit project-coverage-report; } //
       { devShells = non-profiled-shells; } //
       { required = hydra-required-job; };
     "x86_64-darwin" =

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -11,9 +11,6 @@ let
   utils = import ./utils.nix
     { inherit lib; };
 
-  build-latex = import ./build-latex.nix
-    { inherit pkgs; };
-
   r-with-packages = import ./r-with-packages.nix
     { inherit pkgs; };
 
@@ -24,10 +21,7 @@ let
     { inherit self pkgs lib metatheory-agda-library; };
 
   build-latex-doc = import ./build-latex-doc.nix
-    { inherit pkgs lib agda-tools build-latex; };
-
-  unraveling-recursion-paper = import ./unraveling-recursion-paper.nix
-    { inherit self pkgs lib build-latex agda-tools; };
+    { inherit pkgs lib agda-tools; };
 
   latex-documents = import ./latex-documents.nix
     { inherit self build-latex-doc; };
@@ -64,25 +58,18 @@ let
       [ "devShells" ]; # Won't build on Windows
   };
 
-  project-coverage-report =
-    project.projectVariants.ghc96-coverage.projectCoverageReport;
-
   extra-artifacts =
-    { inherit unraveling-recursion-paper; } //
     { inherit metatheory-site; } //
     { inherit metatheory-agda-library; } //
     (latex-documents);
 
   project-variants-hydra-jobs = {
-    ghc810 = (project.flake { }).hydraJobs.ghc810;
     ghc96 = (project.flake { }).hydraJobs.ghc96;
     ghc98 = (project.flake { }).hydraJobs.ghc98;
     ghc910 = (project.flake { }).hydraJobs.ghc910;
   };
 
   project-variants-roots-and-plan-nix = {
-    ghc810.roots = project-variants-hydra-jobs.ghc810.roots;
-    ghc810.plan-nix = project-variants-hydra-jobs.ghc810.plan-nix;
     ghc96.roots = project-variants-hydra-jobs.ghc96.roots;
     ghc96.plan-nix = project-variants-hydra-jobs.ghc96.plan-nix;
     ghc98.roots = project-variants-hydra-jobs.ghc98.roots;
@@ -91,6 +78,9 @@ let
     ghc910.plan-nix = project-variants-hydra-jobs.ghc910.plan-nix;
   };
 
+  project-coverage-report =
+    project.projectVariants.ghc96-coverage.projectCoverageReport;
+
   packages =
     exposed-haskell-packages //
     static-haskell-packages //
@@ -98,7 +88,6 @@ let
 
   non-profiled-shells = rec {
     default = ghc96;
-    ghc810 = mkShell project.projectVariants.ghc810;
     ghc96 = mkShell project.projectVariants.ghc96;
     ghc98 = mkShell project.projectVariants.ghc98;
     ghc910 = mkShell project.projectVariants.ghc910;
@@ -143,7 +132,6 @@ let
     inherit agda-tools;
     inherit r-with-packages;
     inherit build-latex-doc;
-    inherit build-latex;
     inherit extra-artifacts;
     inherit windows-packages;
     inherit static-haskell-packages;

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -21,8 +21,6 @@ let
         ghc98.compiler-nix-name = "ghc98";
         ghc910.compiler-nix-name = "ghc910";
         ghc96-coverage.modules = [{
-          # NOTE: Enabling coverage for some packages breaks tests due to HPC 
-          # (Haskell Program Coverage) instrumentation. 
           packages.plutus-core.doCoverage = true;
         }];
       };

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -18,9 +18,6 @@ let
           enableProfiling = true;
           enableLibraryProfiling = true;
         }];
-        ghc96-coverage.modules = [{
-          doCoverage = true;
-        }];
         ghc98.compiler-nix-name = "ghc98";
         ghc910.compiler-nix-name = "ghc910";
         ghc96-coverage.modules = [{

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -22,6 +22,7 @@ let
         ghc910.compiler-nix-name = "ghc910";
         ghc96-coverage.modules = [{
           packages.plutus-core.doCoverage = true;
+          packages.plutus-core.configureFlags = [ "--ghc-option=-D__HPC_ENABLED__" ];
         }];
       };
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -23,6 +23,11 @@ let
         }];
         ghc98.compiler-nix-name = "ghc98";
         ghc910.compiler-nix-name = "ghc910";
+        ghc96-coverage.modules = [{
+          # NOTE: Enabling coverage for some packages breaks tests due to HPC 
+          # (Haskell Program Coverage) instrumentation. 
+          packages.plutus-core.doCoverage = true;
+        }];
       };
 
       inputMap = { "https://chap.intersectmbo.org/" = inputs.CHaP; };

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -827,6 +827,7 @@ library plutus-core-testlib
     , Stream
     , tagged
     , tasty
+    , tasty-expected-failure
     , tasty-golden
     , tasty-hedgehog
     , tasty-hunit

--- a/plutus-core/testlib/Test/Tasty/Extras.hs
+++ b/plutus-core/testlib/Test/Tasty/Extras.hs
@@ -34,7 +34,7 @@ module Test.Tasty.Extras
     , assertEqualPretty
     , (%=?)
     , (%?=)
-    , ignoreTetWhenHpcEnabled
+    , ignoreTestWhenHpcEnabled
     ) where
 
 import PlutusPrelude hiding (toList)

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
@@ -1238,7 +1238,7 @@ test_definition =
         , test_SwapEls
         , test_IdBuiltinData
         , test_TrackCostsRestricting
-        , test_TrackCostsRetaining
+        , ignoreTestWhenHpcEnabled test_TrackCostsRetaining
         , test_SerialiseDataImpossible
         , test_fixId
         , runTestNestedHere

--- a/plutus-ledger-api/test/Spec/Data/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Data/Eval.hs
@@ -32,6 +32,7 @@ import Data.Maybe (fromJust)
 import Data.Set qualified as Set
 import NoThunks.Class
 import Test.Tasty
+import Test.Tasty.Extras (ignoreTestWhenHpcEnabled)
 import Test.Tasty.HUnit
 
 {- Note [Direct UPLC code]
@@ -130,6 +131,6 @@ tests = testGroup "eval"
     [ testAPI
 --    , testUnlifting
     , evaluationContextCacheIsComplete
-    , evaluationContextNoThunks
+    , ignoreTestWhenHpcEnabled evaluationContextNoThunks
     ]
 

--- a/plutus-ledger-api/test/Spec/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Eval.hs
@@ -32,6 +32,7 @@ import Data.Maybe (fromJust)
 import Data.Set qualified as Set
 import NoThunks.Class
 import Test.Tasty
+import Test.Tasty.Extras (ignoreTestWhenHpcEnabled)
 import Test.Tasty.HUnit
 
 {- Note [Direct UPLC code]
@@ -130,6 +131,6 @@ tests = testGroup "eval"
     [ testAPI
 --    , testUnlifting
     , evaluationContextCacheIsComplete
-    , evaluationContextNoThunks
+    , ignoreTestWhenHpcEnabled evaluationContextNoThunks
     ]
 


### PR DESCRIPTION
This PR enables the build of the project coverage report.
A report is built on each PR, but only published on push to master.
The report will be available [here](https://plutus.cardano.intersectmbo.org/dev/coverage) 
The report currently is only available for the `plutus-core` package, this is because enabling HPC (haskell program coverage) on other packages breaks several tests in their test-suites, see [this PR](https://github.com/IntersectMBO/plutus/pull/6979) for an effort to address this.
There is one test that also fails in plutus-core, when HPC is enabled:
```
      TrackCosts: retaining:                                                             FAIL (0.43s)
        untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs:526:
        Too many elements picked up by GC
        Expected at most: 5
        But got: 7180
        The result was: [106,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0>
        Use -p '/TrackCosts: retaining/' to rerun this test only.
```
For this reason we use a new custom cabal flag named `__HPC_ENABLED__` and a new function `Test.Tasty.Extras.ignoreTestIfHpcEnabled`. This could be avoided if we somehow got the `TrackCosts: retaining:` not to fail when HPC is enabled