### PR TITLE
Autodelete latest haddock build on new deployments

### DIFF
--- a/.github/workflows/haddock-site.yml
+++ b/.github/workflows/haddock-site.yml
@@ -67,6 +67,21 @@ jobs:
     environment:
       name: github-pages
     steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete Oldest Build
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          ls -la 
+          rm -rf haddock/
+          git rm -r --cached haddock/ || true
+          git commit -am "Delete oldest haddock build"
+          git push origin gh-pages
+
       - name: Checkout
         uses: actions/checkout@main
         with:

--- a/.github/workflows/haddock-site.yml
+++ b/.github/workflows/haddock-site.yml
@@ -74,13 +74,17 @@ jobs:
 
       - name: Delete Oldest Build
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          ls -la 
-          rm -rf haddock/
-          git rm -r --cached haddock/ || true
-          git commit -am "Delete oldest haddock build"
-          git push origin gh-pages
+          # Delete the oldest haddock build if there are more than 11 builds.
+          if [[ $(ls -1A haddock | wc -l) -gt 11 ]]; then
+            OLDEST_BUILD=$(ls -1A haddock | sort | head -n 1)
+            rm -rf haddock/$OLDEST_BUILD
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -r --cached haddock/$OLDEST_BUILD || true
+            git commit -am "Delete oldest haddock build $OLDEST_BUILD"
+            git push origin gh-pages
+          fi  
 
       - name: Checkout
         uses: actions/checkout@main


### PR DESCRIPTION
Each haddock build weighs ~500MB.
Every 2 weeks a new version of plutus is released, and with it, a new version of the haddock. 
This PR deletes the oldest haddock build before deploying a new one. 
We keep the last 10 builds.