### PR TITLE
Move `caseList` and `caseData` to the end of the flat encoding

### DIFF
--- a/doc/plutus-core-spec/cardano/builtins6.tex
+++ b/doc/plutus-core-spec/cardano/builtins6.tex
@@ -10,6 +10,11 @@
 \newpage
 \subsection{Batch 6}
 \label{sec:default-builtins-6}
+This section describes some new types and functions which have not been released
+at the time of writing (May 2025), but are expected to be released at a later
+date, with the possible exception of the \texttt{caseList} and \texttt{caseData}
+functions, which are experimental and may be removed at some point and replaced
+with better alternatives.
 
 \subsubsection{Built-in type operators}
 \label{sec:built-in-type-operators-6}
@@ -66,23 +71,6 @@ Operations are defined in Table~\ref{table:built-in-functions-6}.
     \endlastfoot
     \TT{expModInteger}        & $[\ty{integer}, \ty{integer}, \ty{integer}]$ \text{$\;\;\; \to \ty{integer}$}
         & $\mathsf{expMod} $  & Yes & \ref{note:exp-mod-integer}\\
-    \TT{caseList}        & $[\forall a_\#, \forall\star, \star, \star, \listOf{a_\#}] \to \ap$
-                                              & \text{$(t_1, t_2, []) \mapsto (t_1|)$,}
-                                              \text{$(t_1, t_2,
-                                              [x_1,\ldots,x_n]) \mapsto (t_2|x_1,[x_2,\ldots,x_n])\ (n \geq 1)$}
-                                              & & \ref{note:case-list-case-data}\\[5mm]
-    \TT{caseData}        & $[\forall\star, \star, \star, \star, \star, \star, \ty{data}] \to \ap$
-    & $(t_C, t_M, t_L, t_I, t_B, d)$
-    \smallskip
-    \newline  % The big \{ was abutting the text above
-    \text{$\;\;\mapsto
-               \left\{ \begin{array}{ll}  %% This looks better than `cases`
-                 (t_C|n,l)  & \text{if $d = \inj_C(n, l)$} \\
-                 (t_M|l)  & \text{if $d = \inj_M(l)$} \\
-                 (t_L|l)  & \text{if $d = \inj_L(l)$} \\
-                 (t_I|n)  & \text{if $d =\inj_I(n)$} \\
-                 (t_B|s)  & \text{if $d = \inj_B(s)$} \\
-               \end{array}\right.$}  & & \ref{note:case-list-case-data}\\[5mm]
     \TT{dropList}        & $[\forall a_\#, \ty{integer}, \listOf{a_\#}]$ \text{$\;\;\; \to \listOf{a_\#}$}
         & $(k,[x_1,\ldots,x_n])$
         \smallskip
@@ -118,6 +106,23 @@ Operations are defined in Table~\ref{table:built-in-functions-6}.
         \end{array}\right.$}  
       & Yes
       & \\
+    \TT{caseList}        & $[\forall a_\#, \forall\star, \star, \star, \listOf{a_\#}] \to \ap$
+                                              & \text{$(t_1, t_2, []) \mapsto (t_1|)$,}
+                                              \text{$(t_1, t_2,
+                                              [x_1,\ldots,x_n]) \mapsto (t_2|x_1,[x_2,\ldots,x_n])\ (n \geq 1)$}
+                                              & & \ref{note:case-list-case-data}\\[5mm]
+    \TT{caseData}        & $[\forall\star, \star, \star, \star, \star, \star, \ty{data}] \to \ap$
+    & $(t_C, t_M, t_L, t_I, t_B, d)$
+    \smallskip
+    \newline  % The big \{ was abutting the text above
+    \text{$\;\;\mapsto
+               \left\{ \begin{array}{ll}  %% This looks better than `cases`
+                 (t_C|n,l)  & \text{if $d = \inj_C(n, l)$} \\
+                 (t_M|l)  & \text{if $d = \inj_M(l)$} \\
+                 (t_L|l)  & \text{if $d = \inj_L(l)$} \\
+                 (t_I|n)  & \text{if $d =\inj_I(n)$} \\
+                 (t_B|s)  & \text{if $d = \inj_B(s)$} \\
+               \end{array}\right.$}  & & \ref{note:case-list-case-data}\\
 \hline
 \end{longtable}
 

--- a/doc/plutus-core-spec/flat-serialisation.tex
+++ b/doc/plutus-core-spec/flat-serialisation.tex
@@ -740,12 +740,12 @@ and forth between builtin names and their tags.
   Builtin & Binary & Decimal\\
   \hline
  \TT{expModInteger}   & $\bits{1010111}$  & 87 \\
- \TT{caseList}        & $\bits{1011000}$  & 88 \\
- \TT{caseData}        & $\bits{1011001}$  & 89 \\
- \TT{dropList}        & $\bits{1011010}$  & 90 \\
- \TT{lengthOfArray}   & $\bits{1011011}$  & 91 \\
- \TT{listToArray}     & $\bits{1011100}$  & 92 \\
- \TT{indexArray}      & $\bits{1011101}$  & 93 \\
+ \TT{dropList}        & $\bits{1011000}$  & 88 \\
+ \TT{lengthOfArray}   & $\bits{1011001}$  & 89 \\
+ \TT{listToArray}     & $\bits{1011010}$  & 90 \\
+ \TT{indexArray}      & $\bits{1011011}$  & 91 \\
+ \TT{caseList}        & $\bits{1111110}$  & 126 \\
+ \TT{caseData}        & $\bits{1111111}$  & 127 \\
 \hline
 \end{tabular}
 \caption{Tags for built-in functions (Batch 6)}

--- a/doc/plutus-core-spec/plutus-core-specification.tex
+++ b/doc/plutus-core-spec/plutus-core-specification.tex
@@ -5,7 +5,7 @@
   \LARGE{\red{\textsf{DRAFT}}}
 }
 
-\date{15th May 2025}
+\date{30th May 2025}
 \author{Plutus Core Team}
 
 \input{header.tex}

--- a/plutus-core/changelog.d/20250530_195904_kenneth.mackenzie_deprecate_caseList_caseData.md
+++ b/plutus-core/changelog.d/20250530_195904_kenneth.mackenzie_deprecate_caseList_caseData.md
@@ -1,0 +1,7 @@
+### Changed
+
+- The tags for the flat encodings of the as-yet-unreleased `dropList`,
+  `lengthOfArray`, `listToArray`, `indexArray`, `caseList` and `caseData`
+  built-in functions have been changed pending the possible removal of
+  `caseList` and `caseData`.
+

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -178,13 +178,14 @@ data DefaultFun
     | Ripemd_160
     -- Batch 6
     | ExpModInteger
-    | CaseList
-    | CaseData
     | DropList
     -- Arrays
     | LengthOfArray
     | ListToArray
     | IndexArray
+    -- Case
+    | CaseList
+    | CaseData
     deriving stock (Show, Eq, Ord, Enum, Bounded, Generic, Ix)
     deriving anyclass (NFData, Hashable, PrettyBy PrettyConfigPlc)
 
@@ -1487,25 +1488,6 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             chooseListDenotation
             (runCostingFunThreeArguments . paramChooseList)
 
-    toBuiltinMeaning _ver CaseList =
-        let caseListDenotation
-                :: Opaque val (LastArg a b)
-                -> Opaque val (a -> [a] -> b)
-                -> SomeConstant uni [a]
-                -> BuiltinResult (Opaque (HeadSpine val) b)
-            caseListDenotation z f (SomeConstant (Some (ValueOf uniListA xs0))) =
-                case uniListA of
-                    DefaultUniList uniA -> pure $ case xs0 of
-                        []     -> headSpine z []
-                        x : xs -> headSpine f [fromValueOf uniA x, fromValueOf uniListA xs]
-                    _ ->
-                        -- See Note [Structural vs operational errors within builtins].
-                        throwing _StructuralUnliftingError "Expected a list but got something else"
-            {-# INLINE caseListDenotation #-}
-        in makeBuiltinMeaning
-            caseListDenotation
-            (runCostingFunThreeArguments . unimplementedCostingFun)
-
     toBuiltinMeaning _semvar MkCons =
         let mkConsDenotation
                 :: SomeConstant uni a -> SomeConstant uni [a] -> BuiltinResult (Opaque val [a])
@@ -2035,26 +2017,6 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             expModIntegerDenotation
             (runCostingFunThreeArguments . paramExpModInteger)
 
-    toBuiltinMeaning _ver CaseData =
-        let caseDataDenotation
-                :: Opaque val (Integer -> [Data] -> b)
-                -> Opaque val ([(Data, Data)] -> b)
-                -> Opaque val ([Data] -> b)
-                -> Opaque val (Integer -> b)
-                -> Opaque val (BS.ByteString -> b)
-                -> Data
-                -> Opaque (HeadSpine val) b
-            caseDataDenotation fConstr fMap fList fI fB = \case
-                Constr i ds -> headSpine fConstr [fromValue i, fromValue ds]
-                Map es      -> headSpine fMap [fromValue es]
-                List ds     -> headSpine fList [fromValue ds]
-                I i         -> headSpine fI [fromValue i]
-                B b         -> headSpine fB [fromValue b]
-            {-# INLINE caseDataDenotation #-}
-        in makeBuiltinMeaning
-            caseDataDenotation
-            (runCostingFunSixArguments . unimplementedCostingFun)
-
     toBuiltinMeaning _semvar DropList =
         let dropListDenotation
                 :: IntegerCostedLiterally -> SomeConstant uni [a] -> BuiltinResult (Opaque val [a])
@@ -2138,6 +2100,45 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                 throwing _StructuralUnliftingError "Expected an array but got something else"
           {-# INLINE indexArrayDenotation #-}
         in makeBuiltinMeaning indexArrayDenotation (runCostingFunTwoArguments . paramIndexArray)
+
+    toBuiltinMeaning _ver CaseList =
+        let caseListDenotation
+                :: Opaque val (LastArg a b)
+                -> Opaque val (a -> [a] -> b)
+                -> SomeConstant uni [a]
+                -> BuiltinResult (Opaque (HeadSpine val) b)
+            caseListDenotation z f (SomeConstant (Some (ValueOf uniListA xs0))) =
+                case uniListA of
+                    DefaultUniList uniA -> pure $ case xs0 of
+                        []     -> headSpine z []
+                        x : xs -> headSpine f [fromValueOf uniA x, fromValueOf uniListA xs]
+                    _ ->
+                        -- See Note [Structural vs operational errors within builtins].
+                        throwing _StructuralUnliftingError "Expected a list but got something else"
+            {-# INLINE caseListDenotation #-}
+        in makeBuiltinMeaning
+            caseListDenotation
+            (runCostingFunThreeArguments . unimplementedCostingFun)
+
+    toBuiltinMeaning _ver CaseData =
+        let caseDataDenotation
+                :: Opaque val (Integer -> [Data] -> b)
+                -> Opaque val ([(Data, Data)] -> b)
+                -> Opaque val ([Data] -> b)
+                -> Opaque val (Integer -> b)
+                -> Opaque val (BS.ByteString -> b)
+                -> Data
+                -> Opaque (HeadSpine val) b
+            caseDataDenotation fConstr fMap fList fI fB = \case
+                Constr i ds -> headSpine fConstr [fromValue i, fromValue ds]
+                Map es      -> headSpine fMap [fromValue es]
+                List ds     -> headSpine fList [fromValue ds]
+                I i         -> headSpine fI [fromValue i]
+                B b         -> headSpine fB [fromValue b]
+            {-# INLINE caseDataDenotation #-}
+        in makeBuiltinMeaning
+            caseDataDenotation
+            (runCostingFunSixArguments . unimplementedCostingFun)
 
     -- See Note [Inlining meanings of builtins].
     {-# INLINE toBuiltinMeaning #-}
@@ -2281,111 +2282,111 @@ instance Flat DefaultFun where
 
               ExpModInteger                   -> 87
 
-              CaseList                        -> 88
-              CaseData                        -> 89
+              DropList                        -> 88
 
-              DropList                        -> 90
+              LengthOfArray                   -> 89
+              ListToArray                     -> 90
+              IndexArray                      -> 91
 
-              LengthOfArray                   -> 91
-              ListToArray                     -> 92
-              IndexArray                      -> 93
+              CaseList                        -> 126
+              CaseData                        -> 127
 
     decode = go =<< decodeBuiltin
-        where go 0  = pure AddInteger
-              go 1  = pure SubtractInteger
-              go 2  = pure MultiplyInteger
-              go 3  = pure DivideInteger
-              go 4  = pure QuotientInteger
-              go 5  = pure RemainderInteger
-              go 6  = pure ModInteger
-              go 7  = pure EqualsInteger
-              go 8  = pure LessThanInteger
-              go 9  = pure LessThanEqualsInteger
-              go 10 = pure AppendByteString
-              go 11 = pure ConsByteString
-              go 12 = pure SliceByteString
-              go 13 = pure LengthOfByteString
-              go 14 = pure IndexByteString
-              go 15 = pure EqualsByteString
-              go 16 = pure LessThanByteString
-              go 17 = pure LessThanEqualsByteString
-              go 18 = pure Sha2_256
-              go 19 = pure Sha3_256
-              go 20 = pure Blake2b_256
-              go 21 = pure VerifyEd25519Signature
-              go 22 = pure AppendString
-              go 23 = pure EqualsString
-              go 24 = pure EncodeUtf8
-              go 25 = pure DecodeUtf8
-              go 26 = pure IfThenElse
-              go 27 = pure ChooseUnit
-              go 28 = pure Trace
-              go 29 = pure FstPair
-              go 30 = pure SndPair
-              go 31 = pure ChooseList
-              go 32 = pure MkCons
-              go 33 = pure HeadList
-              go 34 = pure TailList
-              go 35 = pure NullList
-              go 36 = pure ChooseData
-              go 37 = pure ConstrData
-              go 38 = pure MapData
-              go 39 = pure ListData
-              go 40 = pure IData
-              go 41 = pure BData
-              go 42 = pure UnConstrData
-              go 43 = pure UnMapData
-              go 44 = pure UnListData
-              go 45 = pure UnIData
-              go 46 = pure UnBData
-              go 47 = pure EqualsData
-              go 48 = pure MkPairData
-              go 49 = pure MkNilData
-              go 50 = pure MkNilPairData
-              go 51 = pure SerialiseData
-              go 52 = pure VerifyEcdsaSecp256k1Signature
-              go 53 = pure VerifySchnorrSecp256k1Signature
-              go 54 = pure Bls12_381_G1_add
-              go 55 = pure Bls12_381_G1_neg
-              go 56 = pure Bls12_381_G1_scalarMul
-              go 57 = pure Bls12_381_G1_equal
-              go 58 = pure Bls12_381_G1_compress
-              go 59 = pure Bls12_381_G1_uncompress
-              go 60 = pure Bls12_381_G1_hashToGroup
-              go 61 = pure Bls12_381_G2_add
-              go 62 = pure Bls12_381_G2_neg
-              go 63 = pure Bls12_381_G2_scalarMul
-              go 64 = pure Bls12_381_G2_equal
-              go 65 = pure Bls12_381_G2_compress
-              go 66 = pure Bls12_381_G2_uncompress
-              go 67 = pure Bls12_381_G2_hashToGroup
-              go 68 = pure Bls12_381_millerLoop
-              go 69 = pure Bls12_381_mulMlResult
-              go 70 = pure Bls12_381_finalVerify
-              go 71 = pure Keccak_256
-              go 72 = pure Blake2b_224
-              go 73 = pure IntegerToByteString
-              go 74 = pure ByteStringToInteger
-              go 75 = pure AndByteString
-              go 76 = pure OrByteString
-              go 77 = pure XorByteString
-              go 78 = pure ComplementByteString
-              go 79 = pure ReadBit
-              go 80 = pure WriteBits
-              go 81 = pure ReplicateByte
-              go 82 = pure ShiftByteString
-              go 83 = pure RotateByteString
-              go 84 = pure CountSetBits
-              go 85 = pure FindFirstSetBit
-              go 86 = pure Ripemd_160
-              go 87 = pure ExpModInteger
-              go 88 = pure CaseList
-              go 89 = pure CaseData
-              go 90 = pure DropList
-              go 91 = pure LengthOfArray
-              go 92 = pure ListToArray
-              go 93 = pure IndexArray
-              go t  = fail $ "Failed to decode builtin tag, got: " ++ show t
+        where go 0   = pure AddInteger
+              go 1   = pure SubtractInteger
+              go 2   = pure MultiplyInteger
+              go 3   = pure DivideInteger
+              go 4   = pure QuotientInteger
+              go 5   = pure RemainderInteger
+              go 6   = pure ModInteger
+              go 7   = pure EqualsInteger
+              go 8   = pure LessThanInteger
+              go 9   = pure LessThanEqualsInteger
+              go 10  = pure AppendByteString
+              go 11  = pure ConsByteString
+              go 12  = pure SliceByteString
+              go 13  = pure LengthOfByteString
+              go 14  = pure IndexByteString
+              go 15  = pure EqualsByteString
+              go 16  = pure LessThanByteString
+              go 17  = pure LessThanEqualsByteString
+              go 18  = pure Sha2_256
+              go 19  = pure Sha3_256
+              go 20  = pure Blake2b_256
+              go 21  = pure VerifyEd25519Signature
+              go 22  = pure AppendString
+              go 23  = pure EqualsString
+              go 24  = pure EncodeUtf8
+              go 25  = pure DecodeUtf8
+              go 26  = pure IfThenElse
+              go 27  = pure ChooseUnit
+              go 28  = pure Trace
+              go 29  = pure FstPair
+              go 30  = pure SndPair
+              go 31  = pure ChooseList
+              go 32  = pure MkCons
+              go 33  = pure HeadList
+              go 34  = pure TailList
+              go 35  = pure NullList
+              go 36  = pure ChooseData
+              go 37  = pure ConstrData
+              go 38  = pure MapData
+              go 39  = pure ListData
+              go 40  = pure IData
+              go 41  = pure BData
+              go 42  = pure UnConstrData
+              go 43  = pure UnMapData
+              go 44  = pure UnListData
+              go 45  = pure UnIData
+              go 46  = pure UnBData
+              go 47  = pure EqualsData
+              go 48  = pure MkPairData
+              go 49  = pure MkNilData
+              go 50  = pure MkNilPairData
+              go 51  = pure SerialiseData
+              go 52  = pure VerifyEcdsaSecp256k1Signature
+              go 53  = pure VerifySchnorrSecp256k1Signature
+              go 54  = pure Bls12_381_G1_add
+              go 55  = pure Bls12_381_G1_neg
+              go 56  = pure Bls12_381_G1_scalarMul
+              go 57  = pure Bls12_381_G1_equal
+              go 58  = pure Bls12_381_G1_compress
+              go 59  = pure Bls12_381_G1_uncompress
+              go 60  = pure Bls12_381_G1_hashToGroup
+              go 61  = pure Bls12_381_G2_add
+              go 62  = pure Bls12_381_G2_neg
+              go 63  = pure Bls12_381_G2_scalarMul
+              go 64  = pure Bls12_381_G2_equal
+              go 65  = pure Bls12_381_G2_compress
+              go 66  = pure Bls12_381_G2_uncompress
+              go 67  = pure Bls12_381_G2_hashToGroup
+              go 68  = pure Bls12_381_millerLoop
+              go 69  = pure Bls12_381_mulMlResult
+              go 70  = pure Bls12_381_finalVerify
+              go 71  = pure Keccak_256
+              go 72  = pure Blake2b_224
+              go 73  = pure IntegerToByteString
+              go 74  = pure ByteStringToInteger
+              go 75  = pure AndByteString
+              go 76  = pure OrByteString
+              go 77  = pure XorByteString
+              go 78  = pure ComplementByteString
+              go 79  = pure ReadBit
+              go 80  = pure WriteBits
+              go 81  = pure ReplicateByte
+              go 82  = pure ShiftByteString
+              go 83  = pure RotateByteString
+              go 84  = pure CountSetBits
+              go 85  = pure FindFirstSetBit
+              go 86  = pure Ripemd_160
+              go 87  = pure ExpModInteger
+              go 88  = pure DropList
+              go 89  = pure LengthOfArray
+              go 90  = pure ListToArray
+              go 91  = pure IndexArray
+              go 126 = pure CaseList
+              go 127 = pure CaseData
+              go t   = fail $ "Failed to decode builtin tag, got: " ++ show t
 
     size _ n = n + builtinTagWidth
 


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/plutus-private/issues/1613.

It seems that we may decide not to release the `caseList` and `caseData` builtins.  This PR moves them to the very end of the flat encoding (tags 126 and 127) and adjusts the tags for `dropList` and the array builtins (which we're definitely going to release) to fill the gap.  The point of this is to make the changes as early as possible to stabilise the encoding before anything gets released and to make it easier to remove `caseList` and `caseData` if we decide to do  so (which will involve further changes to the implementation and specification).