### PR TITLE
Spec: serialise arrays as lists; miscellaneous updates

### DIFF
--- a/doc/plutus-core-spec/cardano/builtins1.tex
+++ b/doc/plutus-core-spec/cardano/builtins1.tex
@@ -267,13 +267,13 @@ it applies at each possible monomorphisation in an obvious way.
     \TT{fstPair}                  & $[\forall a_\#, \forall b_\#, \pairOf{a_\#}{b_\#}] \to a_\#$       & $(x,y) \mapsto x$ & No & \\[2mm]
     \TT{sndPair}                  & $[\forall a_\#, \forall b_\#, \pairOf{a_\#}{b_\#}] \to b_\#$       & $(x,y) \mapsto y$ & No & \\[2mm]
     \TT{chooseList}               & $[\forall a_\#, \forall\star, \listOf{a_\#}, \star, \star] \to \star$
-                                              & \text{$([], t_1, t_2) \mapsto t_1$,} \text{$([x_1,\ldots,x_n],t_1,t_2) \mapsto t_2\ (n \geq 1)$}. & No & \\[2mm]
-    \TT{mkCons}                   & $[\forall a_\#, a_\#, \listOf{a_\#}] \to \listOf{a _\#}$  & $(x,[x_1,\ldots,x_n]) \mapsto [x,x_1,\ldots,x_n]$ & No & \\[2mm]
-    \TT{headList}                 & $[\forall a_\#, \listOf{a_\#}] \to a_\#$               & $[]\mapsto \errorX, [x_1,x_2, \ldots, x_n] \mapsto x_1$ & Yes & \\[2mm]
+                                              & \text{$([], t_1, t_2) \mapsto t_1$,} \text{$([x_1,\ldots,x_n],t_1,t_2) \mapsto t_2\ (n \geq 1)$}. & No & \ref{note:list-semantics}\\[2mm]
+    \TT{mkCons}                   & $[\forall a_\#, a_\#, \listOf{a_\#}] \to \listOf{a _\#}$  & $(x,[x_1,\ldots,x_n]) \mapsto [x,x_1,\ldots,x_n]$ & No & \ref{note:list-semantics}\\[2mm]
+    \TT{headList}                 & $[\forall a_\#, \listOf{a_\#}] \to a_\#$               & $[]\mapsto \errorX, [x_1,x_2, \ldots, x_n] \mapsto x_1$ & Yes & \ref{note:list-semantics}\\[2mm]
     \TT{tailList}                 & $[\forall a_\#, \listOf{a_\#}] \to \listOf{a_\#}$
-                                        &  \text{$[] \mapsto \errorX$,} \text{$ [x_1,x_2, \ldots, x_n] \mapsto [x_2, \ldots, x_n]$} & Yes & \\[2mm]
+                                        &  \text{$[] \mapsto \errorX$,} \text{$ [x_1,x_2, \ldots, x_n] \mapsto [x_2, \ldots, x_n]$} & Yes & \ref{note:list-semantics}\\[2mm]
     \TT{nullList}                 & $[\forall a_\#, \listOf{a_\#}] \to \ty{bool}$            & $ [] \mapsto \true,
-                                                                                                    [x_1,\ldots, x_n] \mapsto \false$ & No & \\[2mm]
+                                                                                                    [x_1,\ldots, x_n] \mapsto \false$ & No & \ref{note:list-semantics} \\[2mm]
     \TT{chooseData}               & $[\forall\star, \ty{data}, \star, \star, \star, \star, \star] \to \star$
     & $ (d,t_C, t_M, t_L, t_I, t_B) $
     \smallskip
@@ -476,4 +476,11 @@ any Plutus Core value) returns $v$.  We do not specify the semantics any
 further.  An implementation may choose to discard $s$ or to perform some
 side-effect such as writing it to a terminal or log file.
 
+\note{Semantics of lists.}
+\label{note:list-semantics}
+The mathematical denotation of lists is as finite seqeunces of elements.  We
+expect that in practice they will be implemented in such a way (for example as
+linked lists)
+that \texttt{chooseList}, \texttt{mkCons}, \texttt{headList}, \texttt{tailList},
+and \texttt{nullList} are all constant-time operations.
 \newpage

--- a/doc/plutus-core-spec/cardano/builtins6.tex
+++ b/doc/plutus-core-spec/cardano/builtins6.tex
@@ -84,14 +84,14 @@ Operations are defined in Table~\ref{table:built-in-functions-6}.
       & $[] \mapsto 0$
         \newline 
         $[x_1,\ldots,x_n] \mapsto n\ (n \geq 1)$ 
-      &  
-      & \\
+      & 
+      & \ref{note:array-semantics}\\
     \TT{listToArray} 
       & $[\forall a_\#, \listOf{a_\#}] \to \arrayOf{a_\#}$ 
       & $[] \mapsto []$
         \newline 
         $[x_1,\ldots,x_n] \mapsto [x_1,\ldots,x_n]\ (n \geq 1)$
-      & & \\
+      & & \ref{note:array-semantics}\\
     \TT{indexArray} 
       & $[\forall a_\#, \arrayOf{a_\#}, \ty{integer}]$ \text{$\;\;\; \to \ty{a_\#}$}
       &  $([x_1,\ldots,x_n], k)$
@@ -102,7 +102,7 @@ Operations are defined in Table~\ref{table:built-in-functions-6}.
             x_{k+1}   & \text{if $0 \leq k \leq n-1$} \\ \relax
             \errorX   & \text{if $k > n-1$}\\
         \end{array}\right.$}  
-      & Yes & \\
+      & Yes & \ref{note:array-semantics}\\
 \hline
 \end{longtable}
 
@@ -127,5 +127,10 @@ follows, for example, from Proposition I.3.1 of~\cite{Koblitz-GTM}.  See
 Note~\ref{note:integer-division-functions} of
 Section~\ref{sec:built-in-functions-1} for the definition of $\modfn$.
 
-
+\note{Semantics of arrays.}
+\label{note:array-semantics}
+The denotation of the array type is identical to that of lists, but we expect
+that in practice arrays will be implemented in such a way that the
+\texttt{lengthOfArray} and \texttt{indexArray} functions will be constant time and
+\texttt{listToArray} may be nontrivial, requiring linear time.
 

--- a/doc/plutus-core-spec/flat-serialisation.tex
+++ b/doc/plutus-core-spec/flat-serialisation.tex
@@ -155,58 +155,23 @@ $\bits{1}$ bit, then emitting a $\bits{0}$ bit to mark the end of the list.
 \Dlist_X(\bits{1} \cdot s) &= (s'', x \cdot l) \quad \text{if $D_X(s) = (s', x)$ and $\Dlist_X(s') = (s'', l).$}
 \end{align*}
 
-\subsection{Arrays}
-Arrays are encoded as a sequence of blocks of up to 255 elements.
-Each block is preceded by a single unsigned byte containing the count of elements in the block, 
-and the end of the encoding is marked by a zero-length block. 
-
-Let $X$ be the set of elements in the array for which we have defined an encoder $\E_X$ and a 
-decoder $\D_X$. We define an encoder $\Earray_X$ which encodes arrays of elements of $X$:
-
-$$
-\Earray_X(s, [x_1, \ldots, x_n]) =
-\begin{cases}
-  s \cdot \E_8(0) & \text{if } n = 0 \\
-  \text{let } k = \min(n, 255) \text{ in } \\
-  \Earray_X(s \cdot \E_8(k) \cdot \E_X(x_1) \cdots \E_X(x_k), [x_{k+1}, \ldots, x_n])
-    & \text{if } n > 0
-\end{cases}
-$$
-
-The corresponding decoder is given by:
-
-$$
-\Darray_X(s) =
-\begin{cases}
-  (s', []) & \text{if } \D_8(s) = (s', 0) \\
-  \text{let } (s', k) = \D_8(s) \text{ in } \\
-  \text{let } (s'', x_1) = \D_X(s') \text{ and } \ldots \text{ and } (s^{(k)}, x_k) = \D_X(s^{(k-1)}) \text{ in } \\
-  \text{let } (s''', l) = \Darray_X(s^{(k)}) \text{ in } \\
-  (s''', [x_1, \ldots, x_k] \cdot l) & \text{if } 1 \leq k \leq 255
-\end{cases}
-$$
-
-The decoder reads the initial byte to determine the length of the subsequent block. 
-If the length $k$ is greater than 0 and no more bytes are available to decode $k$ 
-elements of type $X$, the decoder would fail as per the general behaviour of decoders 
-described in Section~\ref{sec:encoding-and-decoding}. 
-The concatenation of the decoded block $[x_1, \ldots, x_k]$ with the recursively 
-decoded list $l$ (from the remainder $s^{(k)}$) forms the final result.
-
 \subsection{Natural numbers}
-Every natural number $n$ of arbirary size can be uniquely written in the following form:
+Every natural number $m$ can be uniquely written in the form
 
 $$
-n = \sum_{i=0}^{n}k_i2^{7i} \text{ where for any $i$ with } 0 \leq i \leq n \text{, } 0 \leq k_i \leq 127  \text{ and } k_n \ne 0
+m = \sum_{i=0}^{n}k_i2^{7i}
 $$
+with $n \geq 0$, $0 \leq k_i \leq 127$ for $0 \leq i \leq n$, and $k_n \ne 0$.
+Each $k_i$ is 7 bit binary block, $k_0$ being the least significant block.
 
-\noindent Here, each $k_i$ is 7 bit binary block; $k_0$ being the least significant block.
+\medskip
+\noindent With this representation, the encoder for natural numbers is 
 
 $$
 \E_{\N} (s, \sum_{i=0}^{n}k_i2^{7i}) =
 \begin{cases}
   \E_7(\Elist_7(s, []), k_{0}) & \text{if } n = 0 \\
-  \E_7(\Elist_7(s, [k_0, \ldots, k_{n-1}]), k_{n}) & \text{if } n \ne 0
+  \E_7(\Elist_7(s, [k_0, \ldots, k_{n-1}]), k_{n}) & \text{if } n \ne 0.
 \end{cases}
 $$
 
@@ -214,13 +179,13 @@ $$
 $$
 \D_{\N}(s) =
 \begin{cases}
-  \text{let } \Dlist_7(s) = (s', ks) \\
-  D_7(s') & \text{if } ks = [] \\
-  (s'', \sum_{i=0}^{n}k_i2^{7i}) & \text{if } ks = [k_0, \ldots, k_{n-1}] \text{ and } \D_7(s') = (s'', k_{n})
+  D_7(s') & \text{if $\Dlist_7(s) = (s',[])$} \\
+  (s'', \sum_{i=0}^{n}k_i2^{7i}) & \text{if $\Dlist_7(s) = (s', [k_0, \ldots, k_{n-1}])$ and $\D_7(s') = (s'', k_{n})$ with $n\geq 1$}.
 \end{cases}
 $$
 
-\noindent Intuitively, every 7 bit blocks except the last block are prefixed by 1 and the last block is prefixed by 0.
+\noindent Intuitively, every 7 bit block except for the last one is prefixed by 1
+and the last block is prefixed by 0.
 
 \subsection{Integers}
 Signed integers are encoded by converting them to natural numbers using the
@@ -559,26 +524,7 @@ $$
 \subsection{Constants}
 \label{sec:flat-constants}
 Values of built-in types can mostly be encoded quite simply by using encoders
-already defined.  Note that the unit value \texttt{(con unit ())} does not have
-an explicit encoding: the type has only one possible value, so there is no need
-to use any space to serialise it.
-
-The $\ty{data}$ type is encoded by converting to a bytestring using the CBOR
-encoder $\eData$ described in Appendix~\ref{appendix:data-cbor-encoding} and
-then using $\E_{\B^*}$.  The decoding process is the opposite of this: a
-bytestring is obtained using $\D_{\B^*}$ and this is then decoded from CBOR
-using $\dData$ to obtain a $\ty{data}$ object.
-
-We do not provide serialisation and deserialisation for constants of type
-$\ty{bls12\_381\_G1\_element}$, $\ty{bls12\_381\_G2\_element}$, or
-$\ty{bls12\_381\_mlresult}$.  We have specified tags for these types, but if one
-of these tags is encountered during deserialisation then deserialisation fails
-and any subsequent input is ignored.  Note however that constants of the first
-two types can be serialised by using the compression functions defined in
-Section~\ref{sec:bls-builtins-4} and serialising the resulting bytestrings.
-Decoding can similarly be performed indirectly by using
-\texttt{bls12\_381\_G1\_uncompress} and \texttt{bls12\_381\_G2\_uncompress} on
-bytestring constants during program execution.
+already defined:
 
 \begin{alignat*}{2}
   & \Econstant{\ty{integer}}(s,n)                  &&= \E_{\Z}(s, n) \\
@@ -588,7 +534,7 @@ bytestring constants during program execution.
   & \Econstant{\ty{bool}}(s, \texttt{False})       &&= s \cdot \bits{0}\\
   & \Econstant{\ty{bool}}(s, \texttt{True})        &&= s \cdot \bits{1}\\
   & \Econstant{\listOf{\tn}}(s,l)                  &&= \Elist^{\tn}_{\mathsf{constant}}(s, l) \\
-  & \Econstant{\arrayOf{\tn}}(s,l)                 &&= \Earray^{\tn}_{\mathsf{constant}}(s, l) \\
+  & \Econstant{\arrayOf{\tn}}(s,a)                 &&= \Earray^{\tn}_{\mathsf{constant}}(s, a) \\
   & \Econstant{\pairOf{\tn_1}{\tn_2}}(s,(c_1,c_2)) &&= \Econstant{\tn_2}(\Econstant{\tn_1}(s, c_1), c_2)\\
   & \Econstant{\ty{data}}(s,d)                     &&= \E_{\B^*}(s, \eData(d))
 \end{alignat*}
@@ -600,8 +546,8 @@ bytestring constants during program execution.
   &\dConstant{\ty{unit}}(s)                 &&= s  \\
   &\dConstant{\ty{bool}}(\bits{0} \cdot s)  &&= (s, \texttt{False}) \\
   &\dConstant{\ty{bool}}(\bits{1} \cdot s)  &&= (s, \texttt{True}) \\
-  &\dConstant{\listOf{\tn}}(s)              &&= \Dlist^{\tn}_{\mathsf{constant}}(s, l) \\
-  &\dConstant{\arrayOf{\tn}}(s)             &&= \Darray^{\tn}_{\mathsf{constant}}(s, l) \\
+  &\dConstant{\listOf{\tn}}(s)              &&= \Dlist^{\tn}_{\mathsf{constant}}(s) \\
+  &\dConstant{\arrayOf{\tn}}(s)             &&= \Darray^{\tn}_{\mathsf{constant}}(s) \\
   &\dConstant{\pairOf{\tn_1}{\tn_2}}(s)     &&= (s'', (c_1, c_2))
   && \begin{cases}
        \text{if}  & \dConstant{\tn_1}(s) = (s', c_1) \\
@@ -609,8 +555,38 @@ bytestring constants during program execution.
      \end{cases}\\
   &\dConstant{\ty{data}}(s)                  &&= (s', d) &&
                                            \text{if $\D_{\B*}(s) = (s', t)$
-                                            and $\dData(t) = (t', d)$ for some $t'$}
+                                            and $\dData(t) = (t', d)$ for some $t'$}.
 \end{alignat*}
+
+\paragraph{Units.} The unit value \texttt{(con unit ())} does not have
+an explicit encoding: the type has only one possible value, so there is no need
+to use any space to serialise it.
+
+\paragraph{Data.} The $\ty{data}$ type is encoded by converting to a bytestring using the CBOR
+encoder $\eData$ described in Appendix~\ref{appendix:data-cbor-encoding} and
+then using $\E_{\B^*}$.  The decoding process is the opposite of this: a
+bytestring is obtained using $\D_{\B^*}$ and this is then decoded from CBOR
+using $\dData$ to obtain a $\ty{data}$ object.
+
+\paragraph{Arrays.} Arrays use the same encoders and decoders as lists: given a set $X$ for which we
+have defined an encoder $\E_X$ and a decoder $\D_X$, arrays of elements of $X$
+are encoded using $\Elist_X$ and decoded using $\Dlist_X$.  In practice the
+run-time implementations of lists and arrays may differ and some extra work may
+be required to convert arrays to lists before encoding and lists to arrays after
+decoding.
+
+\paragraph{BLS12-381 elements.}
+We do not provide serialisation and deserialisation methods for constants of type
+$\ty{bls12\_381\_G1\_element}$, $\ty{bls12\_381\_G2\_element}$, or
+$\ty{bls12\_381\_mlresult}$.  We have specified tags for these types, but if one
+of these tags is encountered during deserialisation then deserialisation fails
+and any subsequent input is ignored.  Note however that constants of the first
+two types can be serialised by using the compression functions defined in
+Section~\ref{sec:bls-builtins-4} and serialising the resulting bytestrings.
+Decoding can similarly be performed indirectly by using
+\texttt{bls12\_381\_G1\_uncompress} and \texttt{bls12\_381\_G2\_uncompress} on
+bytestring constants during program execution.
+
 
 \subsection{Built-in functions}
 Built-in functions are represented by seven-bit integer tags and encoded and

--- a/doc/plutus-core-spec/flat-serialisation.tex
+++ b/doc/plutus-core-spec/flat-serialisation.tex
@@ -140,6 +140,7 @@ encoders $\E_1, \E_2, \E_3, \ldots$ and decoders $\D_1, \D_2, \D_3\ldots$.
 
 
 \subsection{Lists}
+\label{sec:flat:lists}
 Suppose that we have a set $X$ for which we have defined an encoder $\E_X$ and a
 decoder $\D_X$; we define an encoder $\Elist_X$ which encodes lists of elements
 of $X$ by emitting the encodings of the elements of the list, each preceded by a
@@ -568,12 +569,13 @@ then using $\E_{\B^*}$.  The decoding process is the opposite of this: a
 bytestring is obtained using $\D_{\B^*}$ and this is then decoded from CBOR
 using $\dData$ to obtain a $\ty{data}$ object.
 
-\paragraph{Arrays.} Arrays use the same encoders and decoders as lists: given a
-set $X$ for which we have defined an encoder $\E_X$ and a decoder $\D_X$, arrays
-of elements of $X$ are encoded using $\Elist_X$ and decoded using $\Dlist_X$.
-In practice the run-time implementations of lists and arrays may differ and some
-extra work may be required to convert arrays to lists before encoding and lists
-to arrays after decoding.
+\paragraph{Arrays.} Arrays use the same encoders and decoders as lists (see
+Section~\ref{sec:flat:lists}): given a set $X$ for which we have defined an
+encoder $\E_X$ and a decoder $\D_X$, arrays of elements of $X$ are encoded using
+$\Elist_X$ and decoded using $\Dlist_X$.  In practice the run-time
+implementations of lists and arrays may differ and some extra work may be
+required to convert arrays to lists before encoding and lists to arrays after
+decoding.
 
 \paragraph{BLS12-381 elements.}
 We do not provide serialisation and deserialisation methods for constants of type

--- a/doc/plutus-core-spec/flat-serialisation.tex
+++ b/doc/plutus-core-spec/flat-serialisation.tex
@@ -568,12 +568,12 @@ then using $\E_{\B^*}$.  The decoding process is the opposite of this: a
 bytestring is obtained using $\D_{\B^*}$ and this is then decoded from CBOR
 using $\dData$ to obtain a $\ty{data}$ object.
 
-\paragraph{Arrays.} Arrays use the same encoders and decoders as lists: given a set $X$ for which we
-have defined an encoder $\E_X$ and a decoder $\D_X$, arrays of elements of $X$
-are encoded using $\Elist_X$ and decoded using $\Dlist_X$.  In practice the
-run-time implementations of lists and arrays may differ and some extra work may
-be required to convert arrays to lists before encoding and lists to arrays after
-decoding.
+\paragraph{Arrays.} Arrays use the same encoders and decoders as lists: given a
+set $X$ for which we have defined an encoder $\E_X$ and a decoder $\D_X$, arrays
+of elements of $X$ are encoded using $\Elist_X$ and decoded using $\Dlist_X$.
+In practice the run-time implementations of lists and arrays may differ and some
+extra work may be required to convert arrays to lists before encoding and lists
+to arrays after decoding.
 
 \paragraph{BLS12-381 elements.}
 We do not provide serialisation and deserialisation methods for constants of type

--- a/doc/plutus-core-spec/plutus-core-specification.tex
+++ b/doc/plutus-core-spec/plutus-core-specification.tex
@@ -5,7 +5,7 @@
   \LARGE{\red{\textsf{DRAFT}}}
 }
 
-\date{16th July 2025}
+\date{5th September 2025}
 \author{Plutus Core Team}
 
 \input{header.tex}

--- a/doc/plutus-core-spec/plutus-core-specification.tex
+++ b/doc/plutus-core-spec/plutus-core-specification.tex
@@ -5,7 +5,7 @@
   \LARGE{\red{\textsf{DRAFT}}}
 }
 
-\date{5th September 2025}
+\date{15th September 2025}
 \author{Plutus Core Team}
 
 \input{header.tex}


### PR DESCRIPTION
This updates the specification to reflect the change to array (de)serialisation in #7296.  I tidied up and clarified a few other things while I was at it. 

Edit: here's a copy of the rendered PDF:

[plutus-core-specification.pdf](https://github.com/user-attachments/files/22282536/plutus-core-specification.pdf)
