### PR TITLE
Add golden test for `validation` benchmark suite

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -280,7 +280,7 @@ benchmark casing
 ---------------- validation ----------------
 
 library validation-internal
-  import:          lang, ghc-version-support, os-support
+  import:          lang, os-support
   hs-source-dirs:  validation/src
   exposed-modules: PlutusBenchmark.Validation.Common
   build-depends:
@@ -333,19 +333,14 @@ benchmark validation-decode
   type:           exitcode-stdio-1.0
   main-is:        BenchDec.hs
   hs-source-dirs: validation/bench
-  other-modules:  Common
   build-depends:
-    , base                     >=4.9     && <5
+    , base                 >=4.9     && <5
     , bytestring
-    , criterion                >=1.5.9.0
+    , criterion            >=1.5.9.0
     , deepseq
-    , directory
-    , filepath
-    , flat                     ^>=0.6
-    , optparse-applicative
-    , plutus-benchmark-common
-    , plutus-core              ^>=1.52
-    , plutus-ledger-api        ^>=1.52
+    , plutus-core          ^>=1.52
+    , plutus-ledger-api    ^>=1.52
+    , validation-internal
 
 ---------------- validation-full ----------------
 
@@ -354,19 +349,14 @@ benchmark validation-full
   type:           exitcode-stdio-1.0
   main-is:        BenchFull.hs
   hs-source-dirs: validation/bench
-  other-modules:  Common
   build-depends:
-    , base                     >=4.9     && <5
+    , base                 >=4.9     && <5
     , bytestring
-    , criterion                >=1.5.9.0
+    , criterion            >=1.5.9.0
     , deepseq
-    , directory
-    , filepath
-    , flat                     ^>=0.6
-    , optparse-applicative
-    , plutus-benchmark-common
-    , plutus-core              ^>=1.52
-    , plutus-ledger-api        ^>=1.52
+    , plutus-core          ^>=1.52
+    , plutus-ledger-api    ^>=1.52
+    , validation-internal
 
 ---------------- Cek cost model calibration ----------------
 
@@ -636,19 +626,13 @@ benchmark validation-agda-cek
   type:           exitcode-stdio-1.0
   main-is:        BenchAgdaCek.hs
   hs-source-dirs: validation/bench
-  other-modules:  Common
   build-depends:
     , agda-internal
-    , base                     >=4.9     && <5
-    , bytestring
-    , criterion                >=1.5.9.0
+    , base                     >=4.9   && <5
     , deepseq
-    , directory
-    , filepath
-    , flat                     ^>=0.6
-    , optparse-applicative
     , plutus-benchmark-common
     , plutus-core              ^>=1.52
+    , validation-internal
 
 benchmark nofib-agda-cek
   import:         lang, ghc-version-support, os-support

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -279,12 +279,10 @@ benchmark casing
 
 ---------------- validation ----------------
 
-benchmark validation
-  import:         lang, os-support
-  type:           exitcode-stdio-1.0
-  main-is:        BenchCek.hs
-  hs-source-dirs: validation/bench
-  other-modules:  Common
+library validation-internal
+  import:          lang, ghc-version-support, os-support
+  hs-source-dirs:  validation/src
+  exposed-modules: PlutusBenchmark.Validation.Common
   build-depends:
     , base                     >=4.9     && <5
     , bytestring
@@ -295,7 +293,38 @@ benchmark validation
     , optparse-applicative
     , plutus-benchmark-common
     , plutus-core              ^>=1.52
+
+benchmark validation
+  import:         lang, os-support
+  type:           exitcode-stdio-1.0
+  main-is:        BenchCek.hs
+  hs-source-dirs: validation/bench
+  build-depends:
+    , base                     >=4.9   && <5
+    , plutus-benchmark-common
+    , plutus-core              ^>=1.52
     , plutus-ledger-api        ^>=1.52
+    , validation-internal
+
+test-suite validation-tests
+  import:         lang, ghc-version-support, os-support
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: validation/test
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base                             >=4.9   && <5
+    , bytestring
+    , directory
+    , filepath
+    , flat                             ^>=0.6
+    , plutus-benchmark-common
+    , plutus-core                      ^>=1.52
+    , plutus-core:plutus-core-testlib
+    , plutus-tx                        ^>=1.52
+    , plutus-tx:plutus-tx-testlib
+    , tasty
+    , validation-internal
 
 ---------------- validation-decode ----------------
 

--- a/plutus-benchmark/validation/bench/BenchAgdaCek.hs
+++ b/plutus-benchmark/validation/bench/BenchAgdaCek.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Common (benchWith, unsafeUnflat)
 import PlutusBenchmark.Agda.Common (benchTermAgdaCek)
 import PlutusBenchmark.Common (toNamedDeBruijnTerm)
+import PlutusBenchmark.Validation.Common (benchWith, unsafeUnflat)
 import UntypedPlutusCore qualified as UPLC
 
 import Control.DeepSeq (force)

--- a/plutus-benchmark/validation/bench/BenchCek.hs
+++ b/plutus-benchmark/validation/bench/BenchCek.hs
@@ -1,9 +1,9 @@
 {- | Validation benchmarks for the CEK machine. -}
 module Main where
 
-import Common (benchTermCek, benchWith, mkEvalCtx, unsafeUnflat)
 import Control.Exception (evaluate)
 import PlutusBenchmark.Common (toNamedDeBruijnTerm)
+import PlutusBenchmark.Validation.Common (benchTermCek, benchWith, mkEvalCtx, unsafeUnflat)
 import PlutusCore.Default (BuiltinSemanticsVariant (DefaultFunSemanticsVariantA))
 import PlutusLedgerApi.Common (PlutusLedgerLanguage (PlutusV1))
 import UntypedPlutusCore as UPLC

--- a/plutus-benchmark/validation/bench/BenchDec.hs
+++ b/plutus-benchmark/validation/bench/BenchDec.hs
@@ -5,12 +5,12 @@ import PlutusLedgerApi.Common.Versions
 import PlutusLedgerApi.V1
 import UntypedPlutusCore qualified as UPLC
 
-import Common
 import Control.DeepSeq (force)
 import Control.Exception
 import Criterion
 import Data.ByteString as BS
 import Data.Functor
+import PlutusBenchmark.Validation.Common
 
 {-|
 for each data/*.flat validation script, it benchmarks

--- a/plutus-benchmark/validation/bench/BenchFull.hs
+++ b/plutus-benchmark/validation/bench/BenchFull.hs
@@ -7,11 +7,11 @@ import PlutusLedgerApi.Common.Versions
 import PlutusLedgerApi.V1
 import UntypedPlutusCore qualified as UPLC
 
-import Common
 import Control.DeepSeq (force)
 import Control.Exception
 import Criterion
 import Data.ByteString as BS
+import PlutusBenchmark.Validation.Common
 
 {-|
 for each data/*.flat validation script, it benchmarks

--- a/plutus-benchmark/validation/src/PlutusBenchmark/Validation/Common.hs
+++ b/plutus-benchmark/validation/src/PlutusBenchmark/Validation/Common.hs
@@ -1,12 +1,13 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
-module Common (
+module PlutusBenchmark.Validation.Common (
     benchWith
     , unsafeUnflat
     , mkEvalCtx
     , benchTermCek
     , peelDataArguments
     , Term
+    , getScriptDirectory
     ) where
 
 import PlutusBenchmark.Common (benchTermCek, getConfig, getDataDir, mkEvalCtx)

--- a/plutus-benchmark/validation/test/9.6/auction_1-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_1-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               185_243_960
+Memory:                831_092
+Term Size:               3_685
+Flat Size:               3_722
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_1-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_1-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               628_192_291
+Memory:              3_455_036
+Term Size:               9_615
+Flat Size:               8_875
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_1-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_1-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               634_004_628
+Memory:              3_463_550
+Term Size:               9_615
+Flat Size:               8_837
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_1-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_1-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               239_873_979
+Memory:              1_053_348
+Term Size:               3_685
+Flat Size:               3_921
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_2-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_2-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               185_243_960
+Memory:                831_092
+Term Size:               3_685
+Flat Size:               3_722
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_2-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_2-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               628_192_291
+Memory:              3_455_036
+Term Size:               9_615
+Flat Size:               8_875
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_2-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_2-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               829_358_119
+Memory:              4_603_050
+Term Size:               9_615
+Flat Size:               9_046
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_2-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_2-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               634_004_628
+Memory:              3_463_550
+Term Size:               9_615
+Flat Size:               8_837
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/auction_2-5.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/auction_2-5.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               239_873_979
+Memory:              1_053_348
+Term Size:               3_685
+Flat Size:               3_921
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/coop-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/coop-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               261_690_778
+Memory:              1_002_314
+Term Size:               1_705
+Flat Size:               4_353
+
+(con unit ())

--- a/plutus-benchmark/validation/test/9.6/coop-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/coop-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               771_378_523
+Memory:              3_075_549
+Term Size:               3_722
+Flat Size:               9_245
+
+(con unit ())

--- a/plutus-benchmark/validation/test/9.6/coop-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/coop-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:             2_146_553_523
+Memory:             11_725_239
+Term Size:               3_722
+Flat Size:               8_722
+
+(con unit ())

--- a/plutus-benchmark/validation/test/9.6/coop-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/coop-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               896_329_242
+Memory:              3_989_698
+Term Size:               4_291
+Flat Size:              10_077
+
+(con unit ())

--- a/plutus-benchmark/validation/test/9.6/coop-5.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/coop-5.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               415_168_389
+Memory:              1_716_514
+Term Size:               4_291
+Flat Size:               8_259
+
+(con unit ())

--- a/plutus-benchmark/validation/test/9.6/coop-6.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/coop-6.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               731_324_990
+Memory:              2_859_657
+Term Size:               1_926
+Flat Size:               7_333
+
+(con unit ())

--- a/plutus-benchmark/validation/test/9.6/coop-7.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/coop-7.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               368_455_190
+Memory:              1_382_935
+Term Size:               1_926
+Flat Size:               5_936
+
+(con unit ())

--- a/plutus-benchmark/validation/test/9.6/crowdfunding-success-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/crowdfunding-success-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               215_172_293
+Memory:                959_418
+Term Size:               4_674
+Flat Size:               4_515
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/crowdfunding-success-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/crowdfunding-success-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               215_172_293
+Memory:                959_418
+Term Size:               4_674
+Flat Size:               4_515
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/crowdfunding-success-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/crowdfunding-success-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               215_172_293
+Memory:                959_418
+Term Size:               4_674
+Flat Size:               4_515
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/currency-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/currency-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               260_867_407
+Memory:              1_365_668
+Term Size:               4_488
+Flat Size:               4_089
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/escrow-redeem_1-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/escrow-redeem_1-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               354_980_023
+Memory:              1_791_342
+Term Size:               6_070
+Flat Size:               5_687
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/escrow-redeem_1-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/escrow-redeem_1-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               354_980_023
+Memory:              1_791_342
+Term Size:               6_070
+Flat Size:               5_687
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/escrow-redeem_2-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/escrow-redeem_2-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               414_701_543
+Memory:              2_106_710
+Term Size:               6_070
+Flat Size:               5_832
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/escrow-redeem_2-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/escrow-redeem_2-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               414_701_543
+Memory:              2_106_710
+Term Size:               6_070
+Flat Size:               5_832
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/escrow-redeem_2-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/escrow-redeem_2-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               414_701_543
+Memory:              2_106_710
+Term Size:               6_070
+Flat Size:               5_832
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/escrow-refund-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/escrow-refund-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               158_714_514
+Memory:                719_208
+Term Size:               6_070
+Flat Size:               5_414
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-increase-margin-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-increase-margin-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               260_892_271
+Memory:              1_365_668
+Term Size:               4_488
+Flat Size:               4_054
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-increase-margin-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-increase-margin-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               550_162_284
+Memory:              2_880_706
+Term Size:               6_106
+Flat Size:               6_280
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-increase-margin-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-increase-margin-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               550_162_284
+Memory:              2_880_706
+Term Size:               6_106
+Flat Size:               6_280
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-increase-margin-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-increase-margin-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               476_262_153
+Memory:              2_541_290
+Term Size:              11_675
+Flat Size:              10_537
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-increase-margin-5.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-increase-margin-5.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               801_539_739
+Memory:              4_102_467
+Term Size:              11_675
+Flat Size:              10_792
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-pay-out-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-pay-out-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               260_892_271
+Memory:              1_365_668
+Term Size:               4_488
+Flat Size:               4_054
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-pay-out-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-pay-out-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               550_162_284
+Memory:              2_880_706
+Term Size:               6_106
+Flat Size:               6_280
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-pay-out-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-pay-out-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               550_162_284
+Memory:              2_880_706
+Term Size:               6_106
+Flat Size:               6_280
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-pay-out-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-pay-out-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               800_034_975
+Memory:              4_094_663
+Term Size:              11_675
+Flat Size:              10_792
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-settle-early-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-settle-early-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               260_892_271
+Memory:              1_365_668
+Term Size:               4_488
+Flat Size:               4_054
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-settle-early-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-settle-early-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               550_162_284
+Memory:              2_880_706
+Term Size:               6_106
+Flat Size:               6_280
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-settle-early-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-settle-early-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               550_162_284
+Memory:              2_880_706
+Term Size:               6_106
+Flat Size:               6_280
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/future-settle-early-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/future-settle-early-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               598_224_552
+Memory:              2_916_171
+Term Size:              11_675
+Flat Size:              10_681
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_1-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_1-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               378_390_466
+Memory:              1_931_718
+Term Size:               9_413
+Flat Size:               8_611
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_1-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_1-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               208_348_058
+Memory:                918_246
+Term Size:               3_218
+Flat Size:               3_433
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_1-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_1-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               633_795_192
+Memory:              3_426_302
+Term Size:               9_413
+Flat Size:               8_824
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_1-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_1-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               242_120_569
+Memory:              1_065_558
+Term Size:               3_218
+Flat Size:               3_590
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_2-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_2-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               378_390_466
+Memory:              1_931_718
+Term Size:               9_413
+Flat Size:               8_611
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_2-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_2-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               208_348_058
+Memory:                918_246
+Term Size:               3_218
+Flat Size:               3_433
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_2-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_2-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               633_795_192
+Memory:              3_426_302
+Term Size:               9_413
+Flat Size:               8_824
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_2-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_2-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               242_120_569
+Memory:              1_065_558
+Term Size:               3_218
+Flat Size:               3_590
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_2-5.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_2-5.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               633_817_780
+Memory:              3_426_302
+Term Size:               9_413
+Flat Size:               8_829
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/game-sm-success_2-6.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/game-sm-success_2-6.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               242_120_569
+Memory:              1_065_558
+Term Size:               3_218
+Flat Size:               3_590
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-01.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-01.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               385_936_325
+Memory:              2_022_360
+Term Size:              10_264
+Flat Size:               9_268
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-02.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-02.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               374_468_532
+Memory:              1_947_414
+Term Size:              10_264
+Flat Size:               9_331
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-03.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-03.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               378_665_957
+Memory:              1_969_308
+Term Size:              10_264
+Flat Size:               9_392
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-04.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-04.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               382_863_382
+Memory:              1_991_202
+Term Size:              10_264
+Flat Size:               9_453
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-05.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-05.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               545_327_785
+Memory:              2_965_986
+Term Size:              10_264
+Flat Size:               9_373
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-06.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-06.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               385_936_325
+Memory:              2_022_360
+Term Size:              10_264
+Flat Size:               9_268
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-07.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-07.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               374_468_532
+Memory:              1_947_414
+Term Size:              10_264
+Flat Size:               9_331
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-08.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-08.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               378_665_957
+Memory:              1_969_308
+Term Size:              10_264
+Flat Size:               9_392
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-09.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-09.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               382_863_382
+Memory:              1_991_202
+Term Size:              10_264
+Flat Size:               9_453
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/multisig-sm-10.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/multisig-sm-10.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               545_327_785
+Memory:              2_965_986
+Term Size:              10_264
+Flat Size:               9_373
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/ping-pong-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/ping-pong-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               324_464_526
+Memory:              1_680_090
+Term Size:               8_868
+Flat Size:               7_760
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/ping-pong-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/ping-pong-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               324_464_526
+Memory:              1_680_090
+Term Size:               8_868
+Flat Size:               7_760
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/ping-pong_2-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/ping-pong_2-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               201_666_086
+Memory:                981_952
+Term Size:               8_868
+Flat Size:               7_619
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/prism-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/prism-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               174_276_007
+Memory:                764_974
+Term Size:               3_119
+Flat Size:               3_057
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/prism-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/prism-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               407_908_488
+Memory:              2_066_140
+Term Size:               9_267
+Flat Size:               8_672
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/prism-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/prism-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               379_936_672
+Memory:              1_910_858
+Term Size:               4_536
+Flat Size:               4_683
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/pubkey-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/pubkey-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               148_251_224
+Memory:                648_826
+Term Size:               3_220
+Flat Size:               3_093
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_1-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_1-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               827_551_021
+Memory:              3_706_110
+Term Size:              14_235
+Flat Size:              12_907
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_1-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_1-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               203_638_059
+Memory:                897_094
+Term Size:               3_218
+Flat Size:               3_478
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_1-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_1-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               951_554_273
+Memory:              4_342_742
+Term Size:              14_235
+Flat Size:              12_958
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_1-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_1-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               216_086_468
+Memory:                951_808
+Term Size:               3_218
+Flat Size:               3_527
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_1-5.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_1-5.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:             1_206_898_458
+Memory:              5_587_098
+Term Size:              14_235
+Flat Size:              13_198
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_1-6.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_1-6.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               266_443_981
+Memory:              1_173_858
+Term Size:               3_218
+Flat Size:               3_767
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_2-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_2-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               827_551_021
+Memory:              3_706_110
+Term Size:              14_235
+Flat Size:              12_907
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_2-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_2-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               203_638_059
+Memory:                897_094
+Term Size:               3_218
+Flat Size:               3_478
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_2-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_2-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               951_554_273
+Memory:              4_342_742
+Term Size:              14_235
+Flat Size:              12_958
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/stablecoin_2-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/stablecoin_2-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               216_086_468
+Memory:                951_808
+Term Size:               3_218
+Flat Size:               3_527
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/token-account-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/token-account-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               195_373_694
+Memory:                978_444
+Term Size:               4_477
+Flat Size:               4_032
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/token-account-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/token-account-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               355_866_023
+Memory:              1_826_496
+Term Size:               4_181
+Flat Size:               4_117
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/uniswap-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/uniswap-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               443_304_976
+Memory:              2_449_452
+Term Size:               4_510
+Flat Size:               4_133
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/uniswap-2.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/uniswap-2.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               230_772_794
+Memory:              1_126_608
+Term Size:               4_477
+Flat Size:               4_184
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/uniswap-3.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/uniswap-3.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:             1_650_842_606
+Memory:              8_675_126
+Term Size:              11_751
+Flat Size:              12_724
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/uniswap-4.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/uniswap-4.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               347_527_720
+Memory:              1_535_808
+Term Size:               3_412
+Flat Size:               4_552
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/uniswap-5.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/uniswap-5.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:             1_083_644_672
+Memory:              5_520_347
+Term Size:              11_751
+Flat Size:              12_524
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/uniswap-6.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/uniswap-6.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               332_999_979
+Memory:              1_488_850
+Term Size:               3_412
+Flat Size:               4_345
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/9.6/vesting-1.flat.eval.golden
+++ b/plutus-benchmark/validation/test/9.6/vesting-1.flat.eval.golden
@@ -1,0 +1,6 @@
+CPU:               351_952_372
+Memory:              1_861_958
+Term Size:               6_246
+Flat Size:               5_556
+
+(delay (lam i i))

--- a/plutus-benchmark/validation/test/Spec.hs
+++ b/plutus-benchmark/validation/test/Spec.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Test.Tasty
+import Test.Tasty.Extras (TestNested, runTestNested, testNestedGhc)
+
+import PlutusBenchmark.NaturalSort
+import PlutusBenchmark.Validation.Common
+
+import PlutusCore.Annotation qualified as PLC
+import PlutusTx.Code qualified as Tx
+import PlutusTx.Test qualified as Tx
+import UntypedPlutusCore qualified as UPLC
+
+import Data.ByteString qualified as BS
+import Flat
+import System.Directory (listDirectory)
+import System.FilePath
+
+runTestGhc :: [TestNested] -> TestTree
+runTestGhc = runTestNested ["validation", "test"] . pure . testNestedGhc
+
+mkCase :: FilePath -> FilePath -> IO TestNested
+mkCase path name = do
+  bs <- BS.readFile (path </> name)
+  let
+    parsed ::
+      Either
+        DecodeException
+        (UPLC.Program UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun PLC.SrcSpans)
+    parsed =
+      (fmap mempty . UPLC.programMapNames UPLC.fakeNameDeBruijn . UPLC.unUnrestrictedProgram)
+        <$> unflat @(UPLC.UnrestrictedProgram UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()) bs
+  case parsed of
+    Left err -> error $ show err
+    Right parsed' ->
+      pure $
+        Tx.goldenEvalCekCatchBudget
+          name
+          (Tx.DeserializedCode parsed' Nothing mempty)
+
+allTests :: IO TestTree
+allTests = do
+  scriptDirectory <- getScriptDirectory
+  files <-
+    (naturalSort . filter (isExtensionOf ".flat"))
+      <$> listDirectory scriptDirectory
+
+  runTestGhc <$> traverse (mkCase scriptDirectory) files
+
+main :: IO ()
+main = allTests >>= defaultMain


### PR DESCRIPTION
It's not _that_ useful to have golden cases for validation since all of the scripts in `validation` suite is smart contract execution, which would evaluate into some small value, typically unit or `id`. 

However, this is useful for detecting any irregularities in costing and for detecting cases when CEK changes causes existing code in `validation` to fail entirely. 