### PR TITLE
Remove dependency on QuickCheck 2.16 + remove allow-newer QuickCheck

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump both the following dates if you need newer packages from Hackage
-  , hackage.haskell.org 2025-07-16T09:24:19Z
+  , hackage.haskell.org 2025-08-28T10:04:41Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2025-07-02T14:54:39Z
+  , cardano-haskell-packages 2025-08-27T16:08:15Z
 
 packages: cardano-constitution
           plutus-benchmark
@@ -84,12 +84,6 @@ allow-newer:
   , inline-r:bytestring
   , inline-r:containers
   , inline-r:primitive
-
-allow-newer:
-  -- https://github.com/phadej/vec/issues/121
-  ral:QuickCheck,
-  fin:QuickCheck,
-  bin:QuickCheck,
 
 -- https://github.com/IntersectMBO/plutus/pull/7236
 constraints: setup.optparse-applicative >=0.19.0.0

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump both the following dates if you need newer packages from Hackage
-  , hackage.haskell.org 2025-08-28T10:04:41Z
+  , hackage.haskell.org 2025-07-16T09:24:19Z
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2025-08-27T16:08:15Z
 

--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1756376505,
-        "narHash": "sha256-WHbrgbxgVUNk4lksf5VdsmR3WIiHSujB4S0RBdMCWAc=",
+        "lastModified": 1756844684,
+        "narHash": "sha256-/zjKxmmRG9eq44+cc0AP181w+PlAqFANvISokEs+y/U=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d58d13c9d2a1b26e076ad73b1890f10a8ae5df84",
+        "rev": "a85c23bf9fddcd7c8765f27ad36881bc617a5ee8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1751474634,
-        "narHash": "sha256-aB46saAQxsJRoqbxLhnSzC5Sbk0TxcdKIrHjNCjSlqQ=",
+        "lastModified": 1756312114,
+        "narHash": "sha256-FZSEC/I8JIgLFS01WTcSOOtfzUr2dHrNTuBfDWCL2dg=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "d0da4a4a6b2548405a9e151394ec9a539106e74f",
+        "rev": "8668deda6ff4c91896a2422f80fabd1450170cf6",
         "type": "github"
       },
       "original": {
@@ -209,11 +209,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1752763356,
-        "narHash": "sha256-+7BswrTM19IJsggFW18PC6kviFbiIzVFsuTfE6NlPGQ=",
+        "lastModified": 1756376505,
+        "narHash": "sha256-WHbrgbxgVUNk4lksf5VdsmR3WIiHSujB4S0RBdMCWAc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3be667c0df3f39d500e9b8c881fa3e2249fab898",
+        "rev": "d58d13c9d2a1b26e076ad73b1890f10a8ae5df84",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -168,23 +168,6 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -225,11 +208,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1752020830,
-        "narHash": "sha256-85nTyeqTovfgaOem+L9N9++X+ti1Ssv8UiQXfwJys5I=",
+        "lastModified": 1756772734,
+        "narHash": "sha256-kot2lTSCBuWIuJAm28n9PSbrIqrOn92u83kVWFBtZtI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "63ed2b6d60df881899c29c9dd4e5fb1a3124fe21",
+        "rev": "0dabf399347c164d6309843a0fe84460cbc008ec",
         "type": "github"
       },
       "original": {
@@ -263,7 +246,6 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": [
           "hackage"
         ],
@@ -298,11 +280,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1752099430,
-        "narHash": "sha256-OJVP5hw33ZeLmvaj2g7PaJI58Wv0ev/p0wPHecZZ658=",
+        "lastModified": 1756774299,
+        "narHash": "sha256-sHqFfSIi0ghs7xsS/033rUYzNU6DYSsMze+oxIS2hc4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "fa7fea87304b918d232cc887b96405f304daaba2",
+        "rev": "ac987ef18ca39c612dc08a80ee4550c99b66fd9a",
         "type": "github"
       },
       "original": {
@@ -573,11 +555,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1750543273,
-        "narHash": "sha256-WaswH0Y+Fmupvv8AkIlQBlUy/IdD3Inx9PDuE+5iRYY=",
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "a53c57c9a8d22a66a2f0c4c969e806da03f08c28",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
         "type": "github"
       },
       "original": {
@@ -669,11 +651,11 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1748852332,
-        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "lastModified": 1754477006,
+        "narHash": "sha256-suIgZZHXdb4ca9nN4MIcmdjeN+ZWsTwCtYAG4HExqAo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "rev": "4896699973299bffae27d0d9828226983544d9e9",
         "type": "github"
       },
       "original": {
@@ -685,11 +667,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748856973,
-        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "lastModified": 1754393734,
+        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
         "type": "github"
       },
       "original": {
@@ -791,11 +773,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1752020034,
-        "narHash": "sha256-gw/qSy3bJy+Uqc1LyJKFjowtErjeJHooigqWM2tzrkI=",
+        "lastModified": 1756771957,
+        "narHash": "sha256-4gpnaFvpLwD+jk1BGkGcNPWPy0pKHCLd0suGPrP9tJk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "9080298ccf1df5b26c059dca6676324ab1fcee3d",
+        "rev": "ad1a53a776a6e1a9e106898d88df9920a6e80d4a",
         "type": "github"
       },
       "original": {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -9,5 +9,26 @@ import inputs.nixpkgs {
     inputs.haskell-nix.overlay
     inputs.iohk-nix.overlays.haskell-nix-crypto
     inputs.iohk-nix.overlays.haskell-nix-extra
+
+    # Disable the libsigsegv test suite on x86_64-darwin.
+    #
+    # On Apple Silicon machines using older Rosetta releases,
+    # libsigsegv's stack overflow tests fail with "Abort trap"
+    # due to incomplete emulation of synchronous exceptions.
+    #
+    # Newer Rosetta versions (e.g. darwin24.6.0) do not exhibit this issue,
+    # so this workaround can be removed once those versions are widespread.
+    #
+    # This package is a transitive dependency of TeX Live,
+    # so without this overlay TeX Live cannot be built with affected
+    # Rosetta versions.
+    #
+    # TODO: Remove this once `ci.iog.io` macOS builders are updated to a
+    # newer version of macOS.
+    (final: prev: {
+      libsigsegv = prev.libsigsegv.overrideAttrs (old: {
+        doCheck = old.doCheck && prev.stdenv.hostPlatform.system != "x86_64-darwin";
+      });
+    })
   ];
 }

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -832,7 +832,7 @@ library plutus-core-testlib
     , pretty-simple
     , prettyprinter               >=1.1.0.1
     , prettyprinter-configurable
-    , QuickCheck                  >=2.16
+    , QuickCheck
     , quickcheck-instances
     , quickcheck-transformer
     , size-based

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Builtin.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/Builtin.hs
@@ -30,7 +30,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Vector.Strict qualified as Strict
-import Test.QuickCheck hiding (Some (..))
+import Test.QuickCheck
 import Test.QuickCheck.Instances.ByteString ()
 import Test.QuickCheck.Instances.Vector ()
 import Universe

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/BLS12_381.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/BLS12_381.hs
@@ -23,9 +23,9 @@ import Data.ByteString as BS (empty, length, pack)
 import Data.List as List (foldl', genericReplicate, length, nub)
 import Text.Printf (printf)
 
-import Test.QuickCheck hiding (Some (..))
+import Test.QuickCheck
 import Test.Tasty
-import Test.Tasty.QuickCheck hiding (Some (..))
+import Test.Tasty.QuickCheck
 
 -- QuickCheck utilities
 

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Costing.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Costing.hs
@@ -22,7 +22,7 @@ import Data.Maybe
 import Data.SatInt
 import Test.QuickCheck.Gen
 import Test.Tasty
-import Test.Tasty.QuickCheck hiding (Some (..))
+import Test.Tasty.QuickCheck
 
 deriving newtype instance Foldable NonEmptyList  -- QuickCheck...
 


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/plutus-private/issues/1780