### PR TITLE
Certifier produces certificate as Agda project; optimise certificate

### DIFF
--- a/plutus-executables/plutus-executables.cabal
+++ b/plutus-executables/plutus-executables.cabal
@@ -161,10 +161,8 @@ test-suite test-certifier
     , base
     , directory
     , filepath
-    , plutus-core:plutus-core-testlib
     , process
     , tasty
     , tasty-hunit
-    , text
 
   build-tool-depends: plutus-executables:uplc

--- a/plutus-executables/plutus-executables.cabal
+++ b/plutus-executables/plutus-executables.cabal
@@ -159,6 +159,7 @@ test-suite test-certifier
   other-modules:      Test.Certifier.Executable
   build-depends:
     , base
+    , directory
     , filepath
     , plutus-core:plutus-core-testlib
     , process

--- a/plutus-executables/test/certifier/Test/Certifier/Executable.hs
+++ b/plutus-executables/test/certifier/Test/Certifier/Executable.hs
@@ -18,7 +18,8 @@ import Test.Tasty.HUnit
 {- | Run an external executable with some arguments.  This is for use inside
     HUnit Assertions -}
 
--- TODO: this is a mess, makeExampleM uses another function to run the certifier, need to
+-- TODO(https://github.com/IntersectMBO/plutus-private/issues/1582):
+-- this is a mess, makeExampleM uses another function to run the certifier, need to
 -- refactor things to introduce less duplication
 makeUplcCert :: String -> IO FilePath
 makeUplcCert name = do

--- a/plutus-metatheory/changelog.d/20250512_141822_ana.pantilie95_split_certificates_2.rst
+++ b/plutus-metatheory/changelog.d/20250512_141822_ana.pantilie95_split_certificates_2.rst
@@ -1,0 +1,4 @@
+Changed
+-------
+
+- Certificates now are generated as Agda projects, and common ASTs are shared to greatly reduce the size of the certificates.

--- a/plutus-metatheory/changelog.d/20250512_141822_ana.pantilie95_split_certificates_2.rst
+++ b/plutus-metatheory/changelog.d/20250512_141822_ana.pantilie95_split_certificates_2.rst
@@ -1,4 +1,4 @@
 Changed
 -------
 
-- Certificates now are generated as Agda projects, and common ASTs are shared to greatly reduce the size of the certificates.
+- Certificates now are generated as Agda projects, and the UPLC ASTs are deduplicated to greatly reduce the size of the certificates.

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -85,6 +85,7 @@ library
     , plutus-core:plutus-core-execlib
     , process
     , text
+    , time
     , transformers
 
   exposed-modules: Paths_plutus_metatheory

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -80,6 +80,7 @@ library
     , ieee754
     , megaparsec
     , memory
+    , mtl
     , optparse-applicative
     , plutus-core                      ^>=1.45
     , plutus-core:plutus-core-execlib

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -73,6 +73,7 @@ library
     , base
     , bytestring
     , composition-prelude
+    , directory
     , extra
     , filepath
     , ghc-prim

--- a/plutus-metatheory/src/Certifier.hs
+++ b/plutus-metatheory/src/Certifier.hs
@@ -9,6 +9,7 @@ import Data.Maybe (fromJust)
 import Data.Time.Clock.System (getSystemTime, systemNanoseconds)
 import System.Directory (createDirectory)
 import System.Exit (ExitCode (..), exitSuccess, exitWith)
+import System.FilePath ((</>))
 
 import FFI.AgdaUnparse (AgdaUnparse (..))
 import FFI.SimplifierTrace (mkFfiSimplifierTrace)
@@ -270,8 +271,8 @@ writeCertificateProject AgdaCertificateProject { mainModule, astModules, project
   time <- systemNanoseconds <$> getSystemTime
   let actualProjectDir = projectDir <> "-" <> show time
   createDirectory actualProjectDir
-  createDirectory (actualProjectDir <> "/src")
-  writeFile (actualProjectDir <> "/src/" <> mainModulePath) mainModuleContents
-  writeFile (actualProjectDir <> "/" <> agdalibPath) agdalibContents
-  mapM_ (\(path, contents) -> writeFile (actualProjectDir <> "/src/" <> path) contents) astModules
+  createDirectory (actualProjectDir </> "src")
+  writeFile (actualProjectDir </> "src" </> mainModulePath) mainModuleContents
+  writeFile (actualProjectDir </> agdalibPath) agdalibContents
+  mapM_ (\(path, contents) -> writeFile (actualProjectDir </> "src" </> path) contents) astModules
   putStrLn $ "Agda certificate project written to " <> actualProjectDir

--- a/plutus-metatheory/src/Certifier.hs
+++ b/plutus-metatheory/src/Certifier.hs
@@ -1,5 +1,11 @@
 module Certifier (runCertifier) where
 
+import Control.Monad ((>=>))
+import Data.List (find)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (fromJust)
+
 import FFI.AgdaUnparse (agdaUnparse)
 import FFI.SimplifierTrace (mkFfiSimplifierTrace)
 import FFI.Untyped (UTerm)
@@ -60,3 +66,102 @@ rawCertificate certName rawTrace =
   \\ncertificate : passed? (runCertifier asts) ≡ true\
   \\ncertificate = refl\
   \\n"
+
+type AstId = Int
+type EquivClass = Int
+
+data Ast = Ast
+  { astId      :: AstId
+  , equivClass :: Maybe EquivClass
+  , astTerm    :: UTerm
+  }
+
+initAst :: AstId -> UTerm -> Ast
+initAst astId term =
+  Ast
+    { astId = astId
+    , equivClass = Nothing
+    , astTerm = term
+    }
+
+unsafeEquivClass :: Ast -> EquivClass
+unsafeEquivClass ast =
+  case equivClass ast of
+    Just cl -> cl
+    Nothing -> error "EquivClass is missing."
+
+mkAgdaTrace :: [(SimplifierStage, (UTerm, UTerm))] -> [(SimplifierStage, (EquivClass, EquivClass))]
+mkAgdaTrace sTrace =
+  let initTr = initAstTrace sTrace
+      allRawAsts = initTr >>= (\(stage, (before, after)) -> [before, after])
+      groupedAsts = findEquivClasses allRawAsts
+      processedAsts = groupedAsts >>= NE.toList
+      processedAstTrace = processAstTrace processedAsts initTr
+   in fmap (\(st, (bf, af)) -> (st, (unsafeEquivClass bf, unsafeEquivClass af))) processedAstTrace
+
+processAstTrace :: [Ast] -> [(SimplifierStage, (Ast, Ast))] -> [(SimplifierStage, (Ast, Ast))]
+processAstTrace _ [] = []
+processAstTrace allAsts ((stage, (rawBefore, rawAfter)) : rest) =
+  let Just processedBefore = find (\ast -> astId ast == astId rawBefore) allAsts
+      Just processedAfter = find (\ast -> astId ast == astId rawAfter) allAsts
+   in (stage, (processedBefore, processedAfter)) : processAstTrace allAsts rest
+
+initAstTrace :: [(SimplifierStage, (UTerm, UTerm))] -> [(SimplifierStage, (Ast, Ast))]
+initAstTrace sTrace = go 0 sTrace
+  where
+    go :: AstId -> [(SimplifierStage, (UTerm, UTerm))] -> [(SimplifierStage, (Ast, Ast))]
+    go _ [] = []
+    go astId ((stage, (before, after)) : rest) =
+      let beforeAst = initAst astId before
+          afterAst = initAst (astId + 1) after
+       in (stage, (beforeAst, afterAst)) : go (astId + 2) rest
+
+findEquivClasses :: [Ast] -> [NonEmpty Ast]
+findEquivClasses =
+  go 0 . NE.groupBy (\x y -> astTerm x == astTerm y)
+  where
+    go :: EquivClass -> [NonEmpty Ast] -> [NonEmpty Ast]
+    go _ [] = []
+    go cl (asts : rest) =
+      let asts' = fmap (\x -> x {equivClass = Just cl}) asts
+       in asts' : go (cl + 1) rest
+
+chooseRepresentatives :: [NonEmpty Ast] -> [Ast]
+chooseRepresentatives = fmap NE.head
+
+mkAgdaAstFiles :: [Ast] -> [(FilePath, String)]
+mkAgdaAstFiles = fmap go
+  where
+    go ast =
+      let agdaAst = agdaUnparse (astTerm ast)
+          agdaId = fromJust . equivClass $ ast
+          agdaIdStr = "ast" <> show agdaId
+          agdaAstTy = agdaIdStr <> " : Untyped"
+          agdaAstDef = agdaIdStr <> " = " <> agdaAst
+          agdaAstFile = "Ast" <> show agdaId <> ".agda"
+       in (agdaAstFile, mkAstModule agdaIdStr agdaAstTy agdaAstDef)
+
+mkAstModule :: String -> String -> String -> String
+mkAstModule agdaIdStr agdaAstTy agdaAstDef =
+  "module " <> agdaIdStr <> " where\
+  \\n\
+  \\nopen import VerifiedCompilation\
+  \\nopen import VerifiedCompilation.Certificate\
+  \\nopen import Untyped\
+  \\nopen import RawU\
+  \\nopen import Builtin\
+  \\nopen import Data.Unit\
+  \\nopen import Data.Nat\
+  \\nopen import Data.Integer\
+  \\nopen import Utils\
+  \\nimport Agda.Builtin.Bool\
+  \\nimport Relation.Nullary\
+  \\nimport VerifiedCompilation.UntypedTranslation\
+  \\nopen import Agda.Builtin.Maybe\
+  \\nopen import Data.Empty using (⊥)\
+  \\nopen import Data.Bool.Base using (Bool; false; true)\
+  \\nopen import Agda.Builtin.Equality using (_≡_; refl)\
+  \\n\
+  \\n" <> agdaAstTy <> "\n\
+  \\n" <> agdaAstDef <> "\n"
+

--- a/plutus-metatheory/src/Certifier.hs
+++ b/plutus-metatheory/src/Certifier.hs
@@ -163,7 +163,7 @@ mkAstModule agdaIdStr agdaAstTy agdaAstDef =
 
 mkAgdaOpenImport :: String -> String
 mkAgdaOpenImport agdaModuleName =
-  "\\nopen import " <> agdaModuleName
+  "open import " <> agdaModuleName
 
 newtype AgdaVar = AgdaVar String
 
@@ -206,8 +206,8 @@ mkCertificateModule certModule agdaTrace imports =
   \\nopen import Data.Empty using (⊥)\
   \\nopen import Data.Bool.Base using (Bool; false; true)\
   \\nopen import Agda.Builtin.Equality using (_≡_; refl)\
-  \\n" <> unlines imports <> "\\n" <>
-  "\\n\
+  \\n" <> unlines imports <> "\n" <>
+  "\n\
   \\nasts : List (SimplifierTag × Untyped × Untyped)\
   \\nasts = " <> agdaTrace <>
   "\n\
@@ -226,7 +226,7 @@ mkAgdaLib :: String -> (FilePath, String)
 mkAgdaLib name =
   let contents =
         "name: " <> name <>
-        "\\ndepend:\
+        "\ndepend:\
         \\n  standard-library-2.1.1\
         \\n  plutus-metatheory\
         \\ninclude: src"

--- a/plutus-metatheory/src/Certifier.hs
+++ b/plutus-metatheory/src/Certifier.hs
@@ -5,6 +5,7 @@ import Data.List (find)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromJust)
+import Data.Time.Clock.System (getSystemTime, systemNanoseconds)
 import System.Directory (createDirectory)
 
 import FFI.AgdaUnparse (AgdaUnparse (..))
@@ -251,9 +252,11 @@ writeCertificateProject AgdaCertificateProject { mainModule, astModules, project
       (agdalibPath, agdalibContents) = agdalib
       astModulePaths = fmap fst astModules
       astModuleContents = fmap snd astModules
-  createDirectory projectDir
-  createDirectory (projectDir <> "/src")
-  writeFile (projectDir <> "/src/" <> mainModulePath) mainModuleContents
-  writeFile (projectDir <> "/" <> agdalibPath) agdalibContents
-  mapM_ (\(path, contents) -> writeFile (projectDir <> "/src/" <> path) contents) astModules
-  putStrLn $ "Agda certificate project written to " <> projectDir
+  time <- systemNanoseconds <$> getSystemTime
+  let actualProjectDir = projectDir <> "-" <> show time
+  createDirectory actualProjectDir
+  createDirectory (actualProjectDir <> "/src")
+  writeFile (actualProjectDir <> "/src/" <> mainModulePath) mainModuleContents
+  writeFile (actualProjectDir <> "/" <> agdalibPath) agdalibContents
+  mapM_ (\(path, contents) -> writeFile (actualProjectDir <> "/src/" <> path) contents) astModules
+  putStrLn $ "Agda certificate project written to " <> actualProjectDir

--- a/plutus-metatheory/src/FFI/AgdaUnparse.hs
+++ b/plutus-metatheory/src/FFI/AgdaUnparse.hs
@@ -21,6 +21,9 @@ import UntypedPlutusCore.Transform.Simplifier
 usToHyphen :: String -> String
 usToHyphen = map (\c -> if c == '_' then '-' else c)
 
+newtype AgdaId = AgdaId String
+  deriving (Eq, Ord)
+
 -- | A class for types that can be unparsed to Agda code.
 class AgdaUnparse a where
   agdaUnparse :: a -> String

--- a/plutus-metatheory/src/FFI/AgdaUnparse.hs
+++ b/plutus-metatheory/src/FFI/AgdaUnparse.hs
@@ -21,9 +21,6 @@ import UntypedPlutusCore.Transform.Simplifier
 usToHyphen :: String -> String
 usToHyphen = map (\c -> if c == '_' then '-' else c)
 
-newtype AgdaId = AgdaId String
-  deriving (Eq, Ord)
-
 -- | A class for types that can be unparsed to Agda code.
 class AgdaUnparse a where
   agdaUnparse :: a -> String

--- a/plutus-metatheory/src/FFI/Untyped.hs
+++ b/plutus-metatheory/src/FFI/Untyped.hs
@@ -25,7 +25,7 @@ data UTerm = UVar Integer
            | UForce UTerm
            | UConstr Integer [UTerm]
            | UCase UTerm [UTerm]
-           deriving Show
+           deriving (Eq, Show)
 
 unIndex :: Index -> Integer
 unIndex (Index n) = toInteger n


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/plutus-private/issues/1346
Fixes https://github.com/IntersectMBO/plutus-private/issues/1546

If you run:
```
cabal exec uplc -- example -s fibonacci | cabal exec uplc -- optimise --certify FibCert
```
you get the following output:
```
................
        ]
      )
    ]
    (con integer 5)
  ]
)
The compilation was successfully certified.
Agda certificate project written to FibCert-911718221
```
The certifier creates a new directory called `FibCert-911718221`, which is the name the user provides followed by system time in nanoseconds. I decided to append this because we have multiple `Plinth` files which contain multiple `compile` evaluations, each of which representing one program with its own certificate. Until we modify `compile` to allow the user to provide a name for each one, I think this is a good enough workaround for now. (This PR doesn't modify the plugin, that's in a different PR; this PR just modifies the structure of the certificates).

The `FibCert-911718221` directory looks like:
<img width="272" alt="Screenshot 2025-05-12 at 14 08 16" src="https://github.com/user-attachments/assets/760e554a-ee01-4b91-a204-e5709718397d" />

Each `Ast` file contains just the UPLC program AST which is imported into `FibCert`, and that reconstructs the trace. One key difference from master, is that the same AST can appear in loads of places in the trace, if the simplifier didn't modify it in any way. In order to save space, I'm detecting this and just storing it once. Detecting whether two ASTs are equal is trivial since it's just testing for structural (syntactic) equality, so I don't think it hurts to add this to the things we just have to trust are correct.

In this example, `FibCert` looks like:
```
asts : List (SimplifierTag × Untyped × Untyped)
asts = ((floatDelayT , (ast0 , ast0)) ∷ (forceDelayT , (ast0 , ast1)) ∷ (caseOfCaseT , (ast1 , ast1)) ∷ (caseReduceT , (ast1 , ast1)) ∷ (inlineT , (ast1 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (cseT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (cseT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (cseT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ (cseT , (ast2 , ast2)) ∷ (floatDelayT , (ast2 , ast2)) ∷ (forceDelayT , (ast2 , ast2)) ∷ (caseOfCaseT , (ast2 , ast2)) ∷ (caseReduceT , (ast2 , ast2)) ∷ (inlineT , (ast2 , ast2)) ∷ [])

certificate : passed? (runCertifier asts) ≡ true
certificate = refl
```

As you can see, we only have `3` unique ASTs in this example, so we've reduced the number of ASTs from `(length trace) * 2` to just `3`.

We also generate an `.agda-lib` file for each certificate, so that users don't have to the add project dependencies manually.