### PR TITLE
Remove unused test inputs

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
@@ -22,12 +22,15 @@ import Prettyprinter
 
 {- Note [Adding new builtins: protocol versions]
 
-  *** ATTENTION! ***
-  New built-in functions must initially be added under
-  `futurePV` and should only be moved to an earlier MajorProtocolVersion once
-  they have been fully implemented and costed and their release under the
-  relevant protocol version has been officially approved.  Remember to update
-  the tests in `Spec.Versions` and `Spec.Data.Versions` when this happens.
+  *** ATTENTION! *** New built-in functions must initially be added in a batch
+  under `futurePV` in `builtinsAvailableIn` in `Common.Versions` and should only
+  be moved to an earlier MajorProtocolVersion once they have been fully
+  implemented and costed and their release under the relevant protocol version
+  has been officially approved.  Remember to update the tests in `Spec.Versions`
+  and `Spec.Data.Versions` when this happens.  If there are some builtins that
+  are not to be released then leave them under `futurePV` (splitting the batch
+  if necessary) and also make sure that the names of their cost model parameters
+  come at the end of the `ParamName` types.
 -}
 
 -- | This represents the major component of the Cardano protocol version.
@@ -106,11 +109,9 @@ newestPV = pv11PV
 
 {-| This is a placeholder for when we don't yet know what protocol version will
   be used for something. It's a very high protocol version that should never
-  appear in reality.  New builtins should always be given this protocol version
-  until they've been finalised (at which point they should be moved to
-  the PV named in `newestPV`).
+  appear in reality.
 
-We should not assign names to future protocol versions until it's
+  We should not assign names to future protocol versions until it's
   confirmed that they are correct, otherwise we could accidentally
   associate something with the wrong protocol version.
 -}

--- a/plutus-ledger-api/test/Spec/Data/Versions.hs
+++ b/plutus-ledger-api/test/Spec/Data/Versions.hs
@@ -307,9 +307,6 @@ testBuiltinAvailabilityCompatibility =
                       , ComplementByteString , ReadBit, WriteBits
                       , ReplicateByte , ShiftByteString, RotateByteString
                       , CountSetBits, FindFirstSetBit, Ripemd_160 ])
-                   , ((PlutusV3, futurePV), Set.fromList
-                      [ ExpModInteger, DropList
-                      , ListToArray, IndexArray, LengthOfArray ])
                    ]
         builtinsAvailableIn_old
             :: PlutusLedgerLanguage

--- a/plutus-ledger-api/test/Spec/Versions.hs
+++ b/plutus-ledger-api/test/Spec/Versions.hs
@@ -308,9 +308,6 @@ testBuiltinAvailabilityCompatibility =
                       , ComplementByteString , ReadBit, WriteBits
                       , ReplicateByte , ShiftByteString, RotateByteString
                       , CountSetBits, FindFirstSetBit, Ripemd_160 ])
-                   , ((PlutusV3, futurePV), Set.fromList
-                      [ ExpModInteger, DropList
-                      , ListToArray, IndexArray, LengthOfArray ])
                    ]
         builtinsAvailableIn_old
             :: PlutusLedgerLanguage


### PR DESCRIPTION
In #7223 I refactored the `builtinsAvailableIn` code quite substantially and added a check to make sure that it did exactly the same as the previous version (see [this comment](https://github.com/IntersectMBO/plutus/pull/7223#discussion_r2218084218)).  I've just noticed that this contained some data that was never used so I've removed it here.  I've also updated some comments.