### PR TITLE
[Benchmark] Pull 'force' out of 'bench'

### DIFF
--- a/plutus-benchmark/bitwise/bench/Main.hs
+++ b/plutus-benchmark/bitwise/bench/Main.hs
@@ -4,7 +4,7 @@
 
 module Main (main) where
 
-import Criterion.Main (bench, defaultMain)
+import Criterion.Main (defaultMain)
 import PlutusBenchmark.Common (benchProgramCek, mkMostRecentEvalCtx)
 import PlutusBenchmark.Ed25519.Compiled (checkValidCompiled, msgAsData, pkAsData, signatureAsData)
 import PlutusBenchmark.NQueens.Compiled (dimAsData, nqueensCompiled)
@@ -12,8 +12,8 @@ import PlutusTx.Code (getPlcNoAnn, unsafeApplyCode)
 
 main :: IO ()
 main = defaultMain [
-  bench "Ed25519" . benchProgramCek mkMostRecentEvalCtx . getPlcNoAnn $
+  benchProgramCek "Ed25519" mkMostRecentEvalCtx . getPlcNoAnn $
     checkValidCompiled `unsafeApplyCode` signatureAsData `unsafeApplyCode` msgAsData `unsafeApplyCode` pkAsData,
-  bench "8-queens" . benchProgramCek mkMostRecentEvalCtx . getPlcNoAnn $
+  benchProgramCek "8-queens" mkMostRecentEvalCtx . getPlcNoAnn $
     nqueensCompiled `unsafeApplyCode` dimAsData
   ]

--- a/plutus-benchmark/bls12-381-costs/bench/Bench.hs
+++ b/plutus-benchmark/bls12-381-costs/bench/Bench.hs
@@ -18,22 +18,22 @@ import Data.ByteString qualified as BS (empty)
 benchHashAndAddG1 :: EvaluationContext -> Integer -> Benchmark
 benchHashAndAddG1 ctx n =
     let prog = mkHashAndAddG1Script (listOfByteStringsOfLength n 4)
-    in bench (show n) $ benchProgramCek ctx prog
+    in benchProgramCek (show n) ctx prog
 
 benchHashAndAddG2 :: EvaluationContext -> Integer -> Benchmark
 benchHashAndAddG2 ctx n =
     let prog = mkHashAndAddG2Script (listOfByteStringsOfLength n 4)
-    in bench (show n) $ benchProgramCek ctx prog
+    in benchProgramCek (show n) ctx prog
 
 benchUncompressAndAddG1 :: EvaluationContext -> Integer -> Benchmark
 benchUncompressAndAddG1 ctx n =
     let prog = mkUncompressAndAddG1Script (listOfByteStringsOfLength n 4)
-    in bench (show n) $ benchProgramCek ctx prog
+    in benchProgramCek (show n) ctx prog
 
 benchUncompressAndAddG2 :: EvaluationContext -> Integer -> Benchmark
 benchUncompressAndAddG2 ctx n =
     let prog = mkUncompressAndAddG2Script (listOfByteStringsOfLength n 4)
-    in bench (show n) $ benchProgramCek ctx prog
+    in benchProgramCek (show n) ctx prog
 
 benchPairing :: EvaluationContext -> Benchmark
 benchPairing ctx =
@@ -45,35 +45,35 @@ benchPairing ctx =
               q1 = Tx.bls12_381_G1_hashToGroup (Tx.toBuiltin b3) emptyDst
               q2 = Tx.bls12_381_G2_hashToGroup (Tx.toBuiltin b4) emptyDst
               prog = mkPairingScript p1 p2 q1 q2
-          in bench "pairing" $ benchProgramCek ctx prog
+          in benchProgramCek "pairing" ctx prog
       _ -> error "Unexpected list returned by listOfByteStringsOfLength"
 
 benchGroth16Verify :: EvaluationContext -> Benchmark
-benchGroth16Verify ctx = bench "groth16Verify" $ benchProgramCek ctx mkGroth16VerifyScript
+benchGroth16Verify ctx = benchProgramCek "groth16Verify" ctx mkGroth16VerifyScript
 
 benchSimpleVerify :: EvaluationContext -> Benchmark
-benchSimpleVerify ctx = bench "simpleVerify" $ benchProgramCek ctx mkVerifyBlsSimplePolicy
+benchSimpleVerify ctx = benchProgramCek "simpleVerify" ctx mkVerifyBlsSimplePolicy
 
 benchVrf :: EvaluationContext -> Benchmark
-benchVrf ctx = bench "vrf" $ benchProgramCek ctx mkVrfBlsPolicy
+benchVrf ctx = benchProgramCek "vrf" ctx mkVrfBlsPolicy
 
 benchG1Verify :: EvaluationContext -> Benchmark
-benchG1Verify ctx = bench "g1Verify" $ benchProgramCek ctx mkG1VerifyPolicy
+benchG1Verify ctx = benchProgramCek "g1Verify" ctx mkG1VerifyPolicy
 
 benchG2Verify :: EvaluationContext -> Benchmark
-benchG2Verify ctx = bench "g2Verify" $ benchProgramCek ctx mkG2VerifyPolicy
+benchG2Verify ctx = benchProgramCek "g2Verify" ctx mkG2VerifyPolicy
 
 aggregateSigSingleKey :: EvaluationContext -> Benchmark
-aggregateSigSingleKey ctx = bench "aggregateSignatureSingleKey" $ benchProgramCek ctx mkAggregateSingleKeyG1Policy
+aggregateSigSingleKey ctx = benchProgramCek "aggregateSignatureSingleKey" ctx mkAggregateSingleKeyG1Policy
 
 aggregateSigMultiKey :: EvaluationContext -> Benchmark
-aggregateSigMultiKey ctx = bench "aggregateSignatureMultiKey" $ benchProgramCek ctx mkAggregateMultiKeyG2Policy
+aggregateSigMultiKey ctx = benchProgramCek "aggregateSignatureMultiKey" ctx mkAggregateMultiKeyG2Policy
 
 schnorrG1Verify :: EvaluationContext -> Benchmark
-schnorrG1Verify ctx = bench "schnorrG1Verify" $ benchProgramCek ctx mkSchnorrG1VerifyPolicy
+schnorrG1Verify ctx = benchProgramCek "schnorrG1Verify" ctx mkSchnorrG1VerifyPolicy
 
 schnorrG2Verify :: EvaluationContext -> Benchmark
-schnorrG2Verify ctx = bench "schnorrG2Verify" $ benchProgramCek ctx mkSchnorrG2VerifyPolicy
+schnorrG2Verify ctx = benchProgramCek "schnorrG2Verify" ctx mkSchnorrG2VerifyPolicy
 
 main :: IO ()
 main = do

--- a/plutus-benchmark/cek-calibration/Main.hs
+++ b/plutus-benchmark/cek-calibration/Main.hs
@@ -70,7 +70,7 @@ mkListTerm n =
   in code
 
 mkListBM :: EvaluationContext -> Integer -> Benchmark
-mkListBM ctx n = bench (Haskell.show n) $ benchTermCek ctx (mkListTerm n)
+mkListBM ctx n = benchTermCek (Haskell.show n) ctx (mkListTerm n)
 
 mkListBMs :: EvaluationContext -> [Integer] -> Benchmark
 mkListBMs ctx ns = bgroup "List" [mkListBM ctx n | n <- ns]

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -134,14 +134,14 @@ evaluateCekForBench
     -> ()
 evaluateCekForBench evalCtx = either (error . show) (\_ -> ()) . evaluateCekLikeInProd evalCtx
 
-benchTermCek :: LedgerApi.EvaluationContext -> Term -> Benchmarkable
-benchTermCek evalCtx term =
+benchTermCek :: String -> LedgerApi.EvaluationContext -> Term -> Benchmark
+benchTermCek name evalCtx term =
     let !term' = force term
-    in whnf (evaluateCekForBench evalCtx) term'
+    in bench name $ whnf (evaluateCekForBench evalCtx) term'
 
-benchProgramCek :: LedgerApi.EvaluationContext -> Program -> Benchmarkable
-benchProgramCek evalCtx (UPLC.Program _ _ term) =
-  benchTermCek evalCtx term
+benchProgramCek :: String -> LedgerApi.EvaluationContext -> Program -> Benchmark
+benchProgramCek name evalCtx (UPLC.Program _ _ term) =
+  benchTermCek name evalCtx term
 
 ---------------- Printing tables of information about costs ----------------
 

--- a/plutus-benchmark/lists/bench/Bench.hs
+++ b/plutus-benchmark/lists/bench/Bench.hs
@@ -43,11 +43,11 @@ benchmarks ctx =
     where
       mkBMsForSort name f =
         bgroup name $ sizesForSort <&> \n ->
-          bench (show n) $ benchTermCek ctx (f n)
+          benchTermCek (show n) ctx (f n)
       sizesForSort = [50, 100..300]
       mkBMsForSum name f =
         bgroup name $ sizesForSum <&> \n ->
-          bench (show n) $ benchTermCek ctx (f [1..n])
+          benchTermCek (show n) ctx (f [1..n])
       sizesForSum = [100, 500, 1000, 2500, 5000]
 
 main :: IO ()

--- a/plutus-benchmark/marlowe/bench/BenchCek.hs
+++ b/plutus-benchmark/marlowe/bench/BenchCek.hs
@@ -9,4 +9,4 @@ import Control.Exception (evaluate)
 main :: IO ()
 main = do
   evalCtx <- evaluate mkMostRecentEvalCtx
-  runBenchmarks (benchProgramCek evalCtx)
+  runBenchmarks $ flip benchProgramCek evalCtx

--- a/plutus-benchmark/nofib/bench/BenchCek.hs
+++ b/plutus-benchmark/nofib/bench/BenchCek.hs
@@ -11,4 +11,4 @@ import Control.Exception (evaluate)
 main :: IO ()
 main = do
   evalCtx <- evaluate mkMostRecentEvalCtx
-  benchWith $ benchTermCek evalCtx
+  benchWith $ flip benchTermCek evalCtx

--- a/plutus-benchmark/nofib/bench/BenchHaskell.hs
+++ b/plutus-benchmark/nofib/bench/BenchHaskell.hs
@@ -12,17 +12,17 @@ import PlutusBenchmark.NoFib.Knights qualified as Knights
 import PlutusBenchmark.NoFib.Prime qualified as Prime
 import PlutusBenchmark.NoFib.Queens qualified as Queens
 
-benchClausify :: Clausify.StaticFormula -> Benchmarkable
-benchClausify f = nf Clausify.runClausify f
+benchClausify :: String -> Clausify.StaticFormula -> Benchmark
+benchClausify name f = bench name $ whnf Clausify.runClausify f
 
-benchKnights :: Integer -> Integer -> Benchmarkable
-benchKnights depth sz = nf (Knights.runKnights depth) sz
+benchKnights :: String -> Integer -> Integer -> Benchmark
+benchKnights name depth sz = bench name $ whnf (Knights.runKnights depth) sz
 
-benchPrime :: Prime.PrimeID -> Benchmarkable
-benchPrime pid = nf Prime.runFixedPrimalityTest pid
+benchPrime :: String -> Prime.PrimeID -> Benchmark
+benchPrime name pid = bench name $ whnf Prime.runFixedPrimalityTest pid
 
-benchQueens :: Integer -> Queens.Algorithm -> Benchmarkable
-benchQueens sz alg = nf (Queens.runQueens sz) alg
+benchQueens :: String -> Integer -> Queens.Algorithm -> Benchmark
+benchQueens name sz alg = bench name $ whnf (Queens.runQueens sz) alg
 
 main :: IO ()
 main = do

--- a/plutus-benchmark/nofib/bench/Shared.hs
+++ b/plutus-benchmark/nofib/bench/Shared.hs
@@ -17,62 +17,65 @@ import Criterion.Main
 
 {- | Package together functions to create benchmarks for each program given suitable inputs. -}
 type BenchmarkRunners =
-    ( Clausify.StaticFormula -> Benchmarkable
-    , Integer -> Integer -> Benchmarkable
-    , Prime.PrimeID -> Benchmarkable
-    , Integer -> Queens.Algorithm -> Benchmarkable
+    ( String -> Clausify.StaticFormula -> Benchmark
+    , String -> Integer -> Integer -> Benchmark
+    , String -> Prime.PrimeID -> Benchmark
+    , String -> Integer -> Queens.Algorithm -> Benchmark
     )
 
 {- | Make a benchmarks with a number of different inputs.  The input values have
    been chosen to complete in a reasonable time. -}
 mkBenchMarks :: BenchmarkRunners -> [Benchmark]
 mkBenchMarks (benchClausify, benchKnights, benchPrime, benchQueens) = [
-    bgroup "clausify" [ bench "formula1" $ benchClausify Clausify.F1
-                      , bench "formula2" $ benchClausify Clausify.F2
-                      , bench "formula3" $ benchClausify Clausify.F3
-                      , bench "formula4" $ benchClausify Clausify.F4
-                      , bench "formula5" $ benchClausify Clausify.F5
+    bgroup "clausify" [ benchClausify "formula1" Clausify.F1
+                      , benchClausify "formula2" Clausify.F2
+                      , benchClausify "formula3" Clausify.F3
+                      , benchClausify "formula4" Clausify.F4
+                      , benchClausify "formula5" Clausify.F5
                       ]
-  , bgroup "knights" [ bench "4x4" $ benchKnights 100 4
-                     , bench "6x6" $ benchKnights 100 6
-                     , bench "8x8" $ benchKnights 100 8
+  , bgroup "knights" [ benchKnights "4x4" 100 4
+                     , benchKnights "6x6" 100 6
+                     , benchKnights "8x8" 100 8
                      ]
-  , bgroup "primetest" [ bench "05digits" $ benchPrime Prime.P5
-                       , bench "10digits" $ benchPrime Prime.P10
-                       , bench "30digits" $ benchPrime Prime.P30
-                       , bench "50digits" $ benchPrime Prime.P50
+  , bgroup "primetest" [ benchPrime "05digits" Prime.P5
+                       , benchPrime "10digits" Prime.P10
+                       , benchPrime "30digits" Prime.P30
+                       , benchPrime "50digits" Prime.P50
                        -- Larger primes are available in Primes.hs, but may take a long time.
                        ]
   , bgroup "queens4x4" [ -- N-queens problem on a 4x4 board
-                      bench "bt"    $ benchQueens 4 Queens.Bt
-                    , bench "bm"    $ benchQueens 4 Queens.Bm
-                    , bench "bjbt1" $ benchQueens 4 Queens.Bjbt1
-                    , bench "bjbt2" $ benchQueens 4 Queens.Bjbt2
-                    , bench "fc"    $ benchQueens 4 Queens.Fc
+                      benchQueens "bt"    4 Queens.Bt
+                    , benchQueens "bm"    4 Queens.Bm
+                    , benchQueens "bjbt1" 4 Queens.Bjbt1
+                    , benchQueens "bjbt2" 4 Queens.Bjbt2
+                    , benchQueens "fc"    4 Queens.Fc
                     ]
   , bgroup "queens5x5" [ -- N-queens problem on a 5x5 board
-                      bench "bt"    $ benchQueens 5 Queens.Bt
-                    , bench "bm"    $ benchQueens 5 Queens.Bm
-                    , bench "bjbt1" $ benchQueens 5 Queens.Bjbt1
-                    , bench "bjbt2" $ benchQueens 5 Queens.Bjbt2
-                    , bench "fc"    $ benchQueens 5 Queens.Fc
+                      benchQueens "bt"    5 Queens.Bt
+                    , benchQueens "bm"    5 Queens.Bm
+                    , benchQueens "bjbt1" 5 Queens.Bjbt1
+                    , benchQueens "bjbt2" 5 Queens.Bjbt2
+                    , benchQueens "fc"    5 Queens.Fc
                     ]
        ]
 
 
 ---------------- Create a benchmark with given inputs ----------------
 
-benchClausifyWith :: (Term -> Benchmarkable) -> Clausify.StaticFormula -> Benchmarkable
-benchClausifyWith benchmarker f = benchmarker $ Clausify.mkClausifyTerm f
+benchClausifyWith
+    :: (String -> Term -> Benchmark) -> String -> Clausify.StaticFormula -> Benchmark
+benchClausifyWith benchmarker name f = benchmarker name $ Clausify.mkClausifyTerm f
 
-benchPrimeWith :: (Term -> Benchmarkable) -> Prime.PrimeID -> Benchmarkable
-benchPrimeWith benchmarker pid = benchmarker $ Prime.mkPrimalityBenchTerm pid
+benchPrimeWith :: (String -> Term -> Benchmark) -> String -> Prime.PrimeID -> Benchmark
+benchPrimeWith benchmarker name pid = benchmarker name $ Prime.mkPrimalityBenchTerm pid
 
-benchQueensWith :: (Term -> Benchmarkable) -> Integer -> Queens.Algorithm -> Benchmarkable
-benchQueensWith benchmarker sz alg = benchmarker $ Queens.mkQueensTerm sz alg
+benchQueensWith
+    :: (String -> Term -> Benchmark) -> String -> Integer -> Queens.Algorithm -> Benchmark
+benchQueensWith benchmarker name sz alg = benchmarker name $ Queens.mkQueensTerm sz alg
 
-benchKnightsWith :: (Term -> Benchmarkable) -> Integer -> Integer -> Benchmarkable
-benchKnightsWith benchmarker depth sz = benchmarker $ Knights.mkKnightsTerm depth sz
+benchKnightsWith
+    :: (String -> Term -> Benchmark) -> String -> Integer -> Integer -> Benchmark
+benchKnightsWith benchmarker name depth sz = benchmarker name $ Knights.mkKnightsTerm depth sz
 
 {- This runs all of the benchmarks, which will take a long time.
    To run an individual benmark, try, for example,
@@ -98,7 +101,7 @@ benchKnightsWith benchmarker depth sz = benchmarker $ Knights.mkKnightsTerm dept
 
 -- Given a function (involving some evaluator) which constructs a Benchmarkable
 -- from a Term, use it to construct and run all of the benchmarks
-benchWith :: (Term -> Benchmarkable) -> IO ()
+benchWith :: (String -> Term -> Benchmark) -> IO ()
 benchWith benchmarker = do
   let runners = ( benchClausifyWith benchmarker, benchKnightsWith benchmarker
                 , benchPrimeWith benchmarker, benchQueensWith benchmarker)

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -576,6 +576,7 @@ library agda-internal
   build-depends:
     , base               >=4.9   && <5
     , criterion
+    , deepseq
     , plutus-core        ^>=1.48
     , plutus-metatheory  ^>=1.48
 

--- a/plutus-benchmark/validation/bench/BenchAgdaCek.hs
+++ b/plutus-benchmark/validation/bench/BenchAgdaCek.hs
@@ -13,7 +13,7 @@ import Control.DeepSeq (force)
 -- Run the validation benchmarks using the Agda CEK machine.
 main :: IO ()
 main = do
-  let mkAgdaCekBM file program =
+  let mkAgdaCekBM name file program =
           let !benchTerm = force . toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file program
-          in benchTermAgdaCek benchTerm
+          in benchTermAgdaCek name benchTerm
   benchWith mkAgdaCekBM

--- a/plutus-benchmark/validation/bench/BenchCek.hs
+++ b/plutus-benchmark/validation/bench/BenchCek.hs
@@ -21,6 +21,9 @@ main = do
   -- The validation benchmarks were all created with PlutusV1, so let's make
   -- sure that the evaluation context matches.
   evalCtx <- evaluate $ mkEvalCtx PlutusV1 DefaultFunSemanticsVariantA
-  let mkCekBM file program =
-          benchTermCek evalCtx . toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file program
+  let mkCekBM name file
+          = benchTermCek name evalCtx
+          . toNamedDeBruijnTerm
+          . UPLC._progTerm
+          . unsafeUnflat file
   benchWith mkCekBM

--- a/plutus-benchmark/validation/bench/BenchDec.hs
+++ b/plutus-benchmark/validation/bench/BenchDec.hs
@@ -24,8 +24,8 @@ the time taken to only flat-deserialize the script
 main :: IO ()
 main = benchWith mkDecBM
   where
-    mkDecBM :: FilePath -> BS.ByteString -> Benchmarkable
-    mkDecBM file bsFlat =
+    mkDecBM :: String -> FilePath -> BS.ByteString -> Benchmark
+    mkDecBM name file bsFlat =
         let
             UPLC.Program _ v (fullyApplied :: Term) = unsafeUnflat file bsFlat
 
@@ -40,5 +40,4 @@ main = benchWith mkDecBM
                 force (serialiseUPLC $ UPLC.Program () v unsaturated)
 
             -- Deserialize using 'FakeNamedDeBruijn' to get the fake names added
-        in whnf (either throw id . void . deserialiseScript futurePV
-                ) benchScript
+        in bench name $ whnf (either throw id . void . deserialiseScript futurePV) benchScript

--- a/plutus-benchmark/validation/bench/BenchFull.hs
+++ b/plutus-benchmark/validation/bench/BenchFull.hs
@@ -27,8 +27,8 @@ main = do
   -- The validation benchmarks were all created with PlutusV1, so let's make
   -- sure that the evaluation context matches.
   evalCtx <- evaluate $ mkEvalCtx PlutusV1 DefaultFunSemanticsVariantA
-  let mkFullBM :: FilePath -> BS.ByteString -> Benchmarkable
-      mkFullBM file bsFlat =
+  let mkFullBM :: String -> FilePath -> BS.ByteString -> Benchmark
+      mkFullBM name file bsFlat =
         let UPLC.Program () ver body = unsafeUnflat file bsFlat
               -- We make some effort to mimic what happens on-chain, including the provision of
               -- the script arguments. However, the inputs we have are *fully applied*. So we try
@@ -49,5 +49,5 @@ main = do
               (unExRestrictingBudget enormousBudget)
               (either (error . show) id $ deserialiseScript futurePV script)
               args
-        in whnf eval benchScript
+        in bench name $ whnf eval benchScript
   benchWith mkFullBM

--- a/plutus-benchmark/validation/bench/Common.hs
+++ b/plutus-benchmark/validation/bench/Common.hs
@@ -102,7 +102,7 @@ parserInfo :: Config -> ParserInfo BenchOptions
 parserInfo cfg =
     info (helper <*> parseBenchOptions cfg) $ header "Plutus Core validation benchmark suite"
 
-benchWith :: (FilePath -> BS.ByteString -> Benchmarkable) -> IO ()
+benchWith :: (String -> FilePath -> BS.ByteString -> Benchmark) -> IO ()
 benchWith act = do
     cfg <- getConfig 20.0  -- Run each benchmark for at least 20 seconds.  Change this with -L or --timeout (longer is better).
     options <- execParser $ parserInfo cfg
@@ -123,7 +123,7 @@ benchWith act = do
     mkScriptBM :: FilePath -> FilePath -> Benchmark
     mkScriptBM dir file =
         env (BS.readFile $ dir </> file) $ \(~scriptBS) ->
-            bench (dropExtension file) $ act file scriptBS
+            act (dropExtension file) file scriptBS
 
 type Term = UPLC.Term UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
 


### PR DESCRIPTION
I was investigating an issue with #7012 not being faster than the baseline despite clearly doing strictly less work and came to the conclusion that the only reasonable explanation is that something is wrong with the benchmarks. So here's an investigation.