### PR TITLE
Allow 'turtle' package to use a new version of 'optparse-applicative'

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -90,3 +90,7 @@ allow-newer:
   ral:QuickCheck,
   fin:QuickCheck,
   bin:QuickCheck,
+
+-- This forces turtle to use a newer version of optparse-applicative.
+constraints: setup.optparse-applicative >=0.19.0.0
+allow-newer: turtle:optparse-applicative

--- a/cabal.project
+++ b/cabal.project
@@ -91,6 +91,6 @@ allow-newer:
   fin:QuickCheck,
   bin:QuickCheck,
 
--- This forces turtle to use a newer version of optparse-applicative.
+-- https://github.com/IntersectMBO/plutus/pull/7236
 constraints: setup.optparse-applicative >=0.19.0.0
 allow-newer: turtle:optparse-applicative


### PR DESCRIPTION
The `cabal.project.freeze` file generated by `cabal freeze` contains packages pinned to multiple versions eg:

```
any.foldl ==1.4.17 || ==1.4.18,
any.optparse-applicative ==0.18.1.0 || ==0.19.0.0,
```

The `/scripts/combined-haddock.sh` then reads the freeze file to extract version information and replace `/nix/store` paths with `https://` hrefs in the generated html files. But the new `||` syntax causes the [haddock build to fail](https://github.com/IntersectMBO/plutus/actions/runs/16352594468/job/46202949272) with:
```
sed: file dist-newstyle/sedscript.txt line 123: unknown option to `s'
```

This presence of offending packages in the `cabal.project.freeze` file is confirmed by `dist-newstyle/cache/plan.json`: 
```
    {
      "type": "pre-existing",
      "id": "optparse-applicative-0.19.0.0-EMzEmM6bTtg9FYcsfPfhCM",
      "pkg-name": "optparse-applicative",
      "pkg-version": "0.19.0.0",
      "depends": [
        "base-4.18.3.0",
        "prettyprinter-1.7.1-BxNhIqpyTtt2Mpd5bWf0h1",
        "prettyprinter-ansi-terminal-1.1.3-FRZX2D1cIESBgIPDeBTyKm",
        "process-1.6.19.0",
        "text-2.0.2",
        "transformers-0.6.1.0"
      ]
    }
...
    {
      "type": "pre-existing",
      "id": "optparse-applicative-0.18.1.0-IM7nYpjCzAe9lJGlopmyJR",
      "pkg-name": "optparse-applicative",
      "pkg-version": "0.18.1.0",
      "depends": [
        "base-4.18.3.0",
        "prettyprinter-1.7.1-BxNhIqpyTtt2Mpd5bWf0h1",
        "prettyprinter-ansi-terminal-1.1.3-FRZX2D1cIESBgIPDeBTyKm",
        "process-1.6.19.0",
        "text-2.0.2",
        "transformers-0.6.1.0",
        "transformers-compat-0.7.2-Gt8KxspbTpUIHfKPq3SCp6"
      ]
    },
```

The reason we get two `pre-existing` packages inside the `nix develop` shell is that both version were made available in that shell. If we look at the plan nix builds: `nix build .#hydraJobs.x86_64-linux.ghc96:plan-nix && jq . result/plan.json |less` both `0.18.1.0` and `0.19.0.0` are present, but they are both configured.
As to why both are in the plan to begin with, tracing the dependency back in the `plan.json`, it looks like the custom setup for `plutus-cert` depends on turtle and that is what brings in `0.18.1.0`:
```
    {
      "type": "configured",
      "id": "plutus-cert-0.1.0.0-3e93cc72a5109a20cd23e7005a74be8029716f936a19164a516256e08665fd2f",
      "pkg-name": "plutus-cert",
      "pkg-version": "0.1.0.0",
      "flags": {},
      "style": "global",
      "pkg-src": {
        "type": "source-repo",
        "source-repo": {
          "type": "git",
          "location": "https://github.com/jaccokrijnen/plutus-cert",
          "tag": "e814b9171398cbdfecdc6823067156a7e9fc76a3"
        }
      },
      "pkg-src-sha256": "8a4cd3afa7c23b4a34636bf03d20eae481b3705741b1fd75399617287b5b5d39",
      "components": {
        "lib": {
          "depends": [
            "base-4.18.3.0"
          ],
          "exe-depends": []
        },
        "setup": {
          "depends": [
            "Cabal-3.10.3.0",
            "base-4.18.3.0",
            "process-1.6.19.0",
            "turtle-1.6.2-EqP8q7PGvvmQMHcTCjbUc"
          ],
          "exe-depends": []
        }
      }
    },
```

We can force `turtle` to use a newer version of `optparse-applicative` by adding to the `cabal.project` file:
```
+constraints: setup.optparse-applicative >=0.19.0.0
+allow-newer: turtle:optparse-applicative
``` 
