### PR TITLE
[Test] Make 'test_mangle' not fail

### DIFF
--- a/plutus-core/plutus-core/test/Names/Spec.hs
+++ b/plutus-core/plutus-core/test/Names/Spec.hs
@@ -27,6 +27,7 @@ import Control.Monad.Except (modifyError)
 import Data.String (IsString (fromString))
 import Data.Text qualified as Text
 import Hedgehog (Gen, Property, forAll, property, tripping, (/==), (===))
+import Hedgehog.Gen qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.HUnit (assertBool, testCase, (@?=))
@@ -53,9 +54,10 @@ test_DeBruijnInteresting =
 test_mangle :: TestTree
 test_mangle =
   testPropertyNamed "equality does not survive mangling" "equality_mangling" . property $ do
-    (term, termMangled) <- forAll . runAstGen $ do
+    (term, termMangled) <- forAll . runAstGen . Gen.justT $ do
       term <- AST.genTerm
-      (,) term <$> mangleNames term
+      mayTermMang <- mangleNames term
+      pure $ (,) term <$> mayTermMang
     term /== termMangled
     termMangled /== term
 

--- a/plutus-core/testlib/UntypedPlutusCore/Generators/Hedgehog/AST.hs
+++ b/plutus-core/testlib/UntypedPlutusCore/Generators/Hedgehog/AST.hs
@@ -8,6 +8,8 @@ module UntypedPlutusCore.Generators.Hedgehog.AST
   , mangleNames
   ) where
 
+import PlutusPrelude
+
 import PlutusCore.Generators.Hedgehog.AST qualified as PLC
 
 import PlutusCore.Compiler.Erase
@@ -37,7 +39,9 @@ genProgram
 genProgram = fmap eraseProgram PLC.genProgram
 
 -- See Note [Name mangling]
-mangleNames :: Term Name DefaultUni DefaultFun () -> PLC.AstGen (Term Name DefaultUni DefaultFun ())
+mangleNames
+    :: Term Name DefaultUni DefaultFun ()
+    -> PLC.AstGen (Maybe (Term Name DefaultUni DefaultFun ()))
 mangleNames term = do
-    mang <- PLC.genNameMangler $ setOf vTerm term
-    termSubstNamesM (fmap (fmap $ UPLC.Var ()) . mang) term
+    mayMang <- PLC.genNameMangler $ setOf vTerm term
+    for mayMang $ \mang -> termSubstNamesM (fmap (fmap $ UPLC.Var ()) . mang) term

--- a/plutus-core/untyped-plutus-core/testlib/Scoping/Spec.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Scoping/Spec.hs
@@ -20,6 +20,7 @@ import PlutusCore.Rename
 import PlutusCore.Test qualified as T
 
 import Hedgehog
+import Hedgehog.Gen qualified as Gen
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit
@@ -28,9 +29,10 @@ test_mangle :: TestTree
 test_mangle =
   testPropertyNamed "equality does not survive mangling" "equality_mangling" $
       withDiscards 1000000 . T.mapTestLimitAtLeast 300 (`div` 3) . property $ do
-          (term, termMangled) <- forAll . runAstGen $ do
+          (term, termMangled) <- forAll . runAstGen . Gen.justT $ do
             term <- genTerm
-            (,) term <$> mangleNames term
+            mayTermMang <- mangleNames term
+            pure $ (,) term <$> mayTermMang
           term /== termMangled
           termMangled /== term
 


### PR DESCRIPTION
Fixes the issue with the nightly suite found by @kwxm:

> ```
>     equality does not survive mangling:                              FAIL (0.28s)
>         ⚐ equality_mangling gave up after 100 discards, passed 202 tests.
>       Use -p '/equality does not survive mangling/' to rerun this test only.
> ```

Tested it like this.

```
$ cabal test plutus-core-test --test-options "-p /mangling/ --hedgehog-tests 100000"
<...>
Test suite plutus-core-test: RUNNING...
all tests
  names
    equality does not survive mangling: OK (77.03s)
        ✓ equality_mangling passed 100000 tests.
```