### PR TITLE
[Names] Remove 'Monoid' instances

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Analysis/Definitions.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Analysis/Definitions.hs
@@ -15,7 +15,7 @@ import PlutusCore.Core.Type (Term (LamAbs, TyAbs, Var), Type (TyForall, TyLam, T
 import PlutusCore.Error (UniqueError (..))
 import PlutusCore.Name.Unique (HasUnique, TermUnique (TermUnique), TypeUnique (TypeUnique),
                                Unique (Unique), theUnique)
-import PlutusCore.Name.UniqueMap (UniqueMap, insertByNameIndex, lookupNameIndex)
+import PlutusCore.Name.UniqueMap (UniqueMap, emptyUniqueMap, insertByNameIndex, lookupNameIndex)
 
 
 import Control.Lens (forMOf_, (^.))
@@ -183,4 +183,4 @@ runTermDefs
         Monad m)
     => Term tyname name uni fun ann
     -> m (UniqueInfos ann, [UniqueError ann])
-runTermDefs = runWriterT . flip execStateT mempty . termDefs
+runTermDefs = runWriterT . flip execStateT emptyUniqueMap . termDefs

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
@@ -23,12 +23,12 @@ import PlutusCore.Rename.Monad
 import Universe
 
 instance (GEq uni, Eq ann) => Eq (Type TyName uni ann) where
-    ty1 == ty2 = runEqRename @TypeRenaming $ eqTypeM ty1 ty2
+    ty1 == ty2 = runEqRename @TypeRenaming emptyRenaming $ eqTypeM ty1 ty2
 
 instance
         ( GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, Eq ann
         ) => Eq (Term TyName Name uni fun ann) where
-    term1 == term2 = runEqRename $ eqTermM term1 term2
+    term1 == term2 = runEqRename emptyScopedRenaming $ eqTermM term1 term2
 
 -- Simple Structural Equality of a `Term NamedDeBruijn`. This implies three things:
 -- b) We do not do equality "modulo starting index". E.g. `LamAbs 0 (Var 0) /= LamAbs 1 (Var 1)`.

--- a/plutus-core/plutus-core/src/PlutusCore/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Eq.hs
@@ -129,12 +129,6 @@ instance Wrapped (RL a)
 instance HasUnique name unique => HasUnique (LR name) (LR unique)
 instance HasUnique name unique => HasUnique (RL name) (RL unique)
 
-instance Semigroup a => Semigroup (Bilateral a) where
-    Bilateral l1 r1 <> Bilateral l2 r2 = Bilateral (l1 <> l2) (r1 <> r2)
-
-instance Monoid a => Monoid (Bilateral a) where
-    mempty = Bilateral mempty mempty
-
 -- To rename from left to right is to update the left renaming.
 instance HasRenaming ren unique => HasRenaming (Bilateral ren) (LR unique) where
     renaming = bilateralL . renaming . coerced @(Renaming unique)
@@ -150,8 +144,8 @@ type EqRename ren = RenameT (Bilateral ren) Maybe ()
 type ScopedEqRename = EqRename ScopedRenaming
 
 -- | Run an 'EqRename' computation.
-runEqRename :: Monoid ren => EqRename ren -> Bool
-runEqRename = isJust . runRenameT
+runEqRename :: ren -> EqRename ren -> Bool
+runEqRename emp = isJust . runRenameT (Bilateral emp emp)
 
 -- See Note [Modulo alpha].
 -- | Record that two names map to each other.

--- a/plutus-core/plutus-core/src/PlutusCore/Name/UniqueMap.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Name/UniqueMap.hs
@@ -6,6 +6,7 @@
 
 module PlutusCore.Name.UniqueMap (
   UniqueMap (..),
+  emptyUniqueMap,
   insertByUnique,
   insertByName,
   singletonByName,
@@ -37,7 +38,10 @@ newtype UniqueMap unique a = UniqueMap
   { unUniqueMap :: IM.IntMap a
   }
   deriving stock (Show, Eq)
-  deriving newtype (Semigroup, Monoid, Functor, Foldable)
+  deriving newtype (Functor, Foldable)
+
+emptyUniqueMap :: UniqueMap unique a
+emptyUniqueMap = UniqueMap mempty
 
 -- | Insert a value @a@ by a @unique@.
 insertByUnique ::
@@ -54,7 +58,7 @@ insertByName = insertByUnique . view unique
 
 -- | Create the singleton map of the @unique@ of a @name@ and a value @a@.
 singletonByName :: (HasUnique name unique) => name -> a -> UniqueMap unique a
-singletonByName n a = insertByName n a mempty
+singletonByName n a = insertByName n a emptyUniqueMap
 
 -- | Insert a named value @a@ by the index of the @unique@ of the @name@.
 insertNamed ::
@@ -83,7 +87,7 @@ fromFoldable ::
   (i -> a -> UniqueMap unique a -> UniqueMap unique a) ->
   f (i, a) ->
   UniqueMap unique a
-fromFoldable ins = List.foldl' (flip $ uncurry ins) mempty
+fromFoldable ins = List.foldl' (flip $ uncurry ins) emptyUniqueMap
 
 -- | Convert a 'Foldable' with uniques into a 'UniqueMap'.
 fromUniques :: (Foldable f) => (Coercible Unique unique) => f (unique, a) -> UniqueMap unique a

--- a/plutus-core/plutus-core/src/PlutusCore/Normalize/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Normalize/Internal.hs
@@ -17,7 +17,7 @@ import PlutusCore.Core.Plated (termSubterms, termSubtypes)
 import PlutusCore.Core.Type (Normalized (..), Term, Type (..))
 import PlutusCore.MkPlc (mkTyBuiltinOf)
 import PlutusCore.Name.Unique (HasUnique, TypeUnique (TypeUnique), Unique (Unique))
-import PlutusCore.Name.UniqueMap (UniqueMap, insertByName, lookupName)
+import PlutusCore.Name.UniqueMap (UniqueMap, emptyUniqueMap, insertByName, lookupName)
 import PlutusCore.Quote (MonadQuote)
 import PlutusCore.Rename (Dupable, dupable, liftDupable)
 import PlutusPrelude (Alternative, over, (<<$>>), (<<*>>))
@@ -107,7 +107,7 @@ type MonadNormalizeType uni m =
 
 -- | Run a 'NormalizeTypeT' computation.
 runNormalizeTypeT :: NormalizeTypeT m tyname uni ann a -> m a
-runNormalizeTypeT = flip runReaderT (NormalizeTypeEnv mempty) . unNormalizeTypeT
+runNormalizeTypeT = flip runReaderT (NormalizeTypeEnv emptyUniqueMap) . unNormalizeTypeT
 
 -- | Locally extend a 'TypeVarEnv' in a 'NormalizeTypeT' computation.
 withExtendedTypeVarEnv ::

--- a/plutus-core/plutus-core/src/PlutusCore/Rename.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Rename.hs
@@ -54,16 +54,16 @@ liftDupable = liftQuote . rename . unDupable
 
 instance HasUniques (Type tyname uni ann) => Rename (Type tyname uni ann) where
     -- See Note [Marking].
-    rename = through markNonFreshType >=> runRenameT @TypeRenaming . renameTypeM
+    rename = through markNonFreshType >=> runRenameT @TypeRenaming emptyRenaming . renameTypeM
 
 instance HasUniques (Term tyname name uni fun ann) => Rename (Term tyname name uni fun ann) where
     -- See Note [Marking].
-    rename = through markNonFreshTerm >=> runRenameT . renameTermM
+    rename = through markNonFreshTerm >=> runRenameT emptyScopedRenaming . renameTermM
 
 instance HasUniques (Program tyname name uni fun ann) =>
     Rename (Program tyname name uni fun ann) where
     -- See Note [Marking].
-    rename = through markNonFreshProgram >=> runRenameT . renameProgramM
+    rename = through markNonFreshProgram >=> runRenameT emptyScopedRenaming . renameProgramM
 
 instance Rename a => Rename (Normalized a) where
     rename = traverse rename

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
@@ -25,7 +25,7 @@ import PlutusCore.Error (ExpectedShapeOr (ExpectedExact, ExpectedShape),
 import PlutusCore.MkPlc (mkIterTyAppNoAnn, mkIterTyFun, mkTyBuiltinOf)
 import PlutusCore.Name.Unique (HasText (theText), Name (Name), Named (Named), TermUnique,
                                TyName (TyName), TypeUnique, theUnique)
-import PlutusCore.Name.UniqueMap (UniqueMap, insertNamed, lookupName)
+import PlutusCore.Name.UniqueMap (UniqueMap, emptyUniqueMap, insertNamed, lookupName)
 import PlutusCore.Normalize.Internal (MonadNormalizeType)
 import PlutusCore.Normalize.Internal qualified as Norm
 import PlutusCore.Quote (MonadQuote (liftQuote), freshTyName)
@@ -227,7 +227,7 @@ type MonadTypeCheckPlc uni fun ann m =
 -- config, so that the kinder checker can be run with an empty config (such as @()@) and access to
 -- a 'TypeCheckConfig' is not needed.
 runTypeCheckM :: cfg -> TypeCheckT uni fun cfg m a -> m a
-runTypeCheckM config a = runReaderT a $ TypeCheckEnv config mempty mempty
+runTypeCheckM config a = runReaderT a $ TypeCheckEnv config emptyUniqueMap emptyUniqueMap
 
 -- | Extend the context of a 'TypeCheckM' computation with a kinded variable.
 withTyVar :: TyName -> Kind () -> TypeCheckT uni fun cfg m a -> TypeCheckT uni fun cfg m a

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Definitions.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Definitions.hs
@@ -14,6 +14,7 @@ import Control.Monad.State (MonadState, execStateT)
 import Control.Monad.Writer (MonadWriter, runWriterT)
 import PlutusCore.Error (UniqueError)
 import PlutusCore.Name.Unique
+import PlutusCore.Name.UniqueMap (emptyUniqueMap)
 import PlutusIR.Core.Plated
 import PlutusIR.Core.Type
 
@@ -98,4 +99,4 @@ runTermDefs
         Monad m)
     => Term tyname name uni fun ann
     -> m (UniqueInfos ann, [UniqueError ann])
-runTermDefs = runWriterT . flip execStateT mempty . termDefs
+runTermDefs = runWriterT . flip execStateT emptyUniqueMap . termDefs

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/VarInfo.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/VarInfo.hs
@@ -18,12 +18,6 @@ data VarsInfo tyname name uni a = VarsInfo
   , typeVarInfoMap :: PLC.UniqueMap PLC.TypeUnique (TyVarInfo tyname name uni a)
   }
 
-instance Semigroup (VarsInfo tyname name uni a) where
-  (VarsInfo t ty) <> (VarsInfo t' ty') = VarsInfo (t <> t') (ty <> ty')
-
-instance Monoid (VarsInfo tyname name uni a) where
-  mempty = VarsInfo mempty mempty
-
 -- | Lookup the 'VarInfo' for a 'name'.
 lookupVarInfo ::
   (PLC.HasUnique name PLC.TermUnique)
@@ -84,25 +78,29 @@ termVarInfo ::
   , PLC.HasUnique tyname PLC.TypeUnique)
   => Term tyname name uni fun a
   -> VarsInfo tyname name uni a
-termVarInfo = \case
-  Let _ _ bs t   -> foldMap bindingVarInfo bs <> termVarInfo t
-  LamAbs _ n ty t ->
-    VarsInfo (UMap.insertByName n (NormalVar Strict ty Nothing) mempty) mempty
-    <> termVarInfo t
-  TyAbs _ n _ t   ->
-    VarsInfo mempty (UMap.insertByName n NormalTyVar mempty)
-    <> termVarInfo t
-  -- No binders
-  t@(Apply{})    -> foldMapOf termSubterms termVarInfo t
-  t@(TyInst{})   -> foldMapOf termSubterms termVarInfo t
-  t@(IWrap{})    -> foldMapOf termSubterms termVarInfo t
-  t@(Unwrap{})   -> foldMapOf termSubterms termVarInfo t
-  t@(Constr{})   -> foldMapOf termSubterms termVarInfo t
-  t@(Case{})     -> foldMapOf termSubterms termVarInfo t
-  t@(Var{})      -> foldMapOf termSubterms termVarInfo t
-  t@(Constant{}) -> foldMapOf termSubterms termVarInfo t
-  t@(Error{})    -> foldMapOf termSubterms termVarInfo t
-  t@(Builtin{})  -> foldMapOf termSubterms termVarInfo t
+termVarInfo = undefined
+
+-- \case
+--   Let _ _ bs t   -> foldMap bindingVarInfo bs <> termVarInfo t
+--   LamAbs _ n ty t ->
+--     VarsInfo
+--       (UMap.insertByName n (NormalVar Strict ty Nothing) UMap.emptyUniqueMap)
+--       UMap.emptyUniqueMap
+--     <> termVarInfo t
+--   TyAbs _ n _ t   ->
+--     VarsInfo UMap.emptyUniqueMap (UMap.insertByName n NormalTyVar UMap.emptyUniqueMap)
+--     <> termVarInfo t
+--   -- No binders
+--   t@(Apply{})    -> foldMapOf termSubterms termVarInfo t
+--   t@(TyInst{})   -> foldMapOf termSubterms termVarInfo t
+--   t@(IWrap{})    -> foldMapOf termSubterms termVarInfo t
+--   t@(Unwrap{})   -> foldMapOf termSubterms termVarInfo t
+--   t@(Constr{})   -> foldMapOf termSubterms termVarInfo t
+--   t@(Case{})     -> foldMapOf termSubterms termVarInfo t
+--   t@(Var{})      -> foldMapOf termSubterms termVarInfo t
+--   t@(Constant{}) -> foldMapOf termSubterms termVarInfo t
+--   t@(Error{})    -> foldMapOf termSubterms termVarInfo t
+--   t@(Builtin{})  -> foldMapOf termSubterms termVarInfo t
 
 datatypeMatcherArity :: Datatype tyname uni fun a -> Arity
 datatypeMatcherArity (Datatype _ _ tyvars _ constrs)=
@@ -128,25 +126,25 @@ bindingVarInfo ::
   , PLC.HasUnique tyname PLC.TypeUnique)
   => Binding tyname name uni fun a
   -> VarsInfo tyname name uni a
-bindingVarInfo = \case
+bindingVarInfo = undefined {- \case
   -- TODO: arity for term bindings
   TermBind _ s (VarDecl _ n ty) t ->
-    VarsInfo (UMap.insertByName n (NormalVar s ty Nothing) mempty) mempty
+    VarsInfo (UMap.insertByName n (NormalVar s ty Nothing) UMap.emptyUniqueMap) UMap.emptyUniqueMap
     <> termVarInfo t
   TypeBind _ (TyVarDecl _ n _) _ ->
-    VarsInfo mempty (UMap.insertByName n NormalTyVar mempty)
+    VarsInfo UMap.emptyUniqueMap (UMap.insertByName n NormalTyVar UMap.emptyUniqueMap)
   DatatypeBind _ d@(Datatype _ (TyVarDecl _ tyname _) _ matcher constrs) ->
     let
       dtInfo =
         let info = DatatypeTyVar d
-        in VarsInfo mempty (UMap.insertByName tyname info mempty)
+        in VarsInfo UMap.emptyUniqueMap (UMap.insertByName tyname info UMap.emptyUniqueMap)
       matcherInfo =
         let info = DatatypeMatcher tyname
-        in VarsInfo (UMap.insertByName matcher info mempty) mempty
+        in VarsInfo (UMap.insertByName matcher info UMap.emptyUniqueMap) UMap.emptyUniqueMap
       constrInfo i (VarDecl _ n _) =
         let info = DatatypeConstructor i tyname
         in VarsInfo (UMap.insertByName n info mempty) mempty
-    in dtInfo <> matcherInfo <> ifoldMap constrInfo constrs
+    in dtInfo <> matcherInfo <> ifoldMap constrInfo constrs -}
 
 -- | Get the arities of the constructors for the given datatype name.
 getConstructorArities

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Rename.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Rename.hs
@@ -198,7 +198,7 @@ recursive and non-recursive data types with a single function.
 
 instance PLC.HasUniques (Term tyname name uni fun ann) => PLC.Rename (Term tyname name uni fun ann) where
     -- See Note [Marking]
-    rename = through markNonFreshTerm >=> PLC.runRenameT . renameTermM
+    rename = through markNonFreshTerm >=> PLC.runRenameT PLC.emptyScopedRenaming . renameTermM
 
 instance PLC.HasUniques (Term tyname name uni fun ann) => PLC.Rename (Program tyname name uni fun ann) where
     rename (Program ann v term) = Program ann v <$> PLC.rename term

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
@@ -39,6 +39,7 @@ import PlutusCore.Core qualified as PLC
 import PlutusCore.Error as PLC
 import PlutusCore.MkPlc (mkIterTyFun)
 -- we mirror inferTypeM, checkTypeM of plc-tc and extend it for plutus-ir terms
+import PlutusCore.Name.UniqueMap (emptyUniqueMap)
 import PlutusCore.TypeCheck.Internal hiding (checkTypeM, inferTypeM, runTypeCheckM)
 
 import Control.Monad (when)
@@ -442,7 +443,7 @@ withNoEscapingTypes = local $ set (tceTypeCheckConfig.pirConfigAllowEscape) NoEs
 -- | Run a 'TypeCheckM' computation by supplying a 'TypeCheckConfig' to it.
 -- Differs from its PLC version in that is passes an extra env flag 'YesEscape'.
 runTypeCheckM :: PirTCConfig uni fun -> PirTCEnv uni fun m a -> m a
-runTypeCheckM config a = runReaderT a $ TypeCheckEnv config mempty mempty
+runTypeCheckM config a = runReaderT a $ TypeCheckEnv config emptyUniqueMap emptyUniqueMap
 
 -- Helpers
 ----------

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Definitions.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Definitions.hs
@@ -12,6 +12,7 @@ import UntypedPlutusCore.Core
 import PlutusCore.Analysis.Definitions (ScopeType (TermScope), UniqueInfos, addDef, addUsage)
 import PlutusCore.Error (UniqueError)
 import PlutusCore.Name.Unique (HasUnique, TermUnique (TermUnique), Unique (Unique))
+import PlutusCore.Name.UniqueMap (emptyUniqueMap)
 
 import Control.Lens (forMOf_)
 import Control.Monad.State (MonadState, execStateT)
@@ -48,4 +49,4 @@ runTermDefs
         Monad m)
     => Term name uni fun ann
     -> m (UniqueInfos ann, [UniqueError ann])
-runTermDefs = runWriterT . flip execStateT mempty . termDefs
+runTermDefs = runWriterT . flip execStateT emptyUniqueMap . termDefs

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
@@ -24,7 +24,7 @@ import Data.Vector qualified as V
 
 instance (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, Eq ann) =>
             Eq (Term Name uni fun ann) where
-    term1 == term2 = runEqRename $ eqTermM term1 term2
+    term1 == term2 = runEqRename emptyRenaming $ eqTermM term1 term2
 
 type HashableTermConstraints uni fun ann =
   ( GEq uni

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Rename.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Rename.hs
@@ -20,8 +20,8 @@ import PlutusCore.Rename (Rename (..))
 
 instance HasUniques (Term name uni fun ann) => Rename (Term name uni fun ann) where
     -- See Note [Marking].
-    rename = through markNonFreshTerm >=> runRenameT . renameTermM
+    rename = through markNonFreshTerm >=> runRenameT emptyRenaming . renameTermM
 
 instance HasUniques (Program name uni fun ann) => Rename (Program name uni fun ann) where
     -- See Note [Marking].
-    rename = through markNonFreshProgram >=> runRenameT . renameProgramM
+    rename = through markNonFreshProgram >=> runRenameT emptyRenaming . renameProgramM

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/FloatDelay.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/FloatDelay.hs
@@ -107,7 +107,7 @@ simplifyArgs ::
   PLC.UniqueSet PLC.TermUnique ->
   Term name uni fun a ->
   (Term name uni fun a, PLC.UniqueMap PLC.TermUnique a)
-simplifyArgs blacklist = runWriter . go
+simplifyArgs blacklist = undefined {- runWriter . go
   where
     go :: Term name uni fun ann -> Writer (PLC.UniqueMap PLC.TermUnique ann) (Term name uni fun ann)
     go = \case
@@ -116,7 +116,7 @@ simplifyArgs blacklist = runWriter . go
         , n `USet.notMemberByName` blacklist -> do
             tell (UMap.singletonByName n delayAnn)
             (Apply appAnn . LamAbs lamAnn n <$> go lamBody) <*> go arg
-      t -> forOf termSubterms t go
+      t -> forOf termSubterms t go -}
 
 -- | Third pass. Turns @Force n@ into @Force (Delay n)@ for all eligibile @n@.
 simplifyBodies

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -84,14 +84,12 @@ A map of unprocessed variable and its substitution range.
 -}
 newtype TermEnv name uni fun a = TermEnv
   {_unTermEnv :: PLC.UniqueMap TermUnique (InlineTerm name uni fun a)}
-  deriving newtype (Semigroup, Monoid)
 
 {-| Wrapper of term substitution so that it's similar to the PIR inliner.
 See Note [Differences from PIR inliner] 1
 -}
 newtype Subst name uni fun a = Subst {_termEnv :: TermEnv name uni fun a}
   deriving stock (Generic)
-  deriving newtype (Semigroup, Monoid)
 
 makeLenses ''TermEnv
 makeLenses ''Subst
@@ -117,11 +115,8 @@ data S name uni fun a = S
 
 makeLenses ''S
 
-instance Semigroup (S name uni fun a) where
-  S a1 b1 <> S a2 b2 = S (a1 <> a2) (b1 <> b2)
-
-instance Monoid (S name uni fun a) where
-  mempty = S mempty mempty
+emptyS :: S name uni fun a
+emptyS = S (Subst $ TermEnv UMap.emptyUniqueMap) UMap.emptyUniqueMap
 
 type ExternalConstraints name uni fun m =
   ( HasUnique name TermUnique
@@ -216,7 +211,7 @@ inline
   t = do
     result <-
       liftQuote $
-        flip evalStateT mempty $
+        flip evalStateT emptyS $
           runReaderT
             (processTerm t)
             InlineInfo


### PR DESCRIPTION
This shows just how annoying it is to address https://github.com/IntersectMBO/plutus/issues/6138. Dropping `mempty` is fine, but now half the optimization are broken in non-trivial ways. I'm not sure what to do about it, maybe it's worth fixing all of that.