### PR TITLE
[Refectoring] Remove Prism from type checking/compiler error handling 

### DIFF
--- a/plutus-core/executables/plutus/AnyProgram/IO.hs
+++ b/plutus-core/executables/plutus/AnyProgram/IO.hs
@@ -12,7 +12,6 @@ import AnyProgram.With
 import Common
 import GetOpt
 import PlutusCore.Default
-import PlutusCore.Error
 import PlutusCore.Pretty qualified as PP
 import PlutusPrelude hiding ((%~))
 import Types
@@ -43,7 +42,7 @@ readProgram sngS fileS =
         _ -> case fileS^.fType.fFormat of
                 Text -> do
                     bs <- readFileName (fromJust $ fileS^.fName)
-                    case parseProgram @ParserErrorBundle sngS $ T.decodeUtf8Lenient bs of
+                    case parseProgram sngS $ T.decodeUtf8Lenient bs of
                         Left err  -> failE $ show err
                         Right res -> pure res
                 Flat_ -> withLang @Flat sngS $ do

--- a/plutus-core/executables/plutus/AnyProgram/Parse.hs
+++ b/plutus-core/executables/plutus/AnyProgram/Parse.hs
@@ -22,8 +22,7 @@ import PlutusCore.Data
 --
 -- This could alternatively be achieved by
 -- using a "Parsable" typeclass + withL @Parsable hasomorphism
-parseProgram :: (AsParserErrorBundle e
-               , MonadError e m)
+parseProgram :: (MonadError ParserErrorBundle m)
              => SLang n -> T.Text -> m (FromLang n)
 parseProgram s txt = PLC.runQuoteT $
     case s of

--- a/plutus-core/executables/plutus/Debugger/TUI/Main.hs
+++ b/plutus-core/executables/plutus/Debugger/TUI/Main.hs
@@ -43,7 +43,7 @@ import Brick.Main qualified as B
 import Brick.Util qualified as B
 import Brick.Widgets.Edit qualified as BE
 import Control.Concurrent
-import Control.Monad.Except (runExcept)
+import Control.Monad.Except (runExcept, tryError)
 import Control.Monad.Primitive (unsafeIOToPrim)
 import Control.Monad.ST (RealWorld)
 import Data.Maybe

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -93,17 +93,12 @@ module PlutusCore
     , module TypeCheck
     , normalizeTypesIn
     , normalizeTypesInProgram
-    , AsTypeError (..)
     , TypeError
     -- * Errors
     , Error (..)
-    , AsError (..)
     , NormCheckError (..)
-    , AsNormCheckError (..)
     , UniqueError (..)
-    , AsUniqueError (..)
     , FreeVariableError (..)
-    , AsFreeVariableError (..)
     -- * Quotation and term construction
     , Quote
     , runQuote

--- a/plutus-core/plutus-core/src/PlutusCore/Check/Normal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Check/Normal.hs
@@ -22,15 +22,15 @@ import Universe.Core (HasUniApply (matchUniApply), SomeTypeIn (..))
 
 -- | Ensure that all types in the 'Program' are normalized.
 checkProgram
-    :: (AsNormCheckError e tyname name uni fun ann, HasUniApply uni, MonadError e m)
+    :: (HasUniApply uni, MonadError (NormCheckError tyname name uni fun ann) m)
     => Program tyname name uni fun ann -> m ()
 checkProgram (Program _ _ t) = checkTerm t
 
 -- | Ensure that all types in the 'Term' are normalized.
 checkTerm
-    :: (AsNormCheckError e tyname name uni fun ann, HasUniApply uni, MonadError e m)
+    :: (HasUniApply uni, MonadError (NormCheckError tyname name uni fun ann) m)
     => Term tyname name uni fun ann -> m ()
-checkTerm p = throwingEither _NormCheckError $ check p
+checkTerm p = liftEither $ check p
 
 check
     :: HasUniApply uni

--- a/plutus-core/plutus-core/src/PlutusCore/Check/Uniques.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Check/Uniques.hs
@@ -2,7 +2,6 @@ module PlutusCore.Check.Uniques
     ( checkProgram
     , checkTerm
     , UniqueError (..)
-    , AsUniqueError (..)
     ) where
 
 import PlutusCore.Analysis.Definitions
@@ -11,8 +10,7 @@ import PlutusCore.Error
 import PlutusCore.Name.Unique
 
 import Control.Monad (when)
-import Control.Monad.Error.Lens
-import Control.Monad.Except (MonadError)
+import Control.Monad.Except (MonadError, throwError)
 
 import Data.Foldable
 
@@ -20,8 +18,7 @@ checkProgram
     :: (Ord ann,
         HasUnique name TermUnique,
         HasUnique tyname TypeUnique,
-        AsUniqueError e ann,
-        MonadError e m)
+        MonadError (UniqueError ann) m)
     => (UniqueError ann -> Bool)
     -> Program tyname name uni fun ann
     -> m ()
@@ -31,11 +28,10 @@ checkTerm
     :: (Ord ann,
         HasUnique name TermUnique,
         HasUnique tyname TypeUnique,
-        AsUniqueError e ann,
-        MonadError e m)
+        MonadError (UniqueError ann) m)
     => (UniqueError ann -> Bool)
     -> Term tyname name uni fun ann
     -> m ()
 checkTerm p t = do
     (_, errs) <- runTermDefs t
-    for_ errs $ \e -> when (p e) $ throwing _UniqueError e
+    for_ errs $ \e -> when (p e) $ throwError e

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
@@ -17,7 +17,6 @@ module PlutusCore.DeBruijn
     , TyDeBruijn (..)
     , NamedTyDeBruijn (..)
     , FreeVariableError (..)
-    , AsFreeVariableError (..)
     , unNameDeBruijn
     , unNameTyDeBruijn
     , fakeNameDeBruijn
@@ -74,28 +73,28 @@ unDeBruijnTermWith = (runDeBruijnT .) . unDeBruijnTermWithM
 -- | Convert a 'Type' with 'NamedTyDeBruijn's into a 'Type' with 'TyName's.
 -- Will throw an error if a free variable is encountered.
 unDeBruijnTy
-    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
+    :: (MonadQuote m, MonadError FreeVariableError m)
     => Type NamedTyDeBruijn uni ann -> m (Type TyName uni ann)
 unDeBruijnTy = unDeBruijnTyWith freeIndexThrow
 
 -- | Convert a 'Term' with 'NamedTyDeBruijn's and 'NamedDeBruijn's into a 'Term' with 'TyName's and
 --  'Name's. Will throw an error if a free variable is encountered.
 unDeBruijnTerm
-    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
+    :: (MonadQuote m, MonadError FreeVariableError m)
     => Term NamedTyDeBruijn NamedDeBruijn uni fun ann -> m (Term TyName Name uni fun ann)
 unDeBruijnTerm = unDeBruijnTermWith freeIndexThrow
 
 -- | Convert a 'Type' with 'TyName's into a 'Type' with 'NamedTyDeBruijn's.
 -- Will throw an error if a free variable is encountered.
 deBruijnTy
-    :: (AsFreeVariableError e, MonadError e m)
+    :: (MonadError FreeVariableError m)
     => Type TyName uni ann -> m (Type NamedTyDeBruijn uni ann)
 deBruijnTy = deBruijnTyWith freeUniqueThrow
 
 -- | Convert a 'Term' with 'TyName's and 'Name's into a 'Term' with 'NamedTyDeBruijn's and
 -- 'NamedDeBruijn's. Will throw an error if a free variable is encountered.
 deBruijnTerm
-    :: (AsFreeVariableError e, MonadError e m)
+    :: (MonadError FreeVariableError m)
     => Term TyName Name uni fun ann -> m (Term NamedTyDeBruijn NamedDeBruijn uni fun ann)
 deBruijnTerm = deBruijnTermWith freeUniqueThrow
 

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -20,7 +20,6 @@ module PlutusCore.DeBruijn.Internal
   , TyDeBruijn (..)
   , NamedTyDeBruijn (..)
   , FreeVariableError (..)
-  , AsFreeVariableError (..)
   , Level (..)
   , LevelInfo (..)
   , declareUnique
@@ -51,7 +50,6 @@ import PlutusCore.Quote
 
 import Control.Exception
 import Control.Lens hiding (Index, Level, index, ix)
-import Control.Monad.Error.Lens
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
@@ -347,14 +345,12 @@ deBruijnToTyName
 deBruijnToTyName h (NamedTyDeBruijn n) = TyName <$> deBruijnToName h n
 
 -- | The default handler of throwing an error upon encountering a free name (unique).
-freeUniqueThrow :: (AsFreeVariableError e, MonadError e m) => Unique -> m Index
-freeUniqueThrow =
-  throwing _FreeVariableError . FreeUnique
+freeUniqueThrow :: (MonadError FreeVariableError m) => Unique -> m Index
+freeUniqueThrow = throwError . FreeUnique
 
 -- | The default handler of throwing an error upon encountering a free debruijn index.
-freeIndexThrow :: (AsFreeVariableError e, MonadError e m) => Index -> m Unique
-freeIndexThrow =
-  throwing _FreeVariableError . FreeIndex
+freeIndexThrow :: (MonadError FreeVariableError m) => Index -> m Unique
+freeIndexThrow = throwError . FreeIndex
 
 {- | A different implementation of a handler,  where "free" debruijn indices do not throw an error
 but are instead gracefully converted to fresh uniques.

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -12,19 +12,13 @@
 
 module PlutusCore.Error
     ( ParserError (..)
-    , AsParserErrorBundle (..)
     , ParserErrorBundle (..)
     , NormCheckError (..)
-    , AsNormCheckError (..)
     , UniqueError (..)
-    , AsUniqueError (..)
     , ExpectedShapeOr (..)
     , TypeError (..)
-    , AsTypeError (..)
     , FreeVariableError (..)
-    , AsFreeVariableError (..)
     , Error (..)
-    , AsError (..)
     , throwingEither
     , ShowErrorComponent (..)
     , ApplyProgramError (..)
@@ -135,6 +129,7 @@ data TypeError term uni fun ann
 
 -- Make a custom data type and wrap @ParseErrorBundle@ in it so I can use @makeClassyPrisms@
 -- on @ParseErrorBundle@.
+-- TODO: this can be killed
 data ParserErrorBundle
     = ParseErrorB !(ParseErrorBundle T.Text ParserError)
     deriving stock (Eq, Generic)
@@ -283,29 +278,6 @@ instance (PrettyUni uni, Pretty fun, Pretty ann) =>
     prettyBy config (TypeErrorE e)            = prettyBy config e
     prettyBy config (NormCheckErrorE e)       = prettyBy config e
     prettyBy _      (FreeVariableErrorE e)    = pretty e
-
-makeClassyPrisms ''ParseError
-makeClassyPrisms ''ParserErrorBundle
-makeClassyPrisms ''UniqueError
-makeClassyPrisms ''NormCheckError
-makeClassyPrisms ''TypeError
-makeClassyPrisms ''Error
-
-instance AsParserErrorBundle (Error uni fun ann) where
-    _ParserErrorBundle = _ParseErrorE
-
-instance AsUniqueError (Error uni fun ann) ann where
-    _UniqueError = _UniqueCoherencyErrorE
-
-instance AsTypeError (Error uni fun ann) (Term TyName Name uni fun ()) uni fun ann where
-    _TypeError = _TypeErrorE
-
-instance (tyname ~ TyName, name ~ Name) =>
-            AsNormCheckError (Error uni fun ann) tyname name uni fun ann where
-    _NormCheckError = _NormCheckErrorE
-
-instance AsFreeVariableError (Error uni fun ann) where
-    _FreeVariableError = _FreeVariableErrorE
 
 -- | Errors from `applyProgram` for PIR, PLC, UPLC.
 data ApplyProgramError =

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -16,7 +16,7 @@ module PlutusCore.Parser
 import PlutusCore.Annotation
 import PlutusCore.Core (Program (..), Term (..), Type)
 import PlutusCore.Default
-import PlutusCore.Error (AsParserErrorBundle, ParserError (..))
+import PlutusCore.Error (ParserError (..), ParserErrorBundle)
 import PlutusCore.MkPlc (mkIterApp, mkIterInst)
 import PlutusCore.Name.Unique (Name, TyName)
 import PlutusCore.Parser.Builtin as Export
@@ -114,7 +114,7 @@ term = leadingWhitespace go
 -- "test" to the parser as the name of the input stream; to supply a name
 -- explicity, use `parse program <name> <input>`.
 parseProgram ::
-    (AsParserErrorBundle e, MonadError e m, MonadQuote m)
+    (MonadError ParserErrorBundle m, MonadQuote m)
     => Text
     -> m (Program TyName Name DefaultUni DefaultFun SrcSpan)
 parseProgram = parseGen program
@@ -132,12 +132,12 @@ program = leadingWhitespace go
 
 -- | Parse a PLC term. The resulting program will have fresh names. The underlying monad
 -- must be capable of handling any parse errors.
-parseTerm :: (AsParserErrorBundle e, MonadError e m, MonadQuote m) =>
+parseTerm :: (MonadError ParserErrorBundle m, MonadQuote m) =>
     Text -> m (Term TyName Name DefaultUni DefaultFun SrcSpan)
 parseTerm = parseGen term
 
 -- | Parse a PLC type. The resulting program will have fresh names. The underlying monad
 -- must be capable of handling any parse errors.
-parseType :: (AsParserErrorBundle e, MonadError e m, MonadQuote m) =>
+parseType :: (MonadError ParserErrorBundle m, MonadQuote m) =>
     Text -> m (Type TyName DefaultUni SrcSpan)
 parseType = parseGen pType

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
@@ -6,7 +6,7 @@
 module PlutusCore.Parser.ParserCommon where
 
 import Control.Monad (when)
-import Control.Monad.Except (MonadError)
+import Control.Monad.Except
 import Control.Monad.Reader (ReaderT, ask, local, runReaderT)
 import Control.Monad.State (StateT, evalStateT)
 import Data.Map qualified as M
@@ -60,21 +60,21 @@ whenVersion p act = do
     Just v  -> when (p v) act
 
 parse
-  :: (AsParserErrorBundle e, MonadError e m, MonadQuote m)
+  :: (MonadError ParserErrorBundle m, MonadQuote m)
   => Parser a
   -> String
   -> Text
   -> m a
 parse p file str = do
   let res = fmap toErrorB (runReaderT (evalStateT (runParserT p file str) initial) Nothing)
-  throwingEither _ParserErrorBundle =<< liftQuote res
+  liftEither =<< liftQuote res
 
 toErrorB :: Either (ParseErrorBundle Text ParserError) a -> Either ParserErrorBundle a
 toErrorB (Left err) = Left $ ParseErrorB err
 toErrorB (Right a)  = Right a
 
 -- | Generic parser function in which the file path is just "test".
-parseGen :: (AsParserErrorBundle e, MonadError e m, MonadQuote m) => Parser a -> Text -> m a
+parseGen :: (MonadError ParserErrorBundle m, MonadQuote m) => Parser a -> Text -> m a
 parseGen stuff = parse stuff "test"
 
 -- | Space consumer.

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
@@ -7,6 +7,7 @@ module PlutusCore.TypeCheck
     ( ToKind
     , MonadKindCheck
     , MonadTypeCheck
+    , TypeErrorPlc
     , Typecheckable
     -- * Configuration.
     , BuiltinTypes (..)
@@ -30,6 +31,7 @@ import PlutusPrelude
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
+import PlutusCore.Error
 import PlutusCore.Name.Unique
 import PlutusCore.Normalize
 import PlutusCore.Quote
@@ -52,7 +54,7 @@ defKindCheckConfig = KindCheckConfig DetectNameMismatches
 -- | Extract the 'TypeScheme' from a 'BuiltinMeaning' and convert it to the
 -- corresponding 'Type' for each built-in function.
 builtinMeaningsToTypes
-    :: (MonadKindCheck err term uni fun ann m, Typecheckable uni fun)
+    :: (MonadKindCheck (TypeError term uni fun ann) term uni fun ann m, Typecheckable uni fun)
     => BuiltinSemanticsVariant fun
     -> ann
     -> m (BuiltinTypes uni fun)
@@ -64,14 +66,14 @@ builtinMeaningsToTypes semvar ann =
 
 -- | Get the default type checking config.
 getDefTypeCheckConfig
-    :: (MonadKindCheck err term uni fun ann m, Typecheckable uni fun)
+    :: (MonadKindCheck (TypeError term uni fun ann) term uni fun ann m, Typecheckable uni fun)
     => ann -> m (TypeCheckConfig uni fun)
 getDefTypeCheckConfig ann =
     TypeCheckConfig defKindCheckConfig <$> builtinMeaningsToTypes def ann
 
 -- | Infer the kind of a type.
 inferKind
-    :: MonadKindCheck err term uni fun ann m
+    :: MonadKindCheck (TypeError term uni fun ann) term uni fun ann m
     => KindCheckConfig -> Type TyName uni ann -> m (Kind ())
 inferKind config = runTypeCheckM config . inferKindM
 
@@ -79,13 +81,13 @@ inferKind config = runTypeCheckM config . inferKindM
 -- Infers the kind of the type and checks that it's equal to the given kind
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkKind
-    :: MonadKindCheck err term uni fun ann m
+    :: MonadKindCheck (TypeError term uni fun ann) term uni fun ann m
     => KindCheckConfig -> ann -> Type TyName uni ann -> Kind () -> m ()
 checkKind config ann ty = runTypeCheckM config . checkKindM ann ty
 
 -- | Infer the type of a term.
 inferType
-    :: MonadTypeCheckPlc err uni fun ann m
+    :: MonadTypeCheckPlc uni fun ann m
     => TypeCheckConfig uni fun
     -> Term TyName Name uni fun ann
     -> m (Normalized (Type TyName uni ()))
@@ -95,7 +97,7 @@ inferType config = rename >=> runTypeCheckM config . inferTypeM
 -- Infers the type of the term and checks that it's equal to the given type
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkType
-    :: MonadTypeCheckPlc err uni fun ann m
+    :: MonadTypeCheckPlc uni fun ann m
     => TypeCheckConfig uni fun
     -> ann
     -> Term TyName Name uni fun ann
@@ -107,7 +109,7 @@ checkType config ann term ty = do
 
 -- | Infer the type of a program.
 inferTypeOfProgram
-    :: MonadTypeCheckPlc err uni fun ann m
+    :: MonadTypeCheckPlc uni fun ann m
     => TypeCheckConfig uni fun
     -> Program TyName Name uni fun ann
     -> m (Normalized (Type TyName uni ()))
@@ -117,7 +119,7 @@ inferTypeOfProgram config (Program _ _ term) = inferType config term
 -- Infers the type of the program and checks that it's equal to the given type
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkTypeOfProgram
-    :: MonadTypeCheckPlc err uni fun ann m
+    :: MonadTypeCheckPlc uni fun ann m
     => TypeCheckConfig uni fun
     -> ann
     -> Program TyName Name uni fun ann

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
@@ -19,9 +19,8 @@ module PlutusCore.TypeCheck.Internal
     ) where
 
 import PlutusCore.Builtin.KnownKind (ToKind, kindOfBuiltinType)
-import PlutusCore.Builtin.Result (throwing)
 import PlutusCore.Core.Type (Kind (..), Normalized (..), Term (..), Type (..), toPatFuncKind)
-import PlutusCore.Error (AsTypeError (_TypeError), ExpectedShapeOr (ExpectedExact, ExpectedShape),
+import PlutusCore.Error (ExpectedShapeOr (ExpectedExact, ExpectedShape),
                          TypeError (FreeTypeVariableE, FreeVariableE, KindMismatch, NameMismatch, TyNameMismatch, TypeMismatch, UnknownBuiltinFunctionE))
 import PlutusCore.MkPlc (mkIterTyAppNoAnn, mkIterTyFun, mkTyBuiltinOf)
 import PlutusCore.Name.Unique (HasText (theText), Name (Name), Named (Named), TermUnique,
@@ -35,7 +34,7 @@ import PlutusPrelude (Lens', lens, over, view, void, zipExact, (<<$>>), (<<*>>),
 
 import Control.Lens (Ixed (ix), makeClassy, makeLenses, preview, (^?))
 import Control.Monad (when)
-import Control.Monad.Except (MonadError)
+import Control.Monad.Except (MonadError, throwError)
 -- Using @transformers@ rather than @mtl@, because the former doesn't impose the 'Monad' constraint
 -- on 'local'.
 import Control.Monad.Trans.Reader (ReaderT (runReaderT), ask, local)
@@ -194,7 +193,6 @@ type TypeCheckT uni fun cfg m = ReaderT (TypeCheckEnv uni fun cfg) m
 -- | The constraints that are required for kind checking.
 type MonadKindCheck err term uni fun ann m =
     ( MonadError err m                  -- Kind/type checking can fail
-    , AsTypeError err term uni fun ann  -- with a 'TypeError'.
     , ToKind uni                        -- For getting the kind of a built-in type.
     )
 
@@ -208,9 +206,14 @@ type MonadTypeCheck err term uni fun ann m =
                                              -- built-in functions.
     )
 
+-- | The PLC type error type.
+type TypeErrorPlc uni fun ann = TypeError (Term TyName Name uni fun ()) uni fun ann
+
 -- | The constraints that are required for type checking Plutus Core.
-type MonadTypeCheckPlc err uni fun ann m =
-    MonadTypeCheck err (Term TyName Name uni fun ()) uni fun ann m
+type MonadTypeCheckPlc uni fun ann m =
+    MonadTypeCheck
+      (TypeErrorPlc uni fun ann)
+      (Term TyName Name uni fun ()) uni fun ann m
 
 -- #########################
 -- ## Auxiliary functions ##
@@ -232,14 +235,14 @@ withTyVar name = local . over tceTyVarKinds . insertNamed name
 
 -- | Look up the type of a built-in function.
 lookupBuiltinM
-    :: (MonadTypeCheck err term uni fun ann m, HasTypeCheckConfig cfg uni fun)
+    :: (MonadTypeCheck (TypeError term uni fun ann) term uni fun ann m, HasTypeCheckConfig cfg uni fun)
     => ann -> fun -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 lookupBuiltinM ann fun = do
     BuiltinTypes arr <- view $ tceTypeCheckConfig . tccBuiltinTypes
     -- Believe it or not, but 'Data.Array' doesn't seem to expose any way of indexing into an array
     -- safely.
     case preview (ix fun) arr of
-        Nothing -> throwing _TypeError $ UnknownBuiltinFunctionE ann fun
+        Nothing -> throwError $ UnknownBuiltinFunctionE ann fun
         Just ty -> liftDupable ty
 
 -- | Extend the context of a 'TypeCheckM' computation with a typed variable.
@@ -252,33 +255,33 @@ withVar name = local . over tceVarTypes . insertNamed name . dupable
 
 -- | Look up a type variable in the current context.
 lookupTyVarM
-    :: (MonadKindCheck err term uni fun ann m, HasKindCheckConfig cfg)
+    :: (MonadKindCheck (TypeError term uni fun ann) term uni fun ann m, HasKindCheckConfig cfg)
     => ann -> TyName -> TypeCheckT uni fun cfg m (Kind ())
 lookupTyVarM ann name = do
     env <- ask
     let handleNameMismatches = env ^. tceTypeCheckConfig . kccHandleNameMismatches
     case lookupName name $ _tceTyVarKinds env of
-        Nothing                    -> throwing _TypeError $ FreeTypeVariableE ann name
+        Nothing                    -> throwError $ FreeTypeVariableE ann name
         Just (Named nameOrig kind) ->
             if handleNameMismatches == IgnoreNameMismatches || view theText name == nameOrig
                 then pure kind
-                else throwing _TypeError $
+                else throwError $
                         TyNameMismatch ann (TyName . Name nameOrig $ name ^. theUnique) name
 
 -- | Look up a term variable in the current context.
 lookupVarM
-    :: (MonadTypeCheck err term uni fun ann m, HasTypeCheckConfig cfg uni fun)
+    :: (MonadTypeCheck (TypeError term uni fun ann) term uni fun ann m, HasTypeCheckConfig cfg uni fun)
     => ann -> Name -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 lookupVarM ann name = do
     env <- ask
     let handleNameMismatches =
             env ^. tceTypeCheckConfig . tccKindCheckConfig . kccHandleNameMismatches
     case lookupName name $ _tceVarTypes env of
-        Nothing                  -> throwing _TypeError $ FreeVariableE ann name
+        Nothing                  -> throwError $ FreeVariableE ann name
         Just (Named nameOrig ty) ->
             if handleNameMismatches == IgnoreNameMismatches || view theText name == nameOrig
                 then liftDupable ty
-                else throwing _TypeError $
+                else throwError $
                         NameMismatch ann (Name nameOrig $ name ^. theUnique) name
 
 -- ########################
@@ -307,7 +310,7 @@ substNormalizeTypeM ty name body = Norm.runNormalizeTypeT $ Norm.substNormalizeT
 
 -- | Infer the kind of a type.
 inferKindM
-    :: (MonadKindCheck err term uni fun ann m, HasKindCheckConfig cfg)
+    :: (MonadKindCheck (TypeError term uni fun ann) term uni fun ann m, HasKindCheckConfig cfg)
     => Type TyName uni ann -> TypeCheckT uni fun cfg m (Kind ())
 
 -- b :: k
@@ -340,7 +343,7 @@ inferKindM (TyApp ann fun arg)     = do
             pure cod
         _ -> do
             let expectedKindArrow = ExpectedShape "fun k l" ["k", "l"]
-            throwing _TypeError $ KindMismatch ann (void fun) expectedKindArrow funKind
+            throwError $ KindMismatch ann (void fun) expectedKindArrow funKind
 
 -- [check| G !- a :: *]    [check| G !- b :: *]
 -- --------------------------------------------
@@ -377,7 +380,7 @@ inferKindM (TySOP ann tyls)        = do
 
 -- | Check a 'Type' against a 'Kind'.
 checkKindM
-    :: (MonadKindCheck err term uni fun ann m, HasKindCheckConfig cfg)
+    :: (MonadKindCheck (TypeError term uni fun ann) term uni fun ann m, HasKindCheckConfig cfg)
     => ann -> Type TyName uni ann -> Kind () -> TypeCheckT uni fun cfg m ()
 
 -- [infer| G !- ty : tyK]    tyK ~ k
@@ -385,7 +388,7 @@ checkKindM
 -- [check| G !- ty : k]
 checkKindM ann ty k = do
     tyK <- inferKindM ty
-    when (tyK /= k) $ throwing _TypeError (KindMismatch ann (void ty) (ExpectedExact k) tyK)
+    when (tyK /= k) $ throwError (KindMismatch ann (void ty) (ExpectedExact k) tyK)
 
 -- ###################
 -- ## Type checking ##
@@ -421,7 +424,7 @@ unfoldIFixOf pat arg k = do
 -- See Note [Typing rules].
 -- | Synthesize the type of a term, returning a normalized type.
 inferTypeM
-    :: (MonadTypeCheckPlc err uni fun ann m, HasTypeCheckConfig cfg uni fun)
+    :: (MonadTypeCheckPlc uni fun ann m, HasTypeCheckConfig cfg uni fun)
     => Term TyName Name uni fun ann -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 
 -- c : vTy
@@ -470,7 +473,7 @@ inferTypeM (Apply ann fun arg) = do
             pure $ Normalized vCod
         _ -> do
             let expectedTyFun = ExpectedShape "fun k l" ["k", "l"]
-            throwing _TypeError (TypeMismatch ann (void fun) expectedTyFun vFunTy)
+            throwError (TypeMismatch ann (void fun) expectedTyFun vFunTy)
 
 -- [infer| G !- body : all (n :: nK) vCod]    [check| G !- ty :: tyK]    ty ~> vTy
 -- -------------------------------------------------------------------------------
@@ -484,7 +487,7 @@ inferTypeM (TyInst ann body ty) = do
             substNormalizeTypeM vTy n vCod
         _ -> do
             let expectedTyForall = ExpectedShape "all a kind body" ["a", "kind", "body"]
-            throwing _TypeError (TypeMismatch ann (void body) expectedTyForall vBodyTy)
+            throwError (TypeMismatch ann (void body) expectedTyForall vBodyTy)
 
 -- [infer| G !- arg :: k]    [check| G !- pat :: (k -> *) -> k -> *]    pat ~> vPat    arg ~> vArg
 -- [check| G !- term : NORM (vPat (\(a :: k) -> ifix vPat a) vArg)]
@@ -510,7 +513,7 @@ inferTypeM (Unwrap ann term) = do
             unfoldIFixOf (Normalized vPat) (Normalized vArg) k
         _                  -> do
             let expectedTyIFix = ExpectedShape "ifix pat arg" ["pat", "arg"]
-            throwing _TypeError (TypeMismatch ann (void term) expectedTyIFix vTermTy)
+            throwError (TypeMismatch ann (void term) expectedTyIFix vTermTy)
 
 -- [check| G !- ty :: *]    ty ~> vTy
 -- ----------------------------------
@@ -543,11 +546,11 @@ inferTypeM t@(Constr ann resTy i args) = do
                 Just ps -> for_ ps $ \(arg, pTy) -> checkTypeM ann arg (Normalized pTy)
                 -- the number of args does not match the number of types in the i'th SOP
                 -- alternative
-                Nothing -> throwing _TypeError (TypeMismatch ann (void t) expectedSop vResTy)
+                Nothing -> throwError (TypeMismatch ann (void t) expectedSop vResTy)
             -- result type does not contain an i'th sum alternative
-            Nothing -> throwing _TypeError (TypeMismatch ann (void t) expectedSop vResTy)
+            Nothing -> throwError (TypeMismatch ann (void t) expectedSop vResTy)
         -- result type is not a SOP type
-        _ -> throwing _TypeError (TypeMismatch ann (void t) expectedSop vResTy)
+        _ -> throwError (TypeMismatch ann (void t) expectedSop vResTy)
 
     pure vResTy
 
@@ -572,9 +575,9 @@ inferTypeM (Case ann resTy scrut cases) = do
                 checkTypeM ann c (Normalized $ mkIterTyFun () argTypes (unNormalized vResTy))
             -- scrutinee does not have a SOP type with the right number of alternatives
             -- for the number of cases
-            Nothing -> throwing _TypeError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
+            Nothing -> throwError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
         -- scrutinee does not have a SOP type at all
-        _ -> throwing _TypeError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
+        _ -> throwError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
 
     -- If we got through all that, then every case type is correct, including that
     -- they all result in vResTy, so we can safely conclude that that is the type of the
@@ -585,7 +588,7 @@ inferTypeM (Case ann resTy scrut cases) = do
 -- See Note [Typing rules].
 -- | Check a 'Term' against a 'NormalizedType'.
 checkTypeM
-    :: (MonadTypeCheckPlc err uni fun ann m, HasTypeCheckConfig cfg uni fun)
+    :: (MonadTypeCheckPlc uni fun ann m, HasTypeCheckConfig cfg uni fun)
     => ann
     -> Term TyName Name uni fun ann
     -> Normalized (Type TyName uni ())
@@ -598,4 +601,4 @@ checkTypeM ann term vTy = do
     vTermTy <- inferTypeM term
     when (vTermTy /= vTy) $ do
         let expectedVTy = ExpectedExact $ unNormalized vTy
-        throwing _TypeError $ TypeMismatch ann (void term) expectedVTy vTermTy
+        throwError $ TypeMismatch ann (void term) expectedVTy vTermTy

--- a/plutus-core/plutus-core/test/Names/Spec.hs
+++ b/plutus-core/plutus-core/test/Names/Spec.hs
@@ -10,6 +10,7 @@ import PlutusCore (DefaultFun, DefaultUni, FreeVariableError, Kind (Type), Name 
                    NamedTyDeBruijn, Program, Quote, Rename (rename), Term (..), TyName (..),
                    Type (..), Unique (..), deBruijnTerm, runQuote, runQuoteT, unDeBruijnTerm)
 import PlutusCore qualified
+import PlutusCore.Error qualified as PLC
 import PlutusCore.Generators.Hedgehog (TermOf (..), forAllNoShowT, forAllPretty, generalizeT)
 import PlutusCore.Generators.Hedgehog.AST as AST (genName, genProgram, genTerm, mangleNames,
                                                   runAstGen)
@@ -22,6 +23,7 @@ import PlutusCore.Test (BindingRemoval (BindingRemovalNotOk), Prerename (Prerena
                         checkFails, mapTestLimitAtLeast, noMarkRename, test_scopingGood,
                         test_scopingSpoilRenamer)
 
+import Control.Monad.Except (modifyError)
 import Data.String (IsString (fromString))
 import Data.Text qualified as Text
 import Hedgehog (Gen, Property, assert, forAll, property, tripping)
@@ -198,7 +200,7 @@ prop_printing_parsing_roundtrip = property $ generalizeT do
   tripping name display parse
   where
     parse :: String -> Either (PlutusCore.Error DefaultUni DefaultFun ()) Name
-    parse str = runQuoteT do
+    parse str = runQuoteT $ modifyError PLC.ParseErrorE $ do
       Parser.parse Parser.name "test_printing_parsing_roundtrip" (Text.pack str)
 
 test_names :: TestTree

--- a/plutus-core/plutus-core/test/Parser/Spec.hs
+++ b/plutus-core/plutus-core/test/Parser/Spec.hs
@@ -5,7 +5,6 @@
 module Parser.Spec (tests) where
 
 import PlutusCore
-import PlutusCore.Error (ParserErrorBundle)
 import PlutusCore.Generators.Hedgehog.AST
 import PlutusCore.Test (isSerialisable)
 import PlutusPrelude
@@ -25,7 +24,7 @@ propTermSrcSpan = property $ do
     let code = display (term :: Term TyName Name DefaultUni DefaultFun ())
     let (endingLine, endingCol) = length &&& T.length . last $ T.lines code
     trailingSpaces <- forAll $ Gen.text (Range.linear 0 10) (Gen.element [' ', '\n'])
-    case runQuoteT . parseTerm @ParserErrorBundle $ code <> trailingSpaces of
+    case runQuoteT . parseTerm $ code <> trailingSpaces of
         Right parsed ->
             let sp = termAnn parsed
              in (srcSpanELine sp, srcSpanECol sp) === (endingLine, endingCol + 1)

--- a/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
@@ -26,7 +26,7 @@ import PlutusCore.Examples.Everything (examples)
 import PlutusCore.StdLib.Everything (stdLib)
 
 import Control.Monad (unless)
-import Control.Monad.Except (MonadError, runExcept)
+import Control.Monad.Except
 import Data.Text qualified as Text
 import Test.Tasty
 import Test.Tasty.Extras
@@ -36,7 +36,7 @@ kindcheck
     :: (uni ~ DefaultUni, fun ~ DefaultFun, MonadError (Error uni fun ()) m)
     => Type TyName uni () -> m (Type TyName uni ())
 kindcheck ty = do
-    _ <- runQuoteT $ inferKind defKindCheckConfig ty
+    _ <- runQuoteT $ modifyError TypeErrorE $ inferKind defKindCheckConfig ty
     return ty
 
 typecheck
@@ -44,7 +44,7 @@ typecheck
     => BuiltinSemanticsVariant fun
     -> Term TyName Name uni fun ()
     -> m (Normalized (Type TyName uni ()))
-typecheck semvar term = runQuoteT $ do
+typecheck semvar term = runQuoteT $ modifyError TypeErrorE $ do
     tcConfig <- TypeCheckConfig defKindCheckConfig <$> builtinMeaningsToTypes semvar ()
     inferType tcConfig term
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Check/Uniques.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Check/Uniques.hs
@@ -2,7 +2,6 @@ module PlutusIR.Check.Uniques
     ( checkProgram
     , checkTerm
     , UniqueError (..)
-    , AsUniqueError (..)
     ) where
 
 import PlutusCore.Error
@@ -11,8 +10,7 @@ import PlutusIR.Analysis.Definitions
 import PlutusIR.Core
 
 import Control.Monad (when)
-import Control.Monad.Error.Lens
-import Control.Monad.Except (MonadError)
+import Control.Monad.Except (MonadError, throwError)
 
 import Data.Foldable
 
@@ -20,8 +18,7 @@ checkProgram
     :: (Ord ann,
         HasUnique name TermUnique,
         HasUnique tyname TypeUnique,
-        AsUniqueError e ann,
-        MonadError e m)
+        MonadError (UniqueError ann) m)
     => (UniqueError ann -> Bool)
     -> Program tyname name uni fun ann
     -> m ()
@@ -31,11 +28,10 @@ checkTerm
     :: (Ord ann,
         HasUnique name TermUnique,
         HasUnique tyname TypeUnique,
-        AsUniqueError e ann,
-        MonadError e m)
+        MonadError (UniqueError ann) m)
     => (UniqueError ann -> Bool)
     -> Term tyname name uni fun ann
     -> m ()
 checkTerm p t = do
     (_, errs) <- runTermDefs t
-    for_ errs $ \e -> when (p e) $ throwing _UniqueError e
+    for_ errs $ \e -> when (p e) $ throwError e

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
@@ -30,7 +30,7 @@ import PlutusCore.MkPlc qualified as PLC
 import PlutusCore.Quote
 import PlutusCore.StdLib.Type qualified as Types
 
-import Control.Monad.Error.Lens
+import Control.Monad.Except
 
 import Data.Text qualified as T
 import Data.Traversable
@@ -554,7 +554,7 @@ mkDestructorTy dt@(Datatype ann _ tvs _ _) = do
 
 -- | Compile a 'Datatype' bound with the given body.
 compileDatatype
-    :: Compiling m e uni fun a
+    :: Compiling m uni fun a
     => Recursivity
     -> PIRTerm uni fun a
     -> Datatype TyName Name uni (Provenance a)
@@ -601,7 +601,7 @@ compileDatatypeDefs opts r d@(Datatype ann tn _ destr constrs) = do
     pure (concreteTyDef, constrDefs, destrDef)
 
 compileRecDatatypes
-    :: Compiling m e uni fun a
+    :: Compiling m uni fun a
     => PIRTerm uni fun a
     -> NE.NonEmpty (Datatype TyName Name uni (Provenance a))
     -> m (PIRTerm uni fun a)
@@ -609,4 +609,4 @@ compileRecDatatypes body ds = case ds of
     d NE.:| [] -> compileDatatype Rec body d
     _          -> do
       p <- getEnclosing
-      throwing _Error $ UnsupportedError p "Mutually recursive datatypes"
+      throwError $ UnsupportedError p "Mutually recursive datatypes"

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Error.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Error.hs
@@ -7,13 +7,12 @@
 {-# LANGUAGE TemplateHaskell        #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
-module PlutusIR.Compiler.Error (Error (..), AsError (..)) where
+module PlutusIR.Compiler.Error (Error (..)) where
 
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty qualified as PLC
 
 import Control.Exception
-import Control.Lens
 
 import Data.Text qualified as T
 import Data.Typeable
@@ -25,10 +24,6 @@ data Error uni fun a
     | UnsupportedError !a !T.Text     -- ^ An error relating specifically to an unsupported feature.
     | PLCError !(PLC.Error uni fun a) -- ^ An error from running some PLC function, lifted into
                                       -- this error type for convenience.
-makeClassyPrisms ''Error
-
-instance PLC.AsTypeError (Error uni fun ann) (PLC.Term PLC.TyName PLC.Name uni fun ()) uni fun ann where
-    _TypeError = _PLCError . PLC._TypeError
 
 instance (PLC.PrettyUni uni, PP.Pretty fun, PP.Pretty ann) => Show (Error uni fun ann) where
     show = show . PLC.prettyPlcClassicSimple

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Lower.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Lower.hs
@@ -9,13 +9,13 @@ import PlutusIR.Error
 
 import PlutusCore qualified as PLC
 
-import Control.Monad.Error.Lens
+import Control.Monad.Except
 
 -- | Turns a PIR 'Term' with no remaining PIR-specific features into a PLC 'PLC.Term' by simply
 -- translating the constructors across.
-lowerTerm :: Compiling m e uni fun a => PIRTerm uni fun a -> m (PLCTerm uni fun a)
+lowerTerm :: Compiling m uni fun a => PIRTerm uni fun a -> m (PLCTerm uni fun a)
 lowerTerm = \case
-    Let x _ _ _      -> throwing _Error $
+    Let x _ _ _      -> throwError $
         CompilationError x "Let bindings should have been eliminated before lowering"
     Var x n          -> pure $ PLC.Var x n
     TyAbs x n k t    -> PLC.TyAbs x n k <$> lowerTerm t

--- a/plutus-core/plutus-ir/src/PlutusIR/Error.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Error.hs
@@ -10,21 +10,16 @@
 {-# LANGUAGE UndecidableInstances   #-}
 module PlutusIR.Error
     ( Error (..)
-    , PLC.AsTypeError (..)
     , PLC.TypeError
-    , AsTypeErrorExt (..)
-    , AsError (..)
     , TypeErrorExt (..)
     , PLC.Normalized (..)
     ) where
 
 import PlutusCore qualified as PLC
-import PlutusCore.Error qualified as PLC
 import PlutusCore.Pretty qualified as PLC
 import PlutusIR qualified as PIR
 import PlutusPrelude
 
-import Control.Lens
 import Data.Text qualified as T
 import Prettyprinter as PP
 
@@ -35,7 +30,6 @@ data TypeErrorExt uni ann =
          !(PLC.Type PLC.TyName uni ann)
     deriving stock (Show, Eq, Generic, Functor)
     deriving anyclass (NFData)
-makeClassyPrisms ''TypeErrorExt
 
 data Error uni fun a = CompilationError !a !T.Text -- ^ A generic compilation error.
                      | UnsupportedError !a !T.Text -- ^ An error relating specifically to an unsupported feature.
@@ -44,22 +38,6 @@ data Error uni fun a = CompilationError !a !T.Text -- ^ A generic compilation er
                      | PLCTypeError !(PLC.TypeError (PIR.Term PIR.TyName PIR.Name uni fun ()) uni fun a)
                      | PIRTypeError !(TypeErrorExt uni a)
                      deriving stock (Functor)
-makeClassyPrisms ''Error
-
-instance PLC.AsTypeError (Error uni fun a) (PIR.Term PIR.TyName PIR.Name uni fun ()) uni fun a where
-    _TypeError = _PLCTypeError
-
-instance AsTypeErrorExt (Error uni fun a) uni a where
-    _TypeErrorExt = _PIRTypeError
-
-instance PLC.AsFreeVariableError (Error uni fun a) where
-    _FreeVariableError = _PLCError . PLC._FreeVariableError
-
-instance PLC.AsUniqueError (Error uni fun a) a where
-    _UniqueError = _PLCError . PLC._UniqueError
-
-instance PLC.AsParserErrorBundle (Error uni fun a) where
-    _ParserErrorBundle = _PLCError . PLC._ParseErrorE
 
 -- Pretty-printing
 ------------------

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -27,7 +27,7 @@ import Control.Monad.Combinators.NonEmpty qualified as NE
 import Control.Monad.Except (MonadError)
 import Data.Text (Text)
 import PlutusCore (MonadQuote)
-import PlutusCore.Error (AsParserErrorBundle)
+import PlutusCore.Error (ParserErrorBundle)
 import Text.Megaparsec hiding (ParseError, State, many, parse, some)
 import Text.Megaparsec.Char.Lexer qualified as Lex
 
@@ -163,7 +163,7 @@ program = leadingWhitespace go
 -- "test" to the parser as the name of the input stream; to supply a name
 -- explicity, use `parse program <name> <input>`.
 parseProgram ::
-    (AsParserErrorBundle e, MonadError e m, MonadQuote m)
+    (MonadError ParserErrorBundle m, MonadQuote m)
     => Text
     -> m (Program TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan)
 parseProgram = parseGen program

--- a/plutus-core/plutus-ir/src/PlutusIR/Pass.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Pass.hs
@@ -12,7 +12,7 @@ import PlutusCore qualified as PLC
 import PlutusCore.Name.Unique
 
 import Control.Monad (void, when)
-import Control.Monad.Except (ExceptT, MonadError, throwError)
+import Control.Monad.Except
 import Control.Monad.Trans.Class (lift)
 import Data.Foldable
 import Data.Text (Text)
@@ -50,7 +50,9 @@ checkCondition c t = case c of
     -- Typechecking requires globally unique names
     renamed <- PLC.rename t
     TC.inferType tcconfig renamed
-  GloballyUniqueNames -> void $ Uniques.checkTerm (const True) t
+  GloballyUniqueNames ->
+    void $ modifyError (PLCError . PLC.UniqueCoherencyErrorE) $
+      Uniques.checkTerm (const True) t
   Custom f -> case f t of
     Just (a, e) -> throwError $ CompilationError a e
     Nothing     -> pure ()
@@ -141,7 +143,7 @@ renamePass =
 -- | A pass that does typechecking, useful when you want to do it explicitly
 -- and not as part of a precondition check.
 typecheckPass
-  :: (TC.MonadTypeCheckPir err uni fun a m, Ord a)
+  :: (TC.MonadTypeCheckPir uni fun a m, Ord a)
   => TC.PirTCConfig uni fun
   -> Pass m TyName Name uni fun a
 typecheckPass tcconfig = NamedPass "typechecking" $ Pass run [GloballyUniqueNames] []

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck.hs
@@ -17,14 +17,14 @@ module PlutusIR.TypeCheck (
   MonadTypeCheckPir,
 ) where
 
+import PlutusPrelude
+
 import PlutusCore.Rename
 import PlutusCore.TypeCheck qualified as PLC
 import PlutusIR
 import PlutusIR.Error
 import PlutusIR.Transform.Rename ()
 import PlutusIR.TypeCheck.Internal
-
-import Control.Monad ((>=>))
 
 {- Note [Goal of PIR typechecker]
 
@@ -60,7 +60,7 @@ compiler pipeline:
 
 -- | The default 'TypeCheckConfig'.
 getDefTypeCheckConfig ::
-  (MonadKindCheck err term uni fun ann m, PLC.Typecheckable uni fun) =>
+  (MonadKindCheck (TypeError term uni fun ann) term uni fun ann m, PLC.Typecheckable uni fun) =>
   ann ->
   m (PirTCConfig uni fun)
 getDefTypeCheckConfig ann = do
@@ -72,7 +72,7 @@ Note: The "inferred type" can escape its scope if YesEscape config is passed, se
 [PIR vs Paper Escaping Types Difference]
 -}
 inferType ::
-  (MonadTypeCheckPir err uni fun ann m) =>
+  (MonadTypeCheckPir uni fun ann m) =>
   PirTCConfig uni fun ->
   Term TyName Name uni fun ann ->
   m (Normalized (Type TyName uni ()))
@@ -85,7 +85,7 @@ Note: this may allow witnessing a type that escapes its scope, see
 [PIR vs Paper Escaping Types Difference]
 -}
 checkType ::
-  (MonadTypeCheckPir err uni fun ann m) =>
+  (MonadTypeCheckPir uni fun ann m) =>
   PirTCConfig uni fun ->
   ann ->
   Term TyName Name uni fun ann ->
@@ -100,7 +100,7 @@ Note: The "inferred type" can escape its scope if YesEscape config is passed, se
 [PIR vs Paper Escaping Types Difference]
 -}
 inferTypeOfProgram ::
-  (MonadTypeCheckPir err uni fun ann m) =>
+  (MonadTypeCheckPir uni fun ann m) =>
   PirTCConfig uni fun ->
   Program TyName Name uni fun ann ->
   m (Normalized (Type TyName uni ()))
@@ -113,7 +113,7 @@ Note: this may allow witnessing a type that escapes its scope, see
 [PIR vs Paper Escaping Types Difference]
 -}
 checkTypeOfProgram ::
-  (MonadTypeCheckPir err uni fun ann m) =>
+  (MonadTypeCheckPir uni fun ann m) =>
   PirTCConfig uni fun ->
   ann ->
   Program TyName Name uni fun ann ->

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
@@ -30,6 +30,7 @@ import PlutusIR.Compiler.Datatype
 import PlutusIR.Compiler.Provenance
 import PlutusIR.Compiler.Types
 import PlutusIR.Error
+import PlutusIR.Error qualified as PIR
 import PlutusIR.MkPir qualified as PIR
 import PlutusIR.Transform.Rename ()
 
@@ -41,7 +42,7 @@ import PlutusCore.MkPlc (mkIterTyFun)
 import PlutusCore.TypeCheck.Internal hiding (checkTypeM, inferTypeM, runTypeCheckM)
 
 import Control.Monad (when)
-import Control.Monad.Error.Lens
+import Control.Monad.Except
 import Data.Text qualified as Text
 -- Using @transformers@ rather than @mtl@, because the former doesn't impose the 'Monad' constraint
 -- on 'local'.
@@ -104,9 +105,8 @@ when typechecking inside a let termbind's rhs term.
 type PirTCEnv uni fun m = TypeCheckT uni fun (PirTCConfig uni fun) m
 
 -- | The constraints that are required for type checking Plutus IR.
-type MonadTypeCheckPir err uni fun ann m =
-    ( MonadTypeCheck err (Term TyName Name uni fun ()) uni fun ann m
-    , AsTypeErrorExt err uni ann  -- Plutus IR has additional type errors, see 'TypeErrorExt'.
+type MonadTypeCheckPir uni fun ann m =
+    ( MonadTypeCheck (PIR.Error uni fun ann) (Term TyName Name uni fun ()) uni fun ann m
     )
 
 -- ###########################
@@ -118,7 +118,7 @@ type MonadTypeCheckPir err uni fun ann m =
 -- See Note [Typing rules].
 -- | Check a 'Term' against a 'NormalizedType'.
 checkTypeM
-    :: MonadTypeCheckPir err uni fun ann m
+    :: MonadTypeCheckPir uni fun ann m
     => ann
     -> Term TyName Name uni fun ann
     -> Normalized (Type TyName uni ())
@@ -131,14 +131,14 @@ checkTypeM ann term vTy = do
     vTermTy <- inferTypeM term
     when (vTermTy /= vTy) $ do
         let expectedVTy = ExpectedExact $ unNormalized vTy
-        throwing _TypeError $ TypeMismatch ann (void term) expectedVTy vTermTy
+        throwError $ PLCTypeError $ TypeMismatch ann (void term) expectedVTy vTermTy
 
 -- See Note [Global uniqueness in the type checker].
 -- See Note [Typing rules].
 -- | Synthesize the type of a term, returning a normalized type.
 inferTypeM
-    :: forall err m uni fun ann.
-       MonadTypeCheckPir err uni fun ann m
+    :: forall m uni fun ann.
+       MonadTypeCheckPir uni fun ann m
     => Term TyName Name uni fun ann -> PirTCEnv uni fun m (Normalized (Type TyName uni ()))
 -- c : vTy
 -- -------------------------
@@ -151,20 +151,20 @@ inferTypeM (Constant _ (Some (ValueOf uni _))) =
 -- ------------------------------
 -- [infer| G !- builtin bi : vTy]
 inferTypeM (Builtin ann bn)         =
-    lookupBuiltinM ann bn
+    mapReaderT (modifyError PLCTypeError) $ lookupBuiltinM ann bn
 
 -- [infer| G !- v : ty]    ty ~> vTy
 -- ---------------------------------
 -- [infer| G !- var v : vTy]
 inferTypeM (Var ann name)           =
-    lookupVarM ann name
+    mapReaderT (modifyError PLCTypeError) $ lookupVarM ann name
 
 -- [check| G !- dom :: *]    dom ~> vDom    [infer| G , n : dom !- body : vCod]
 -- ----------------------------------------------------------------------------
 -- [infer| G !- lam n dom body : vDom -> vCod]
 inferTypeM (LamAbs ann n dom body)  = do
-    checkKindM ann dom $ Type ()
-    vDom <- normalizeTypeM $ void dom
+    mapReaderT (modifyError PLCTypeError) $ checkKindM ann dom $ Type ()
+    vDom <- mapReaderT (modifyError PLCTypeError) $ normalizeTypeM $ void dom
     TyFun () <<$>> pure vDom <<*>> withVar n vDom (inferTypeM body)
 
 -- [infer| G , n :: nK !- body : vBodyTy]
@@ -186,7 +186,7 @@ inferTypeM (Apply ann fun arg)      = do
             pure $ Normalized vCod
         _ -> do
             let expectedTyFun = ExpectedShape "fun k l" ["k", "l"]
-            throwing _TypeError $ TypeMismatch ann (void fun) expectedTyFun vFunTy
+            throwError $ PLCTypeError $ TypeMismatch ann (void fun) expectedTyFun vFunTy
 
 -- [infer| G !- body : all (n :: nK) vCod]    [check| G !- ty :: tyK]    ty ~> vTy
 -- -------------------------------------------------------------------------------
@@ -195,20 +195,20 @@ inferTypeM (TyInst ann body ty)     = do
     vBodyTy <- inferTypeM body
     case unNormalized vBodyTy of
         TyForall _ n nK vCod -> do
-            checkKindM ann ty nK
+            mapReaderT (modifyError PLCTypeError) $ checkKindM ann ty nK
             vTy <- normalizeTypeM $ void ty
             substNormalizeTypeM vTy n vCod
         _ -> do
             let expectedTyForall = ExpectedShape "all a kind body" ["a", "kind", "body"]
-            throwing _TypeError (TypeMismatch ann (void body) expectedTyForall vBodyTy)
+            throwError $ PLCTypeError (TypeMismatch ann (void body) expectedTyForall vBodyTy)
 
 -- [infer| G !- arg :: k]    [check| G !- pat :: (k -> *) -> k -> *]    pat ~> vPat    arg ~> vArg
 -- [check| G !- term : NORM (vPat (\(a :: k) -> ifix vPat a) vArg)]
 -- -----------------------------------------------------------------------------------------------
 -- [infer| G !- iwrap pat arg term : ifix vPat vArg]
 inferTypeM (IWrap ann pat arg term) = do
-    k <- inferKindM arg
-    checkKindM ann pat $ toPatFuncKind k
+    k <- mapReaderT (modifyError PLCTypeError) $ inferKindM arg
+    mapReaderT (modifyError PLCTypeError) $ checkKindM ann pat $ toPatFuncKind k
     vPat <- normalizeTypeM $ void pat
     vArg <- normalizeTypeM $ void arg
     checkTypeM ann term =<< unfoldIFixOf vPat vArg k
@@ -221,18 +221,18 @@ inferTypeM (Unwrap ann term)        = do
     vTermTy <- inferTypeM term
     case unNormalized vTermTy of
         TyIFix _ vPat vArg -> do
-            k <- inferKindM $ ann <$ vArg
+            k <- mapReaderT (modifyError PLCTypeError) $ inferKindM $ ann <$ vArg
             -- Subparts of a normalized type, so normalized.
             unfoldIFixOf (Normalized vPat) (Normalized vArg) k
         _                  -> do
             let expectedTyIFix = ExpectedShape "ifix pat arg" ["pat", "arg"]
-            throwing _TypeError (TypeMismatch ann (void term) expectedTyIFix vTermTy)
+            throwError $ PLCTypeError (TypeMismatch ann (void term) expectedTyIFix vTermTy)
 
 -- [check| G !- ty :: *]    ty ~> vTy
 -- ----------------------------------
 -- [infer| G !- error ty : vTy]
 inferTypeM (Error ann ty)           = do
-    checkKindM ann ty $ Type ()
+    mapReaderT (modifyError PLCTypeError) $ checkKindM ann ty $ Type ()
     normalizeTypeM $ void ty
 
 -- resTy ~> vResTy     vResTy = sop s_0 ... s_i ... s_n
@@ -257,11 +257,11 @@ inferTypeM t@(Constr ann resTy i args) = do
                 Just ps -> for_ ps $ \(arg, pTy) -> checkTypeM ann arg (Normalized pTy)
                 -- the number of args does not match the number of types in the i'th SOP
                 -- alternative
-                Nothing -> throwing _TypeError (TypeMismatch ann (void t) expectedSop vResTy)
+                Nothing -> throwError $ PLCTypeError (TypeMismatch ann (void t) expectedSop vResTy)
             -- result type does not contain an i'th sum alternative
-            Nothing -> throwing _TypeError (TypeMismatch ann (void t) expectedSop vResTy)
+            Nothing -> throwError $ PLCTypeError (TypeMismatch ann (void t) expectedSop vResTy)
         -- result type is not a SOP type
-        _ -> throwing _TypeError (TypeMismatch ann (void t) expectedSop vResTy)
+        _ -> throwError $ PLCTypeError (TypeMismatch ann (void t) expectedSop vResTy)
 
     pure vResTy
 
@@ -286,9 +286,9 @@ inferTypeM (Case ann resTy scrut cases) = do
                 checkTypeM ann c (Normalized $ mkIterTyFun () argTypes (unNormalized vResTy))
             -- scrutinee does not have a SOP type with the right number of alternatives
             -- for the number of cases
-            Nothing -> throwing _TypeError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
+            Nothing -> throwError $ PLCTypeError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
         -- scrutinee does not have a SOP type at all
-        _ -> throwing _TypeError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
+        _ -> throwError $ PLCTypeError (TypeMismatch ann (void scrut) expectedSop vScrutTy)
 
     -- If we got through all that, then every case type is correct, including that
     -- they all result in vResTy, so we can safely conclude that that is the type of the
@@ -359,11 +359,11 @@ inferTypeM (Let ann r@Rec bs inTerm) = do
 checkKindFromBinding(G,b)
 -}
 checkKindFromBinding
-    :: forall err m uni fun ann.
-       MonadKindCheck err (Term TyName Name uni fun ()) uni fun ann m
+    :: forall m uni fun ann.
+       MonadTypeCheckPir uni fun ann m
     => Binding TyName Name uni fun ann
     -> PirTCEnv uni fun m ()
-checkKindFromBinding = \case
+checkKindFromBinding = mapReaderT (modifyError PLCTypeError) . \case
     -- For a type binding, correct means that the the RHS is indeed kinded by the declared kind.
     TypeBind _ (TyVarDecl ann _ k) rhs ->
         checkKindM ann rhs $ void k
@@ -391,8 +391,8 @@ checkKindFromBinding = \case
 checkTypeFromBinding(G,b)
 -}
 checkTypeFromBinding
-    :: forall err m uni fun ann.
-       MonadTypeCheckPir err uni fun ann m
+    :: forall m uni fun ann.
+       MonadTypeCheckPir uni fun ann m
     => Recursivity -> Binding TyName Name uni fun ann -> PirTCEnv uni fun m ()
 checkTypeFromBinding recurs = \case
     TypeBind{} -> pure () -- no types to check
@@ -409,7 +409,7 @@ checkTypeFromBinding recurs = \case
            -- We earlier checked that datacons' type is *-kinded (using checkKindBinding), but this is not enough:
            -- we must also check that its result type is EXACTLY `[[TypeCon tyarg1] ... tyargn]` (ignoring annotations)
            when (void (PLC.funTyResultType ty) /= void appliedTyCon) .
-               throwing _TypeErrorExt $ MalformedDataConstrResType ann appliedTyCon
+               throwError $ PIRTypeError $ MalformedDataConstrResType ann appliedTyCon
 
        -- if nonrec binding, make sure that type-constructor is not part of the data-constructor's argument types.
        checkNonRecScope :: Type TyName uni ann -> PirTCEnv uni fun m ()
@@ -419,17 +419,17 @@ checkTypeFromBinding recurs = \case
                -- now we make sure that dataconstructor is not self-recursive, i.e. funargs don't contain tycon
                withTyVarDecls tyargs $ -- tycon not in scope here
                       -- OPTIMIZE: we use inferKind for scope-checking, but a simple ADT-traversal would suffice
-                      for_ (PLC.funTyArgs ty) inferKindM
+                      mapReaderT (modifyError PLCTypeError) $ for_ (PLC.funTyArgs ty) inferKindM
 
 -- | Check that the in-Term's inferred type of a Let has kind *.
 -- Skip this check at the top-level, to allow top-level types to escape; see Note [PIR vs Paper Escaping Types Difference].
 checkStarInferred
-    :: MonadKindCheck err (Term TyName Name uni fun ()) uni fun ann m
+    :: MonadTypeCheckPir uni fun ann m
     => ann -> Normalized (Type TyName uni ()) -> PirTCEnv uni fun m ()
 checkStarInferred ann t = do
     allowEscape <- view $ tceTypeCheckConfig . pirConfigAllowEscape
     case allowEscape of
-        NoEscape  -> checkKindM ann (ann <$ unNormalized t) $ Type ()
+        NoEscape  -> mapReaderT (modifyError PLCTypeError) $ checkKindM ann (ann <$ unNormalized t) $ Type ()
         -- NOTE: we completely skip the check in case of toplevel because we would need an *final, extended Gamma environment*
         -- to run the kind-check in, but we cannot easily get that since we are using a Reader for environments and not State
         YesEscape -> pure ()

--- a/plutus-core/plutus-ir/test/PlutusIR/Compiler/Let/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Compiler/Let/Tests.hs
@@ -4,10 +4,10 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module PlutusIR.Compiler.Let.Tests where
 
-import Control.Monad (join, void)
-import Control.Monad.Except (ExceptT, runExceptT)
+import PlutusPrelude
+
+import Control.Monad.Except
 import Control.Monad.Reader (Reader, runReader)
-import Data.Bifunctor
 import PlutusCore qualified as PLC
 import PlutusIR.Compiler (Provenance (..))
 import PlutusIR.Compiler qualified as PIR
@@ -51,7 +51,7 @@ test_propLets =
       let
         res :: Either e ()
         res = do
-            plcConfig <- PLC.getDefTypeCheckConfig (Original ())
+            plcConfig <- modifyError (PIR.PLCError . PLC.TypeErrorE) $ PLC.getDefTypeCheckConfig (Original ())
             let ctx = PIR.toDefaultCompilationCtx plcConfig
             join $ flip runReader ctx $ PLC.runQuoteT $ runExceptT $ runExceptT v
       in convertToEitherString $ first void res

--- a/plutus-core/plutus-ir/test/PlutusIR/Generators/QuickCheck/Tests.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Generators/QuickCheck/Tests.hs
@@ -28,6 +28,7 @@ import UntypedPlutusCore.Evaluation.Machine.Cek (restrictingLarge, runCekNoEmit,
                                                  unsafeSplitStructuralOperational)
 
 import Control.Exception
+import Control.Monad.Except
 import Control.Monad.Reader
 import Data.Char
 import Data.Either

--- a/plutus-core/prelude/PlutusPrelude.hs
+++ b/plutus-core/prelude/PlutusPrelude.hs
@@ -97,9 +97,7 @@ module PlutusPrelude
     , allSame
     , distinct
     , unsafeFromRight
-    , tryError
     , addTheRest
-    , modifyError
     , lowerInitialChar
     ) where
 
@@ -110,7 +108,6 @@ import Control.DeepSeq (NFData)
 import Control.Exception (Exception, throw)
 import Control.Lens (Fold, Lens', ala, lens, over, set, view, (%~), (&), (.~), (<&>), (^.))
 import Control.Monad
-import Control.Monad.Except (ExceptT, MonadError, catchError, runExceptT, throwError)
 import Control.Monad.Reader (MonadReader, ask)
 import Data.Array (Array, Ix, listArray)
 import Data.Bifunctor (first, second)
@@ -260,13 +257,6 @@ unsafeFromRight (Left e)  = error $ show e
 timesA :: Natural -> (a -> a) -> a -> a
 timesA = ala Endo . stimes
 
--- | A 'MonadError' version of 'try'.
---
--- TODO: remove when we switch to mtl>=2.3
-tryError :: MonadError e m => m a -> m (Either e a)
-tryError a = (Right <$> a) `catchError` (pure . Left)
-{-# INLINE tryError #-}
-
 -- | Pair each element of the given list with all the other elements.
 --
 -- >>> addTheRest "abcd"
@@ -274,15 +264,6 @@ tryError a = (Right <$> a) `catchError` (pure . Left)
 addTheRest :: [a] -> [(a, [a])]
 addTheRest []     = []
 addTheRest (x:xs) = (x, xs) : map (fmap (x :)) (addTheRest xs)
-
-{- A different 'MonadError' analogue to the 'withExceptT' function.
-Modify the value (and possibly the type) of an error in an @ExceptT@-transformed
-monad, while stripping the @ExceptT@ layer.
-
-TODO: remove when we switch to mtl>=2.3.1
--}
-modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
-modifyError f m = runExceptT m >>= either (throwError . f) pure
 
 allSame :: Eq a => [a] -> Bool
 allSame []     = True

--- a/plutus-core/testlib/PlutusIR/Pass/Test.hs
+++ b/plutus-core/testlib/PlutusIR/Pass/Test.hs
@@ -50,7 +50,7 @@ runTestPass
   -> m (Term tyname name uni fun a)
 runTestPass pass t = do
   res <- runExceptT $ do
-    tcconfig <- TC.getDefTypeCheckConfig mempty
+    tcconfig <- modifyError PIR.PLCTypeError $ TC.getDefTypeCheckConfig mempty
     runPass (\_ -> pure ()) True (pass tcconfig) t
   case res of
     Left e  -> throw e
@@ -90,7 +90,7 @@ testPassProp' ann before after pass =
     let
       res :: ExceptT (PIR.Error PLC.DefaultUni PLC.DefaultFun a) m ()
       res = do
-        tcconfig <- getDefTypeCheckConfig ann
+        tcconfig <- modifyError PIR.PLCTypeError $ getDefTypeCheckConfig ann
         let tm' = before tm
         _ <- runPass (\_ -> pure ()) True (pass tcconfig) tm'
         pure ()

--- a/plutus-core/testlib/PlutusIR/Test.hs
+++ b/plutus-core/testlib/PlutusIR/Test.hs
@@ -30,6 +30,7 @@ import PlutusCore.Core qualified as PLC
 import PlutusCore.DeBruijn qualified as PLC
 import PlutusCore.Default qualified as PLC
 import PlutusCore.Error (ParserErrorBundle)
+import PlutusCore.Error qualified as PLC
 import PlutusCore.Pretty
 import PlutusCore.Pretty qualified as PLC
 import PlutusCore.Quote (runQuoteT)
@@ -125,7 +126,7 @@ compileWithOpts ::
     (PIR.Error uni fun (PIR.Provenance a))
     (PLC.Program PIR.TyName PIR.Name uni fun (PIR.Provenance a))
 compileWithOpts optsMod pir = do
-  tcConfig <- PLC.getDefTypeCheckConfig noProvenance
+  tcConfig <- modifyError PIR.PLCTypeError $ PLC.getDefTypeCheckConfig noProvenance
   let pirCtx = optsMod (toDefaultCompilationCtx tcConfig)
   flip runReaderT pirCtx $ runQuoteT $ do
     compiled <- compileProgram pir
@@ -133,8 +134,7 @@ compileWithOpts optsMod pir = do
     -- and as such, these prism errors cannot be unified.
     -- We instead run the ExceptT, collect any PLC error and explicitly lift into a PIR
     -- error by wrapping with PIR._PLCError
-    plcConcrete <- runExceptT $ void $ PLC.inferTypeOfProgram tcConfig compiled
-    liftEither $ first (view (re _PLCError)) plcConcrete
+    _plcConcrete <- modifyError (PLCError . PLC.TypeErrorE) $ PLC.inferTypeOfProgram tcConfig compiled
     pure compiled
 
 withGoldenFileM :: String -> (T.Text -> IO T.Text) -> TestNested
@@ -235,5 +235,5 @@ goldenTypeFromPir x =
   goldenPirM $ \ast -> ppCatch prettyPlcReadable $
     withExceptT (toException :: PIR.Error PLC.DefaultUni PLC.DefaultFun a -> SomeException) $
       runQuoteT $ do
-        tcConfig <- getDefTypeCheckConfig x
+        tcConfig <- modifyError (PLCError . PLC.TypeErrorE) $ getDefTypeCheckConfig x
         inferType tcConfig ast

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Uniques.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Uniques.hs
@@ -2,7 +2,6 @@ module UntypedPlutusCore.Check.Uniques
     ( checkProgram
     , checkTerm
     , UniqueError (..)
-    , AsUniqueError (..)
     ) where
 
 import UntypedPlutusCore.Analysis.Definitions
@@ -12,16 +11,14 @@ import PlutusCore.Error
 import PlutusCore.Name.Unique
 
 import Control.Monad (when)
-import Control.Monad.Error.Lens
-import Control.Monad.Except (MonadError)
+import Control.Monad.Except
 
 import Data.Foldable
 
 checkProgram
     :: (Ord ann,
         HasUnique name TermUnique,
-        AsUniqueError e ann,
-        MonadError e m)
+        MonadError (UniqueError ann) m)
     => (UniqueError ann -> Bool)
     -> Program name uni fun ann
     -> m ()
@@ -30,11 +27,10 @@ checkProgram p (Program _ _ t) = checkTerm p t
 checkTerm
     :: (Ord ann,
         HasUnique name TermUnique,
-        AsUniqueError e ann,
-        MonadError e m)
+        MonadError (UniqueError ann) m)
     => (UniqueError ann -> Bool)
     -> Term name uni fun ann
     -> m ()
 checkTerm p t = do
     (_, errs) <- runTermDefs t
-    for_ errs $ \e -> when (p e) $ throwing _UniqueError e
+    for_ errs $ \e -> when (p e) $ throwError e

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
@@ -14,7 +14,6 @@ module UntypedPlutusCore.DeBruijn
     -- but hide it in the parent module.
     , FakeNamedDeBruijn (unFakeNamedDeBruijn)
     , FreeVariableError (..)
-    , AsFreeVariableError (..)
     , deBruijnTerm
     , unDeBruijnTerm
     , unNameDeBruijn
@@ -43,14 +42,14 @@ This module is just a boring port of the typed version.
 -- | Convert a 'Term' with 'Name's into a 'Term' with 'DeBruijn's.
 -- Will throw an error if a free variable is encountered.
 deBruijnTerm
-    :: (AsFreeVariableError e, MonadError e m)
+    :: (MonadError FreeVariableError m)
     => Term Name uni fun ann -> m (Term NamedDeBruijn uni fun ann)
 deBruijnTerm = deBruijnTermWith freeUniqueThrow
 
 -- | Convert a 'Term' with 'DeBruijn's into a 'Term' with 'Name's.
 -- Will throw an error if a free variable is encountered.
 unDeBruijnTerm
-    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
+    :: (MonadQuote m, MonadError FreeVariableError m)
     => Term NamedDeBruijn uni fun ann -> m (Term Name uni fun ann)
 unDeBruijnTerm = unDeBruijnTermWith freeIndexThrow
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -88,7 +88,7 @@ import Control.Exception qualified as Exception
 import Control.Lens.Review
 import Control.Monad (unless, when)
 import Control.Monad.Catch
-import Control.Monad.Except (MonadError, catchError, throwError)
+import Control.Monad.Except (MonadError, catchError, throwError, tryError)
 import Control.Monad.Primitive (PrimMonad (..))
 import Control.Monad.ST
 import Control.Monad.ST.Unsafe

--- a/plutus-core/untyped-plutus-core/testlib/DeBruijn/UnDeBruijnify.hs
+++ b/plutus-core/untyped-plutus-core/testlib/DeBruijn/UnDeBruijnify.hs
@@ -76,7 +76,7 @@ test_undebruijnify = testNested "Golden"
     nestedGoldenVsPretty act (n,t) =
         nestedGoldenVsDoc n ".uplc" $ toPretty $ act $ mkProg t
 
-    actDefault = progTerm unDeBruijnTerm
+    actDefault = progTerm $ modifyError FreeVariableErrorE . unDeBruijnTerm
 
     actGrace = flip evalStateT mempty
                . progTerm (unDeBruijnTermWith freeIndexAsConsistentLevel)

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
@@ -57,7 +57,7 @@ import Test.Tasty.QuickCheck (Property, property, (===))
 
 -- | Type check and evaluate a term.
 typecheckAnd
-    :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
+    :: ( MonadError (TypeErrorPlc uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , Closed uni, uni `Everywhere` ExMemoryUsage
        )
     => BuiltinSemanticsVariant fun
@@ -77,7 +77,7 @@ typecheckAnd semvar action costingPart term = TPLC.runQuoteT $ do
 
 -- | Type check and evaluate a term, logging enabled.
 typecheckEvaluateCek
-    :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
+    :: ( MonadError (TypeErrorPlc uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni, Pretty fun
        )
     => BuiltinSemanticsVariant fun
@@ -90,7 +90,7 @@ typecheckEvaluateCek semvar =
 
 -- | Type check and evaluate a term, logging disabled.
 typecheckEvaluateCekNoEmit
-    :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
+    :: ( MonadError (TypeErrorPlc uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni, Pretty fun
        )
     => BuiltinSemanticsVariant fun
@@ -103,7 +103,7 @@ typecheckEvaluateCekNoEmit semvar =
 
 -- | Type check and convert a Plutus Core term to a Haskell value.
 typecheckReadKnownCek
-    :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
+    :: ( MonadError (TypeErrorPlc uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni, Pretty fun
        , ReadKnown (UPLC.Term Name uni fun ()) a
        )
@@ -118,7 +118,7 @@ typecheckReadKnownCek semvar =
 -- TPLC/UPLC utilities
 
 type PlcTerm  = TPLC.Term TPLC.TyName TPLC.Name TPLC.DefaultUni TPLC.DefaultFun ()
-type PlcError = TPLC.Error TPLC.DefaultUni TPLC.DefaultFun ()
+type PlcError = TypeErrorPlc TPLC.DefaultUni TPLC.DefaultFun ()
 type UplcTerm = UPLC.Term TPLC.Name TPLC.DefaultUni TPLC.DefaultFun ()
 
 -- Possible CEK evluation results, flattened out

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Debug.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Debug.hs
@@ -12,11 +12,11 @@ module Evaluation.Debug
 
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Pretty
-import PlutusPrelude
 import UntypedPlutusCore
 import UntypedPlutusCore.Evaluation.Machine.SteppableCek.DebugDriver
 import UntypedPlutusCore.Evaluation.Machine.SteppableCek.Internal
 
+import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.ST
 import Control.Monad.Writer

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Golden.hs
@@ -27,6 +27,7 @@ import PlutusCore.MkPlc
 import PlutusCore.Pretty
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
+import Control.Monad.Except
 import Data.Bifunctor
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text (Text)
@@ -419,7 +420,7 @@ runTypecheck
     :: Term TyName Name DefaultUni DefaultFun ()
     -> Either (Error DefaultUni DefaultFun ()) (Normalized (Type TyName DefaultUni ()))
 runTypecheck term =
-  runQuoteT $ do
+  runQuoteT $ modifyError TypeErrorE $ do
     tcConfig <- getDefTypeCheckConfig ()
     inferType tcConfig term
 

--- a/plutus-core/untyped-plutus-core/testlib/Generators.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Generators.hs
@@ -18,7 +18,7 @@ import PlutusCore.Generators.Hedgehog.AST (AstGen, runAstGen)
 import PlutusCore.Generators.Hedgehog.AST qualified as AST
 import PlutusCore.Parser (defaultUni, parseGen)
 import PlutusCore.Pretty (displayPlc)
-import PlutusCore.Quote (QuoteT, runQuoteT)
+import PlutusCore.Quote (runQuoteT)
 import PlutusCore.Test (isSerialisable)
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Core.Type (Program (Program), Term (..), progTerm, termAnn)
@@ -107,7 +107,7 @@ propTermSrcSpan = testPropertyNamed
         annotateShow code
         let (endingLine, endingCol) = length &&& T.length . last $ T.lines code
         trailingSpaces <- forAllPretty $ Gen.text (Range.linear 0 10) (Gen.element [' ', '\n'])
-        case runQuoteT . parseTerm @ParserErrorBundle $ code <> trailingSpaces of
+        case runQuoteT . parseTerm $ code <> trailingSpaces of
             Right parsed ->
                 let sp = termAnn parsed
                  in (srcSpanELine sp, srcSpanECol sp) === (endingLine, endingCol + 1)
@@ -131,7 +131,7 @@ propUnit = testCase "Unit" $ fold
         pTerm
             = either (error . display) display
             . runQuoteT
-            . parseTerm @_ @(QuoteT (Either ParserErrorBundle))
+            . parseTerm
             . T.pack
 
 propDefaultUni :: TestTree
@@ -149,7 +149,7 @@ propDefaultUni = testCase "DefaultUni" $ fold
         pDefaultUni
             = either (error . display) display
             . runQuoteT
-            . parseGen @_ @(QuoteT (Either ParserErrorBundle)) defaultUni
+            . parseGen defaultUni
             . T.pack
 
 test_parsing :: TestTree

--- a/plutus-executables/executables/plc/Main.hs
+++ b/plutus-executables/executables/plc/Main.hs
@@ -19,6 +19,7 @@ import PlutusCore.MkPlc (mkConstant)
 import PlutusCore.Pretty qualified as PP
 import PlutusPrelude
 
+import Control.Monad.Except
 import Data.ByteString.Lazy qualified as BSL (readFile)
 import Flat (unflat)
 import Options.Applicative
@@ -176,7 +177,7 @@ runApplyToData (ApplyOptions inputfiles ifmt outp ofmt mode) = do
 runTypecheck :: TypecheckOptions -> IO ()
 runTypecheck (TypecheckOptions inp fmt outp printMode nameFormat) = do
   prog <- readProgram fmt inp
-  case PLC.runQuoteT $ do
+  case PLC.runQuoteT $ modifyError PLC.TypeErrorE $ do
     tcConfig <- PLC.getDefTypeCheckConfig ()
     PLC.inferTypeOfProgram tcConfig (void prog)
     of

--- a/plutus-executables/executables/uplc/Main.hs
+++ b/plutus-executables/executables/uplc/Main.hs
@@ -26,7 +26,7 @@ import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 
 import Codec.Serialise (DeserialiseFailure, deserialiseOrFail)
 import Control.DeepSeq (force)
-import Control.Monad.Except (runExcept)
+import Control.Monad.Except
 import Control.Monad.IO.Class (liftIO)
 import Criterion (benchmarkWith, whnf)
 import Criterion.Main (defaultConfig)

--- a/plutus-executables/plutus-executables.cabal
+++ b/plutus-executables/plutus-executables.cabal
@@ -74,12 +74,12 @@ executable pir
     , containers
     , lens
     , megaparsec
+    , mtl
     , optparse-applicative
     , plutus-core                      ^>=1.46
     , plutus-core:plutus-core-execlib
     , plutus-core:plutus-ir
     , text
-    , transformers
 
 executable plc
   import:         lang
@@ -90,6 +90,7 @@ executable plc
     , base                             >=4.9   && <5
     , bytestring
     , flat                             ^>=0.6
+    , mtl
     , optparse-applicative
     , plutus-core                      ^>=1.46
     , plutus-core:plutus-core-execlib

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
@@ -24,9 +24,7 @@ import PlutusIR.Compiler qualified as PIR
 import Language.Haskell.TH qualified as TH
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty qualified as PLC
-import PlutusIR qualified as PIR
 
-import Control.Lens
 import Control.Monad.Except
 
 import Data.Text qualified as T
@@ -37,8 +35,6 @@ the priority of the context when displaying it. Lower numbers are more prioritis
 -}
 data WithContext c e = NoContext e | WithContextC Int c (WithContext c e)
   deriving stock Functor
-
-makeClassyPrisms ''WithContext
 
 type CompileError uni fun ann = WithContext T.Text (Error uni fun ann)
 
@@ -76,34 +72,9 @@ data Error uni fun a
   | FreeVariableError !T.Text
   | InvalidMarkerError !String
   | CoreNameLookupError !TH.Name
-makeClassyPrisms ''Error
 
 instance (PLC.PrettyUni uni, PP.Pretty fun, PP.Pretty a) => PP.Pretty (Error uni fun a) where
   pretty = PLC.prettyPlcClassicSimple
-
-instance
-  (uni1 ~ uni2, b ~ PIR.Provenance a)
-  => PLC.AsTypeError (CompileError uni1 fun a) (PIR.Term PIR.TyName PIR.Name uni2 fun ()) uni2 fun b
-  where
-  _TypeError = _NoContext . _PIRError . PIR._TypeError
-
-instance
-  (uni1 ~ uni2, b ~ PIR.Provenance a)
-  => PIR.AsTypeErrorExt (CompileError uni1 fun a) uni2 b
-  where
-  _TypeErrorExt = _NoContext . _PIRError . PIR._TypeErrorExt
-
-instance (uni1 ~ uni2) => PLC.AsNormCheckError (CompileError uni1 fun a) PLC.TyName PLC.Name uni2 fun a where
-  _NormCheckError = _NoContext . _PLCError . PLC._NormCheckError
-
-instance PLC.AsUniqueError (CompileError uni fun a) a where
-  _UniqueError = _NoContext . _PLCError . PLC._UniqueError
-
-instance
-  (uni1 ~ uni2, b ~ PIR.Provenance a)
-  => PIR.AsError (CompileError uni1 fun a) uni2 fun b
-  where
-  _Error = _NoContext . _PIRError
 
 instance
   (PLC.PrettyUni uni, PP.Pretty fun, PP.Pretty a)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Utils.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Utils.hs
@@ -14,7 +14,7 @@ import GHC.Plugins qualified as GHC
 import GHC.Types.TyThing qualified as GHC
 
 import Control.Monad ((<=<))
-import Control.Monad.Except (MonadError)
+import Control.Monad.Except
 import Control.Monad.Reader (MonadReader, ask)
 
 import Language.Haskell.TH.Syntax qualified as TH

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -11,7 +11,6 @@
 
 module PlutusTx.Plugin (plugin, plc) where
 
-import Data.Bifunctor
 import PlutusPrelude
 import PlutusTx.AsData.Internal qualified
 import PlutusTx.Bool ((&&), (||))
@@ -485,7 +484,9 @@ runCompiler
   -> m (PIRProgram uni fun, UPLCProgram uni fun)
 runCompiler moduleName opts expr = do
   -- Plc configuration
-  plcTcConfig <- PLC.getDefTypeCheckConfig PIR.noProvenance
+  plcTcConfig <-
+    modifyError (NoContext . PIRError . PIR.PLCTypeError) $
+    PLC.getDefTypeCheckConfig PIR.noProvenance
   let plcVersion = opts ^. posPlcTargetVersion
 
   let hints = UPLC.InlineHints $ \ann _ -> case ann of
@@ -596,37 +597,43 @@ runCompiler moduleName opts expr = do
     dumpFlat (void pirP) "initial PIR program" (moduleName ++ "_initial.pir-flat")
 
   -- Pir -> (Simplified) Pir pass. We can then dump/store a more legible PIR program.
-  spirP <- flip runReaderT pirCtx $ PIR.compileToReadable pirP
+  spirP <-
+    flip runReaderT pirCtx $
+      modifyError (NoContext . PIRError) $
+        PIR.compileToReadable pirP
   when (opts ^. posDumpPir) . liftIO $
-    dumpFlat (void spirP) "simplified PIR program" (moduleName ++ "_simplified.pir-flat")
+      dumpFlat (void spirP) "simplified PIR program" (moduleName ++ "_simplified.pir-flat")
 
   -- (Simplified) Pir -> Plc translation.
-  plcP <- flip runReaderT pirCtx $ PIR.compileReadableToPlc spirP
+  plcP <- flip runReaderT pirCtx $
+    modifyError (NoContext . PIRError) $
+      PIR.compileReadableToPlc spirP
   when (opts ^. posDumpPlc) . liftIO $
-    dumpFlat (void plcP) "typed PLC program" (moduleName ++ ".tplc-flat")
+      dumpFlat (void plcP) "typed PLC program" (moduleName ++ ".tplc-flat")
 
   -- We do this after dumping the programs so that if we fail typechecking we still get the dump.
   when (opts ^. posDoTypecheck) . void $
-    liftExcept $
-      PLC.inferTypeOfProgram plcTcConfig (plcP $> annMayInline)
+      liftExcept $
+        modifyError PLC.TypeErrorE $
+          PLC.inferTypeOfProgram plcTcConfig (plcP $> annMayInline)
 
   let optCertify = opts ^. posCertify
   (uplcP, simplTrace) <- flip runReaderT plcOpts $ PLC.compileProgramWithTrace plcP
   liftIO $ case optCertify of
-    Just certName -> do
-      result <- runCertifier $ mkCertifier simplTrace certName
-      case result of
-        Right certSuccess ->
-          hPutStrLn stderr $ prettyCertifierSuccess certSuccess
-        Left err ->
-          hPutStrLn stderr $ prettyCertifierError err
-    Nothing -> pure ()
-  dbP <- liftExcept $ traverseOf UPLC.progTerm UPLC.deBruijnTerm uplcP
+      Just certName -> do
+          result <- runCertifier $ mkCertifier simplTrace certName
+          case result of
+              Right certSuccess ->
+                  hPutStrLn stderr $ prettyCertifierSuccess certSuccess
+              Left err ->
+                 hPutStrLn stderr $ prettyCertifierError err
+      Nothing -> pure ()
+  dbP <- liftExcept $ modifyError PLC.FreeVariableErrorE $ traverseOf UPLC.progTerm UPLC.deBruijnTerm uplcP
   when (opts ^. posDumpUPlc) . liftIO $
-    dumpFlat
-      (UPLC.UnrestrictedProgram $ void dbP)
-      "untyped PLC program"
-      (moduleName ++ ".uplc-flat")
+      dumpFlat
+          (UPLC.UnrestrictedProgram $ void dbP)
+          "untyped PLC program"
+          (moduleName ++ ".uplc-flat")
   -- Discard the Provenance information at this point, just keep the SrcSpans
   -- TODO: keep it and do something useful with it
   pure (fmap getSrcSpans spirP, fmap getSrcSpans dbP)
@@ -634,11 +641,7 @@ runCompiler moduleName opts expr = do
   -- ugly trick to take out the concrete plc.error and in case of error, map it / rethrow it
   --  using our 'CompileError'
   liftExcept :: ExceptT (PLC.Error PLC.DefaultUni PLC.DefaultFun Ann) m b -> m b
-  liftExcept act = do
-    plcTcError <- runExceptT act
-    -- also wrap the PLC Error annotations into Original provenances, to match our expected
-    -- 'CompileError'
-    liftEither $ first (view (re PIR._PLCError) . fmap PIR.Original) plcTcError
+  liftExcept = modifyError (NoContext . PLCError)
 
   dumpFlat :: (Flat t) => t -> String -> String -> IO ()
   dumpFlat t desc fileName = do

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -1,8 +1,8 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module PlutusTx.Lift (
   safeLiftWith,
@@ -57,9 +57,8 @@ import UntypedPlutusCore qualified as UPLC
 import Control.Exception
 import Control.Lens hiding (lifted)
 import Control.Monad (void)
-import Control.Monad.Except (ExceptT, MonadError, liftEither, runExceptT)
+import Control.Monad.Except (ExceptT, MonadError, modifyError, runExceptT)
 import Control.Monad.Reader (runReaderT)
-import Data.Bifunctor
 import Data.Default.Class
 import Data.Hashable
 import Data.Proxy
@@ -71,14 +70,10 @@ import Prelude as Haskell
 PIR and UPLC optimization options.
 -}
 safeLiftWith
-  :: forall a e uni fun m
+  :: forall a uni fun m
    . ( Lift.Lift uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
      , PLC.GEq uni
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
      , PrettyUni uni
@@ -97,7 +92,7 @@ safeLiftWith
   -> m (PIR.Term PLC.TyName PLC.Name uni fun (), UPLC.Term UPLC.NamedDeBruijn uni fun ())
 safeLiftWith f g v x = do
   pir <- liftQuote $ runDefT () $ Lift.lift x
-  tcConfig <- PLC.getDefTypeCheckConfig $ Original ()
+  tcConfig <- modifyError (PLCError . PLC.TypeErrorE) $ PLC.getDefTypeCheckConfig $ Original ()
   let ccConfig =
         toDefaultCompilationCtx tcConfig
           & over ccOpts f
@@ -110,21 +105,18 @@ safeLiftWith f g v x = do
       ucOpts = g PLC.defaultCompilationOpts
   plc <- flip runReaderT ccConfig $ compileProgram (Program () v pir)
   uplc <- flip runReaderT ucOpts $ PLC.compileProgram plc
-  UPLC.Program _ _ db <- traverseOf UPLC.progTerm UPLC.deBruijnTerm uplc
+  UPLC.Program _ _ db <-
+    modifyError (PLCError . PLC.FreeVariableErrorE) $ traverseOf UPLC.progTerm UPLC.deBruijnTerm uplc
   pure (void pir, void db)
 
 {-| Get a Plutus Core term corresponding to the given value, applying default PIR/UPLC
 optimizations.
 -}
 safeLift
-  :: forall a e uni fun m
+  :: forall a uni fun m
    . ( Lift.Lift uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
      , PLC.GEq uni
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
      , PrettyUni uni
@@ -143,14 +135,10 @@ safeLift = safeLiftWith id id
 where lifting speed is more important than optimal code.
 -}
 safeLiftUnopt
-  :: forall a e uni fun m
+  :: forall a uni fun m
    . ( Lift.Lift uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
      , PLC.GEq uni
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
      , PrettyUni uni
@@ -175,12 +163,8 @@ optimizations.
 -}
 safeLiftProgram
   :: ( Lift.Lift uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
      , PLC.GEq uni
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
      , PrettyUni uni
@@ -200,12 +184,8 @@ where lifting speed is more important than optimal code.
 -}
 safeLiftProgramUnopt
   :: ( Lift.Lift uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
      , PLC.GEq uni
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
      , PrettyUni uni
@@ -222,12 +202,8 @@ safeLiftProgramUnopt v x = bimap (PIR.Program () v) (UPLC.Program () v) <$> safe
 
 safeLiftCode
   :: ( Lift.Lift uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
      , PLC.GEq uni
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
      , PrettyUni uni
@@ -250,12 +226,8 @@ where lifting speed is more important than optimal code.
 -}
 safeLiftCodeUnopt
   :: ( Lift.Lift uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
      , PLC.GEq uni
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
      , PrettyUni uni
@@ -279,7 +251,7 @@ unsafely
 unsafely ma = runQuote $ do
   run <- runExceptT ma
   case run of
-    Left e  -> throw e
+    Left e -> throw e
     Right t -> pure t
 
 {-| Get a Plutus Core term corresponding to the given value, throwing any errors that
@@ -447,12 +419,9 @@ iff the original term has the given type. We opt for `(\x : <the type> -> x) ter
 
 -- | Check that PLC term has the given type.
 typeCheckAgainst
-  :: forall e a uni fun m
+  :: forall a uni fun m
    . ( Lift.Typeable uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PIR.AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.GEq uni
      , PLC.Typecheckable uni fun
@@ -477,29 +446,21 @@ typeCheckAgainst p (PLC.Program _ v plcTerm) = do
   -- Here we use a 'Default' builtin semantics variant, because the
   -- typechecker needs to be handed a builtin semantics variant (implementation detail).
   -- See Note [Builtin semantics variants]
-  tcConfig <- PLC.getDefTypeCheckConfig (Original ())
+  tcConfig <- modifyError (PLCError . PLC.TypeErrorE) $ PLC.getDefTypeCheckConfig (Original ())
   -- The PIR compiler *pointfully* needs a builtin semantics variant, but in
   -- this instance of only "lifting" it is safe to default to any builtin
   -- semantics variant, since the 'Lift' is impervious to builtins and will
   -- not generate code containing builtins.  See Note [Builtin semantics variants]
   compiled <-
     flip runReaderT (toDefaultCompilationCtx tcConfig) $ compileProgram (Program () v applied)
-  -- PLC errors are parameterized over PLC.Terms, whereas PIR errors over PIR.Terms and as such, these prism errors cannot be unified.
-  -- We instead run the ExceptT, collect any PLC error and explicitly lift into a PIR error by wrapping with PIR._PLCError
-  plcConcrete <- runExceptT $ void $ PLC.inferTypeOfProgram tcConfig compiled
-  -- note: e is a scoped tyvar acting here AsError e uni (Provenance ())
-  let plcPrismatic = first (view (re PIR._PLCError)) plcConcrete
-  liftEither plcPrismatic -- embed prismatic-either to a monaderror
+
+  void $ modifyError (PLCError . PLC.TypeErrorE) $ PLC.inferTypeOfProgram tcConfig compiled
 
 -- | Try to interpret a PLC program as a 'CompiledCodeIn' of the given type. Returns successfully iff the program has the right type.
 typeCode
-  :: forall e a uni fun m
+  :: forall a uni fun m
    . ( Lift.Typeable uni a
-     , PIR.AsTypeError e (PIR.Term TyName Name uni fun ()) uni fun (Provenance ())
-     , PIR.AsTypeErrorExt e uni (Provenance ())
-     , PLC.AsFreeVariableError e
-     , PIR.AsError e uni fun (Provenance ())
-     , MonadError e m
+     , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.GEq uni
      , PLC.Typecheckable uni fun
@@ -518,5 +479,7 @@ typeCode p prog = do
   compiled <-
     flip runReaderT PLC.defaultCompilationOpts $
       PLC.compileProgram prog
-  db <- traverseOf UPLC.progTerm UPLC.deBruijnTerm compiled
+  db <-
+    modifyError (PLCError . PLC.FreeVariableErrorE) $
+      traverseOf UPLC.progTerm UPLC.deBruijnTerm compiled
   pure $ DeserializedCode (mempty <$ db) Nothing mempty


### PR DESCRIPTION
closes #6160 

Removed all prisms from type checking and compiler error handling. All functions previously threw unrealized error types were given minimal error type that can cover all kinds of error the function throws. Function calls within a function that throws different error type now requires changing error type using `modifyError` manually. 

[hoist-error](https://hackage.haskell.org/package/hoist-error-0.3.0.0/docs/Control-Monad-Error-Hoist.html) seems like a viable option at first, but all we need is `Control.Monad.Except.modifyError` since error-throwing function calls are always made within another MonadError. `hoistError` is just a more general version of `modifyError`, and in this case we don't need extra generality!

Changes made in this PR arguably increases verbosity as this requires manually lifting error types of each function calls.