### PR TITLE
Force ambiguity for annotations in CEK

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -120,7 +120,7 @@ nopCostModel =
                   (ModelSixArgumentsConstantCost 600)
     }
 
-nopCostParameters :: MachineParameters CekMachineCosts NopFun (CekValue DefaultUni NopFun ())
+nopCostParameters :: MachineParameters CekMachineCosts NopFun (CekValue DefaultUni NopFun)
 nopCostParameters =
     MachineParameters def . mkMachineVariantParameters def $
         CostModel defaultCekMachineCostsForTesting nopCostModel

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -77,7 +77,7 @@ pairWith f = fmap (\a -> (a, f a))
 
 benchWith
     :: (Pretty fun, Typeable fun)
-    => MachineParameters CekMachineCosts fun (CekValue DefaultUni fun ())
+    => MachineParameters CekMachineCosts fun (CekValue DefaultUni fun)
     -> String
     -> PlainTerm DefaultUni fun
     -> Benchmark
@@ -430,4 +430,3 @@ createThreeTermBuiltinBenchWithWrappers (wrapX, wrapY, wrapZ) fun tys xs ys zs =
     [bgroup (showMemoryUsage (wrapY y))
       [mkBM x y z | z <- zs] | y <- ys] | x <- xs]
   where mkBM x y z = benchDefault (showMemoryUsage (wrapZ z)) $ mkApp3 fun tys x y z
-

--- a/plutus-core/docs/BuiltinsOverview.md
+++ b/plutus-core/docs/BuiltinsOverview.md
@@ -213,7 +213,7 @@ Here's a concrete example of what a `TypeScheme` for `DivideInteger` might look 
 ```haskell
 divideIntegerTypeScheme ::
     TypeScheme
-        (CekValue DefaultUni fun ann)
+        (CekValue DefaultUni fun)
         '[Integer, Integer]
         (BuiltinResult Integer)
 divideIntegerTypeScheme = TypeSchemeArrow $ TypeSchemeArrow TypeSchemeResult

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -147,19 +147,19 @@ defaultCostModelParamsForVariant = \case
 We don't want this to get inlined in order for this definition not to appear
 faster than the used in production. Also see Note [noinline for saving on
 ticks]. -}
-defaultCekParametersA :: Typeable ann => MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ann)
+defaultCekParametersA :: MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 defaultCekParametersA =
     MachineParameters def $
         noinline mkMachineVariantParameters DefaultFunSemanticsVariantA cekCostModelVariantA
 
 -- See Note [No inlining for MachineParameters]
-defaultCekParametersB :: Typeable ann => MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ann)
+defaultCekParametersB :: MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 defaultCekParametersB =
     MachineParameters def $
         noinline mkMachineVariantParameters DefaultFunSemanticsVariantB cekCostModelVariantB
 
 -- See Note [No inlining for MachineParameters]
-defaultCekParametersC :: Typeable ann => MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ann)
+defaultCekParametersC :: MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 defaultCekParametersC =
     MachineParameters def $
         noinline mkMachineVariantParameters DefaultFunSemanticsVariantC cekCostModelVariantC
@@ -182,9 +182,8 @@ defaultBuiltinsRuntimeForSemanticsVariant semvar =
           DefaultFunSemanticsVariantC -> builtinCostModelVariantC
 
 defaultCekParametersForVariant
-  :: Typeable ann
-  => BuiltinSemanticsVariant DefaultFun
-  -> MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ann)
+  :: BuiltinSemanticsVariant DefaultFun
+  -> MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 defaultCekParametersForVariant = \case
   DefaultFunSemanticsVariantA -> defaultCekParametersA
   DefaultFunSemanticsVariantB -> defaultCekParametersB
@@ -208,7 +207,7 @@ defaultBuiltinsRuntimeForTesting
 -- See Note [noinline for saving on ticks].
 defaultBuiltinsRuntimeForTesting = defaultBuiltinsRuntimeForSemanticsVariant DefaultFunSemanticsVariantC
 
-defaultCekParametersForTesting :: Typeable ann => MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ann)
+defaultCekParametersForTesting :: MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 defaultCekParametersForTesting = defaultCekParametersC
 
 defaultCekMachineCostsForTesting :: CekMachineCosts
@@ -355,7 +354,7 @@ unitCostBuiltinCostModel = BuiltinCostModelBase
     , paramIndexArray                      = unitCostTwoArguments
     }
 
-unitCekParameters :: Typeable ann => MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ann)
+unitCekParameters :: MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 unitCekParameters =
     -- See Note [noinline for saving on ticks].
     MachineParameters def $

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
@@ -18,13 +18,13 @@ import GHC.Exts (inline)
 
 -- | The semantics-variant-dependent part of 'MachineParameters'.
 type DefaultMachineVariantParameters =
-    MachineVariantParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ())
+    MachineVariantParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 
 -- | 'MachineParameters' instantiated at CEK-machine-specific types and default builtins.
 -- Encompasses everything we need for evaluating a UPLC program with default builtins using the CEK
 -- machine.
 type DefaultMachineParameters =
-    MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ())
+    MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun)
 
 {- Note [Inlining meanings of builtins]
 It's vitally important to inline the 'toBuiltinMeaning' method of a set of built-in functions as

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -68,7 +68,7 @@ A wrapper around the internal runCek to debruijn input and undebruijn output.
 -}
 runCek
     :: ThrowableBuiltins uni fun
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term Name uni fun ann
@@ -79,7 +79,7 @@ runCek = Common.runCek runCekDeBruijn
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 runCekNoEmit
     :: ThrowableBuiltins uni fun
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost)
@@ -90,7 +90,7 @@ runCekNoEmit = Common.runCekNoEmit runCekDeBruijn
 evaluateCek
     :: ThrowableBuiltins uni fun
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), [Text])
 evaluateCek = Common.evaluateCek runCekDeBruijn
@@ -99,7 +99,7 @@ evaluateCek = Common.evaluateCek runCekDeBruijn
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 evaluateCekNoEmit
     :: ThrowableBuiltins uni fun
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) (Term Name uni fun ())
 evaluateCekNoEmit = Common.evaluateCekNoEmit runCekDeBruijn
@@ -108,7 +108,7 @@ evaluateCekNoEmit = Common.evaluateCekNoEmit runCekDeBruijn
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 readKnownCek
     :: (ThrowableBuiltins uni fun, ReadKnown (Term Name uni fun ()) a)
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) a
 readKnownCek = Common.readKnownCek runCekDeBruijn

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/CommonAPI.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/CommonAPI.hs
@@ -71,7 +71,7 @@ import Data.Text (Text)
 
 -- The type of the machine (runner function).
 type MachineRunner cost uni fun ann =
-      MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+      MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> NTerm uni fun ann
@@ -94,7 +94,7 @@ A wrapper around the internal runCek to debruijn input and undebruijn output.
 -}
 runCek ::
       MachineRunner cost uni fun ann
-    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term Name uni fun ann
@@ -125,7 +125,7 @@ runCek runner params mode emitMode term =
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 runCekNoEmit ::
       MachineRunner cost uni fun ann
-    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost)
@@ -139,7 +139,7 @@ evaluateCek
     :: ThrowableBuiltins uni fun
     => MachineRunner RestrictingSt uni fun ann
     -> EmitterMode uni fun
-    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), [Text])
 evaluateCek runner emitMode params =
@@ -151,7 +151,7 @@ evaluateCek runner emitMode params =
 evaluateCekNoEmit
     :: ThrowableBuiltins uni fun
     => MachineRunner RestrictingSt uni fun ann
-    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) (Term Name uni fun ())
 evaluateCekNoEmit runner params = fst . runCekNoEmit runner params restrictingEnormous
@@ -161,7 +161,7 @@ evaluateCekNoEmit runner params = fst . runCekNoEmit runner params restrictingEn
 readKnownCek
     :: (ThrowableBuiltins uni fun, ReadKnown (Term Name uni fun ()) a)
     => MachineRunner RestrictingSt uni fun ann
-    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) a
 readKnownCek runner params = evaluateCekNoEmit runner params >=> readKnownSelf

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek.hs
@@ -65,7 +65,7 @@ A wrapper around the internal runCek to debruijn input and undebruijn output.
 -}
 runCek
     :: ThrowableBuiltins uni fun
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term Name uni fun ann
@@ -77,7 +77,7 @@ runCek = Common.runCek S.runCekDeBruijn
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 runCekNoEmit
     :: ThrowableBuiltins uni fun
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost)
@@ -88,7 +88,7 @@ runCekNoEmit = Common.runCekNoEmit S.runCekDeBruijn
 evaluateCek
     :: ThrowableBuiltins uni fun
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), [Text])
 evaluateCek = Common.evaluateCek S.runCekDeBruijn
@@ -97,7 +97,7 @@ evaluateCek = Common.evaluateCek S.runCekDeBruijn
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 evaluateCekNoEmit
     :: ThrowableBuiltins uni fun
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) (Term Name uni fun ())
 evaluateCekNoEmit = Common.evaluateCekNoEmit S.runCekDeBruijn
@@ -106,7 +106,7 @@ evaluateCekNoEmit = Common.evaluateCekNoEmit S.runCekDeBruijn
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 readKnownCek
     :: (ThrowableBuiltins uni fun, ReadKnown (Term Name uni fun ()) a)
-    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
+    => MachineParameters CekMachineCosts fun (CekValue uni fun)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) a
 readKnownCek = Common.readKnownCek S.runCekDeBruijn

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
@@ -63,7 +63,7 @@ typecheckAnd
        , CaseBuiltin uni, Closed uni, uni `Everywhere` ExMemoryUsage
        )
     => BuiltinSemanticsVariant fun
-    -> (MachineParameters CekMachineCosts fun (CekValue uni fun ()) ->
+    -> (MachineParameters CekMachineCosts fun (CekValue uni fun) ->
             UPLC.Term Name uni fun () -> a)
     -> CostingPart uni fun -> TPLC.Term TyName Name uni fun () -> m a
 typecheckAnd semvar action costingPart term = TPLC.runQuoteT $ do
@@ -195,5 +195,3 @@ evalOkEq t1 t2 =
 
 evalOkTrue :: PlcTerm -> Property
 evalOkTrue t = evalOkEq t true
-
-

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/FreeVars.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/FreeVars.hs
@@ -58,7 +58,7 @@ testDischargeFree = testGroup "discharge" $ fmap (uncurry testCase)
   where
     freeRemains1 =
         -- dis( empty |- (delay (\x ->var0)) ) === (delay (\x -> var0))
-        dis (VDelay (toFakeTerm fun0var0)
+        dis (VDelay (forgetAnn $ toFakeTerm fun0var0)
             []) -- empty env
         @?=
         toFakeTerm (Delay () fun0var0)
@@ -69,7 +69,7 @@ testDischargeFree = testGroup "discharge" $ fmap (uncurry testCase)
         -- y is discharged from the env
         -- var0 is free so it is left alone
         dis (VLamAbs (fakeNameDeBruijn $ DeBruijn deBruijnInitIndex)
-                (toFakeTerm $
+                (forgetAnn $ toFakeTerm $
                  v 1 @@ -- x
                  [v 2 -- y
                  ,var0 -- free

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Machines.hs
@@ -70,7 +70,7 @@ test_machines =
 
 testBudget
     :: (Ix fun, Show fun, Hashable fun, Pretty fun, Typeable fun)
-    => BuiltinsRuntime fun (CekValue DefaultUni fun ())
+    => BuiltinsRuntime fun (CekValue DefaultUni fun)
     -> TestName
     -> Term Name DefaultUni fun ()
     -> TestNested


### PR DESCRIPTION
For Cek, we intentionally maintain ambiguity of the annotation type for performance reasons(I assume). This PR makes it so that this ambiguity is forcefully enforced by using `GHC.Exts.Any` as the annotation type. This reduces some noise on the types while also allowing construction of UPLC nodes within CEK in nicer way, which is what I needed for [this](https://github.com/IntersectMBO/plutus/pull/7188/files#r2191103734) 

SteppableCek is a bit messy because its context can hold annotations, so it would require more coercsions. 