### PR TITLE
Add support for base integer `==`  (#7065)

### DIFF
--- a/plutus-tx-plugin/changelog.d/20250523_172915_seungheon.ooh_7065_2.md
+++ b/plutus-tx-plugin/changelog.d/20250523_172915_seungheon.ooh_7065_2.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added support for `integerEq` into the plugin, enabling use of `(==) @Integer` and pattern matching on `Integer` type values. 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -1028,9 +1028,8 @@ compileExpr e = traceCompilation 2 ("Compiling expr:" GHC.<+> GHC.ppr e) $ do
       | GHC.getName n == GHC.eqName ->
           throwPlain $ UnsupportedError "Use of == from the Haskell Eq typeclass"
     GHC.Var n
-      | isProbablyIntegerEq n ->
-          throwPlain $
-            UnsupportedError "Use of Haskell Integer equality, possibly via the Haskell Eq typeclass"
+      | isProbablyIntegerEq n -> do
+          lookupGhcId 'Builtins.equalsInteger >>= compileExpr . GHC.Var
     GHC.Var n
       | isProbablyBytestringEq n ->
           throwPlain $

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -15,7 +15,7 @@ import Data.Bifunctor
 import PlutusPrelude
 import PlutusTx.AsData.Internal qualified
 import PlutusTx.Bool ((&&), (||))
-import PlutusTx.Builtins (mkNilOpaque, useFromOpaque, useToOpaque)
+import PlutusTx.Builtins (equalsInteger, mkNilOpaque, useFromOpaque, useToOpaque)
 import PlutusTx.Code
 import PlutusTx.Compiler.Builtins
 import PlutusTx.Compiler.Error
@@ -412,6 +412,7 @@ compileMarkedExpr locStr codeTy origE = do
            , 'useToOpaque
            , 'useFromOpaque
            , 'mkNilOpaque
+           , 'PlutusTx.Builtins.equalsInteger           
            ]
   modBreaks <- asks pcModuleModBreaks
   let coverage =

--- a/plutus-tx-plugin/test/Plugin/Basic/9.6/integerCase.pir.golden
+++ b/plutus-tx-plugin/test/Plugin/Basic/9.6/integerCase.pir.golden
@@ -1,0 +1,32 @@
+let
+  ~ds : integer = 2
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+  !equalsInteger : integer -> integer -> bool = equalsInteger
+  !ifThenElse : all a. bool -> a -> a -> a = ifThenElse
+  ~equalsInteger : integer -> integer -> Bool
+    = \(x : integer) ->
+        let
+          !x : integer = x
+        in
+        \(y : integer) ->
+          let
+            !y : integer = y
+            !b : bool = equalsInteger x y
+          in
+          ifThenElse {Bool} b True False
+  !integerNegate : integer -> integer = \(x : integer) -> subtractInteger 0 x
+in
+Bool_match
+  (equalsInteger ds 1)
+  {all dead. integer}
+  (/\dead -> 42)
+  (/\dead ->
+     Bool_match
+       (equalsInteger ds 2)
+       {all dead. integer}
+       (/\dead -> 100)
+       (/\dead -> integerNegate 1)
+       {all dead. dead})
+  {all dead. dead}

--- a/plutus-tx-plugin/test/Plugin/Basic/9.6/integerPatternMatch.pir.golden
+++ b/plutus-tx-plugin/test/Plugin/Basic/9.6/integerPatternMatch.pir.golden
@@ -1,0 +1,30 @@
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+  !equalsInteger : integer -> integer -> bool = equalsInteger
+  !ifThenElse : all a. bool -> a -> a -> a = ifThenElse
+  ~equalsInteger : integer -> integer -> Bool
+    = \(x : integer) ->
+        let
+          !x : integer = x
+        in
+        \(y : integer) ->
+          let
+            !y : integer = y
+            !b : bool = equalsInteger x y
+          in
+          ifThenElse {Bool} b True False
+  ~integerMatchFunction : integer -> integer
+    = \(ds : integer) ->
+        let
+          !ds : integer = ds
+        in
+        Bool_match
+          (equalsInteger ds 1)
+          {all dead. integer}
+          (/\dead -> 12)
+          (/\dead -> Bool_match (equalsInteger ds 2) {integer} 22 42)
+          {all dead. dead}
+in
+integerMatchFunction 2

--- a/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -47,6 +48,8 @@ basic =
       , goldenUPlc "patternMatchFailure" patternMatchFailure
       , goldenPirReadable "defaultCaseDuplication" defaultCaseDuplication
       , goldenPirReadable "defaultCaseDuplicationNested" defaultCaseDuplicationNested
+      , goldenPirReadable "integerPatternMatch" integerPatternMatch
+      , goldenPirReadable "integerCase" integerCase      
       ]
 
 monoId :: CompiledCode (Integer -> Integer)
@@ -145,3 +148,15 @@ defaultCaseDuplicationNested = plc (Proxy @"defaultCaseDuplicationNested") do
         case y of
           B -> 2
           _ -> 3
+
+integerCase :: CompiledCode Integer
+integerCase = plc (Proxy @"integerCase") ((\case {1 -> 42; 2 -> 100; _ -> -1}) (2 :: Integer))
+
+integerMatchFunction :: Integer -> Integer
+integerMatchFunction 1 = 12
+integerMatchFunction 2 = 22
+integerMatchFunction _ = 42
+
+integerPatternMatch :: CompiledCode Integer
+integerPatternMatch = plc (Proxy @"integerPatternMatch") (integerMatchFunction 2)
+

--- a/plutus-tx-plugin/test/Plugin/Errors/9.6/literalCaseInt.uplc.golden
+++ b/plutus-tx-plugin/test/Plugin/Errors/9.6/literalCaseInt.uplc.golden
@@ -1,1 +1,0 @@
-Error: Unsupported feature: Use of Haskell Integer equality, possibly via the Haskell Eq typeclass

--- a/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
@@ -44,7 +44,6 @@ errors =
       , goldenUPlc "stringLiteral" stringLiteral
       , goldenUPlc "recursiveNewtype" recursiveNewtype
       , goldenUPlc "mutualRecursionUnfoldingsLocal" mutualRecursionUnfoldingsLocal
-      , goldenUPlc "literalCaseInt" literalCaseInt
       , goldenUPlc "literalCaseBs" literalCaseBs
       , goldenUPlc "literalAppendBs" literalAppendBs
       , goldenUPlc "literalCaseOther" literalCaseOther
@@ -84,9 +83,6 @@ oddDirectLocal n = if Builtins.equalsInteger n 0 then False else evenDirectLocal
 -- FIXME: these seem to only get unfoldings when they're in a separate module, even with the simplifier pass
 mutualRecursionUnfoldingsLocal :: CompiledCode Bool
 mutualRecursionUnfoldingsLocal = plc (Proxy @"mutualRecursionUnfoldingsLocal") (evenDirectLocal 4)
-
-literalCaseInt :: CompiledCode (Integer -> Integer)
-literalCaseInt = plc (Proxy @"literalCaseInt") (\case 1 -> 2; x -> x)
 
 literalCaseBs :: CompiledCode (Builtins.BuiltinByteString -> Builtins.BuiltinByteString)
 literalCaseBs = plc (Proxy @"literalCaseBs") (\x -> case x of "abc" -> ""; x -> x)

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}


### PR DESCRIPTION
Add support for base integer equality, thus integer pattern matching. This is accomplished by injecting `(PlutusTx.==) @Integer` into the code given to `compile` and converting all `GHC.Num.Integer.integerEq` into `PlutusTx.Builtins.equalsInteger` on the plugin side. This does bloat the PIR a little bit because it will include binding for `equalsInteger` even when it's not used, but this won't effect uplc at the end as we expect unused bindings from PIR to be correctly erased trivially. 

This feels like a rather sloppy method. In fact, I had other approach in mind, which is to precompile `(PlutusTx.==) @Integer` and load precompiled PIR from the plugin side, but I wasn't able to figure out a way to get this working with `Bool` being defined twice both from imported snippet and the code that snippet will get embedded to. I'll try to pursue that route again if that one is more preferable. 