### PR TITLE
Narrow down files added by the release script

### DIFF
--- a/scripts/interactive-release.sh
+++ b/scripts/interactive-release.sh
@@ -148,9 +148,9 @@ open-plutus-pr() {
     popd > /dev/null
   done
 
-  git add .
-  pre-commit run cabal-fmt || true # pre-commit will fail but will modify the files in place, hence the second git add . below
-  git add .
+  git add '*.cabal' '*CHANGELOG.md' '*CHANGELOG.rst'
+  pre-commit run cabal-fmt || true # pre-commit will fail but will modify the files in place, hence the second git add below
+  git add '*.cabal' 
   git commit -m "Release $VERSION" || true
   git push --force --set-upstream origin $PR_BRANCH
 


### PR DESCRIPTION
The release script calls `git add .` which is a security risk. This PR changes what files are added