### PR TITLE
Improve Deployments of Docusaurus Site & Papers

### DIFF
--- a/.github/workflows/docusaurus-site.yml
+++ b/.github/workflows/docusaurus-site.yml
@@ -1,7 +1,7 @@
 # This workflow builds and deploys the Docusaurus site.
 # 
 # On pull requests, this workflow builds the site and deploys a temporary preview
-# to gh-pages.
+# to gh-pages, but only if the relevant files have changed.
 #
 # On push to master or on workflow dispatch it deploys the site to: 
 # https://plutus.cardano.intersectmbo.org/docs
@@ -15,6 +15,9 @@ on:
       - master 
   workflow_dispatch:
   pull_request:
+    paths:
+      - 'doc/docusaurus/**'
+      - '.github/workflows/docusaurus-site.yml'
 
 jobs:
   run:
@@ -53,10 +56,11 @@ jobs:
           nix develop --no-warn-dirty --accept-flake-config --command bash -c 'yarn && yarn build'
 
       - name: Deploy Preview Site 
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        if: github.event_name == 'pull_request'
         uses: rossjrw/pr-preview-action@v1.6.2
         with:
           source-dir: doc/docusaurus/build
+          umbrella-dir: pr-preview/docs
 
 
       

--- a/.github/workflows/papers-and-specs.yml
+++ b/.github/workflows/papers-and-specs.yml
@@ -1,5 +1,8 @@
 # This workflow builds and deploys various papers.
 # 
+# On pull requests, this workflow builds the papers and deploys a temporary preview
+# to gh-pages, but only if the relevant files have changed.
+#
 # This workflow runs on all push to master and can also be triggered manually.
 # It deploys the artifacts to: https://plutus.cardano.intersectmbo.org/resources
 
@@ -10,6 +13,10 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    paths:
+      - 'doc'
+      - '!doc/docusaurus/**'
 
 jobs:
   deploy:
@@ -42,8 +49,16 @@ jobs:
           done 
 
       - name: Publish Papers
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           folder: _resources
           target-folder: resources
           single-commit: true
+
+      - name: Publish Preview Papers 
+        if: github.event_name == 'pull_request'
+        uses: rossjrw/pr-preview-action@v1.6.2
+        with:
+          source-dir: _resources
+          umbrella-dir: pr-preview/resources


### PR DESCRIPTION
Only deploy a preview of the docusaurus site when the relevant files have changed.
Also deploy a preview for the papers and specs.