### PR TITLE
Add missing example to docusaurus cabal file

### DIFF
--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -32,6 +32,7 @@ library docusaurus-code
   import:         lang, ghc-version-support, os-support
   hs-source-dirs: static/code
   other-modules:
+    AuctionMintingPolicy
     AuctionValidator
     BasicPlutusTx
     BasicPolicies


### PR DESCRIPTION
AuctionMintingPolicy was not included in the cabal file therefore wasn't being built when running `cabal build docusaurus-examples`