### PR TITLE
[Build] Fix 'master'

### DIFF
--- a/plutus-tx-plugin/test/CallTrace/9.6/func03.eval.golden
+++ b/plutus-tx-plugin/test/CallTrace/9.6/func03.eval.golden
@@ -6,4 +6,4 @@ Trace:
 -> func (test/CallTrace/Spec.hs:78:1-78:4)
 -> functionFromOtherModule (test/CallTrace/Spec.hs:93:1-93:23)
 -> $
--> errorWhenTrue (test/CallTrace/OtherModule.hs:9:1-9:13)
+-> errorWhenTrue

--- a/plutus-tx-plugin/test/CallTrace/9.6/func05.eval.golden
+++ b/plutus-tx-plugin/test/CallTrace/9.6/func05.eval.golden
@@ -7,4 +7,4 @@ Trace:
 -> $cmyClassFunc (test/CallTrace/Spec.hs:99:3-99:13)
 -> functionFromOtherModule (test/CallTrace/Spec.hs:93:1-93:23)
 -> $
--> errorWhenTrue (test/CallTrace/OtherModule.hs:9:1-9:13)
+-> errorWhenTrue

--- a/plutus-tx-plugin/test/CallTrace/9.6/func07.eval.golden
+++ b/plutus-tx-plugin/test/CallTrace/9.6/func07.eval.golden
@@ -4,4 +4,4 @@ Caused by: error
 
 Trace:
 -> func (test/CallTrace/Spec.hs:78:1-78:4)
--> $fMyClassInOtherModuleInteger_$cmyClassFuncInOtherModule (test/CallTrace/OtherModule.hs:19:3-19:26)
+-> $fMyClassInOtherModuleInteger_$cmyClassFuncInOtherModule

--- a/plutus-tx-plugin/test/CallTrace/9.6/func08.eval.golden
+++ b/plutus-tx-plugin/test/CallTrace/9.6/func08.eval.golden
@@ -4,4 +4,4 @@ Caused by: error
 
 Trace:
 -> func (test/CallTrace/Spec.hs:78:1-78:4)
--> $fMyClassInOtherModuleInteger_$cmyClassFuncInOtherModule (test/CallTrace/OtherModule.hs:19:3-19:26)
+-> $fMyClassInOtherModuleInteger_$cmyClassFuncInOtherModule

--- a/plutus-tx-plugin/test/CallTrace/9.6/func09.eval.golden
+++ b/plutus-tx-plugin/test/CallTrace/9.6/func09.eval.golden
@@ -4,4 +4,4 @@ Caused by: error
 
 Trace:
 -> func (test/CallTrace/Spec.hs:78:1-78:4)
--> $fMyClassInOtherModule()_$cmyClassFuncInOtherModule (test/CallTrace/OtherModule.hs:23:3-23:26)
+-> $fMyClassInOtherModule()_$cmyClassFuncInOtherModule

--- a/plutus-tx-plugin/test/CallTrace/9.6/funcionFromOtherModule-error.eval.golden
+++ b/plutus-tx-plugin/test/CallTrace/9.6/funcionFromOtherModule-error.eval.golden
@@ -5,4 +5,4 @@ Caused by: error
 Trace:
 -> functionFromOtherModule (test/CallTrace/Spec.hs:93:1-93:23)
 -> $
--> errorWhenTrue (test/CallTrace/OtherModule.hs:9:1-9:13)
+-> errorWhenTrue

--- a/plutus-tx-plugin/test/CallTrace/9.6/successfullEvaluationYieldsNoTraceLog.eval.golden
+++ b/plutus-tx-plugin/test/CallTrace/9.6/successfullEvaluationYieldsNoTraceLog.eval.golden
@@ -1,7 +1,7 @@
 CPU:                 3_745_072
 Memory:                 18_748
 Term Size:                 147
-Flat Size:                 509
+Flat Size:                 343
 
 No Trace Produced
 


### PR DESCRIPTION
`master` appears broken. This fixes it.