### PR TITLE
Remove caseData and caseList builtins from specification

### DIFF
--- a/doc/plutus-core-spec/builtins.tex
+++ b/doc/plutus-core-spec/builtins.tex
@@ -95,13 +95,15 @@ Figure~\ref{fig:type-variables}.
     \label{fig:type-variables}
 \end{minipage}
 % Previously we had fully polymorphic type variables like a_*, which allowed us
-% to re-use this notation with typed PLC.  This was OK until the advent of
-% caseData and caseList, which take term arguments which are expected to be
-% whose types involve arrows: the problem is that (a), we can't represent these
-% in the UPLC "type system", and (b) caseData and caseList in fact return a
-% HeadSpine object and if you supply a non-function argument it'll be embedded
-% in one of these and the type mismatch won't be discovered until the HeadSpine
-% is later evaluated.
+% to re-use this notation with typed PLC.  This was OK until the experiments
+% with caseData and caseList, which took arguments which whose types involved
+% arrows: the problem was that (a), we couldn't represent these in the UPLC
+% "type system", and (b) caseData and caseList in fact returned a HeadSpine
+% object and if you supplied a non-function argument it would be embedded in one
+% of these and the type mismatch wouldn't be discovered until the HeadSpine was
+% later evaluated.  At some point we will remove the notational machinery
+% introduced to deal with these builtins, but it will probably make sense to
+% keep the single fully-polymorphic type variable * if we do that.
 
 % If we ever specify TPLC we'll need a richer grammar of types for it, and here
 % we will need genuine type variables which are polymorphic over terms; these
@@ -305,14 +307,12 @@ $$%%
 
 \noindent We will denote elements of $\R^+$ by expressions of the form $(v|v_1,
 \ldots, v_k)$ with $v, v_i \in \R$ and $k \geq 0$, the case $k=0$ indicating a
-list $(v|)$ with a single entry.  The majority of builtins return a single
+list $(v|)$ with a single entry.  Currently all builtins return a single
 value, and to simplify notation we will identify $\R$ with $\{(v|): v \in \R\}
 \subseteq \R^+$.  The intention is that $(v|v_1, \ldots, v_k)$ will
 immediately be interpreted as an application $v \;v_1\; \ldots\; v_k$ in the
 ambient language (eg, typed or untyped Plutus Core); the number of arguments $k$
-may depend on the values of the inputs to the function, as is the case for the
-$\texttt{caseList}$ and $\texttt{caseData}$ functions described in
-Appendix~\ref{sec:default-builtins-6}.
+may depend on the values of the inputs to the function.
 
 \subsubsection{Signatures and denotations of built-in functions}
 \label{sec:signatures}

--- a/doc/plutus-core-spec/cardano/builtins6.tex
+++ b/doc/plutus-core-spec/cardano/builtins6.tex
@@ -11,10 +11,8 @@
 \subsection{Batch 6}
 \label{sec:default-builtins-6}
 This section describes some new types and functions which have not been released
-at the time of writing (May 2025), but are expected to be released at a later
-date, with the possible exception of the \texttt{caseList} and \texttt{caseData}
-functions, which are experimental and may be removed at some point and replaced
-with better alternatives.
+at the time of writing (July 2025), but are expected to be released at a later
+date.
 
 \subsubsection{Built-in type operators}
 \label{sec:built-in-type-operators-6}
@@ -104,25 +102,7 @@ Operations are defined in Table~\ref{table:built-in-functions-6}.
             x_{k+1}   & \text{if $0 \leq k \leq n-1$} \\ \relax
             \errorX   & \text{if $k > n-1$}\\
         \end{array}\right.$}  
-      & Yes
-      & \\
-    \TT{caseList}        & $[\forall a_\#, \forall\star, \star, \star, \listOf{a_\#}] \to \ap$
-                                              & \text{$(t_1, t_2, []) \mapsto (t_1|)$,}
-                                              \text{$(t_1, t_2,
-                                              [x_1,\ldots,x_n]) \mapsto (t_2|x_1,[x_2,\ldots,x_n])\ (n \geq 1)$}
-                                              & & \ref{note:case-list-case-data}\\[5mm]
-    \TT{caseData}        & $[\forall\star, \star, \star, \star, \star, \star, \ty{data}] \to \ap$
-    & $(t_C, t_M, t_L, t_I, t_B, d)$
-    \smallskip
-    \newline  % The big \{ was abutting the text above
-    \text{$\;\;\mapsto
-               \left\{ \begin{array}{ll}  %% This looks better than `cases`
-                 (t_C|n,l)  & \text{if $d = \inj_C(n, l)$} \\
-                 (t_M|l)  & \text{if $d = \inj_M(l)$} \\
-                 (t_L|l)  & \text{if $d = \inj_L(l)$} \\
-                 (t_I|n)  & \text{if $d =\inj_I(n)$} \\
-                 (t_B|s)  & \text{if $d = \inj_B(s)$} \\
-               \end{array}\right.$}  & & \ref{note:case-list-case-data}\\
+      & Yes & \\
 \hline
 \end{longtable}
 
@@ -146,38 +126,6 @@ $$
 follows, for example, from Proposition I.3.1 of~\cite{Koblitz-GTM}.  See
 Note~\ref{note:integer-division-functions} of
 Section~\ref{sec:built-in-functions-1} for the definition of $\modfn$.
-
-\note{\texttt{caseList} and \texttt{caseData} in UPLC.}
-\label{note:case-list-case-data}
-The \texttt{caseList} function takes two inputs $t_1$ and $t_2$ and a list $l$
-and returns the delayed application $(t_1|)$ if $l$ is empty and
-$(t_2|h,l^{\prime})$ if $l$ is nonempty with head $h$ and tail $l^{\prime}$.
-The intended usage is that if $l$ is a list with elements of type $\alpha$ then
-$t_1$ should be a term of some type $\beta$ and $t_2$ a function of type
-$\alpha \rightarrow
-\mathtt{list}(\alpha) \rightarrow \beta$; however, Untyped Plutus Core has no notion
-of type for general terms and when \texttt{caseList} is applied there is no
-check that the inputs $t_1$ and $t_2$ are of the expected type.  In UPLC, when
-the list $l$ is nonempty the deferred application $(t_2|h,l^{\prime})$ will
-immediately be turned into a genuine application by the evaluator, and at that
-point there may be an error because the term $t_2$ cannot be applied to the
-arguments $h$ and $l^{\prime}$ (although even then an error may not occur if,
-for example $t_2 h l^{\prime}$ is not a saturated application (ie, $t_2$ expects
-more than two arguments)) .  In the case of the empty list, the value $(t_1|)$
-is effectively constant and no error will occur.  However, an error will occur
-immediately if the final argument of \texttt{caseList} is not of
-type \texttt{list}.
-
-The \texttt{caseData} function behaves similarly: the argument $d$ is expected
-to be an object of the built-in \texttt{data} type (see
-Section~\ref{sec:built-in-types-1}) and $t_C, t_M, t_L, t_I$, and $t_B$ are
-expected to be functions which will be applied to the contents of
-the \texttt{Constr}, \texttt{Map}, \texttt{List}, \texttt{I} and \texttt{B}
-constructors of the \texttt{data} argument respectively, but again there is no
-typecheck of the functional arguments when \texttt{caseData} is applied and a
-type mismatch can only be detected when the evaluator attempts to evaluate the
-deferred application.  However, there will be an immediate error if the final
-argument of \texttt{caseData} is not of type \texttt{data}.
 
 
 

--- a/doc/plutus-core-spec/flat-serialisation.tex
+++ b/doc/plutus-core-spec/flat-serialisation.tex
@@ -747,8 +747,6 @@ and forth between builtin names and their tags.
  \TT{lengthOfArray}   & $\bits{1011001}$  & 89 \\
  \TT{listToArray}     & $\bits{1011010}$  & 90 \\
  \TT{indexArray}      & $\bits{1011011}$  & 91 \\
- \TT{caseList}        & $\bits{1111110}$  & 126 \\
- \TT{caseData}        & $\bits{1111111}$  & 127 \\
 \hline
 \end{tabular}
 \caption{Tags for built-in functions (Batch 6)}

--- a/doc/plutus-core-spec/notation.tex
+++ b/doc/plutus-core-spec/notation.tex
@@ -123,7 +123,7 @@ functions between bytestrings and bitstrings
   denoted by $\epsilon$: we also use this symbol for the empty bytestring, but
   this should not cause any confusion.
 
-\item In the special case of bitstrings sometimes use notation such as
+\item In the special case of bitstrings we sometimes use notation such as
   \texttt{101110} to denote the list $[1,0,1,1,1,0]$; we use a teletype font to
   avoid confusion with decimal numbers.
 

--- a/doc/plutus-core-spec/plutus-core-specification.tex
+++ b/doc/plutus-core-spec/plutus-core-specification.tex
@@ -5,7 +5,7 @@
   \LARGE{\red{\textsf{DRAFT}}}
 }
 
-\date{18th June 2025}
+\date{16th July 2025}
 \author{Plutus Core Team}
 
 \input{header.tex}


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/plutus-private/issues/1670

This removes the `caseList` and `caseData` builtins from the PLC specification to reflect #7190.  These were added to the specification in #6895, which required reworking the specification significantly to allow builtins to return "deferred applications" (`HeadSpine` objects) of the form `(v|v₁,...,vₖ)`.  These are no longer required and may be removed in a separate PR to make it easier to restore them later if required.