### PR TITLE
Add some missing parentheses in the conformance tests

### DIFF
--- a/plutus-conformance/test-cases/uplc/evaluation/term/constr/constr-09/constr-09.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/term/constr/constr-09/constr-09.uplc
@@ -1,4 +1,4 @@
 -- Tag cannot exceeed 2^64-1 = maxBound :: Word64
 (program 1.1.0
-    (constr 18446744073709551616 (con string "Maximum tag plus one") (con unit ())
+    (constr 18446744073709551616 (con string "Maximum tag plus one") (con unit ()))
 )

--- a/plutus-conformance/test-cases/uplc/evaluation/term/constr/constr-10/constr-10.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/term/constr/constr-10/constr-10.uplc
@@ -1,4 +1,4 @@
 -- Version check fails before tag check
 (program 1.0.0
-    (constr 18446744073709551616 (con string "Maximum tag plus one") (con unit ())
+    (constr 18446744073709551616 (con string "Maximum tag plus one") (con unit ()))
 )


### PR DESCRIPTION
Add some missing parentheses (pointed out by @RSoulatIOHK).