### PR TITLE
Add a way to generate callstack trace message

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -46,10 +46,11 @@ type NameInfo = Map.Map TH.Name GHC.TyThing
 
 -- | Compilation options.
 data CompileOptions = CompileOptions
-  { coProfile     :: ProfileOpts
-  , coCoverage    :: CoverageOpts
-  , coRemoveTrace :: Bool
-  , coInlineFix   :: Bool
+  { coProfile           :: ProfileOpts
+  , coCoverage          :: CoverageOpts
+  , coRemoveTrace       :: Bool
+  , coInlineFix         :: Bool
+  , coGenerateCallStack :: Bool
   }
 
 data CompileContext uni fun = CompileContext
@@ -77,6 +78,8 @@ data CompileState = CompileState
   {- ^ The IDs of the previous steps taken by the PlutusTx compiler leading up to
   the current point. This is used when generating debug traces.
   -}
+  , csCallStack     :: [GHC.Id]
+  -- ^ The callstack of called function IDs. This is used to generate callstack information.
   }
 
 -- | Verbosity level of the Plutus Tx compiler.

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -76,6 +76,7 @@ data PluginOptions = PluginOptions
     _posRemoveTrace                    :: Bool
   , _posDumpCompilationTrace           :: Bool
   , _posCertify                        :: Maybe String
+  , _posGenerateCallStack              :: Bool
   }
 
 makeLenses ''PluginOptions
@@ -309,6 +310,9 @@ pluginOptions =
             rest <- many (alphaNumChar <|> char '_' <|> char '\\')
             pure (firstC : rest)
        in (k, PluginOption typeRep (plcParserOption p k) posCertify desc [])
+    , let k = "generate-callstack"
+          desc = "Generate callstack string and replace 'callStack' with callstack at the location."
+       in (k, PluginOption typeRep (setTrue k) posGenerateCallStack desc [])
     ]
 
 flag :: (a -> a) -> OptionKey -> Maybe OptionValue -> Validation ParseError (a -> a)
@@ -381,6 +385,7 @@ defaultPluginOptions =
     , _posRemoveTrace = False
     , _posDumpCompilationTrace = False
     , _posCertify = Nothing
+    , _posGenerateCallStack = False
     }
 
 processOne

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -412,6 +412,7 @@ compileMarkedExpr locStr codeTy origE = do
            , 'useFromOpaque
            , 'mkNilOpaque
            , 'PlutusTx.Builtins.equalsInteger
+           , 'PlutusTx.Trace.callStack
            ]
   modBreaks <- asks pcModuleModBreaks
   let coverage =
@@ -427,6 +428,7 @@ compileMarkedExpr locStr codeTy origE = do
                 , coCoverage = coverage
                 , coRemoveTrace = _posRemoveTrace opts
                 , coInlineFix = _posInlineFix opts
+                , coGenerateCallStack = _posGenerateCallStack opts
                 }
           , ccFlags = flags
           , ccFamInstEnvs = famEnvs
@@ -441,7 +443,7 @@ compileMarkedExpr locStr codeTy origE = do
           , ccRewriteRules = makeRewriteRules opts
           , ccSafeToInline = False
           }
-      st = CompileState 0 mempty
+      st = CompileState 0 mempty mempty
   -- See Note [Occurrence analysis]
   let origE' = GHC.occurAnalyseExpr origE
 

--- a/plutus-tx/src/PlutusTx/Trace.hs
+++ b/plutus-tx/src/PlutusTx/Trace.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 
 module PlutusTx.Trace (
@@ -6,6 +7,7 @@ module PlutusTx.Trace (
   traceIfFalse,
   traceIfTrue,
   traceBool,
+  callStack,
 ) where
 
 import PlutusTx.Bool
@@ -32,3 +34,8 @@ evaluates to 'True' or 'False'.
 traceBool :: BuiltinString -> BuiltinString -> Bool -> Bool
 traceBool trueLabel falseLabel c = if c then trace trueLabel True else trace falseLabel False
 {-# INLINEABLE traceBool #-}
+
+-- | Log the callstack and then terminate the evaluation with an error.
+callStack :: Builtins.BuiltinString
+callStack = "<CallStack>"
+{-# NOINLINE callStack #-}


### PR DESCRIPTION
Add plugin option to generate callstack trace message. Currently this won't handle cases when a function has `PlutusTx.Trace.callStack` and that function is called in multiple places (working on it. more detail on first commit message).

<details>
<summary>Example</summary>
```hs
-- SillyCalss.hs
class SillyClass a where
  sillyThing :: a -> Integer

instance SillyClass Integer where
  sillyThing = traceError callStack

-- Demo.hs
rob :: Integer -> Integer -> Integer
rob x = sillyThing @Integer

-- entrypoint
tom :: Integer -> Integer
tom = rob (x PTx.+ 20)

{-
tracemsg :
tom:demo/Demo.hs:44:1-44:3
\-rob:demo/Demo.hs:32:1-32:3
\-$fSillyClassInteger
\-$fSillyClassInteger_$csillyThing
-}
```
<\details>
