### PR TITLE
Add SrcSpans of Vars in the compilation trace

### DIFF
--- a/plutus-tx-plugin/changelog.d/20250831_170659_unsafeFixIO_var_srcspan.md
+++ b/plutus-tx-plugin/changelog.d/20250831_170659_unsafeFixIO_var_srcspan.md
@@ -1,0 +1,5 @@
+### Added
+
+- During compilation, if a `Var` carries `SrcSpan`, the `SrcSpan` is added to the
+  compilation trace. The effect can be seen both in the full compilation trace
+  (via `dump-compilation-trace`), or in the error message when the compilation fails.


### PR DESCRIPTION
The effect can be seen both in the full compilation trace (via `dump-compilation-trace`), or in the error message when the compilation fails.

Unfortunately most `Var`s don't have `SrcSpan`, but this is better than nothing.