### PR TITLE
Remove some placeholder comments

### DIFF
--- a/plutus-core/cost-model/create-cost-model/BuiltinMemoryModels.hs
+++ b/plutus-core/cost-model/create-cost-model/BuiltinMemoryModels.hs
@@ -170,8 +170,6 @@ builtinMemoryModels = BuiltinCostModelBase
   , paramFindFirstSetBit                 = Id $ ModelOneArgumentConstantCost 1
   , paramRipemd_160                      = Id $ hashMemModel Hash.ripemd_160
   , paramExpModInteger                   = Id $ ModelThreeArgumentsLinearInZ identityFunction
-  -- paramCaseList
-  -- paramCaseData
   , paramDropList                        = Id $ ModelTwoArgumentsConstantCost 4
   , paramLengthOfArray                   = Id $ ModelOneArgumentConstantCost 10
   , paramListToArray                     = Id $ ModelOneArgumentLinearInX $ OneVariableLinearFunction 7 1

--- a/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
+++ b/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
@@ -270,8 +270,6 @@ createBuiltinCostModel bmfile rfile = do
   paramRipemd_160                      <- getParams readCF1 paramRipemd_160
   -- Batch 6
   paramExpModInteger                   <- getParams readCF3 paramExpModInteger
-  -- paramCaseList
-  -- paramCaseData
   paramDropList                        <- getParams readCF2 paramDropList
   -- Arrays
   paramLengthOfArray                   <- getParams readCF1 paramLengthOfArray

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
@@ -186,8 +186,6 @@ data BuiltinCostModelBase f =
     , paramRipemd_160                      :: f ModelOneArgument
     -- Batch 6
     , paramExpModInteger                   :: f ModelThreeArguments
-    -- , paramCaseList here
-    -- , paramCaseData here
     , paramDropList                        :: f ModelTwoArguments
     -- Arrays
     , paramLengthOfArray                   :: f ModelOneArgument

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -348,8 +348,6 @@ unitCostBuiltinCostModel = BuiltinCostModelBase
     , paramRipemd_160                      = unitCostOneArgument
     -- Batch 6
     , paramExpModInteger                   = unitCostThreeArguments
-    -- paramCaseList
-    -- paramCaseData
     , paramDropList                        = unitCostTwoArguments
     -- Arrays
     , paramLengthOfArray                   = unitCostOneArgument


### PR DESCRIPTION
This just removes some comments that were placeholders for `caseList` and `caseData` costing stuff that we're not going to need any more.