### PR TITLE
Make `FrameAwaitFunValue` handle multiple arguments at once

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -336,6 +336,7 @@ library
     , prettyprinter-configurable
     , primitive
     , profunctors
+    , queues
     , recursion-schemes
     , satint
     , semigroups                  >=0.19.1


### PR DESCRIPTION
This is part of effort to add multi-application as per https://github.com/IntersectMBO/plutus/issues/6225.

`FrameAwaitFunValue` is very often nested and used iteratively; this PR makes all the nested structures stored in a single frame. 