### PR TITLE
[Refactoring] Remove prismatic error handling from Ck/Cek machines

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -22,7 +22,6 @@ import PlutusCore.Evaluation.Machine.BuiltinCostModel hiding (BuiltinCostModel)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.ExMemoryUsage (ExMemoryUsage)
 import PlutusCore.Evaluation.Machine.MachineParameters
-import PlutusCore.Evaluation.Result (evaluationFailure)
 import PlutusCore.Pretty
 import PlutusPrelude
 import UntypedPlutusCore.Evaluation.Machine.Cek
@@ -137,7 +136,7 @@ infixr >:
 n >: k =
     case n of
       SomeConstant (Some (ValueOf DefaultUniInteger _)) -> k
-      _                                                 -> evaluationFailure
+      _                                                 -> builtinResultFailure
 {-# INLINE (>:) #-}
 
 {- | The meanings of the builtins.  Each one takes a number of arguments and

--- a/plutus-core/docs/BuiltinsOverview.md
+++ b/plutus-core/docs/BuiltinsOverview.md
@@ -402,7 +402,7 @@ Here's an example instance (where `Term` is the type of TPLC terms):
 ```haskell
 instance HasConstant (Term TyName Name uni fun ()) where
     asConstant (Constant _ val) = pure val
-    asConstant _                = throwNotAConstant
+    asConstant _                = throwError notAConstant
 ```
 
 Unlifting of constants then is just a matter of unwrapping a value as a constant and checking that the constant is of the right type, which is what the default implementation of `readKnown` does:
@@ -452,5 +452,5 @@ instance
         ( TypeError ('Text "‘BuiltinResult’ cannot appear in the type of an argument")
         , uni ~ UniOf val
         ) => ReadKnownIn uni val (BuiltinResult a) where
-    readKnown _ = throwUnderTypeError
+    readKnown _ = throwError underTypeError
 ```

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -5,7 +5,7 @@
 
 module PlutusCore.Builtin.HasConstant
     ( BuiltinError (..)
-    , throwNotAConstant
+    , notAConstant
     , HasConstant (..)
     , HasConstantIn
     , fromValueOf
@@ -17,6 +17,8 @@ import PlutusCore.Core
 import PlutusCore.Name.Unique
 
 import Universe
+
+import Control.Monad.Except
 
 {- Note [Existence of HasConstant]
 We don't really need 'HasConstant' and could get away with only having 'HasConstantIn', however
@@ -56,6 +58,6 @@ fromValue = fromValueOf knownUni
 
 instance HasConstant (Term TyName Name uni fun ()) where
     asConstant (Constant _ val) = pure val
-    asConstant _                = throwNotAConstant
+    asConstant _                = throwError notAConstant
 
     fromConstant = Constant ()

--- a/plutus-core/plutus-core/src/PlutusCore/Crypto/Utils.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Crypto/Utils.hs
@@ -3,8 +3,7 @@
 
 module PlutusCore.Crypto.Utils (failWithMessage, byteStringAsHex) where
 
-import PlutusCore.Builtin.Result (BuiltinResult, emit)
-import PlutusCore.Evaluation.Result (evaluationFailure)
+import PlutusCore.Builtin.Result (BuiltinResult, builtinResultFailure, emit)
 
 import Data.ByteString (ByteString, foldr')
 import Data.Kind (Type)
@@ -14,7 +13,7 @@ import Text.Printf (printf)
 failWithMessage :: forall (a :: Type). Text -> Text -> BuiltinResult a
 failWithMessage location reason = do
   emit $ location <> ": " <> reason
-  evaluationFailure
+  builtinResultFailure
 
 byteStringAsHex :: ByteString -> String
 byteStringAsHex bs = "0x" ++ (Prelude.concat $ foldr' (\w s -> (printf "%02x" w):s) [] bs)

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -39,6 +39,7 @@ import PlutusCore.Crypto.Secp256k1 (verifyEcdsaSecp256k1Signature, verifySchnorr
 
 import Codec.Serialise (serialise)
 import Control.Monad (unless)
+import Control.Monad.Except (throwError)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Ix (Ix)
@@ -774,7 +775,7 @@ check that the value inside of it is a list (by matching on the type tag):
             nullListDenotation (SomeConstant (Some (ValueOf uniListA xs))) = do
                 case uniListA of
                     DefaultUniList _ -> pure $ null xs
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE nullListDenotation #-}
         in makeBuiltinMeaning
             nullListDenotation
@@ -795,7 +796,7 @@ Here's a similar built-in function:
                     DefaultUniPair uniA _ ->              -- [1]
                         pure . fromValueOf uniA $ fst xy  -- [2]
                     _ ->
-                        throwing _StructuralUnliftingError "Expected a pair but got something else"
+                        throwError $ structuralUnliftingError "Expected a pair but got something else"
             {-# INLINE fstPairDenotation #-}
         in makeBuiltinMeaning
             fstPairDenotation
@@ -815,7 +816,7 @@ manual unlifting for arguments having non-monomorphized polymorphic built-in typ
                     DefaultUniList _ -> pure $ case xs of
                         []    -> a
                         _ : _ -> b
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE chooseListDenotation #-}
         in makeBuiltinMeaning
             chooseListDenotation
@@ -839,9 +840,9 @@ Our final example is this:
                     DefaultUniList uniA' -> case uniA `geq` uniA' of       -- [1]
                         Just Refl ->                                       -- [2]
                             pure . fromValueOf uniListA $ x : xs           -- [3]
-                        _ -> throwing _StructuralUnliftingError
+                        _ -> throwError $ structuralUnliftingError
                             "The type of the value does not match the type of elements in the list"
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE mkConsDenotation #-}
         in makeBuiltinMeaning
             mkConsDenotation
@@ -1002,7 +1003,7 @@ Here's how we can define it as a built-in function using 'headSpine':
                         []     -> headSpine z []                                             -- [1]
                         x : xs -> headSpine f [fromValueOf uniA x, fromValueOf uniListA xs]  -- [2]
                     _ ->
-                        throwing _StructuralUnliftingError "Expected a list but got something else"
+                        throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE caseListDenotation #-}
         in makeBuiltinMeaning
             caseListDenotation
@@ -1453,7 +1454,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                     DefaultUniPair uniA _ -> pure . fromValueOf uniA $ fst xy
                     _                     ->
                         -- See Note [Structural vs operational errors within builtins].
-                        throwing _StructuralUnliftingError "Expected a pair but got something else"
+                        throwError $ structuralUnliftingError "Expected a pair but got something else"
             {-# INLINE fstPairDenotation #-}
         in makeBuiltinMeaning
             fstPairDenotation
@@ -1466,7 +1467,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                     DefaultUniPair _ uniB -> pure . fromValueOf uniB $ snd xy
                     _                     ->
                         -- See Note [Structural vs operational errors within builtins].
-                        throwing _StructuralUnliftingError "Expected a pair but got something else"
+                        throwError $ structuralUnliftingError "Expected a pair but got something else"
             {-# INLINE sndPairDenotation #-}
         in makeBuiltinMeaning
             sndPairDenotation
@@ -1482,7 +1483,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                         _ : _ -> b
                     _ ->
                         -- See Note [Structural vs operational errors within builtins].
-                        throwing _StructuralUnliftingError "Expected a list but got something else"
+                        throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE chooseListDenotation #-}
         in makeBuiltinMeaning
             chooseListDenotation
@@ -1498,9 +1499,9 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                 case uniListA of
                     DefaultUniList uniA' -> case uniA `geq` uniA' of
                         Just Refl -> pure . fromValueOf uniListA $ x : xs
-                        _         -> throwing _StructuralUnliftingError
+                        _         -> throwError $ structuralUnliftingError
                             "The type of the value does not match the type of elements in the list"
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE mkConsDenotation #-}
         in makeBuiltinMeaning
             mkConsDenotation
@@ -1513,7 +1514,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                     DefaultUniList uniA -> case xs of
                         []    -> fail "Expected a non-empty list but got an empty one"
                         x : _ -> pure $ fromValueOf uniA x
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE headListDenotation #-}
         in makeBuiltinMeaning
             headListDenotation
@@ -1527,7 +1528,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                       case xs of
                         []      -> fail "Expected a non-empty list but got an empty one"
                         _ : xs' -> pure $ fromValueOf uniListA xs'
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE tailListDenotation #-}
         in makeBuiltinMeaning
             tailListDenotation
@@ -1538,7 +1539,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             nullListDenotation (SomeConstant (Some (ValueOf uniListA xs))) =
                 case uniListA of
                     DefaultUniList _uniA -> pure $ null xs
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE nullListDenotation #-}
         in makeBuiltinMeaning
             nullListDenotation
@@ -2059,9 +2060,9 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                             IP _ -> case drop maxBound xs of
                                [] -> pure []
                                _ ->
-                                   throwing _StructuralUnliftingError
+                                   throwError $ structuralUnliftingError
                                        "Panic: unreachable clause executed"
-                    _ -> throwing _StructuralUnliftingError "Expected a list but got something else"
+                    _ -> throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE dropListDenotation #-}
         in makeBuiltinMeaning
             dropListDenotation
@@ -2072,7 +2073,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
           lengthOfArrayDenotation (SomeConstant (Some (ValueOf uni vec))) =
             case uni of
               DefaultUniArray _uniA -> pure $ Vector.length vec
-              _ -> throwing _StructuralUnliftingError "Expected an array but got something else"
+              _ -> throwError $ structuralUnliftingError "Expected an array but got something else"
           {-# INLINE lengthOfArrayDenotation #-}
         in makeBuiltinMeaning lengthOfArrayDenotation (runCostingFunOneArgument . paramLengthOfArray)
 
@@ -2081,7 +2082,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
           listToArrayDenotation (SomeConstant (Some (ValueOf uniListA xs))) =
             case uniListA of
               DefaultUniList uniA -> pure $ fromValueOf (DefaultUniArray uniA) $ Vector.fromList xs
-              _ -> throwing _StructuralUnliftingError  "Expected a list but got something else"
+              _ -> throwError $ structuralUnliftingError  "Expected a list but got something else"
           {-# INLINE listToArrayDenotation #-}
         in makeBuiltinMeaning listToArrayDenotation (runCostingFunOneArgument . paramListToArray)
 
@@ -2097,7 +2098,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                     -- See Note [Structural vs operational errors within builtins].
                     -- The arguments are going to be printed in the "cause" part of the error
                     -- message, so we don't need to repeat them here.
-                throwing _StructuralUnliftingError "Expected an array but got something else"
+                throwError $ structuralUnliftingError "Expected an array but got something else"
           {-# INLINE indexArrayDenotation #-}
         in makeBuiltinMeaning indexArrayDenotation (runCostingFunTwoArguments . paramIndexArray)
 
@@ -2114,7 +2115,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                         x : xs -> headSpine f [fromValueOf uniA x, fromValueOf uniListA xs]
                     _ ->
                         -- See Note [Structural vs operational errors within builtins].
-                        throwing _StructuralUnliftingError "Expected a list but got something else"
+                        throwError $ structuralUnliftingError "Expected a list but got something else"
             {-# INLINE caseListDenotation #-}
         in makeBuiltinMeaning
             caseListDenotation

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -51,6 +51,7 @@ import PlutusCore.Evaluation.Machine.ExMemoryUsage (IntegerCostedLiterally (..),
                                                     NumBytesCostedAsNumWords (..))
 import PlutusCore.Pretty.Extra (juxtRenderContext)
 
+import Control.Monad.Except (throwError)
 import Data.ByteString (ByteString)
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Proxy (Proxy (Proxy))
@@ -401,7 +402,7 @@ instance (KnownBuiltinTypeIn DefaultUni term Integer, Integral a, Bounded a, Typ
             -- TODO: benchmark an alternative 'integerToIntMaybe', modified from @ghc-bignum@
             if fromIntegral (minBound :: a) <= i && i <= fromIntegral (maxBound :: a)
                 then pure . AsInteger $ fromIntegral i
-                else throwing _OperationalUnliftingError . MkUnliftingError $ fold
+                else throwError . operationalUnliftingError $ fold
                         [ Text.pack $ show i
                         , " is not within the bounds of "
                         , Text.pack . show . typeRep $ Proxy @a
@@ -511,7 +512,7 @@ instance KnownBuiltinTypeIn DefaultUni term Integer => ReadKnownIn DefaultUni te
             if i >= 0
             -- TODO: benchmark alternatives: ghc>=9 integerToNatural
             then pure $ fromInteger i
-            else throwing _OperationalUnliftingError . MkUnliftingError $ fold
+            else throwError . operationalUnliftingError $ fold
                  [ Text.pack $ show i
                  , " is not within the bounds of Natural"
                  ]

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Error.hs
@@ -16,12 +16,9 @@
 
 module PlutusCore.Evaluation.Error
     ( EvaluationError (..)
-    , AsEvaluationError (..)
     ) where
 
 import PlutusPrelude
-
-import PlutusCore.Evaluation.Result
 
 import Control.Lens
 import Data.Bifoldable
@@ -52,10 +49,6 @@ data EvaluationError structural operational
     deriving stock (Show, Eq, Functor, Generic)
     deriving anyclass (NFData)
 
-mtraverse makeClassyPrisms
-    [ ''EvaluationError
-    ]
-
 instance Bifunctor EvaluationError where
     bimap f _ (StructuralError err)  = StructuralError $ f err
     bimap _ g (OperationalError err) = OperationalError $ g err
@@ -70,12 +63,6 @@ instance Bitraversable EvaluationError where
     bitraverse f _ (StructuralError err)  = StructuralError <$> f err
     bitraverse _ g (OperationalError err) = OperationalError <$> g err
     {-# INLINE bitraverse #-}
-
--- | A raw evaluation failure is always an operational error.
-instance AsEvaluationFailure operational =>
-        AsEvaluationFailure (EvaluationError structural operational) where
-    _EvaluationFailure = _OperationalError . _EvaluationFailure
-    {-# INLINE _EvaluationFailure #-}
 
 instance
         ( HasPrettyDefaults config ~ 'True

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/ErrorWithCause.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/ErrorWithCause.hs
@@ -9,19 +9,15 @@
 
 module PlutusCore.Evaluation.ErrorWithCause
     ( ErrorWithCause (..)
-    , throwingWithCause
-    , throwingWithCause_
-    , throwBuiltinErrorWithCause
+    , throwErrorWithCause
     ) where
 
 import PlutusPrelude
 
-import PlutusCore.Builtin.Result
-import PlutusCore.Evaluation.Result
 import PlutusCore.Pretty
 
-import Control.Lens
 import Control.Monad.Except
+import Data.Bifunctor
 import Prettyprinter
 
 -- | An error and (optionally) what caused it.
@@ -34,11 +30,6 @@ data ErrorWithCause err cause = ErrorWithCause
 instance Bifunctor ErrorWithCause where
     bimap f g (ErrorWithCause err cause) = ErrorWithCause (f err) (g <$> cause)
     {-# INLINE bimap #-}
-
-instance AsEvaluationError err structural operational =>
-        AsEvaluationError (ErrorWithCause err cause) structural operational where
-    _EvaluationError = iso _ewcError (flip ErrorWithCause Nothing) . _EvaluationError
-    {-# INLINE _EvaluationError #-}
 
 instance (Pretty err, Pretty cause) => Pretty (ErrorWithCause err cause) where
     pretty (ErrorWithCause e c) = pretty e <+> "caused by:" <+> pretty c
@@ -61,35 +52,10 @@ instance (PrettyPlc cause, PrettyPlc err) =>
 deriving anyclass instance (PrettyPlc cause, PrettyPlc err, Typeable cause, Typeable err) =>
     Exception (ErrorWithCause err cause)
 
--- | "Prismatically" throw an error and its (optional) cause.
-throwingWithCause
-    -- Binds @exc@ so it can be used as a convenient parameter with @TypeApplications@.
-    :: forall exc e t term m x. (exc ~ ErrorWithCause e term, MonadError exc m)
-    => AReview e t -> t -> term -> m x
-throwingWithCause l t cause = reviews l (\e -> throwError . ErrorWithCause e $ Just cause) t
-{-# INLINE throwingWithCause #-}
-
--- | "Prismatically" throw a contentless error and its (optional) cause. 'throwingWithCause_' is to
--- 'throwingWithCause' as 'throwing_' is to 'throwing'.
-throwingWithCause_
-    -- Binds @exc@ so it can be used as a convenient parameter with @TypeApplications@.
-    :: forall exc e term m x. (exc ~ ErrorWithCause e term, MonadError exc m)
-    => AReview e () -> term -> m x
-throwingWithCause_ l = throwingWithCause l ()
-{-# INLINE throwingWithCause_ #-}
-
--- | Attach a @cause@ to a 'BuiltinError' and throw that.
--- Note that an evaluator might require the cause to be computed lazily for best performance on the
--- happy path, hence this function must not force its first argument.
--- TODO: wrap @cause@ in 'Lazy' once we have it.
-throwBuiltinErrorWithCause
-    :: ( MonadError (ErrorWithCause err cause) m
-       , AsUnliftingEvaluationError err, AsEvaluationFailure err
-       )
-    => cause -> BuiltinError -> m void
-throwBuiltinErrorWithCause cause = \case
-    BuiltinUnliftingEvaluationError unlErr ->
-        throwingWithCause _UnliftingEvaluationError unlErr cause
-    BuiltinEvaluationFailure ->
-        throwingWithCause_ _EvaluationFailure cause
-{-# INLINE throwBuiltinErrorWithCause #-}
+throwErrorWithCause
+  :: MonadError (ErrorWithCause e cause) m
+  => e
+  -> cause
+  -> m x
+throwErrorWithCause e = throwError . ErrorWithCause e . Just
+{-# INLINE throwErrorWithCause #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -40,6 +40,7 @@ import Control.Lens ((^?))
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.ST
+import Data.Bifunctor
 import Data.DList (DList)
 import Data.DList qualified as DList
 import Data.List.Extras (wix)
@@ -98,14 +99,15 @@ type CkM uni fun s =
         (ExceptT (CkEvaluationException uni fun)
             (ST s))
 
-instance AsEvaluationFailure CkUserError where
-    _EvaluationFailure = _EvaluationFailureVia CkEvaluationFailure
-
-instance AsUnliftingError CkUserError where
-    _UnliftingError = _UnliftingErrorVia CkEvaluationFailure
-
 instance Pretty CkUserError where
     pretty CkEvaluationFailure = "The provided Plutus code called 'error'."
+
+instance BuiltinErrorToEvaluationError (MachineError fun) CkUserError where
+  builtinErrorToEvaluationError (BuiltinUnliftingEvaluationError err) =
+    bimap UnliftingMachineError (const CkEvaluationFailure) (unUnliftingEvaluationError err)
+  builtinErrorToEvaluationError BuiltinEvaluationFailure =
+    OperationalError CkEvaluationFailure
+  {-# INLINE builtinErrorToEvaluationError #-}
 
 -- The 'DList' is just be consistent with the CEK machine (see Note [DList-based emitting]).
 emitCkM :: DList Text -> CkM uni fun s ()
@@ -119,7 +121,7 @@ type instance UniOf (CkValue uni fun) = uni
 
 instance HasConstant (CkValue uni fun) where
     asConstant (VCon val) = pure val
-    asConstant _          = throwNotAConstant
+    asConstant _          = throwError notAConstant
 
     fromConstant = VCon
 
@@ -187,9 +189,9 @@ stack |> Constr _ ty i es               = case es of
     t : ts -> FrameConstr ty i ts [] : stack |> t
 stack |> Case _ _ arg cs         = FrameCase cs : stack |> arg
 _     |> err@Error{}             =
-    throwingWithCause _OperationalError CkEvaluationFailure $ void err
+    throwErrorWithCause (OperationalError CkEvaluationFailure) $ void err
 _     |> var@Var{}               =
-    throwingWithCause _StructuralError OpenTermEvaluatedMachineError var
+    throwErrorWithCause (StructuralError OpenTermEvaluatedMachineError) var
 
 -- FIXME: make sure that the specification is up to date and that this matches.
 -- Tracked by https://github.com/IntersectMBO/plutus-private/issues/1552.
@@ -217,7 +219,7 @@ FrameIWrap pat arg : stack <| value   = stack <| VIWrap pat arg value
 FrameUnwrap        : stack <| wrapped = case wrapped of
     VIWrap _ _ term -> stack <| term
     _               ->
-        throwingWithCause _StructuralError NonWrapUnwrappedMachineError $ ckValueToTerm wrapped
+        throwErrorWithCause (StructuralError NonWrapUnwrappedMachineError) $ ckValueToTerm wrapped
 FrameConstr ty i todo done : stack <| e =
     let done' = e:done
     in case todo of
@@ -230,8 +232,8 @@ FrameCase cs : stack <| e = case e of
             go [] s         = s
             go (arg:rest) s = go rest (FrameAwaitFunValue arg : s)
         Nothing ->
-            throwingWithCause _StructuralError (MissingCaseBranchMachineError i) $ ckValueToTerm e
-    _ -> throwingWithCause _StructuralError NonConstrScrutinizedMachineError $ ckValueToTerm e
+            throwErrorWithCause (StructuralError $ MissingCaseBranchMachineError i) $ ckValueToTerm e
+    _ -> throwErrorWithCause (StructuralError NonConstrScrutinizedMachineError) $ ckValueToTerm e
 
 -- | Transfers a 'Spine' onto the stack. The first argument will be at the top of the stack.
 --
@@ -290,9 +292,9 @@ instantiateEvaluate stack ty (VBuiltin term runtime) = do
         -- otherwise we could just assemble a 'VBuiltin' without trying to evaluate the
         -- application.
         BuiltinExpectForce runtime' -> evalBuiltinApp stack term' runtime'
-        _ -> throwingWithCause _StructuralError BuiltinTermArgumentExpectedMachineError term'
+        _ -> throwErrorWithCause (StructuralError BuiltinTermArgumentExpectedMachineError) term'
 instantiateEvaluate _ _ val =
-    throwingWithCause _StructuralError NonPolymorphicInstantiationMachineError $ ckValueToTerm val
+    throwErrorWithCause (StructuralError NonPolymorphicInstantiationMachineError) $ ckValueToTerm val
 
 -- | Apply a function to an argument and proceed.
 -- If the function is a lambda, then perform substitution and proceed.
@@ -315,9 +317,9 @@ applyEvaluate stack (VBuiltin term runtime) arg = do
         BuiltinExpectArgument f -> do
             evalBuiltinApp stack term' $ f arg
         _ ->
-            throwingWithCause _StructuralError UnexpectedBuiltinTermArgumentMachineError term'
+            throwErrorWithCause (StructuralError UnexpectedBuiltinTermArgumentMachineError) term'
 applyEvaluate _ val _ =
-    throwingWithCause _StructuralError NonFunctionalApplicationMachineError $ ckValueToTerm val
+    throwErrorWithCause (StructuralError NonFunctionalApplicationMachineError) $ ckValueToTerm val
 
 runCk
     :: BuiltinsRuntime fun (CkValue uni fun)

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
@@ -9,10 +9,7 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 module PlutusCore.Evaluation.Result
-    ( AsEvaluationFailure (..)
-    , evaluationFailure
-    , _EvaluationFailureVia
-    , EvaluationResult (..)
+    ( EvaluationResult (..)
     , isEvaluationSuccess
     , isEvaluationFailure
     ) where
@@ -21,36 +18,7 @@ import PlutusPrelude
 
 import PlutusCore.Pretty
 
-import Control.Lens
 import Control.Monad.Except (MonadError, catchError, throwError)
-
--- Note that we can't just use 'makeClassyPrisms' for 'EvaluationResult' as that would generate
--- @_EvaluationSuccess@ as well as @_EvaluationFailure@, which would no longer be prismatic error
--- handling: it'd constrain the monad, not the error in it.
---
--- We could define
---
---     data EvaluationFailure = EvaluationFailure
---
--- just for the purpose of using 'makeClassyPrisms' over it, but then it's clearer to write out
--- the class definition manually than to hide it behind a TH function called over a redundant
--- data type name-clashing with the useful 'EvaluationResult'.
--- | A class for viewing errors as evaluation failures (in the sense of Plutus).
-class AsEvaluationFailure err where
-    _EvaluationFailure :: Prism' err ()
-
-evaluationFailure :: AsEvaluationFailure err => err
-evaluationFailure = _EvaluationFailure # ()
-{-# INLINE evaluationFailure #-}
-
--- | Construct a prism focusing on the @*EvaluationFailure@ part of @err@ by taking
--- that @*EvaluationFailure@ and
---
--- 1. returning it for the setter part of the prism
--- 2. checking the error for equality with @*EvaluationFailure@ for the opposite direction.
-_EvaluationFailureVia :: Eq err => err -> Prism' err ()
-_EvaluationFailureVia = only
-{-# INLINE _EvaluationFailureVia #-}
 
 -- | The parameterized type of results various evaluation engines return.
 -- On the PLC side this becomes (via @makeKnown@) either a call to 'Error' or
@@ -60,30 +28,6 @@ data EvaluationResult a
     | EvaluationFailure
     deriving stock (Show, Eq, Generic, Functor, Foldable, Traversable)
     deriving anyclass (NFData)
-
--- >>> evaluationFailure :: EvaluationResult Bool
--- EvaluationFailure
---
--- >>> import Control.Lens
--- >>> matching _EvaluationFailure (EvaluationFailure :: EvaluationResult Bool)
--- Right ()
---
--- >>> matching _EvaluationFailure $ EvaluationSuccess True
--- Left (EvaluationSuccess True)
-instance AsEvaluationFailure (EvaluationResult a) where
-    _EvaluationFailure = prism (const EvaluationFailure) $ \case
-        a@EvaluationSuccess{} -> Left a
-        EvaluationFailure     -> Right ()
-    {-# INLINE _EvaluationFailure #-}
-
--- This and the next one are two instances that allow us to write the following:
---
--- >>> import Control.Monad.Error.Lens
--- >>> throwing_ _EvaluationFailure :: EvaluationResult Bool
--- EvaluationFailure
-instance AsEvaluationFailure () where
-    _EvaluationFailure = id
-    {-# INLINE _EvaluationFailure #-}
 
 instance MonadError () EvaluationResult where
     throwError () = EvaluationFailure

--- a/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
@@ -164,7 +164,7 @@ type instance UniOf Val = DefaultUni
 instance ExMemoryUsage Val where
     memoryUsage = error "Not supposed to be executed"
 instance HasConstant Val where
-    asConstant _ = throwNotAConstant
+    asConstant _ = throwError notAConstant
     fromConstant _ = Val
 
 -- | Return the last element of the list that is smaller than or equal to the given one.

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -33,7 +33,7 @@ module PlutusIR.Core.Type
 
 import PlutusCore (Kind, Name, TyName, Type (..), Version (..))
 import PlutusCore qualified as PLC
-import PlutusCore.Builtin (HasConstant (..), throwNotAConstant)
+import PlutusCore.Builtin (HasConstant (..), notAConstant)
 import PlutusCore.Core (UniOf)
 import PlutusCore.Evaluation.Machine.ExMemoryUsage
 import PlutusCore.Flat ()
@@ -172,7 +172,7 @@ type instance UniOf (Term tyname name uni fun ann) = uni
 
 instance HasConstant (Term tyname name uni fun ()) where
   asConstant (Constant _ val) = pure val
-  asConstant _                = throwNotAConstant
+  asConstant _                = throwError notAConstant
 
   fromConstant = Constant ()
 

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Interesting.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Interesting.hs
@@ -28,7 +28,6 @@ import PlutusCore.Generators.Hedgehog.TypedBuiltinGen
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
-import PlutusCore.Evaluation.Result
 import PlutusCore.MkPlc
 import PlutusCore.Name.Unique
 import PlutusCore.Quote
@@ -238,7 +237,7 @@ genDivideByZero = do
     op <- Gen.element [DivideInteger, QuotientInteger, ModInteger, RemainderInteger]
     TermOf i _ <- genTermLoose $ typeRep @Integer
     let term = mkIterAppNoAnn (Builtin () op) [i, mkConstant @Integer () 0]
-    return $ TermOf term evaluationFailure
+    return $ TermOf term builtinResultFailure
 
 -- | Check that division by zero results in 'Error' even if a function doesn't use that argument.
 genDivideByZeroDrop :: TermGen (BuiltinResult Integer)
@@ -252,7 +251,7 @@ genDivideByZeroDrop = do
                 [ mkConstant @Integer () iv
                 , mkIterAppNoAnn (Builtin () op) [i, mkConstant @Integer () 0]
                 ]
-    return $ TermOf term evaluationFailure
+    return $ TermOf term builtinResultFailure
 
 -- | Apply a function to all interesting generators and collect the results.
 fromInterestingTermGens

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -26,6 +26,7 @@ module UntypedPlutusCore.Core.Type
     ) where
 
 import Control.Lens
+import Control.Monad.Except
 import PlutusPrelude
 
 import Data.Vector
@@ -128,7 +129,7 @@ instance TermLike (Term name uni fun) TPLC.TyName name uni fun where
 
 instance TPLC.HasConstant (Term name uni fun ()) where
     asConstant (Constant _ val) = pure val
-    asConstant _                = TPLC.throwNotAConstant
+    asConstant _                = throwError TPLC.notAConstant
 
     fromConstant = Constant ()
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -30,11 +30,11 @@ import PlutusPrelude
 import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
 import PlutusCore.Evaluation.Machine.ExBudget
-import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 
 import Control.Lens (imap)
 import Control.Monad (when)
+import Control.Monad.Except
 import Data.Hashable (Hashable)
 import Data.HashMap.Monoidal as HashMap
 import Data.Map.Strict qualified as Map
@@ -149,8 +149,10 @@ restricting (ExRestrictingBudget initB@(ExBudget cpuInit memInit)) = ExBudgetMod
                     -- @spend@ without this bang. Bangs on @cpuLeft'@ and @memLeft'@ don't help
                     -- either as those are forced by 'writeCpu' and 'writeMem' anyway. Go figure.
                     !budgetLeft = ExBudget cpuLeft' memLeft'
-                throwing _OperationalError
-                    (CekOutOfExError $ ExRestrictingBudget budgetLeft)
+                throwError $
+                  ErrorWithCause
+                    (OperationalError (CekOutOfExError $ ExRestrictingBudget budgetLeft))
+                    Nothing
         spender = CekBudgetSpender spend
         remaining = ExBudget <$> readCpu <*> readMem
         cumulative = do

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek/Internal.hs
@@ -166,7 +166,7 @@ computeCek !ctx !env (Case ann scrut cs) = do
     pure $ Computing (FrameCases ann env cs ctx) env scrut
 -- s ; ρ ▻ error A  ↦  <> A
 computeCek !_ !_ (Error _) =
-    throwingWithCause _OperationalError CekEvaluationFailure $ Error ()
+    throwErrorWithCause (OperationalError CekEvaluationFailure) (Error ())
 
 returnCek
     :: forall uni fun ann s
@@ -205,13 +205,13 @@ returnCek (FrameCases ann env cs ctx) e = case e of
     -- Word64 value wraps to -1 as an Int64. So you can't wrap around enough to get an
     -- "apparently good" value.
     (VConstr i _) | fromIntegral @_ @Integer i > fromIntegral @Int @Integer maxBound ->
-                    throwingDischarged _StructuralError (MissingCaseBranchMachineError i) e
+                    throwErrorDischarged (StructuralError $ MissingCaseBranchMachineError i) e
     (VConstr i args) -> case (V.!?) cs (fromIntegral i) of
         Just t  ->
               let ctx' = transferArgStack ann args ctx
               in computeCek ctx' env t
-        Nothing -> throwingDischarged _StructuralError (MissingCaseBranchMachineError i) e
-    _ -> throwingDischarged _StructuralError NonConstrScrutinizedMachineError e
+        Nothing -> throwErrorDischarged (StructuralError $ MissingCaseBranchMachineError i) e
+    _ -> throwErrorDischarged (StructuralError NonConstrScrutinizedMachineError) e
 
 -- | @force@ a term and proceed.
 -- If v is a delay then compute the body of v;
@@ -240,9 +240,9 @@ forceEvaluate ann !ctx (VBuiltin fun term runtime) = do
             -- application.
             evalBuiltinApp ann ctx fun term' runtime'
         _ ->
-            throwingWithCause _StructuralError BuiltinTermArgumentExpectedMachineError term'
+          throwErrorWithCause (StructuralError BuiltinTermArgumentExpectedMachineError) term'
 forceEvaluate _ !_ val =
-    throwingDischarged _StructuralError NonPolymorphicInstantiationMachineError val
+    throwErrorDischarged (StructuralError NonPolymorphicInstantiationMachineError) val
 
 -- | Apply a function to an argument and proceed.
 -- If the function is a lambda 'lam x ty body' then extend the environment with a binding of @v@
@@ -273,9 +273,9 @@ applyEvaluate ann !ctx (VBuiltin fun term runtime) arg = do
         -- argument next.
         BuiltinExpectArgument f -> evalBuiltinApp ann ctx fun term' $ f arg
         _ ->
-            throwingWithCause _StructuralError UnexpectedBuiltinTermArgumentMachineError term'
+          throwErrorWithCause (StructuralError UnexpectedBuiltinTermArgumentMachineError) term'
 applyEvaluate _ !_ val _ =
-    throwingDischarged _StructuralError NonFunctionalApplicationMachineError val
+    throwErrorDischarged (StructuralError NonFunctionalApplicationMachineError) val
 
 -- MAYBE: runCekDeBruijn can be shared between original&debug ceks by passing a `enterComputeCek` func.
 runCekDeBruijn
@@ -416,14 +416,13 @@ cekStepCost costs = runIdentity . \case
     BCase    -> cekCaseCost costs
 
 -- | Call 'dischargeCekValue' over the received 'CekVal' and feed the resulting 'Term' to
--- 'throwingWithCause' as the cause of the failure.
-throwingDischarged
-    :: ThrowableBuiltins uni fun
-    => AReview (EvaluationError (MachineError fun) CekUserError) t
-    -> t
-    -> CekValue uni fun ann
-    -> CekM uni fun s x
-throwingDischarged l t = throwingWithCause l t . dischargeCekValue
+-- 'throwErrorWithCause' as the cause of the failure.
+throwErrorDischarged
+  :: ThrowableBuiltins uni fun
+  => EvaluationError (MachineError fun) CekUserError
+  -> CekValue uni fun ann
+  -> CekM uni fun s x
+throwErrorDischarged err = throwErrorWithCause err . dischargeCekValue
 
 -- | Look up a variable name in the environment.
 lookupVarName
@@ -432,7 +431,8 @@ lookupVarName
     => NamedDeBruijn -> CekValEnv uni fun ann -> CekM uni fun s (CekValue uni fun ann)
 lookupVarName varName@(NamedDeBruijn _ varIx) varEnv =
     case varEnv `Env.indexOne` coerce varIx of
-        Nothing  -> throwingWithCause _StructuralError OpenTermEvaluatedMachineError $ Var () varName
+        Nothing  ->
+          throwErrorWithCause (StructuralError OpenTermEvaluatedMachineError) (Var () varName)
         Just val -> pure val
 
 -- | Evaluate a 'HeadSpine' by pushing the arguments (if any) onto the stack and proceeding with

--- a/plutus-ledger-api/test-plugin/Spec/Data/Value.hs
+++ b/plutus-ledger-api/test-plugin/Spec/Data/Value.hs
@@ -165,7 +165,9 @@ eqValueCode valueCode1 valueCode2 = (res, cost) where
         . PLC.unDeBruijnTermWith (Haskell.error "Free variable")
         . PLC._progTerm
         $ getPlc prog
-    res = either Haskell.throw id $ errOrRes >>= PLC.readKnownSelf
+    res =
+      either Haskell.throw id $
+        errOrRes >>= PLC.readKnownSelf
 
 -- | Check equality of two compiled 'Value's directly in Haskell.
 haskellEqValue :: Value -> Value -> Bool

--- a/plutus-ledger-api/test-plugin/Spec/Value.hs
+++ b/plutus-ledger-api/test-plugin/Spec/Value.hs
@@ -165,7 +165,9 @@ eqValueCode valueCode1 valueCode2 = (res, cost) where
         . PLC.unDeBruijnTermWith (Haskell.error "Free variable")
         . PLC._progTerm
         $ getPlc prog
-    res = either Haskell.throw id $ errOrRes >>= PLC.readKnownSelf
+    res =
+      either Haskell.throw id $
+        errOrRes >>= PLC.readKnownSelf
 
 -- | Check equality of two compiled 'Value's directly in Haskell.
 haskellEqValue :: Value -> Value -> Bool

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -1,8 +1,8 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module PlutusTx.Lift (
   safeLiftWith,
@@ -251,7 +251,7 @@ unsafely
 unsafely ma = runQuote $ do
   run <- runExceptT ma
   case run of
-    Left e  -> throw e
+    Left e -> throw e
     Right t -> pure t
 
 {-| Get a Plutus Core term corresponding to the given value, throwing any errors that


### PR DESCRIPTION
Closes #6160 

Removes prismatic error handling from Ck/Cek machine implementations.

There is a very minor performance degradation, and I don't know where it's coming from. I'll see if I can dig into ghc core tomorrow