### PR TITLE
Enable BLS12-381 MSM builtins at PV11

### DIFF
--- a/plutus-ledger-api/changelog.d/20251002_130633_kenneth.mackenzie_enable_bls_msm.md
+++ b/plutus-ledger-api/changelog.d/20251002_130633_kenneth.mackenzie_enable_bls_msm.md
@@ -1,0 +1,7 @@
+### Added
+
+- The two BLS12-381 multi-scalar multiplication functions
+  `bls12_381_G1_multiScalarMul` and `bls12_381_G2_multiScalarMul` will become
+  available on the chain at Protocol Version 11 once a protocol parameter update
+  has taken place to add the relevant cost model parameters.
+

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
@@ -215,10 +215,14 @@ batch5 =
   , Ripemd_160
   ]
 
+-- Add new builtins for release in PV11 here.  Once PV11 has happened (by which
+-- time we should have replaced pv11PV by the real name), mark this as not to be
+-- changed and open a new batch.
 batch6 :: [DefaultFun]
 batch6 =
   [ ExpModInteger, DropList
   , LengthOfArray, ListToArray, IndexArray
+  , Bls12_381_G1_multiScalarMul, Bls12_381_G2_multiScalarMul
   ]
 
 {-| Given a ledger language, return a map indicating which builtin functions were

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/Data/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/Data/EvaluationContext.hs
@@ -88,6 +88,8 @@ clearBuiltinCostModel r = r
                , paramLengthOfArray = mempty
                , paramListToArray = mempty
                , paramIndexArray = mempty
+               , paramBls12_381_G1_multiScalarMul = mempty
+               , paramBls12_381_G2_multiScalarMul = mempty
                }
 
 

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/V3/EvaluationContext.hs
@@ -95,6 +95,8 @@ clearBuiltinCostModel r = r
                , paramLengthOfArray = mempty
                , paramListToArray = mempty
                , paramIndexArray = mempty
+               , paramBls12_381_G1_multiScalarMul = mempty
+               , paramBls12_381_G2_multiScalarMul = mempty
                }
 
 


### PR DESCRIPTION
Closes #7330.

Closes https://github.com/IntersectMBO/plutus-private/issues/1812

This enables the two BLS12-381 MSM buitins at PV11 by adding them to `batch6` of the builtins, which makes them visible to the `builtinsAvailableIn` check that gets performed during deserialisation.  The cost model parameter names were added in an earlier PR, so there's no need to do anything for them here.