### PR TITLE
Add new metatheory-jailbreak devShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ plutus-pab/test-node/alonzo-purple/db
 .nvimrc
 release-*
 TestCert.*
+worktrees

--- a/nix/agda-tools.nix
+++ b/nix/agda-tools.nix
@@ -143,7 +143,6 @@ let
 
   # Path to the stdlib .agda-lib file for shell export.
   NIX_AGDA_STDLIB = "${agda-stdlib}/standard-library.agda-lib";
-
 in
 
 {

--- a/nix/metatheory.nix
+++ b/nix/metatheory.nix
@@ -105,7 +105,6 @@ let
       exit 1
     fi
   '';
-
 in
 
 {

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -97,9 +97,20 @@ let
     ghc910 = mkShell project.projectVariants.ghc910;
   };
 
+  # The default shell contains the agda-with-stdlib-and-metatheory package which will
+  # break on `nix develop` if the .lagda files are broken. In order to escape this
+  # situation we introduce a shell that doesn't contain that executable.
+  metatheory-jailbreak-shell = non-profiled-shells.default.overrideAttrs (attrs: {
+    buildInputs =
+      lib.remove metatheory.agda-with-stdlib-and-metatheory attrs.buildInputs;
+    nativeBuildInputs =
+      lib.remove metatheory.agda-with-stdlib-and-metatheory attrs.nativeBuildInputs;
+  });
+
   devShells =
     (non-profiled-shells) //
-    { profiled = mkShell project.projectVariants.ghc96-profiled; };
+    { profiled = mkShell project.projectVariants.ghc96-profiled; } //
+    { metatheory-jailbreak = metatheory-jailbreak-shell; };
 
   nested-ci-jobs = {
     "x86_64-linux" =


### PR DESCRIPTION
The default shell contains the `agda-with-stdlib-and-metatheory` package which will break on `nix develop` if the `.lagda` files are broken. 
In order to escape this situation and make development possible, we introduce a shell that doesn't contain that executable.