### PR TITLE
BuiltinList lookup uses `dropList` builtin to improve performance.

### DIFF
--- a/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index-out-of-bounds.pir.golden
+++ b/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index-out-of-bounds.pir.golden
@@ -5,34 +5,27 @@ let
   data Unit | Unit_match where
     Unit : Unit
 in
-letrec
-  !go : list integer -> integer -> integer
-    = \(xs : list integer) (i : integer) ->
-        (let
-            r = Unit -> Unit -> integer
-          in
-          \(z : r) (f : integer -> list integer -> r) (xs : list integer) ->
-            chooseList
-              {integer}
-              {all dead. r}
-              xs
-              (/\dead -> z)
-              (/\dead -> f (headList {integer} xs) (tailList {integer} xs))
-              {r})
-          (\(ds : Unit) ->
-             let
-               !x : Unit = trace {Unit} "PT22" Unit
-             in
-             error {Unit -> integer})
-          (\(x : integer) (xs : list integer) (ds : Unit) (eta : Unit) ->
-             Bool_match
-               (ifThenElse {Bool} (equalsInteger 0 i) True False)
-               {all dead. integer}
-               (/\dead -> x)
-               (/\dead -> go xs (subtractInteger i 1))
-               {all dead. dead})
-          xs
-          Unit
-          Unit
-in
-\(v : list integer) -> go v 20
+\(v : list integer) ->
+  let
+    !l : list integer = dropList {integer} 20 v
+  in
+  (let
+      r = Unit -> Unit -> integer
+    in
+    \(z : r) (f : integer -> list integer -> r) (xs : list integer) ->
+      chooseList
+        {integer}
+        {all dead. r}
+        xs
+        (/\dead -> z)
+        (/\dead -> f (headList {integer} xs) (tailList {integer} xs))
+        {r})
+    (\(_ann : Unit) ->
+       let
+         !x : Unit = trace {Unit} "PT22" Unit
+       in
+       error {Unit -> integer})
+    (\(x : integer) (xs : list integer) (ds : Unit) (eta : Unit) -> x)
+    l
+    Unit
+    Unit

--- a/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index-out-of-bounds.uplc.golden
+++ b/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index-out-of-bounds.uplc.golden
@@ -1,21 +1,14 @@
 (program
    1.1.0
-   ((\go v -> go v 20)
-      ((\s -> s s)
-         (\s xs i ->
-            force
-              (force (force chooseList)
-                 xs
-                 (delay
-                    (\ds -> (\x -> error) (force trace "PT22" (constr 0 []))))
-                 (delay
-                    ((\x xs ds eta ->
-                        force
-                          (force ifThenElse
-                             (equalsInteger 0 i)
-                             (delay x)
-                             (delay (s s xs (subtractInteger i 1)))))
-                       (force headList xs)
-                       (force tailList xs))))
-              (constr 0 [])
-              (constr 0 [])))))
+   (\v ->
+      (\l ->
+         force
+           (force (force chooseList)
+              l
+              (delay
+                 (\_ann -> (\x -> error) (force trace "PT22" (constr 0 []))))
+              (delay
+                 ((\x xs ds eta -> x) (force headList l) (force tailList l))))
+           (constr 0 [])
+           (constr 0 []))
+        (force dropList 20 v)))

--- a/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index.eval.golden
+++ b/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index.eval.golden
@@ -1,5 +1,5 @@
-cpu: 8343274
-mem: 33698
-size: 81
+cpu: 1064403
+mem: 4200
+size: 50
 
 (con integer 6)

--- a/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index.pir.golden
+++ b/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index.pir.golden
@@ -5,34 +5,27 @@ let
   data Unit | Unit_match where
     Unit : Unit
 in
-letrec
-  !go : list integer -> integer -> integer
-    = \(xs : list integer) (i : integer) ->
-        (let
-            r = Unit -> Unit -> integer
-          in
-          \(z : r) (f : integer -> list integer -> r) (xs : list integer) ->
-            chooseList
-              {integer}
-              {all dead. r}
-              xs
-              (/\dead -> z)
-              (/\dead -> f (headList {integer} xs) (tailList {integer} xs))
-              {r})
-          (\(ds : Unit) ->
-             let
-               !x : Unit = trace {Unit} "PT22" Unit
-             in
-             error {Unit -> integer})
-          (\(x : integer) (xs : list integer) (ds : Unit) (eta : Unit) ->
-             Bool_match
-               (ifThenElse {Bool} (equalsInteger 0 i) True False)
-               {all dead. integer}
-               (/\dead -> x)
-               (/\dead -> go xs (subtractInteger i 1))
-               {all dead. dead})
-          xs
-          Unit
-          Unit
-in
-\(v : list integer) -> go v 5
+\(v : list integer) ->
+  let
+    !l : list integer = dropList {integer} 5 v
+  in
+  (let
+      r = Unit -> Unit -> integer
+    in
+    \(z : r) (f : integer -> list integer -> r) (xs : list integer) ->
+      chooseList
+        {integer}
+        {all dead. r}
+        xs
+        (/\dead -> z)
+        (/\dead -> f (headList {integer} xs) (tailList {integer} xs))
+        {r})
+    (\(_ann : Unit) ->
+       let
+         !x : Unit = trace {Unit} "PT22" Unit
+       in
+       error {Unit -> integer})
+    (\(x : integer) (xs : list integer) (ds : Unit) (eta : Unit) -> x)
+    l
+    Unit
+    Unit

--- a/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index.uplc.golden
+++ b/plutus-tx-plugin/test/BuiltinList/Budget/9.6/index.uplc.golden
@@ -1,21 +1,14 @@
 (program
    1.1.0
-   ((\go v -> go v 5)
-      ((\s -> s s)
-         (\s xs i ->
-            force
-              (force (force chooseList)
-                 xs
-                 (delay
-                    (\ds -> (\x -> error) (force trace "PT22" (constr 0 []))))
-                 (delay
-                    ((\x xs ds eta ->
-                        force
-                          (force ifThenElse
-                             (equalsInteger 0 i)
-                             (delay x)
-                             (delay (s s xs (subtractInteger i 1)))))
-                       (force headList xs)
-                       (force tailList xs))))
-              (constr 0 [])
-              (constr 0 [])))))
+   (\v ->
+      (\l ->
+         force
+           (force (force chooseList)
+              l
+              (delay
+                 (\_ann -> (\x -> error) (force trace "PT22" (constr 0 []))))
+              (delay
+                 ((\x xs ds eta -> x) (force headList l) (force tailList l))))
+           (constr 0 [])
+           (constr 0 []))
+        (force dropList 5 v)))

--- a/plutus-tx/changelog.d/20250526_182207_Yuriy.Lazaryev_lookup_builtin_list_cheaper.md
+++ b/plutus-tx/changelog.d/20250526_182207_Yuriy.Lazaryev_lookup_builtin_list_cheaper.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `BuiltinList` lookup is made cheaper by using the `DropList` builtin function.


### PR DESCRIPTION
`BuiltinList` lookup made many times cheaper by using the new `dropList` builtin instead of recursion.

Note: this PR is built on top of another PR as suggested by @zliu41 in order to separate concerns and make code review easier.

Closes: https://github.com/IntersectMBO/plutus-private/issues/1589