### PR TITLE
[Evaluation] Add 'CekResult' and improve 'dischargeCekValue'

### DIFF
--- a/cardano-constitution/test/Cardano/Constitution/Validator/Data/GoldenTests.hs
+++ b/cardano-constitution/test/Cardano/Constitution/Validator/Data/GoldenTests.hs
@@ -1,4 +1,6 @@
 -- editorconfig-checker-disable-file
+{-# LANGUAGE GADTs #-}
+
 module Cardano.Constitution.Validator.Data.GoldenTests
     ( tests
     ) where
@@ -7,6 +9,7 @@ import Cardano.Constitution.Config
 import Cardano.Constitution.Data.Validator
 import Cardano.Constitution.Validator.TestsCommon
 import Helpers.TestBuilders
+import PlutusCore.Default as UPLC
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Pretty (prettyPlcReadableSimple)
@@ -89,5 +92,5 @@ runForBudget v ctx =
         in case UPLC.runCekDeBruijn defaultCekParametersForTesting counting noEmitter vPs of
                 -- Here, we guard against the case that a ConstitutionValidator **FAILS EARLY** (for some reason),
                 -- resulting in misleading low budget costs.
-                (Left _, _, _) -> error "For safety, we only compare budget of succesful executions."
-                (Right _ , UPLC.CountingSt budget, _) -> budget
+                UPLC.CekReport (UPLC.CekSuccessConstant (UPLC.Some (UPLC.ValueOf UPLC.DefaultUniUnit ()))) (UPLC.CountingSt budget) _ -> budget
+                _ -> error "For safety, we only compare budget of succesful executions."

--- a/cardano-constitution/test/Cardano/Constitution/Validator/Data/TestsCommon.hs
+++ b/cardano-constitution/test/Cardano/Constitution/Validator/Data/TestsCommon.hs
@@ -62,7 +62,7 @@ unsafeRunCekRes = unsafeFromRight .  runCekRes
 runCekRes :: (t ~ Term NamedDeBruijn DefaultUni DefaultFun ())
              => t -> Either (CekEvaluationException NamedDeBruijn DefaultUni DefaultFun) t
 runCekRes t =
-    (\(res,_,_) -> res) $
+    UPLC.cekResultToEither . UPLC._cekReportResult $
     UPLC.runCekDeBruijn defaultCekParametersForTesting restrictingEnormous noEmitter t
 
 liftCode110 :: Lift DefaultUni a => a -> CompiledCode a

--- a/cardano-constitution/test/Cardano/Constitution/Validator/GoldenTests.hs
+++ b/cardano-constitution/test/Cardano/Constitution/Validator/GoldenTests.hs
@@ -1,4 +1,6 @@
 -- editorconfig-checker-disable-file
+{-# LANGUAGE GADTs #-}
+
 module Cardano.Constitution.Validator.GoldenTests
     ( tests
     ) where
@@ -7,6 +9,7 @@ import Cardano.Constitution.Config
 import Cardano.Constitution.Validator
 import Cardano.Constitution.Validator.TestsCommon
 import Helpers.TestBuilders
+import PlutusCore.Default as UPLC
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Pretty (prettyPlcReadableSimple)
@@ -89,5 +92,5 @@ runForBudget v ctx =
         in case UPLC.runCekDeBruijn defaultCekParametersForTesting counting noEmitter vPs of
                 -- Here, we guard against the case that a ConstitutionValidator **FAILS EARLY** (for some reason),
                 -- resulting in misleading low budget costs.
-                (Left _, _, _) -> error "For safety, we only compare budget of succesful executions."
-                (Right _ , UPLC.CountingSt budget, _) -> budget
+                UPLC.CekReport (UPLC.CekSuccessConstant (UPLC.Some (UPLC.ValueOf UPLC.DefaultUniUnit ()))) (UPLC.CountingSt budget) _ -> budget
+                _ -> error "For safety, we only compare budget of succesful executions."

--- a/cardano-constitution/test/Cardano/Constitution/Validator/TestsCommon.hs
+++ b/cardano-constitution/test/Cardano/Constitution/Validator/TestsCommon.hs
@@ -62,7 +62,7 @@ unsafeRunCekRes = unsafeFromRight .  runCekRes
 runCekRes :: (t ~ Term NamedDeBruijn DefaultUni DefaultFun ())
              => t -> Either (CekEvaluationException NamedDeBruijn DefaultUni DefaultFun) t
 runCekRes t =
-    (\(res,_,_) -> res) $
+    UPLC.cekResultToEither . UPLC._cekReportResult $
     UPLC.runCekDeBruijn defaultCekParametersForTesting restrictingEnormous noEmitter t
 
 liftCode110 :: Lift DefaultUni a => a -> CompiledCode a

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -119,10 +119,10 @@ evaluateCekLikeInProd
     -> Either
             (UPLC.CekEvaluationException UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun)
             (UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
-evaluateCekLikeInProd evalCtx term = do
+evaluateCekLikeInProd evalCtx term =
     let -- The validation benchmarks were all created from PlutusV1 scripts
         pv = LedgerApi.ledgerLanguageIntroducedIn LedgerApi.PlutusV1
-    Cek.cekResultToEither . Cek._cekReportResult $
+    in Cek.cekResultToEither . Cek._cekReportResult $
         LedgerApi.evaluateTerm UPLC.restrictingEnormous pv LedgerApi.Quiet evalCtx term
 
 -- | Evaluate a term and either throw if evaluation fails or discard the result and return '()'.

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -79,7 +79,7 @@ getConfig limit = do
 getCostsCek :: UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun () -> (Integer, Integer)
 getCostsCek (UPLC.Program _ _ prog) =
     case Cek.runCekDeBruijn PLC.defaultCekParametersForTesting Cek.tallying Cek.noEmitter prog of
-      (_res, Cek.TallyingSt _ budget, _logs) ->
+      Cek.CekReport _res (Cek.TallyingSt _ budget) _logs ->
           let ExBudget (ExCPU cpu)(ExMemory mem) = budget
           in (fromSatInt cpu, fromSatInt mem)
 
@@ -120,11 +120,10 @@ evaluateCekLikeInProd
             (UPLC.CekEvaluationException UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun)
             (UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
 evaluateCekLikeInProd evalCtx term = do
-    let (getRes, _, _) =
-            let -- The validation benchmarks were all created from PlutusV1 scripts
-                pv = LedgerApi.ledgerLanguageIntroducedIn LedgerApi.PlutusV1
-            in LedgerApi.evaluateTerm UPLC.restrictingEnormous pv LedgerApi.Quiet evalCtx term
-    getRes
+    let -- The validation benchmarks were all created from PlutusV1 scripts
+        pv = LedgerApi.ledgerLanguageIntroducedIn LedgerApi.PlutusV1
+    Cek.cekResultToEither . Cek._cekReportResult $
+        LedgerApi.evaluateTerm UPLC.restrictingEnormous pv LedgerApi.Quiet evalCtx term
 
 -- | Evaluate a term and either throw if evaluation fails or discard the result and return '()'.
 -- Useful for benchmarking.

--- a/plutus-benchmark/lists/exe/Main.hs
+++ b/plutus-benchmark/lists/exe/Main.hs
@@ -20,7 +20,7 @@ import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 
 getBudgetUsage :: Term -> Maybe Integer
 getBudgetUsage term =
-    case (\ (fstT,sndT,_) -> (fstT,sndT) ) $
+    case (\(Cek.CekReport fstT sndT _) -> (Cek.cekResultToEither fstT, sndT)) $
       Cek.runCekDeBruijn PLC.defaultCekParametersForTesting Cek.counting Cek.noEmitter term
     of
       (Left _, _)                 -> Nothing
@@ -29,7 +29,7 @@ getBudgetUsage term =
 
 getCekSteps :: Term -> Maybe Integer
 getCekSteps term =
-    case (\ (fstT,sndT,_) -> (fstT,sndT) ) $
+    case (\(Cek.CekReport fstT sndT _) -> (Cek.cekResultToEither fstT, sndT)) $
       Cek.runCekDeBruijn PLC.unitCekParameters Cek.tallying Cek.noEmitter term
     of
       (Left _, _)                   -> Nothing

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -208,7 +208,8 @@ evaluateWithCek
   -> UPLC.EvaluationResult (UPLC.Term UPLC.NamedDeBruijn DefaultUni DefaultFun ())
 evaluateWithCek =
   UPLC.unsafeSplitStructuralOperational
-  . (\(fstT,_,_) -> fstT)
+  . UPLC.cekResultToEither
+  . UPLC._cekReportResult
   . UPLC.runCekDeBruijn PLC.defaultCekParametersForTesting UPLC.restrictingEnormous UPLC.noEmitter
 
 writeFlatNamed :: UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun () -> IO ()

--- a/plutus-core/changelog.d/20250813_155837_effectfully_add_CekResult.md
+++ b/plutus-core/changelog.d/20250813_155837_effectfully_add_CekResult.md
@@ -1,0 +1,3 @@
+### Changed
+
+- In #7272 made the CEK machine return a `CekReport` and fixed a bug with `dischargeCekValue` not dicharging under `Constr` and `Case`.

--- a/plutus-core/executables/plutus/AnyProgram/Run.hs
+++ b/plutus-core/executables/plutus/AnyProgram/Run.hs
@@ -61,7 +61,8 @@ runPlc (PLC.Program _ _ t)
 runUplc :: (?opts :: Opts, Typeable a)
         => UPLC.UnrestrictedProgram NamedDeBruijn DefaultUni DefaultFun a -> IO ()
 runUplc (UPLC.UnrestrictedProgram (UPLC.Program _ _ t)) =
-    case UPLC.runCekDeBruijn defaultCekParametersForTesting exBudgetMode logEmitter t of
+    case (\(UPLC.CekReport res cost logs) -> (UPLC.cekResultToEither res, cost, logs)) $
+            UPLC.runCekDeBruijn defaultCekParametersForTesting exBudgetMode logEmitter t of
         (Left errorWithCause, _, logs) -> do
             for_ logs (printE . unpack)
             failE $ show errorWithCause

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -385,7 +385,8 @@ makeKnownOrFail x = case makeKnown x of
 readKnownSelf
     :: (ReadKnown val a, BuiltinErrorToEvaluationError structural operational)
     => val -> Either (ErrorWithCause (EvaluationError structural operational) val) a
-readKnownSelf val = fromRightM (flip throwErrorWithCause val . builtinErrorToEvaluationError) $ readKnown val
+readKnownSelf val =
+    fromRightM (flip throwErrorWithCause val . builtinErrorToEvaluationError) $ readKnown val
 {-# INLINE readKnownSelf #-}
 
 instance MakeKnownIn uni val a => MakeKnownIn uni val (BuiltinResult a) where

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
@@ -21,8 +21,6 @@ import PlutusCore.Pretty
 import Control.Monad.Except (MonadError, catchError, throwError)
 
 -- | The parameterized type of results various evaluation engines return.
--- On the PLC side this becomes (via @makeKnown@) either a call to 'Error' or
--- a value of the PLC counterpart of type @a@.
 data EvaluationResult a
     = EvaluationSuccess !a
     | EvaluationFailure

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE ViewPatterns           #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -265,7 +266,7 @@ runUPlcFull ::
 runUPlcFull values = do
   ps <- traverse toUPlc values
   let (UPLC.Program _ _ t) = foldl1 (unsafeFromRight .* UPLC.applyProgram) ps
-      (res, UPLC.CountingSt budget, logs) =
+      UPLC.CekReport (UPLC.cekResultToEither -> res) (UPLC.CountingSt budget) logs =
         UPLC.runCek TPLC.defaultCekParametersForTesting UPLC.counting UPLC.logEmitter t
   case res of
     Left err   -> throwError (SomeException $ EvaluationExceptionWithLogsAndBudget err budget logs)
@@ -316,7 +317,7 @@ runUPlcProfile ::
 runUPlcProfile values = do
   ps <- traverse toUPlc values
   let (UPLC.Program _ _ t) = foldl1 (unsafeFromRight .* UPLC.applyProgram) ps
-      (res, UPLC.CountingSt budget, logs) =
+      UPLC.CekReport (UPLC.cekResultToEither -> res) (UPLC.CountingSt budget) logs =
         UPLC.runCek TPLC.defaultCekParametersForTesting UPLC.counting UPLC.logWithTimeEmitter t
   case res of
     Left err -> throwError (SomeException $ EvaluationExceptionWithLogsAndBudget err budget logs)
@@ -334,7 +335,7 @@ runUPlcProfile' ::
 runUPlcProfile' values = do
   ps <- traverse toUPlc values
   let (UPLC.Program _ _ t) = foldl1 (unsafeFromRight .* UPLC.applyProgram) ps
-      (res, UPLC.CountingSt _, logs) =
+      UPLC.CekReport (UPLC.cekResultToEither -> res) (UPLC.CountingSt _) logs =
         UPLC.runCek TPLC.defaultCekParametersForTesting UPLC.counting UPLC.logWithBudgetEmitter t
   case res of
     Left err -> throwError (SomeException err)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -43,7 +43,12 @@ module UntypedPlutusCore.Evaluation.Machine.Cek
     , logWithCallTraceEmitter
     -- * Misc
     , BuiltinsRuntime (..)
+    , CekResult (..)
+    , CekReport (..)
+    , cekResultToEither
     , CekValue (..)
+    , DischargeResult(..)
+    , dischargeResultToTerm
     , readKnownCek
     , Hashable
     , ThrowableBuiltins
@@ -73,7 +78,7 @@ runCek
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term Name uni fun ann
-    -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost, [Text])
+    -> CekReport cost Name uni fun
 runCek = Common.runCek runCekDeBruijn
 
 -- | Evaluate a term using the CEK machine with logging disabled and keep track of costing.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -22,13 +22,20 @@
 {-# LANGUAGE TypeOperators            #-}
 {-# LANGUAGE UnboxedTuples            #-}
 {-# LANGUAGE UndecidableInstances     #-}
+{-# LANGUAGE ViewPatterns             #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module UntypedPlutusCore.Evaluation.Machine.Cek.Internal
     -- See Note [Compilation peculiarities].
     ( EvaluationResult(..)
+    , CekResult(..)
+    , cekResultToEither
+    , mapTermCekResult
+    , CekReport(..)
     , CekValue(..)
+    , DischargeResult(..)
+    , dischargeResultToTerm
     , ArgStack(..)
     , transferArgStack
     , CekUserError(..)
@@ -162,6 +169,38 @@ this can make a surprisingly large difference.
 -- | The 'Term's that CEK can execute must have DeBruijn binders
 -- 'Name' is not necessary but we leave it here for simplicity and debuggability.
 type NTerm uni fun = Term NamedDeBruijn uni fun
+
+-- | The result of evaluating a term with the CEK machine.
+data CekResult name uni fun
+    = CekFailure (CekEvaluationException name uni fun)
+    | CekSuccessConstant (Some (ValueOf uni))
+    | CekSuccessNonConstant (Term name uni fun ())
+
+-- | All info produced by a CEK machine run.
+data CekReport cost name uni fun = CekReport
+    { _cekReportResult :: CekResult name uni fun  -- ^ The result of evaluation.
+    , _cekReportCost   :: cost                    -- ^ The final @cost@ value.
+    , _cekReportLogs   :: [Text]                  -- ^ Logs emitted during evaluation.
+    }
+
+-- | Convert the given 'CekResult' into an 'Either'.
+-- This is useful, because in the ledger API we care whether the result is a constant or not, but in
+-- tests, executables etc we don't and so handling an either-error-or-term is more natural.
+cekResultToEither
+    :: CekResult name uni fun
+    -> Either (CekEvaluationException name uni fun) (Term name uni fun ())
+cekResultToEither (CekFailure err)             = Left err
+cekResultToEither (CekSuccessConstant val)     = Right $ Constant () val
+cekResultToEither (CekSuccessNonConstant term) = Right term
+
+-- | Apply the given function to the 'Term' (if any) stored in the given 'CekResult'.
+mapTermCekResult
+    :: (Term name uni fun () -> Term name' uni fun ())
+    -> CekResult name uni fun
+    -> CekResult name' uni fun
+mapTermCekResult f (CekFailure err)             = CekFailure $ f <$> err
+mapTermCekResult _ (CekSuccessConstant val)     = CekSuccessConstant val
+mapTermCekResult f (CekSuccessNonConstant term) = CekSuccessNonConstant $ f term
 
 data StepKind
     = BConst
@@ -474,7 +513,7 @@ throwErrorDischarged
   => EvaluationError (MachineError fun) CekUserError
   -> CekValue uni fun ann
   -> CekM uni fun s x
-throwErrorDischarged err = throwErrorWithCause err . dischargeCekValue
+throwErrorDischarged err = throwErrorWithCause err . dischargeResultToTerm . dischargeCekValue
 
 instance ThrowableBuiltins uni fun =>
         MonadError (CekEvaluationException NamedDeBruijn uni fun) (CekM uni fun s) where
@@ -534,57 +573,77 @@ instance Pretty CekUserError where
           ]
     pretty CekEvaluationFailure = "The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'."
 
--- | Instantiate all the free variables of a term by looking them up in an environment.
--- Mutually recursive with dischargeCekVal.
-dischargeCekValEnv :: forall uni fun ann. CekValEnv uni fun ann -> NTerm uni fun () -> NTerm uni fun ()
-dischargeCekValEnv valEnv = go 0
- where
-  -- The lamCnt is just a counter that measures how many lambda-abstractions
-  -- we have descended in the `go` loop.
-  go :: Word64 -> NTerm uni fun () -> NTerm uni fun ()
-  go !lamCnt =  \case
-    LamAbs ann name body -> LamAbs ann name $ go (lamCnt+1) body
-    var@(Var _ (NamedDeBruijn _ ndbnIx)) -> let idx = coerce ndbnIx :: Word64  in
-        if lamCnt >= idx
-        -- the index n is less-than-or-equal than the number of lambdas we have descended
-        -- this means that n points to a bound variable, so we don't discharge it.
-        then var
-        else maybe
-               -- var is free, leave it alone
-               var
-               -- var is in the env, discharge its value
-               dischargeCekValue
-               -- index relative to (as seen from the point of view of) the environment
-               (Env.indexOne valEnv $ idx - lamCnt)
-    Apply ann fun arg    -> Apply ann (go lamCnt fun) $ go lamCnt arg
-    Delay ann term       -> Delay ann $ go lamCnt term
-    Force ann term       -> Force ann $ go lamCnt term
-    t -> t
+-- | Convert the given 'ArgStack' to a list by reversing it.
+argStackToList :: ArgStack uni fun ann -> [CekValue uni fun ann]
+argStackToList = go [] where
+    go acc EmptyStack           = acc
+    go acc (ConsStack arg rest) = go (arg : acc) rest
+
+-- | The result of 'dischargeCekValue'.
+data DischargeResult uni fun
+    = DischargeConstant (Some (ValueOf uni))
+    | DischargeNonConstant (NTerm uni fun ())
+
+deriving stock instance (GShow uni, Everywhere uni Show, Show fun, Closed uni)
+    => Show (DischargeResult uni fun)
+
+deriving stock instance (GEq uni, Everywhere uni Eq, Eq fun, Closed uni)
+    => Eq (DischargeResult uni fun)
+
+dischargeResultToTerm :: DischargeResult uni fun -> NTerm uni fun ()
+dischargeResultToTerm (DischargeConstant val)     = Constant () val
+dischargeResultToTerm (DischargeNonConstant term) = term
 
 -- | Convert a 'CekValue' into a 'Term' by replacing all bound variables with the terms
--- they're bound to (which themselves have to be obtain by recursively discharging values).
-dischargeCekValue :: CekValue uni fun ann -> NTerm uni fun ()
-dischargeCekValue = \case
-    VCon     val                         -> Constant () val
-    VDelay   body env                    -> dischargeCekValEnv env $ Delay () (void body)
-    -- 'computeCek' turns @LamAbs _ name body@ into @VLamAbs name body env@ where @env@ is an
-    -- argument of 'computeCek' and hence we need to start discharging outside of the reassembled
-    -- lambda, otherwise @name@ could clash with the names that we have in @env@.
-    VLamAbs (NamedDeBruijn n _ix) body env ->
-        -- The index on the binder is meaningless, we put `0` by convention, see 'Binder'.
-        dischargeCekValEnv env $ LamAbs () (NamedDeBruijn n deBruijnInitIndex) (void body)
-    -- We only return a discharged builtin application when (a) it's being returned by the machine,
-    -- or (b) it's needed for an error message.
-    -- @term@ is fully discharged, so we can return it directly without any further discharging.
-    VBuiltin _ term _                    -> term
-    VConstr i es                         -> Constr () i (fmap dischargeCekValue $ stack2list es)
-      where
-        stack2list = go []
-        go acc EmptyStack           = acc
-        go acc (ConsStack arg rest) = go (arg : acc) rest
+-- they're bound to (which themselves have to be obtained by recursively discharging values).
+dischargeCekValue :: forall uni fun ann. CekValue uni fun ann -> DischargeResult uni fun
+dischargeCekValue (VCon val) = DischargeConstant val
+dischargeCekValue value0     = DischargeNonConstant $ goValue value0 where
+    goValue :: CekValue uni fun ann -> NTerm uni fun ()
+    goValue = \case
+        VCon val -> Constant () val
+        VDelay body env -> Delay () $ goValEnv env 0 body
+        VLamAbs (NamedDeBruijn n _ix) body env ->
+            -- The index on the binder is meaningless, we put `0` by convention, see 'Binder'.
+            LamAbs () (NamedDeBruijn n deBruijnInitIndex) $ goValEnv env 1 body
+        -- We only return a discharged builtin application when (a) it's being returned by the
+        -- machine, or (b) it's needed for an error message.
+        -- @term@ is fully discharged, so we can return it directly without any further discharging.
+        VBuiltin _ term _ -> term
+        VConstr ind args -> Constr () ind . map goValue $ argStackToList args
+
+    -- Instantiate all the free variables of a term by looking them up in an environment.
+    -- Mutually recursive with dischargeCekVal.
+    goValEnv :: CekValEnv uni fun ann -> Word64 -> NTerm uni fun ann -> NTerm uni fun ()
+    goValEnv env = go where
+        -- @shift@ is just a counter that measures how many lambda-abstractions we have descended
+        -- into so far.
+        go :: Word64 -> NTerm uni fun ann -> NTerm uni fun ()
+        go !shift =  \case
+          LamAbs _ name body -> LamAbs () name $ go (shift + 1) body
+          Var _ named@(NamedDeBruijn _ (coerce -> idx)) ->
+              if shift >= idx
+              -- the index n is less-than-or-equal than the number of lambdas we have descended
+              -- this means that n points to a bound variable, so we don't discharge it.
+              then Var () named
+              else maybe
+                     -- var is free, leave it alone
+                     (Var () named)
+                     -- var is in the env, discharge its value
+                     goValue
+                     -- index relative to (as seen from the point of view of) the environment
+                     (Env.indexOne env $ idx - shift)
+          Apply _ fun arg    -> Apply () (go shift fun) $ go shift arg
+          Delay _ term       -> Delay () $ go shift term
+          Force _ term       -> Force () $ go shift term
+          Constant _ val     -> Constant () val
+          Builtin _ fun      -> Builtin () fun
+          Error _            -> Error ()
+          Constr _ ind args  -> Constr () ind $ map (go shift) args
+          Case _ scrut alts  -> Case () (go shift scrut) $ fmap (go shift) alts
 
 instance (PrettyUni uni, Pretty fun) => PrettyBy PrettyConfigPlc (CekValue uni fun ann) where
-    prettyBy cfg = prettyBy cfg . dischargeCekValue
+    prettyBy cfg = prettyBy cfg . dischargeResultToTerm . dischargeCekValue
 
 type instance UniOf (CekValue uni fun ann) = uni
 
@@ -660,13 +719,13 @@ transferConstantSpine args ctx = foldr (FrameAwaitFunValue . VCon) ctx args
 {-# INLINE transferConstantSpine #-}
 
 runCekM
-    :: forall a cost uni fun ann
+    :: forall cost uni fun ann
     . ThrowableBuiltins uni fun
     => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
-    -> (forall s. GivenCekReqs uni fun ann s => CekM uni fun s a)
-    -> (Either (CekEvaluationException NamedDeBruijn uni fun) a, cost, [Text])
+    -> (forall s. GivenCekReqs uni fun ann s => CekM uni fun s (DischargeResult uni fun))
+    -> CekReport cost NamedDeBruijn uni fun
 runCekM
         (MachineParameters caser (MachineVariantParameters costs runtime))
         (ExBudgetMode getExBudgetInfo)
@@ -682,10 +741,13 @@ runCekM
         ?cekCosts = costs
         ?cekSlippage = defaultSlippage
         ?cekStepCounter = ctr
-    errOrRes <- unCekM $ tryError a
+    res <- unCekM (tryError a) <&> \case
+        Left err                          -> CekFailure err
+        Right (DischargeConstant val)     -> CekSuccessConstant val
+        Right (DischargeNonConstant term) -> CekSuccessNonConstant term
     st <- _exBudgetModeGetFinal
     logs <- _cekEmitterInfoGetFinal
-    pure (errOrRes, st, logs)
+    pure $ CekReport res st logs
 {-# INLINE runCekM #-}
 
 -- See Note [Compilation peculiarities].
@@ -696,7 +758,7 @@ enterComputeCek
     => Context uni fun ann
     -> CekValEnv uni fun ann
     -> NTerm uni fun ann
-    -> CekM uni fun s (NTerm uni fun ())
+    -> CekM uni fun s (DischargeResult uni fun)
 enterComputeCek = computeCek
   where
     -- | The computing part of the CEK machine.
@@ -709,7 +771,7 @@ enterComputeCek = computeCek
         :: Context uni fun ann
         -> CekValEnv uni fun ann
         -> NTerm uni fun ann
-        -> CekM uni fun s (NTerm uni fun ())
+        -> CekM uni fun s (DischargeResult uni fun)
     -- s ; ρ ▻ {L A}  ↦ s , {_ A} ; ρ ▻ L
     computeCek !ctx !env (Var _ varName) = do
         stepAndMaybeSpend BVar
@@ -767,7 +829,7 @@ enterComputeCek = computeCek
     returnCek
         :: Context uni fun ann
         -> CekValue uni fun ann
-        -> CekM uni fun s (NTerm uni fun ())
+        -> CekM uni fun s (DischargeResult uni fun)
     --- Instantiate all the free variable of the resulting term in case there are any.
     -- . ◅ V           ↦  [] V
     returnCek NoFrame val = do
@@ -819,7 +881,7 @@ enterComputeCek = computeCek
     forceEvaluate
         :: Context uni fun ann
         -> CekValue uni fun ann
-        -> CekM uni fun s (NTerm uni fun ())
+        -> CekM uni fun s (DischargeResult uni fun)
     forceEvaluate !ctx (VDelay body env) = computeCek ctx env body
     forceEvaluate !ctx (VBuiltin fun term runtime) = do
         -- @term@ is fully discharged, and so @term'@ is, hence we can put it in a 'VBuiltin'.
@@ -848,16 +910,16 @@ enterComputeCek = computeCek
         :: Context uni fun ann
         -> CekValue uni fun ann   -- lhs of application
         -> CekValue uni fun ann   -- rhs of application
-        -> CekM uni fun s (NTerm uni fun ())
+        -> CekM uni fun s (DischargeResult uni fun)
     applyEvaluate !ctx (VLamAbs _ body env) arg =
         computeCek ctx (Env.cons arg env) body
     -- Annotating @f@ and @exF@ with bangs gave us some speed-up, but only until we added a bang to
     -- 'VCon'. After that the bangs here were making things a tiny bit slower and so we removed them.
-    applyEvaluate !ctx (VBuiltin fun term runtime) arg = do
-        let argTerm = dischargeCekValue arg
+    applyEvaluate !ctx (VBuiltin fun funTerm runtime) arg = do
+        let argTerm = dischargeResultToTerm $ dischargeCekValue arg
             -- @term@ and @argTerm@ are fully discharged, and so @term'@ is, hence we can put it
             -- in a 'VBuiltin'.
-            term' = Apply () term argTerm
+            term' = Apply () funTerm argTerm
         case runtime of
             -- It's only possible to apply a builtin application if the builtin expects a term
             -- argument next.
@@ -914,7 +976,7 @@ enterComputeCek = computeCek
         -> fun
         -> NTerm uni fun ()
         -> BuiltinRuntime (CekValue uni fun ann)
-        -> CekM uni fun s (Term NamedDeBruijn uni fun ())
+        -> CekM uni fun s (DischargeResult uni fun)
     evalBuiltinApp ctx fun term runtime = case runtime of
         BuiltinCostedResult budgets0 getFXs -> do
             let exCat = BBuiltinApp fun
@@ -956,7 +1018,7 @@ runCekDeBruijn
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> NTerm uni fun ann
-    -> (Either (CekEvaluationException NamedDeBruijn uni fun) (NTerm uni fun ()), cost, [Text])
+    -> CekReport cost NamedDeBruijn uni fun
 runCekDeBruijn params mode emitMode term =
     runCekM params mode emitMode $ do
         unCekBudgetSpender ?cekBudgetSpender BStartup $ runIdentity $ cekStartupCost ?cekCosts

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -590,6 +590,9 @@ deriving stock instance (GShow uni, Everywhere uni Show, Show fun, Closed uni)
 deriving stock instance (GEq uni, Everywhere uni Eq, Eq fun, Closed uni)
     => Eq (DischargeResult uni fun)
 
+instance (PrettyUni uni, Pretty fun) => PrettyBy PrettyConfigPlc (DischargeResult uni fun) where
+    prettyBy cfg = prettyBy cfg . dischargeResultToTerm
+
 dischargeResultToTerm :: DischargeResult uni fun -> NTerm uni fun ()
 dischargeResultToTerm (DischargeConstant val)     = Constant () val
 dischargeResultToTerm (DischargeNonConstant term) = term
@@ -604,7 +607,7 @@ dischargeCekValue value0     = DischargeNonConstant $ goValue value0 where
         VCon val -> Constant () val
         VDelay body env -> Delay () $ goValEnv env 0 body
         VLamAbs (NamedDeBruijn n _ix) body env ->
-            -- The index on the binder is meaningless, we put `0` by convention, see 'Binder'.
+            -- The index on the binder is meaningless, we put @0@ by convention, see 'Binder'.
             LamAbs () (NamedDeBruijn n deBruijnInitIndex) $ goValEnv env 1 body
         -- We only return a discharged builtin application when (a) it's being returned by the
         -- machine, or (b) it's needed for an error message.
@@ -613,7 +616,7 @@ dischargeCekValue value0     = DischargeNonConstant $ goValue value0 where
         VConstr ind args -> Constr () ind . map goValue $ argStackToList args
 
     -- Instantiate all the free variables of a term by looking them up in an environment.
-    -- Mutually recursive with dischargeCekVal.
+    -- Mutually recursive with @goValue@.
     goValEnv :: CekValEnv uni fun ann -> Word64 -> NTerm uni fun ann -> NTerm uni fun ()
     goValEnv env = go where
         -- @shift@ is just a counter that measures how many lambda-abstractions we have descended

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/SteppableCek.hs
@@ -70,7 +70,7 @@ runCek
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term Name uni fun ann
-    -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost, [Text])
+    -> CekReport cost Name uni fun
 runCek = Common.runCek S.runCekDeBruijn
 
 -- | Evaluate a term using the Steppable CEK machine with logging disabled and

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/BLS12_381.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/BLS12_381.hs
@@ -10,7 +10,7 @@ where
 
 import Evaluation.Builtins.BLS12_381.TestClasses
 import Evaluation.Builtins.BLS12_381.Utils
-import Evaluation.Builtins.Common (CekResult (..), PlcTerm, bytestring, cekSuccessFalse,
+import Evaluation.Builtins.Common (PlcTerm, TypeCekResult (..), bytestring, cekSuccessFalse,
                                    cekSuccessTrue, evalTerm, integer, mkApp2)
 import PlutusCore.Crypto.BLS12_381.G1 qualified as G1
 import PlutusCore.Crypto.BLS12_381.G2 qualified as G2

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/BLS12_381.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/BLS12_381.hs
@@ -10,7 +10,7 @@ where
 
 import Evaluation.Builtins.BLS12_381.TestClasses
 import Evaluation.Builtins.BLS12_381.Utils
-import Evaluation.Builtins.Common (PlcTerm, TypeCekResult (..), bytestring, cekSuccessFalse,
+import Evaluation.Builtins.Common (PlcTerm, TypeErrorOrCekResult (..), bytestring, cekSuccessFalse,
                                    cekSuccessTrue, evalTerm, integer, mkApp2)
 import PlutusCore.Crypto.BLS12_381.G1 qualified as G1
 import PlutusCore.Crypto.BLS12_381.G2 qualified as G2

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
@@ -15,7 +15,7 @@ module Evaluation.Builtins.Common
     , PlcType
     , PlcTerm
     , UplcTerm
-    , TypeCekResult (..)
+    , TypeErrorOrCekResult (..)
     , evalTerm
     , mkApp1
     , mkApp2
@@ -128,13 +128,13 @@ type PlcError = TypeErrorPlc TPLC.DefaultUni TPLC.DefaultFun ()
 type UplcTerm = UPLC.Term TPLC.Name TPLC.DefaultUni TPLC.DefaultFun ()
 
 -- Possible CEK evluation results, flattened out
-data TypeCekResult =
+data TypeErrorOrCekResult =
     TypeCheckError PlcError
   | CekError
   | CekSuccess UplcTerm
     deriving stock (Eq, Show)
 
-evalTerm :: PlcTerm -> TypeCekResult
+evalTerm :: PlcTerm -> TypeErrorOrCekResult
 evalTerm term =
     case typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting term
     of Left e -> TypeCheckError e
@@ -161,10 +161,10 @@ true = mkConstant () True
 false :: PlcTerm
 false = mkConstant () False
 
-cekSuccessFalse :: TypeCekResult
+cekSuccessFalse :: TypeErrorOrCekResult
 cekSuccessFalse = CekSuccess $ mkConstant () False
 
-cekSuccessTrue :: TypeCekResult
+cekSuccessTrue :: TypeErrorOrCekResult
 cekSuccessTrue = CekSuccess $ mkConstant () True
 
 mkApp1 :: TPLC.DefaultFun -> PlcTerm -> PlcTerm

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Common.hs
@@ -15,7 +15,7 @@ module Evaluation.Builtins.Common
     , PlcType
     , PlcTerm
     , UplcTerm
-    , CekResult (..)
+    , TypeCekResult (..)
     , evalTerm
     , mkApp1
     , mkApp2
@@ -128,13 +128,13 @@ type PlcError = TypeErrorPlc TPLC.DefaultUni TPLC.DefaultFun ()
 type UplcTerm = UPLC.Term TPLC.Name TPLC.DefaultUni TPLC.DefaultFun ()
 
 -- Possible CEK evluation results, flattened out
-data CekResult =
+data TypeCekResult =
     TypeCheckError PlcError
   | CekError
   | CekSuccess UplcTerm
     deriving stock (Eq, Show)
 
-evalTerm :: PlcTerm -> CekResult
+evalTerm :: PlcTerm -> TypeCekResult
 evalTerm term =
     case typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting term
     of Left e -> TypeCheckError e
@@ -161,10 +161,10 @@ true = mkConstant () True
 false :: PlcTerm
 false = mkConstant () False
 
-cekSuccessFalse :: CekResult
+cekSuccessFalse :: TypeCekResult
 cekSuccessFalse = CekSuccess $ mkConstant () False
 
-cekSuccessTrue :: CekResult
+cekSuccessTrue :: TypeCekResult
 cekSuccessTrue = CekSuccess $ mkConstant () True
 
 mkApp1 :: TPLC.DefaultFun -> PlcTerm -> PlcTerm

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/FreeVars.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/FreeVars.hs
@@ -41,7 +41,8 @@ testCekInternalFree = testGroup "cekInternal" $ fmap (uncurry testCase)
   where
       evalV = toFakeTerm
              >>> runCekDeBruijn PLC.defaultCekParametersForTesting counting noEmitter
-             >>> (\(res,_,_) -> res)
+             >>> _cekReportResult
+             >>> cekResultToEither
 
       eval = evalV
              >>> isRight
@@ -61,7 +62,7 @@ testDischargeFree = testGroup "discharge" $ fmap (uncurry testCase)
         dis (VDelay (toFakeTerm fun0var0)
             []) -- empty env
         @?=
-        toFakeTerm (Delay () fun0var0)
+        DischargeNonConstant (toFakeTerm $ Delay () fun0var0)
 
     freeRemains2 =
         -- dis( y:unit |- \x-> x y var0) ) === (\x -> x unit var0)
@@ -78,7 +79,7 @@ testDischargeFree = testGroup "discharge" $ fmap (uncurry testCase)
              [VCon $ someValue ()] -- env has y
             )
          @?=
-         (toFakeTerm $ lamAbs0 $
+         DischargeNonConstant (toFakeTerm . lamAbs0 $
              v 1 @@ -- x
              [ Constant () (someValue ()) -- substituted y
              , var0 -- free

--- a/plutus-executables/executables/uplc/Main.hs
+++ b/plutus-executables/executables/uplc/Main.hs
@@ -353,7 +353,8 @@ runBenchmark (BenchmarkOptions inp ifmt semvar timeLim) = do
   prog <- readProgram ifmt inp
   let criterionConfig = defaultConfig {reportFile = Nothing, timeLimit = timeLim}
       cekparams = PLC.defaultCekParametersForVariant semvar
-      getResult (x,_,_) = either (error . show) (const ()) x  -- Extract an evaluation result
+      -- Extract an evaluation result
+      getResult = either (error . show) (const ()) . Cek.cekResultToEither . Cek._cekReportResult
       evaluate = getResult . Cek.runCekDeBruijn cekparams Cek.restrictingEnormous Cek.noEmitter
       -- readProgam throws away De Bruijn indices and returns an AST with Names;
       -- we have to put them back to get an AST with NamedDeBruijn names.
@@ -392,8 +393,8 @@ runEval (EvalOptions inp ifmt printMode nameFormat budgetMode traceMode
     case budgetM of
        SomeBudgetMode bm ->
             do
-              let (res, budget, logs) = Cek.runCek cekparams bm emitM term
-              case res of
+              let Cek.CekReport res budget logs = Cek.runCek cekparams bm emitM term
+              case Cek.cekResultToEither res of
                 Left err -> hPrint stderr err
                 Right v  ->
                   case nameFormat of
@@ -405,7 +406,7 @@ runEval (EvalOptions inp ifmt printMode nameFormat budgetMode traceMode
               case traceMode of
                 None -> pure ()
                 _    -> writeToOutput outp (T.intercalate "\n" logs)
-              case res of
+              case Cek.cekResultToEither res of
                 Left _  -> exitFailure
                 Right _ -> pure ()
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
@@ -1,9 +1,11 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module PlutusLedgerApi.Common.Eval
     ( EvaluationError (..)
@@ -21,7 +23,7 @@ module PlutusLedgerApi.Common.Eval
     ) where
 
 import PlutusCore
-import PlutusCore.Builtin (CaserBuiltin, readKnown)
+import PlutusCore.Builtin (CaserBuiltin)
 import PlutusCore.Data as Plutus
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
@@ -205,12 +207,7 @@ evaluateTerm
     -> VerboseMode
     -> EvaluationContext
     -> UPLC.Term UPLC.NamedDeBruijn DefaultUni DefaultFun ()
-    -> ( Either
-            (UPLC.CekEvaluationException NamedDeBruijn DefaultUni DefaultFun)
-            (UPLC.Term UPLC.NamedDeBruijn DefaultUni DefaultFun ())
-       , cost
-       , [Text]
-       )
+    -> UPLC.CekReport cost NamedDeBruijn DefaultUni DefaultFun
 evaluateTerm budgetMode pv verbose ectx =
     UPLC.runCekDeBruijn
         (toMachineParameters pv ectx)
@@ -241,7 +238,7 @@ evaluateScriptRestricting
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptRestricting ll pv verbose ectx budget p args = swap $ runWriter @LogOutput $ runExceptT $ do
     appliedTerm <- mkTermToEvaluate ll pv p args
-    let (res, UPLC.RestrictingSt (ExRestrictingBudget final), logs) =
+    let UPLC.CekReport res (UPLC.RestrictingSt (ExRestrictingBudget final)) logs =
             evaluateTerm (UPLC.restricting $ ExRestrictingBudget budget) pv verbose ectx appliedTerm
     processLogsAndErrors ll logs res
     pure (budget `minusExBudget` final)
@@ -263,7 +260,7 @@ evaluateScriptCounting
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptCounting ll pv verbose ectx p args = swap $ runWriter @LogOutput $ runExceptT $ do
     appliedTerm <- mkTermToEvaluate ll pv p args
-    let (res, UPLC.CountingSt final, logs) =
+    let UPLC.CekReport res (UPLC.CountingSt final) logs =
             evaluateTerm UPLC.counting pv verbose ectx appliedTerm
     processLogsAndErrors ll logs res
     pure final
@@ -273,27 +270,20 @@ processLogsAndErrors ::
     (MonadError EvaluationError m, MonadWriter LogOutput m) =>
     PlutusLedgerLanguage ->
     LogOutput ->
-    Either
-        (UPLC.CekEvaluationException NamedDeBruijn DefaultUni DefaultFun)
-        (UPLC.Term UPLC.NamedDeBruijn DefaultUni DefaultFun ()) ->
+    UPLC.CekResult NamedDeBruijn DefaultUni DefaultFun ->
     m ()
 processLogsAndErrors ll logs res = do
     tell logs
     case res of
-        Left e  -> throwError (CekError e)
-        Right v -> unless (isResultValid ll v) (throwError InvalidReturnValue)
+        UPLC.CekFailure err                                        -> throwError $ CekError err
+        -- If evaluation result is '()', then that's correct for all Plutus versions.
+        UPLC.CekSuccessConstant (Some (ValueOf DefaultUniUnit ())) -> pure ()
+        -- If evaluation result is any other constant or term, then it's only correct for V1 and V2.
+        UPLC.CekSuccessConstant{}                                  -> handleOldVersions
+        UPLC.CekSuccessNonConstant{}                               -> handleOldVersions
+  where
+    handleOldVersions = unless (ll == PlutusV1 || ll == PlutusV2) $ throwError InvalidReturnValue
 {-# INLINE processLogsAndErrors #-}
-
-isResultValid ::
-    PlutusLedgerLanguage ->
-    UPLC.Term UPLC.NamedDeBruijn DefaultUni DefaultFun () ->
-    Bool
-isResultValid ll res = ll == PlutusV1 || ll == PlutusV2 || isBuiltinUnit res
-    where
-        isBuiltinUnit t = case readKnown t of
-            Right () -> True
-            _        -> False
-{-# INLINE isResultValid #-}
 
 {- Note [Checking the Plutus Core language version]
 Since long ago this check has been in `mkTermToEvaluate`, which makes it a phase 2 failure.

--- a/plutus-tx-plugin/test/CallTrace/Lib.hs
+++ b/plutus-tx-plugin/test/CallTrace/Lib.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module CallTrace.Lib where
 
@@ -28,7 +29,7 @@ goldenEvalCekTraceWithEmitter emitter name compiledCode =
   nestedGoldenVsDocM name ".eval" $ ppCatch $ do
     uplc <- toUPlc compiledCode
     let
-      (evalRes, UPLC.CountingSt budget, logOut) =
+      UPLC.CekReport (UPLC.cekResultToEither -> evalRes) (UPLC.CountingSt budget) logOut =
         UPLC.runCek
           PLC.defaultCekParametersForTesting
           UPLC.counting

--- a/plutus-tx/src/PlutusTx/Eval.hs
+++ b/plutus-tx/src/PlutusTx/Eval.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE ViewPatterns       #-}
 
 module PlutusTx.Eval where
 
@@ -21,7 +22,8 @@ import PlutusCore.Pretty
 import PlutusTx.Code (CompiledCode, getPlcNoAnn)
 import Prettyprinter (dot, indent, plural, vsep, (<+>))
 import UntypedPlutusCore (DefaultFun, DefaultUni, Program (..))
-import UntypedPlutusCore.Evaluation.Machine.Cek (CekEvaluationException, CountingSt (..), counting,
+import UntypedPlutusCore.Evaluation.Machine.Cek (CekEvaluationException, CekReport (..),
+                                                 CountingSt (..), cekResultToEither, counting,
                                                  logEmitter)
 import UntypedPlutusCore.Evaluation.Machine.Cek.Internal (NTerm, runCekDeBruijn)
 
@@ -100,7 +102,7 @@ evaluateCompiledCode'
 evaluateCompiledCode' params code = EvalResult{..}
  where
   Program _ann _version term = getPlcNoAnn code
-  (evalResult, CountingSt evalResultBudget, evalResultTraces) =
+  CekReport (cekResultToEither -> evalResult) (CountingSt evalResultBudget) evalResultTraces =
     runCekDeBruijn params counting logEmitter term
 
 evaluatesToError :: CompiledCode a -> Bool

--- a/plutus-tx/testlib/PlutusTx/Test/Run/Uplc.hs
+++ b/plutus-tx/testlib/PlutusTx/Test/Run/Uplc.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE ViewPatterns          #-}
 
 module PlutusTx.Test.Run.Uplc where
 
@@ -51,7 +52,7 @@ runPlcCekTrace
        )
 runPlcCekTrace value = do
   term <- toUPlc value
-  let (result, UPLC.TallyingSt tally _, logOut) =
+  let UPLC.CekReport (UPLC.cekResultToEither -> result) (UPLC.TallyingSt tally _) logOut =
         UPLC.runCek
           PLC.defaultCekParametersForTesting
           UPLC.tallying

--- a/plutus-tx/testlib/PlutusTx/Test/Util/Compiled.hs
+++ b/plutus-tx/testlib/PlutusTx/Test/Util/Compiled.hs
@@ -101,7 +101,8 @@ cekResultMatchesHaskellValue actual matches expected =
   unsafeRunTermCek :: Term -> EvaluationResult Term
   unsafeRunTermCek =
     unsafeSplitStructuralOperational
-      . (\(res, _, _) -> res)
+      . Cek.cekResultToEither
+      . _cekReportResult
       . runCekDeBruijn
         PLC.defaultCekParametersForTesting
         Cek.restrictingEnormous


### PR DESCRIPTION
This is something I've been meaning to do for a long time. It adds `CekResult` and `CekReport` so that we never run into very confusing issues with excessive laziness invalidating benchmarking results like it happened in #3876. Plus, 3-tuples are an anti-pattern anyway, so it's good to move from them.

I also fixed a bug in `dischargeCekValue` where it previously wouldn't discharge under `Constr` or `Case` due to a catch-all clause that we forgot to update when introducing SOPs. It doesn't matter on-chain (we only care there if something is a `()` or success in general, not whether `Constr` was discharges correctly), but since we use the CEK machine as a sorta normalizer in tests, we still want it to return the correct answer.

Catch-all clauses are cancer, this is not the first time they're causing problems, see #6816. I'm gonna remove as many of them from the codebase as possible, but in the meantime please be wary not to add more of this cancer to the codebase.