### PR TITLE
Disable Plutus executable build for wasm

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -43,6 +43,10 @@ test-show-details: direct
 package plutus-core
   flags: +with-inline-r +with-cert
 
+if arch(wasm32)
+  package plutus-core
+    flags: +do-not-build-plutus-exec
+
 -- Various dependencies of coq don't work when cross building for windows
 if os(windows)
   -- Note: we enable this and then disable it conditionally, rather than enabling

--- a/plutus-core/changelog.d/20250707_193702_pablo.lamela_disable_exec_for_wasm.md
+++ b/plutus-core/changelog.d/20250707_193702_pablo.lamela_disable_exec_for_wasm.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Disable Plutus executable build for wasm
+


### PR DESCRIPTION
This PR disables compilation of Plutus executable for `wasm32`, because it doesn't compile. This removes the requirement for dependencies of `plutus-core` that must compile to `wasm32` to add this flag for compilation to succeed.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
