### PR TITLE
Fix some Agda unparsing

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -38,6 +38,7 @@ module PlutusCore
     , DefaultUni (..)
     , pattern DefaultUniList
     , pattern DefaultUniPair
+    , pattern DefaultUniArray
     , DefaultFun (..)
     -- * AST
     , Term (..)

--- a/plutus-metatheory/changelog.d/20250507_213709_ana.pantilie95_fix_some_agda_unparsing.rst
+++ b/plutus-metatheory/changelog.d/20250507_213709_ana.pantilie95_fix_some_agda_unparsing.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+- Fixed a few Agda unparsing issues which were causing syntax errors in the certifier's generated certificates.

--- a/plutus-metatheory/src/FFI/AgdaUnparse.hs
+++ b/plutus-metatheory/src/FFI/AgdaUnparse.hs
@@ -116,7 +116,8 @@ instance AgdaUnparse (UPLC.DefaultUni (PLC.Esc a)) where
   agdaUnparse PLC.DefaultUniBLS12_381_G1_Element = "bls12-381-g1-element"
   agdaUnparse PLC.DefaultUniBLS12_381_G2_Element = "bls12-381-g2-element"
   agdaUnparse PLC.DefaultUniBLS12_381_MlResult = "bls12-381-mlresult"
-  agdaUnparse _ = error "oh no... anyway"
+  agdaUnparse (PLC.DefaultUniArray _) = error "Arrays are currently not supported."
+  agdaUnparse (PLC.DefaultUniApply _ _) = error "Application of an unknown type is not supported."
 
 agdaUnparseValue :: DSum (PLC.ValueOf UPLC.DefaultUni) Identity -> String
 agdaUnparseValue dSum =
@@ -149,7 +150,10 @@ agdaUnparseValue dSum =
         "bls12-381-g2-element " ++  agdaUnparse val
       PLC.ValueOf PLC.DefaultUniBLS12_381_MlResult _ :=> Identity val ->
         "bls12-381-mlresult " ++ agdaUnparse val
-      _ -> error "agdaUnparseValue: unexpected value"
+      PLC.ValueOf (PLC.DefaultUniArray _) _ :=> Identity _ ->
+        error "Arrays are currently not supported."
+      PLC.ValueOf (PLC.DefaultUniApply _ _) _ :=> Identity _ ->
+        error "Application of an unknown type is not supported."
   ++ ")"
   where
     agdaUnparseDList elemType xs =


### PR DESCRIPTION
I've been manually testing the plugin with certification turned on. These changes fix some minor bugs in the generated certificates.