### PR TITLE
Revert "Build with -Werror by default (#7298)"

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,9 +18,6 @@ index-state:
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2025-08-27T16:08:15Z
 
-program-options
-  ghc-options: -Werror
-
 packages: cardano-constitution
           plutus-benchmark
           plutus-conformance


### PR DESCRIPTION
It's better to use `-Wall` and `-Wwarn` for development. When developing using ghci, it's very inconvenient if as soon as there's a warning, you can't proceed until it is fixed.