### PR TITLE
Bump brace-expansion to v1.1.12 in docusaurus

### DIFF
--- a/doc/docusaurus/package.json
+++ b/doc/docusaurus/package.json
@@ -43,7 +43,8 @@
     "image-size": "1.2.1",
     "estree-util-value-to-estree": "3.3.3",
     "http-proxy-middleware": "2.0.9",
-    "webpack-dev-server": "5.2.1"
+    "webpack-dev-server": "5.2.1",
+    "brace-expansion": "1.1.12"
   },
   "browserslist": {
     "production": [

--- a/doc/docusaurus/yarn.lock
+++ b/doc/docusaurus/yarn.lock
@@ -3214,10 +3214,10 @@ boxen@^7.0.0:
     widest-line "^4.0.1"
     wrap-ansi "^8.1.0"
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@1.1.12, brace-expansion@^1.1.7:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
+  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
Addresses [Dependabot Alert #51](https://github.com/IntersectMBO/plutus/security/dependabot/51)