### PR TITLE
Make our repo buildable again with `-O0`.

### DIFF
--- a/doc/docusaurus/docusaurus-examples.cabal
+++ b/doc/docusaurus/docusaurus-examples.cabal
@@ -18,6 +18,7 @@ common lang
     -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -Wunused-packages -Wmissing-deriving-strategies
+    -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
 
 common ghc-version-support
   -- See the section on GHC versions in CONTRIBUTING

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Sort.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/Sort.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 module PlutusBenchmark.NoFib.Knights.Sort
         ( insertSort,
@@ -6,7 +8,8 @@ module PlutusBenchmark.NoFib.Knights.Sort
           quickSort
         ) where
 
-import PlutusTx.Prelude qualified as Tx
+import PlutusTx.Prelude as Tx
+import PlutusTx.List as Tx
 
 insertSort :: (Tx.Ord a) => [a] -> [a]
 insertSort xs = foldr insertion [] xs
@@ -24,8 +27,8 @@ mergeSort xs
         = if (n <=1 ) then xs
           else
              (mergeList
-                ( mergeSort (take (n `div` 2) xs))
-                ( mergeSort (drop (n `div` 2) xs)))
+                ( mergeSort (take (n `divide` 2) xs))
+                ( mergeSort (drop (n `divide` 2) xs)))
           where
                 n = length xs
 {-# INLINABLE mergeSort #-}
@@ -98,9 +101,9 @@ randomIntegers s1 s2 =
         if 1 <= s2 && s2 <= 2147483398 then
             rands s1 s2
         else
-            error "randomIntegers: Bad second seed."
+            traceError "randomIntegers: Bad second seed."
     else
-        error "randomIntegers: Bad first seed."
+        traceError "randomIntegers: Bad first seed."
 {-# INLINABLE randomIntegers #-}
 
 rands :: Integer -> Integer -> [Integer]
@@ -109,11 +112,11 @@ rands s1 s2
      else
          z : rands s1'' s2''
      where
-        k    = s1 `div` 53668
+        k    = s1 `divide` 53668
         s1'  = 40014 * (s1 - k * 53668) - k * 12211
         s1'' = if s1' < 0 then s1' + 2147483563 else s1'
 
-        k'   = s2 `div` 52774
+        k'   = s2 `divide` 52774
         s2'  = 40692 * (s2 - k' * 52774) - k' * 3791
         s2'' = if s2' < 0 then s2' + 2147483399 else s2'
 

--- a/plutus-benchmark/nofib/test/9.6/knights10-4x4.golden.eval
+++ b/plutus-benchmark/nofib/test/9.6/knights10-4x4.golden.eval
@@ -1,6 +1,6 @@
-CPU:             1_023_470_754
-Memory:              5_395_058
-Term Size:               1_700
-Flat Size:               1_674
+CPU:             1_028_574_754
+Memory:              5_426_958
+Term Size:               1_726
+Flat Size:               1_699
 
 (constr 0)

--- a/plutus-benchmark/nofib/test/9.6/knights10-4x4.golden.pir
+++ b/plutus-benchmark/nofib/test/9.6/knights10-4x4.golden.pir
@@ -296,137 +296,138 @@
               (\(x : a) (xs : List a) ->
                  /\dead ->
                    let
-                     !xs : List a
-                       = let
-                         !xs : List a
-                           = quickSort
-                               {a}
-                               `$dOrd`
-                               ((let
-                                    a = List a
-                                  in
-                                  \(c : a -> a -> a) (n : a) ->
-                                    letrec
-                                      !go : List a -> a
-                                        = \(ds : List a) ->
-                                            List_match
-                                              {a}
-                                              ds
-                                              {all dead. a}
-                                              (/\dead -> n)
-                                              (\(y : a) (ys : List a) ->
-                                                 /\dead ->
-                                                   let
-                                                     !ds : a = go ys
-                                                   in
-                                                   case
-                                                     (all dead. a)
-                                                     (Ord_match
-                                                        {a}
-                                                        `$dOrd`
-                                                        {a -> a -> bool}
-                                                        (\(v :
-                                                             (\a ->
-                                                                a -> a -> bool)
-                                                               a)
-                                                          (v :
-                                                             a -> a -> Ordering)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> a)
-                                                          (v : a -> a -> a) ->
-                                                           v)
-                                                        y
-                                                        x)
-                                                     [ (/\dead -> ds)
-                                                     , (/\dead -> c y ds) ]
-                                                     {all dead. dead})
-                                              {all dead. dead}
-                                    in
-                                    go xs)
-                                  (\(ds : a) (ds : List a) -> Cons {a} ds ds)
-                                  (Nil {a}))
-                       in
-                       (let
-                           b = List a
-                         in
-                         \(c : a -> b -> b) (n : b) -> c x n)
-                         (\(ds : a) (ds : List a) -> Cons {a} ds ds)
-                         xs
+                     !l : List a
+                       = quickSort
+                           {a}
+                           `$dOrd`
+                           ((let
+                                a = List a
+                              in
+                              \(c : a -> a -> a) (n : a) ->
+                                letrec
+                                  !go : List a -> a
+                                    = \(ds : List a) ->
+                                        List_match
+                                          {a}
+                                          ds
+                                          {all dead. a}
+                                          (/\dead -> n)
+                                          (\(y : a) (ys : List a) ->
+                                             /\dead ->
+                                               let
+                                                 !ds : a = go ys
+                                               in
+                                               case
+                                                 (all dead. a)
+                                                 (Ord_match
+                                                    {a}
+                                                    `$dOrd`
+                                                    {a -> a -> bool}
+                                                    (\(v :
+                                                         (\a -> a -> a -> bool)
+                                                           a)
+                                                      (v : a -> a -> Ordering)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> a)
+                                                      (v : a -> a -> a) ->
+                                                       v)
+                                                    y
+                                                    x)
+                                                 [ (/\dead -> ds)
+                                                 , (/\dead -> c y ds) ]
+                                                 {all dead. dead})
+                                          {all dead. dead}
+                                in
+                                go xs)
+                              (\(ds : a) (ds : List a) -> Cons {a} ds ds)
+                              (Nil {a}))
+                     !l : List a
+                       = (let
+                             a = List a
+                           in
+                           \(c : a -> a -> a) (n : a) -> c x n)
+                           (\(ds : a) (ds : List a) -> Cons {a} ds ds)
+                           (Nil {a})
+                     !r : List a
+                       = quickSort
+                           {a}
+                           `$dOrd`
+                           ((let
+                                a = List a
+                              in
+                              \(c : a -> a -> a) (n : a) ->
+                                letrec
+                                  !go : List a -> a
+                                    = \(ds : List a) ->
+                                        List_match
+                                          {a}
+                                          ds
+                                          {all dead. a}
+                                          (/\dead -> n)
+                                          (\(y : a) (ys : List a) ->
+                                             /\dead ->
+                                               let
+                                                 !ds : a = go ys
+                                               in
+                                               case
+                                                 (all dead. a)
+                                                 (Ord_match
+                                                    {a}
+                                                    `$dOrd`
+                                                    {a -> a -> bool}
+                                                    (\(v :
+                                                         (\a -> a -> a -> bool)
+                                                           a)
+                                                      (v : a -> a -> Ordering)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> bool)
+                                                      (v : a -> a -> a)
+                                                      (v : a -> a -> a) ->
+                                                       v)
+                                                    y
+                                                    x)
+                                                 [ (/\dead -> ds)
+                                                 , (/\dead -> c y ds) ]
+                                                 {all dead. dead})
+                                          {all dead. dead}
+                                in
+                                go xs)
+                              (\(ds : a) (ds : List a) -> Cons {a} ds ds)
+                              (Nil {a}))
                    in
-                   (let
-                       b = List a
-                     in
-                     \(c : a -> b -> b) (n : b) ->
-                       letrec
-                         !go : List a -> b
-                           = \(ds : List a) ->
-                               List_match
-                                 {a}
-                                 ds
-                                 {all dead. b}
-                                 (/\dead -> n)
-                                 (\(y : a) (ys : List a) ->
-                                    /\dead -> c y (go ys))
-                                 {all dead. dead}
-                       in
-                       let
-                         !eta : List a
-                           = quickSort
-                               {a}
-                               `$dOrd`
-                               ((let
-                                    a = List a
-                                  in
-                                  \(c : a -> a -> a) (n : a) ->
-                                    letrec
-                                      !go : List a -> a
-                                        = \(ds : List a) ->
-                                            List_match
-                                              {a}
-                                              ds
-                                              {all dead. a}
-                                              (/\dead -> n)
-                                              (\(y : a) (ys : List a) ->
-                                                 /\dead ->
-                                                   let
-                                                     !ds : a = go ys
-                                                   in
-                                                   case
-                                                     (all dead. a)
-                                                     (Ord_match
-                                                        {a}
-                                                        `$dOrd`
-                                                        {a -> a -> bool}
-                                                        (\(v :
-                                                             (\a ->
-                                                                a -> a -> bool)
-                                                               a)
-                                                          (v :
-                                                             a -> a -> Ordering)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> bool)
-                                                          (v : a -> a -> a)
-                                                          (v : a -> a -> a) ->
-                                                           v)
-                                                        y
-                                                        x)
-                                                     [ (/\dead -> ds)
-                                                     , (/\dead -> c y ds) ]
-                                                     {all dead. dead})
-                                              {all dead. dead}
-                                    in
-                                    go xs)
-                                  (\(ds : a) (ds : List a) -> Cons {a} ds ds)
-                                  (Nil {a}))
-                       in
-                       go eta)
-                     (\(ds : a) (ds : List a) -> Cons {a} ds ds)
-                     xs)
+                   letrec
+                     !go : List a -> List a
+                       = \(ds : List a) ->
+                           List_match
+                             {a}
+                             ds
+                             {all dead. List a}
+                             (/\dead -> r)
+                             (\(x : a) (xs : List a) ->
+                                /\dead -> Cons {a} x (go xs))
+                             {all dead. dead}
+                   in
+                   let
+                     !r : List a = go l
+                   in
+                   letrec
+                     !go : List a -> List a
+                       = \(ds : List a) ->
+                           List_match
+                             {a}
+                             ds
+                             {all dead. List a}
+                             (/\dead -> r)
+                             (\(x : a) (xs : List a) ->
+                                /\dead -> Cons {a} x (go xs))
+                             {all dead. dead}
+                   in
+                   go l)
               {all dead. dead}
   in
   let

--- a/plutus-tx-plugin/test/CallTrace/9.6/func09.golden.eval
+++ b/plutus-tx-plugin/test/CallTrace/9.6/func09.golden.eval
@@ -4,4 +4,4 @@ Caused by: error
 
 Trace:
 -> func (test/CallTrace/Spec.hs:79:1-79:4)
--> $fMyClassInOtherModule()_$cmyClassFuncInOtherModule (test/CallTrace/OtherModule.hs:23:3-23:26)
+-> $fMyClassInOtherModule()_$cmyClassFuncInOtherModule (test/CallTrace/OtherModule.hs:25:3-25:26)

--- a/plutus-tx-plugin/test/CallTrace/OtherModule.hs
+++ b/plutus-tx-plugin/test/CallTrace/OtherModule.hs
@@ -16,8 +16,10 @@ class MyClassInOtherModule a where
   myClassFuncInOtherModule :: a -> BuiltinString
 
 instance MyClassInOtherModule Integer where
-  myClassFuncInOtherModule 8 = wraps True
-  myClassFuncInOtherModule _ = error ()
+  myClassFuncInOtherModule x
+          -- no case on integer here, because our compiler cannot manage it
+          | x == 8 = wraps True
+          | otherwise = error ()
 
 instance MyClassInOtherModule () where
   myClassFuncInOtherModule () =  error ()


### PR DESCRIPTION
I am developing with -O0 which can cut build times in most cases. This makes our repo buildable with -O0.

Also this patch might help with hls and lsp, not 100% sure.

If you don't likek this patch, I can drop it and only keep it locally.