### PR TITLE
Replace `hex-text` with `base16-bytestring` package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -87,8 +87,3 @@ allow-newer:
 --   flags: +force-build
 -- allow-newer: *:plutus-ledger-api
 -- allow-older: *:nothunks
-
-if impl (ghc >= 9.12)
-  allow-newer:
-    -- https://github.com/typeclasses/hex-text/issues/9
-    , hex-text:base

--- a/plutus-core/changelog.d/20250703_123351_erikd_drop_hex_text.md
+++ b/plutus-core/changelog.d/20250703_123351_erikd_drop_hex_text.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Drop `hex-text` package in favor of `base16-bytestring`.

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -382,6 +382,7 @@ test-suite plutus-core-test
   build-depends:
     , aeson
     , base                             >=4.9     && <5
+    , base16-bytestring                ^>=1.0
     , bytestring
     , containers
     , data-default-class
@@ -389,7 +390,6 @@ test-suite plutus-core-test
     , filepath
     , flat                             ^>=0.6
     , hedgehog
-    , hex-text
     , mmorph
     , mtl
     , plutus-core                      ^>=1.48

--- a/plutus-core/plutus-core/test/CBOR/DataStability.hs
+++ b/plutus-core/plutus-core/test/CBOR/DataStability.hs
@@ -33,10 +33,12 @@ where
 import PlutusCore.Data
 
 import Codec.Serialise (deserialise)
+import Data.ByteString.Base16 qualified as Base16 (decode)
+import Data.ByteString.Char8 (ByteString)
 import Data.ByteString.Lazy qualified as BSL (fromStrict, length)
 import Data.Maybe (fromJust)
 import Data.Text (Text)
-import Text.Hex (decodeHex)
+import Data.Text.Encoding qualified as Text (encodeUtf8)
 import Text.Printf (printf)
 
 import Test.Tasty
@@ -135,5 +137,8 @@ testData =
      )
    ]
 
-
-
+-- Lifted from the `hex-text` package which is being dropped because it
+-- is poorly maintained.
+decodeHex :: Text -> Maybe ByteString
+decodeHex txt =
+  either (const Nothing) Just (Base16.decode (Text.encodeUtf8 txt))


### PR DESCRIPTION
* Drop poorly maintained package `hex-text` in favor of `base16-bytestring` which is more widely used and better maintained.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
