### PR TITLE
[Benchmark] Remove preparation noise from the 'validation' benchmarks

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -614,7 +614,6 @@ benchmark validation-agda-cek
     , base                     >=4.9     && <5
     , bytestring
     , criterion                >=1.5.9.0
-    , deepseq
     , directory
     , filepath
     , flat                     ^>=0.6

--- a/plutus-benchmark/validation/bench/BenchAgdaCek.hs
+++ b/plutus-benchmark/validation/bench/BenchAgdaCek.hs
@@ -3,17 +3,9 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Common (benchWith, unsafeUnflat)
+import Common (benchWith)
 import PlutusBenchmark.Agda.Common (benchTermAgdaCek)
-import PlutusBenchmark.Common (toNamedDeBruijnTerm)
-import UntypedPlutusCore qualified as UPLC
-
-import Control.DeepSeq (force)
 
 -- Run the validation benchmarks using the Agda CEK machine.
 main :: IO ()
-main = do
-  let mkAgdaCekBM file program =
-          let !benchTerm = force . toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file program
-          in benchTermAgdaCek benchTerm
-  benchWith mkAgdaCekBM
+main = benchWith $ \(~_) (~_) -> benchTermAgdaCek

--- a/plutus-benchmark/validation/bench/BenchCek.hs
+++ b/plutus-benchmark/validation/bench/BenchCek.hs
@@ -1,12 +1,10 @@
 {- | Validation benchmarks for the CEK machine. -}
 module Main where
 
-import Common (benchTermCek, benchWith, mkEvalCtx, unsafeUnflat)
+import Common (benchTermCek, benchWith, mkEvalCtx)
 import Control.Exception (evaluate)
-import PlutusBenchmark.Common (toNamedDeBruijnTerm)
 import PlutusCore.Default (BuiltinSemanticsVariant (DefaultFunSemanticsVariantA))
 import PlutusLedgerApi.Common (PlutusLedgerLanguage (PlutusV1))
-import UntypedPlutusCore as UPLC
 
 {-|
  Benchmarks only for the CEK execution time of the data/*.flat validation scripts
@@ -21,6 +19,4 @@ main = do
   -- The validation benchmarks were all created with PlutusV1, so let's make
   -- sure that the evaluation context matches.
   evalCtx <- evaluate $ mkEvalCtx PlutusV1 DefaultFunSemanticsVariantA
-  let mkCekBM file program =
-          benchTermCek evalCtx . toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file program
-  benchWith mkCekBM
+  benchWith $ \(~_) (~_) -> benchTermCek evalCtx

--- a/plutus-benchmark/validation/bench/BenchDec.hs
+++ b/plutus-benchmark/validation/bench/BenchDec.hs
@@ -9,7 +9,6 @@ import Common
 import Control.DeepSeq (force)
 import Control.Exception
 import Criterion
-import Data.ByteString as BS
 import Data.Functor
 
 {-|
@@ -24,8 +23,7 @@ the time taken to only flat-deserialize the script
 main :: IO ()
 main = benchWith mkDecBM
   where
-    mkDecBM :: FilePath -> BS.ByteString -> Benchmarkable
-    mkDecBM file bsFlat =
+    mkDecBM file bsFlat _ =
         let
             UPLC.Program _ v (fullyApplied :: Term) = unsafeUnflat file bsFlat
 

--- a/plutus-benchmark/validation/bench/BenchFull.hs
+++ b/plutus-benchmark/validation/bench/BenchFull.hs
@@ -50,4 +50,4 @@ main = do
               (either (error . show) id $ deserialiseScript futurePV script)
               args
         in whnf eval benchScript
-  benchWith mkFullBM
+  benchWith $ \file script (~_) -> mkFullBM file script

--- a/plutus-benchmark/validation/bench/BenchFull.hs
+++ b/plutus-benchmark/validation/bench/BenchFull.hs
@@ -50,4 +50,4 @@ main = do
               (either (error . show) id $ deserialiseScript futurePV script)
               args
         in whnf eval benchScript
-  benchWith $ \file script -> mkFullBM file script
+  benchWith $ \file script (~_) -> mkFullBM file script

--- a/plutus-benchmark/validation/bench/BenchFull.hs
+++ b/plutus-benchmark/validation/bench/BenchFull.hs
@@ -50,4 +50,4 @@ main = do
               (either (error . show) id $ deserialiseScript futurePV script)
               args
         in whnf eval benchScript
-  benchWith $ \file script (~_) -> mkFullBM file script
+  benchWith $ \file script -> mkFullBM file script

--- a/plutus-benchmark/validation/bench/Common.hs
+++ b/plutus-benchmark/validation/bench/Common.hs
@@ -132,7 +132,7 @@ benchWith act = do
     mkScriptBM dir file =
         let readAndPrep = do
                 script <- BS.readFile (dir </> file)
-                pure (script, UPLC.Error ()) -- toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file script)
+                pure (script, toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file script)
         in env readAndPrep $ \(~scriptAndTerm) ->
             -- We use 'uncurry', because for whatever reason lazy matching on a tuple doesn't work
             -- when @Strict@ is enabled.

--- a/plutus-benchmark/validation/bench/Common.hs
+++ b/plutus-benchmark/validation/bench/Common.hs
@@ -107,6 +107,7 @@ parserInfo cfg =
 benchWith
     :: (   FilePath
         -> BS.ByteString
+        -> UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
         -> Benchmarkable
        )
     -> IO ()
@@ -131,11 +132,11 @@ benchWith act = do
     mkScriptBM dir file =
         let readAndPrep = do
                 script <- BS.readFile (dir </> file)
-                pure script
-        in env readAndPrep $ \(~script) ->
+                pure (script, UPLC.Error ()) -- toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file script)
+        in env readAndPrep $ \(~scriptAndTerm) ->
             -- We use 'uncurry', because for whatever reason lazy matching on a tuple doesn't work
             -- when @Strict@ is enabled.
-            bench (dropExtension file) $ act file script
+            bench (dropExtension file) $ uncurry (act file) scriptAndTerm
 
 type Term = UPLC.Term UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
 

--- a/plutus-benchmark/validation/bench/Common.hs
+++ b/plutus-benchmark/validation/bench/Common.hs
@@ -107,7 +107,6 @@ parserInfo cfg =
 benchWith
     :: (   FilePath
         -> BS.ByteString
-        -> UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
         -> Benchmarkable
        )
     -> IO ()
@@ -132,11 +131,11 @@ benchWith act = do
     mkScriptBM dir file =
         let readAndPrep = do
                 script <- BS.readFile (dir </> file)
-                pure (script, UPLC.Error ()) -- toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file script)
-        in env readAndPrep $ \(~scriptAndTerm) ->
+                pure script
+        in env readAndPrep $ \(~script) ->
             -- We use 'uncurry', because for whatever reason lazy matching on a tuple doesn't work
             -- when @Strict@ is enabled.
-            bench (dropExtension file) $ uncurry (act file) scriptAndTerm
+            bench (dropExtension file) $ act file script
 
 type Term = UPLC.Term UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
 

--- a/plutus-benchmark/validation/bench/Common.hs
+++ b/plutus-benchmark/validation/bench/Common.hs
@@ -132,7 +132,7 @@ benchWith act = do
     mkScriptBM dir file =
         let readAndPrep = do
                 script <- BS.readFile (dir </> file)
-                pure (script, toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file script)
+                pure (script, UPLC.Error ()) -- toNamedDeBruijnTerm . UPLC._progTerm $ unsafeUnflat file script)
         in env readAndPrep $ \(~scriptAndTerm) ->
             -- We use 'uncurry', because for whatever reason lazy matching on a tuple doesn't work
             -- when @Strict@ is enabled.


### PR DESCRIPTION
This fixes the `validation` benchmarks unintentionally counting in preparation time (deserialization + conversion to `NamedDeBruijn`) and partially addresses the issue with `validation` benchmarks that I ran into in #7177.