### PR TITLE
[Errors] Make '_OperationalEvaluationError' work in the machines

### DIFF
--- a/plutus-core/changelog.d/20250520_160112_effectfully_make__OperationalEvaluationError_work_in_the_machines.md
+++ b/plutus-core/changelog.d/20250520_160112_effectfully_make__OperationalEvaluationError_work_in_the_machines.md
@@ -1,0 +1,3 @@
+### Changed
+
+- In #7106 improved error reporting in the evaluators.

--- a/plutus-core/plutus-ir/test/PlutusIR/Compiler/Recursion/errorBinding.golden
+++ b/plutus-core/plutus-ir/test/PlutusIR/Compiler/Recursion/errorBinding.golden
@@ -1,5 +1,6 @@
 An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error
 Final budget: ({cpu: 100
 | mem: 100})
 Logs: 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -149,9 +149,8 @@ restricting (ExRestrictingBudget initB@(ExBudget cpuInit memInit)) = ExBudgetMod
                     -- @spend@ without this bang. Bangs on @cpuLeft'@ and @memLeft'@ don't help
                     -- either as those are forced by 'writeCpu' and 'writeMem' anyway. Go figure.
                     !budgetLeft = ExBudget cpuLeft' memLeft'
-                throwingWithCause _EvaluationError
-                    (OperationalEvaluationError . CekOutOfExError $ ExRestrictingBudget budgetLeft)
-                    Nothing
+                throwing _OperationalEvaluationError
+                    (CekOutOfExError $ ExRestrictingBudget budgetLeft)
         spender = CekBudgetSpender spend
         remaining = ExBudget <$> readCpu <*> readMem
         cumulative = do

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -458,7 +458,7 @@ throwingDischarged
     -> t
     -> CekValue uni fun ann
     -> CekM uni fun s x
-throwingDischarged l t = throwingWithCause l t . Just . dischargeCekValue
+throwingDischarged l t = throwingWithCause l t . dischargeCekValue
 
 instance ThrowableBuiltins uni fun =>
         MonadError (CekEvaluationException NamedDeBruijn uni fun) (CekM uni fun s) where
@@ -735,7 +735,7 @@ enterComputeCek = computeCek
         computeCek (FrameCases env cs ctx) env scrut
     -- s ; ρ ▻ error  ↦  <> A
     computeCek !_ !_ (Error _) =
-        throwing_ _EvaluationFailure
+        throwingWithCause _OperationalEvaluationError CekEvaluationFailure $ Error ()
 
     {- | The returning phase of the CEK machine.
     Returns 'EvaluationSuccess' in case the context is empty, otherwise pops up one frame
@@ -819,7 +819,7 @@ enterComputeCek = computeCek
                 -- application.
                 evalBuiltinApp ctx fun term' runtime'
             _ ->
-                throwingWithCause _MachineError BuiltinTermArgumentExpectedMachineError (Just term')
+                throwingWithCause _MachineError BuiltinTermArgumentExpectedMachineError term'
     forceEvaluate !_ val =
         throwingDischarged _MachineError NonPolymorphicInstantiationMachineError val
 
@@ -850,7 +850,7 @@ enterComputeCek = computeCek
             BuiltinExpectArgument f ->
                 evalBuiltinApp ctx fun term' $ f arg
             _ ->
-                throwingWithCause _MachineError UnexpectedBuiltinTermArgumentMachineError (Just term')
+                throwingWithCause _MachineError UnexpectedBuiltinTermArgumentMachineError term'
     applyEvaluate !_ val _ =
         throwingDischarged _MachineError NonFunctionalApplicationMachineError val
 
@@ -928,7 +928,7 @@ enterComputeCek = computeCek
     lookupVarName :: NamedDeBruijn -> CekValEnv uni fun ann -> CekM uni fun s (CekValue uni fun ann)
     lookupVarName varName@(NamedDeBruijn _ varIx) varEnv =
         Env.contIndexOne
-            (throwingWithCause _MachineError OpenTermEvaluatedMachineError . Just $ Var () varName)
+            (throwingWithCause _MachineError OpenTermEvaluatedMachineError $ Var () varName)
             pure
             varEnv
             (coerce varIx)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex3.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex3.golden
@@ -9,3 +9,4 @@ OldState: Returning NewState: Computing
 Driver is going to do a single step
 OldState: Computing NewState is Error: An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex4.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex4.golden
@@ -3,3 +3,4 @@ OldState: Starting NewState: Computing
 Driver is going to do a single step
 OldState: Computing NewState is Error: An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden/polyErrorInst.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden/polyErrorInst.plc.golden
@@ -1,2 +1,3 @@
 (Left An error has occurred:
-The provided Plutus code called 'error'.)
+The provided Plutus code called 'error'.
+Caused by: (error))

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden/polyErrorInst.uplc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden/polyErrorInst.uplc.golden
@@ -1,2 +1,3 @@
 (Left An error has occurred:
-The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.)
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: (error))

--- a/plutus-tx-plugin/test/Strictness/9.6/lambda-default.eval.golden
+++ b/plutus-tx-plugin/test/Strictness/9.6/lambda-default.eval.golden
@@ -1,2 +1,3 @@
 An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Strictness/9.6/lambda-nonstrict.eval.golden
+++ b/plutus-tx-plugin/test/Strictness/9.6/lambda-nonstrict.eval.golden
@@ -1,2 +1,3 @@
 An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Strictness/9.6/lambda-strict.eval.golden
+++ b/plutus-tx-plugin/test/Strictness/9.6/lambda-strict.eval.golden
@@ -1,2 +1,3 @@
 An error has occurred:
 The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error


### PR DESCRIPTION
This replaces

```haskell
instance AsEvaluationFailure err => AsEvaluationFailure (ErrorWithCause err cause) 
```

with

```haskell
instance AsEvaluationError err structural operational =>
        AsEvaluationError (ErrorWithCause err cause) structural operational where
```

making error throwing more uniform in the machines (plus it adds functionality that I need in #7029).

Also makes `throwingWithCause` accept a `term` rather than a `Maybe term`, as the name indicates there really should be a cause.

Also replaces 

```haskell
throwing_ _EvaluationFailure
```

with

```haskell
throwingWithCause _OperationalEvaluationError CekEvaluationFailure $ Error ()
```

in the machines, so that the logs clearly indicate that it was `error` that caused an evaluation failure -- not a builtin.