### PR TITLE
[Refactoring] Cut 'Evaluation' from 'Structural' and 'Operational'

### DIFF
--- a/doc/notes/plutus-core/cek-budgeting-profiling/CostingDetails.md
+++ b/doc/notes/plutus-core/cek-budgeting-profiling/CostingDetails.md
@@ -70,7 +70,7 @@ instance (Eq fun, Hashable fun, ToExMemory term) =>
             Restricting resb ->
                 when (exceedsBudget resb newBudget) $
                     throwingWithCause _EvaluationError
-                        (OperationalEvaluationError $ CekOutOfExError resb newBudget)
+                        (OperationalError $ CekOutOfExError resb newBudget)
                         Nothing  -- No value available for error
 ```
 
@@ -96,7 +96,7 @@ to the current mode:
                 newBudget <- exBudgetStateBudget <%= (<> budget)
                 when (exceedsBudget resb newBudget) $
                     throwingWithCause _EvaluationError
-                        (OperationalEvaluationError $ CekOutOfExError resb newBudget)
+                        (OperationalError $ CekOutOfExError resb newBudget)
                         Nothing
 ```
 
@@ -114,7 +114,7 @@ of memory very quickly.  Changing the code to
             Restricting resb -> 
                 when (exceedsBudget resb newBudget) $
                     throwingWithCause _EvaluationError
-                        (OperationalEvaluationError $ CekOutOfExError resb newBudget)
+                        (OperationalError $ CekOutOfExError resb newBudget)
                         Nothing
 ```
 

--- a/plutus-core/changelog.d/20250521_140320_effectfully_cut_Evaluation_from_Structural_and_Operational.md
+++ b/plutus-core/changelog.d/20250521_140320_effectfully_cut_Evaluation_from_Structural_and_Operational.md
@@ -1,0 +1,4 @@
+### Changed
+
+- `StructuralEvaluationError` and `OperationalEvaluationError` were renamed to `StructuralError` and `OperationalError` respectively.
+- `_MachineError` was made obsolete in favor of `_StructuralError`.

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -247,7 +247,7 @@ typeMismatchError
     -> uni (Esc b)
     -> UnliftingEvaluationError
 typeMismatchError uniExp uniAct =
-    MkUnliftingEvaluationError . StructuralEvaluationError . fromString $ concat
+    MkUnliftingEvaluationError . StructuralError . fromString $ concat
         [ "Type mismatch: "
         , "expected: " ++ displayBy botRenderContext (SomeTypeIn uniExp)
         , "; actual: " ++ displayBy botRenderContext (SomeTypeIn uniAct)

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Result.hs
@@ -174,7 +174,7 @@ Such cases tend to be functions returning a value of a concrete error type (as o
 variable).
 -}
 
--- See Note [Ignoring context in OperationalEvaluationError].
+-- See Note [Ignoring context in OperationalError].
 -- | Construct a prism focusing on the @*EvaluationFailure@ part of @err@ by taking
 -- that @*EvaluationFailure@ and
 --
@@ -190,12 +190,12 @@ _UnliftingErrorVia err = iso (MkUnliftingError . display) (const err)
 
 -- | See Note [Structural vs operational errors within builtins]
 _StructuralUnliftingError :: AsBuiltinError err => Prism' err UnliftingError
-_StructuralUnliftingError = _BuiltinUnliftingEvaluationError . _StructuralEvaluationError
+_StructuralUnliftingError = _BuiltinUnliftingEvaluationError . _StructuralError
 {-# INLINE _StructuralUnliftingError #-}
 
 -- | See Note [Structural vs operational errors within builtins]
 _OperationalUnliftingError :: AsBuiltinError err => Prism' err UnliftingError
-_OperationalUnliftingError = _BuiltinUnliftingEvaluationError . _OperationalEvaluationError
+_OperationalUnliftingError = _BuiltinUnliftingEvaluationError . _OperationalError
 {-# INLINE _OperationalUnliftingError #-}
 
 throwNotAConstant :: MonadError BuiltinError m => m void
@@ -269,7 +269,7 @@ instance MonadError BuiltinError BuiltinResult where
         operationalLogs = case builtinErr of
             BuiltinUnliftingEvaluationError
                 (MkUnliftingEvaluationError
-                    (OperationalEvaluationError
+                    (OperationalError
                         (MkUnliftingError operationalErr))) -> pure operationalErr
             _ -> mempty
     {-# INLINE throwError #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Error.hs
@@ -47,8 +47,8 @@ structural error, only an operational one. This creates a sort of \"runtime type
 and it would be great to stick to it and enforce in tests etc, but we currently don't.
 -}
 data EvaluationError structural operational
-    = StructuralEvaluationError !structural
-    | OperationalEvaluationError !operational
+    = StructuralError !structural
+    | OperationalError !operational
     deriving stock (Show, Eq, Functor, Generic)
     deriving anyclass (NFData)
 
@@ -57,34 +57,34 @@ mtraverse makeClassyPrisms
     ]
 
 instance Bifunctor EvaluationError where
-    bimap f _ (StructuralEvaluationError err)  = StructuralEvaluationError $ f err
-    bimap _ g (OperationalEvaluationError err) = OperationalEvaluationError $ g err
+    bimap f _ (StructuralError err)  = StructuralError $ f err
+    bimap _ g (OperationalError err) = OperationalError $ g err
     {-# INLINE bimap #-}
 
 instance Bifoldable EvaluationError where
-    bifoldMap f _ (StructuralEvaluationError err)  = f err
-    bifoldMap _ g (OperationalEvaluationError err) = g err
+    bifoldMap f _ (StructuralError err)  = f err
+    bifoldMap _ g (OperationalError err) = g err
     {-# INLINE bifoldMap #-}
 
 instance Bitraversable EvaluationError where
-    bitraverse f _ (StructuralEvaluationError err)  = StructuralEvaluationError <$> f err
-    bitraverse _ g (OperationalEvaluationError err) = OperationalEvaluationError <$> g err
+    bitraverse f _ (StructuralError err)  = StructuralError <$> f err
+    bitraverse _ g (OperationalError err) = OperationalError <$> g err
     {-# INLINE bitraverse #-}
 
 -- | A raw evaluation failure is always an operational error.
 instance AsEvaluationFailure operational =>
         AsEvaluationFailure (EvaluationError structural operational) where
-    _EvaluationFailure = _OperationalEvaluationError . _EvaluationFailure
+    _EvaluationFailure = _OperationalError . _EvaluationFailure
     {-# INLINE _EvaluationFailure #-}
 
 instance
         ( HasPrettyDefaults config ~ 'True
         , PrettyBy config structural, Pretty operational
         ) => PrettyBy config (EvaluationError structural operational) where
-    prettyBy config (StructuralEvaluationError structural)   = prettyBy config structural
-    prettyBy _      (OperationalEvaluationError operational) = pretty operational
+    prettyBy config (StructuralError structural)   = prettyBy config structural
+    prettyBy _      (OperationalError operational) = pretty operational
 
 instance (Pretty structural, Pretty operational) =>
         Pretty (EvaluationError structural operational) where
-    pretty (StructuralEvaluationError structural)   = pretty structural
-    pretty (OperationalEvaluationError operational) = pretty operational
+    pretty (StructuralError structural)   = pretty structural
+    pretty (OperationalError operational) = pretty operational

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
@@ -73,11 +73,6 @@ mtraverse makeClassyPrisms
     [ ''MachineError
     ]
 
-instance structural ~ MachineError fun =>
-        AsMachineError (EvaluationError structural operational) fun where
-    _MachineError = _StructuralEvaluationError
-    {-# INLINE _MachineError #-}
-
 instance AsUnliftingError (MachineError fun) where
     _UnliftingError = _UnliftingMachineError
     {-# INLINE _UnliftingError #-}
@@ -85,31 +80,31 @@ instance AsUnliftingError (MachineError fun) where
 type EvaluationException structural operational =
     ErrorWithCause (EvaluationError structural operational)
 
-{- Note [Ignoring context in OperationalEvaluationError]
-The 'OperationalEvaluationError' error has a term argument, but 'splitStructuralOperational' just
+{- Note [Ignoring context in OperationalError]
+The 'OperationalError' error has a term argument, but 'splitStructuralOperational' just
 discards this and returns 'EvaluationFailure'. This means that, for example, if we use the @plc@
 command to execute a program containing a division by zero, @plc@ exits silently without reporting
 that anything has gone wrong (but returning a non-zero exit code to the shell via 'exitFailure').
-This is because 'OperationalEvaluationError' is used in cases when a PLC program itself goes wrong
+This is because 'OperationalError' is used in cases when a PLC program itself goes wrong
 (see the Haddock of 'EvaluationError'). This is used to signal unsuccessful validation and so is
 not regarded as a real error; in contrast structural errors are genuine errors and we report their
 context if available.
 -}
 
 -- See the Haddock of 'EvaluationError' for what structural and operational errors are.
--- See Note [Ignoring context in OperationalEvaluationError].
--- | Preserve the contents of an 'StructuralEvaluationError' as a 'Left' and turn an
--- 'OperationalEvaluationError' into a @Right EvaluationFailure@ (thus erasing the content of the
+-- See Note [Ignoring context in OperationalError].
+-- | Preserve the contents of an 'StructuralError' as a 'Left' and turn an
+-- 'OperationalError' into a @Right EvaluationFailure@ (thus erasing the content of the
 -- error in the latter case).
 splitStructuralOperational
     :: Either (EvaluationException structural operational term) a
     -> Either (ErrorWithCause structural term) (EvaluationResult a)
 splitStructuralOperational (Right term) = Right $ EvaluationSuccess term
 splitStructuralOperational (Left (ErrorWithCause evalErr cause)) = case evalErr of
-    StructuralEvaluationError err -> Left $ ErrorWithCause err cause
-    OperationalEvaluationError _  -> Right EvaluationFailure
+    StructuralError err -> Left $ ErrorWithCause err cause
+    OperationalError _  -> Right EvaluationFailure
 
--- | Throw on a 'StructuralEvaluationError' and turn an 'OperationalEvaluationError' into an
+-- | Throw on a 'StructuralError' and turn an 'OperationalError' into an
 -- 'EvaluationFailure' (thus erasing the content of the error in the latter case).
 unsafeSplitStructuralOperational
     :: (PrettyPlc structural, PrettyPlc term, Typeable structural, Typeable term)

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
@@ -115,8 +115,8 @@ handleError :: Type TyName DefaultUni ()
        -> Either (U.ErrorWithCause (U.EvaluationError structural operational) term)
                  (Term TyName Name DefaultUni DefaultFun ())
 handleError ty e = case U._ewcError e of
-  U.StructuralEvaluationError _  -> throwError e
-  U.OperationalEvaluationError _ -> return (Error () ty)
+  U.StructuralError _  -> throwError e
+  U.OperationalError _ -> return (Error () ty)
 
 -- untyped version of `handleError`
 handleUError ::
@@ -124,8 +124,8 @@ handleUError ::
        -> Either (U.ErrorWithCause (U.EvaluationError structural operational) term)
                  (U.Term Name DefaultUni DefaultFun ())
 handleUError e = case U._ewcError e of
-  U.StructuralEvaluationError _  -> throwError e
-  U.OperationalEvaluationError _ -> return (U.Error ())
+  U.StructuralError _  -> throwError e
+  U.OperationalError _ -> return (U.Error ())
 
 -- |Property: check if the type is preserved by evaluation.
 --

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -149,7 +149,7 @@ restricting (ExRestrictingBudget initB@(ExBudget cpuInit memInit)) = ExBudgetMod
                     -- @spend@ without this bang. Bangs on @cpuLeft'@ and @memLeft'@ don't help
                     -- either as those are forced by 'writeCpu' and 'writeMem' anyway. Go figure.
                     !budgetLeft = ExBudget cpuLeft' memLeft'
-                throwing _OperationalEvaluationError
+                throwing _OperationalError
                     (CekOutOfExError $ ExRestrictingBudget budgetLeft)
         spender = CekBudgetSpender spend
         remaining = ExBudget <$> readCpu <*> readMem

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek/Internal.hs
@@ -166,7 +166,7 @@ computeCek !ctx !env (Case ann scrut cs) = do
     pure $ Computing (FrameCases ann env cs ctx) env scrut
 -- s ; ρ ▻ error A  ↦  <> A
 computeCek !_ !_ (Error _) =
-    throwingWithCause _OperationalEvaluationError CekEvaluationFailure $ Error ()
+    throwingWithCause _OperationalError CekEvaluationFailure $ Error ()
 
 returnCek
     :: forall uni fun ann s
@@ -205,13 +205,13 @@ returnCek (FrameCases ann env cs ctx) e = case e of
     -- Word64 value wraps to -1 as an Int64. So you can't wrap around enough to get an
     -- "apparently good" value.
     (VConstr i _) | fromIntegral @_ @Integer i > fromIntegral @Int @Integer maxBound ->
-                    throwingDischarged _MachineError (MissingCaseBranchMachineError i) e
+                    throwingDischarged _StructuralError (MissingCaseBranchMachineError i) e
     (VConstr i args) -> case (V.!?) cs (fromIntegral i) of
         Just t  ->
               let ctx' = transferArgStack ann args ctx
               in computeCek ctx' env t
-        Nothing -> throwingDischarged _MachineError (MissingCaseBranchMachineError i) e
-    _ -> throwingDischarged _MachineError NonConstrScrutinizedMachineError e
+        Nothing -> throwingDischarged _StructuralError (MissingCaseBranchMachineError i) e
+    _ -> throwingDischarged _StructuralError NonConstrScrutinizedMachineError e
 
 -- | @force@ a term and proceed.
 -- If v is a delay then compute the body of v;
@@ -240,9 +240,9 @@ forceEvaluate ann !ctx (VBuiltin fun term runtime) = do
             -- application.
             evalBuiltinApp ann ctx fun term' runtime'
         _ ->
-            throwingWithCause _MachineError BuiltinTermArgumentExpectedMachineError term'
+            throwingWithCause _StructuralError BuiltinTermArgumentExpectedMachineError term'
 forceEvaluate _ !_ val =
-    throwingDischarged _MachineError NonPolymorphicInstantiationMachineError val
+    throwingDischarged _StructuralError NonPolymorphicInstantiationMachineError val
 
 -- | Apply a function to an argument and proceed.
 -- If the function is a lambda 'lam x ty body' then extend the environment with a binding of @v@
@@ -273,9 +273,9 @@ applyEvaluate ann !ctx (VBuiltin fun term runtime) arg = do
         -- argument next.
         BuiltinExpectArgument f -> evalBuiltinApp ann ctx fun term' $ f arg
         _ ->
-            throwingWithCause _MachineError UnexpectedBuiltinTermArgumentMachineError term'
+            throwingWithCause _StructuralError UnexpectedBuiltinTermArgumentMachineError term'
 applyEvaluate _ !_ val _ =
-    throwingDischarged _MachineError NonFunctionalApplicationMachineError val
+    throwingDischarged _StructuralError NonFunctionalApplicationMachineError val
 
 -- MAYBE: runCekDeBruijn can be shared between original&debug ceks by passing a `enterComputeCek` func.
 runCekDeBruijn
@@ -432,7 +432,7 @@ lookupVarName
     => NamedDeBruijn -> CekValEnv uni fun ann -> CekM uni fun s (CekValue uni fun ann)
 lookupVarName varName@(NamedDeBruijn _ varIx) varEnv =
     case varEnv `Env.indexOne` coerce varIx of
-        Nothing  -> throwingWithCause _MachineError OpenTermEvaluatedMachineError $ Var () varName
+        Nothing  -> throwingWithCause _StructuralError OpenTermEvaluatedMachineError $ Var () varName
         Just val -> pure val
 
 -- | Evaluate a 'HeadSpine' by pushing the arguments (if any) onto the stack and proceeding with

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
@@ -529,7 +529,7 @@ typecheckAndEvalToOutOfEx :: Term TyName Name DefaultUni DefaultFun () -> Assert
 typecheckAndEvalToOutOfEx term =
     let evalRestricting params = fst . runCekNoEmit params restrictingLarge
     in case typecheckAnd def evalRestricting defaultBuiltinCostModelForTesting term of
-        Right (Left (ErrorWithCause (OperationalEvaluationError (CekOutOfExError _)) _)) ->
+        Right (Left (ErrorWithCause (OperationalError (CekOutOfExError _)) _)) ->
             pure ()
         err -> assertFailure $ "Expected a 'CekOutOfExError' but got: " ++ displayPlc err
 


### PR DESCRIPTION
Makes names shorter and replaces `_MachineError` with `_StructuralError` for consistency with `_OperationalError`. 