### PR TITLE
Spec.Data.Value.UnionBudget: raw sorted-merge vs builtin matrix

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -273,6 +273,7 @@ test-suite plutus-ledger-api-plugin-test
     Spec.Data.MintValue.V3
     Spec.Data.ScriptContext
     Spec.Data.Value
+    Spec.Data.Value.UnionBudget
     Spec.Envelope
     Spec.MintValue.V3
     Spec.ReturnUnit.V1

--- a/plutus-tx-plugin/test-ledger-api/Spec.hs
+++ b/plutus-tx-plugin/test-ledger-api/Spec.hs
@@ -5,6 +5,7 @@ import Spec.Data.Budget qualified
 import Spec.Data.MintValue.V3 qualified
 import Spec.Data.ScriptContext qualified
 import Spec.Data.Value qualified
+import Spec.Data.Value.UnionBudget qualified
 import Spec.Envelope qualified
 import Spec.MintValue.V3 qualified
 import Spec.ReturnUnit.V1 qualified
@@ -27,6 +28,7 @@ tests =
     , Spec.Data.Budget.tests
     , Spec.Data.ScriptContext.tests
     , Spec.Data.Value.test_EqValue
+    , Spec.Data.Value.UnionBudget.tests
     , Spec.Data.MintValue.V3.tests
     , Spec.Envelope.tests
     , Spec.ReturnUnit.V1.tests

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget.hs
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget.hs
@@ -1,0 +1,353 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{-|
+Budget comparison between the on-chain builtin union path
+('unsafeDataAsValue' + 'unionValue' + 'mkValue') and a hand-rolled
+sorted-merge over the raw 'BuiltinData' representation.
+
+* S1   — ada only (1 token).
+* S3   — ada + 2 single-token policies (3 tokens total).
+* S8   — ada + 7 single-token policies (8 tokens total).
+* S100 — ada + 10 policies with 10 tokens each (~101 tokens).
+
+Currency symbols are 28 bytes and token names are 32 bytes, matching the
+sizes that appear on-chain.
+
+The bundle pattern is 'BuiltinData' -> 'BuiltinData' -> 'BuiltinData' --
+the union is the only operation measured; no downstream 'valueOf' or
+'lookupCoin' is folded into the cost.
+
+The raw 'unionValuePositiveRaw' is a Plinth translation of Philip's
+'pvalueUnionFast' (Plutarch). It is a sorted-merge with a three-way
+branch on key comparison and assumes both inputs are sorted by
+lexicographic key (ada ('') first, then policy_01..policy_10) and that
+the inner-pair values are strictly positive integers, so the inner sum
+never produces a zero that would need filtering. Both 'valueS1', 'valueS3',
+'valueS8', 'valueS100' below satisfy these preconditions. -}
+module Spec.Data.Value.UnionBudget where
+
+import PlutusTx.Prelude
+
+import PlutusLedgerApi.Test.V1.Data.Value (listsToValue)
+import PlutusLedgerApi.V1.Data.Value qualified as DValue
+import PlutusTx.Builtins qualified as B
+import PlutusTx.Builtins.Internal qualified as BI
+import PlutusTx.Code (CompiledCode, unsafeApplyCode)
+import PlutusTx.IsData qualified as Tx
+import PlutusTx.Lift (liftCodeDef)
+import PlutusTx.TH (compile)
+import PlutusTx.Test (goldenBundle)
+import Test.Tasty (TestTree)
+import Test.Tasty.Extras (runTestNested, testNestedGhc)
+
+tests :: TestTree
+tests =
+  runTestNested ["test-ledger-api", "Spec", "Data", "Value", "UnionBudget"]
+    . pure
+    . testNestedGhc
+    $ [ goldenBundle
+          "union_S1_builtin"
+          unionValueBuiltinRaw
+          (unionValueBuiltinRaw `unsafeApplyCode` valueS1 `unsafeApplyCode` valueS1)
+      , goldenBundle
+          "union_S1_raw"
+          unionValuePositiveRaw
+          (unionValuePositiveRaw `unsafeApplyCode` valueS1 `unsafeApplyCode` valueS1)
+      , goldenBundle
+          "union_S3_builtin"
+          unionValueBuiltinRaw
+          (unionValueBuiltinRaw `unsafeApplyCode` valueS3 `unsafeApplyCode` valueS3)
+      , goldenBundle
+          "union_S3_raw"
+          unionValuePositiveRaw
+          (unionValuePositiveRaw `unsafeApplyCode` valueS3 `unsafeApplyCode` valueS3)
+      , goldenBundle
+          "union_S8_builtin"
+          unionValueBuiltinRaw
+          (unionValueBuiltinRaw `unsafeApplyCode` valueS8 `unsafeApplyCode` valueS8)
+      , goldenBundle
+          "union_S8_raw"
+          unionValuePositiveRaw
+          (unionValuePositiveRaw `unsafeApplyCode` valueS8 `unsafeApplyCode` valueS8)
+      , goldenBundle
+          "union_S100_builtin"
+          unionValueBuiltinRaw
+          (unionValueBuiltinRaw `unsafeApplyCode` valueS100 `unsafeApplyCode` valueS100)
+      , goldenBundle
+          "union_S100_raw"
+          unionValuePositiveRaw
+          (unionValuePositiveRaw `unsafeApplyCode` valueS100 `unsafeApplyCode` valueS100)
+      ]
+
+-- --------------------------------------------------------------------------
+-- Raw 28-byte currency-symbol bytes.
+-- --------------------------------------------------------------------------
+
+bsPolicy01 :: BuiltinByteString
+bsPolicy01 = "policy_01___________________"
+{-# INLINEABLE bsPolicy01 #-}
+
+bsPolicy02 :: BuiltinByteString
+bsPolicy02 = "policy_02___________________"
+{-# INLINEABLE bsPolicy02 #-}
+
+bsPolicy03 :: BuiltinByteString
+bsPolicy03 = "policy_03___________________"
+{-# INLINEABLE bsPolicy03 #-}
+
+bsPolicy04 :: BuiltinByteString
+bsPolicy04 = "policy_04___________________"
+{-# INLINEABLE bsPolicy04 #-}
+
+bsPolicy05 :: BuiltinByteString
+bsPolicy05 = "policy_05___________________"
+{-# INLINEABLE bsPolicy05 #-}
+
+bsPolicy06 :: BuiltinByteString
+bsPolicy06 = "policy_06___________________"
+{-# INLINEABLE bsPolicy06 #-}
+
+bsPolicy07 :: BuiltinByteString
+bsPolicy07 = "policy_07___________________"
+{-# INLINEABLE bsPolicy07 #-}
+
+bsPolicy08 :: BuiltinByteString
+bsPolicy08 = "policy_08___________________"
+{-# INLINEABLE bsPolicy08 #-}
+
+bsPolicy09 :: BuiltinByteString
+bsPolicy09 = "policy_09___________________"
+{-# INLINEABLE bsPolicy09 #-}
+
+bsPolicy10 :: BuiltinByteString
+bsPolicy10 = "policy_10___________________"
+{-# INLINEABLE bsPolicy10 #-}
+
+-- --------------------------------------------------------------------------
+-- Raw 32-byte token-name bytes.
+-- --------------------------------------------------------------------------
+
+bsTok01 :: BuiltinByteString
+bsTok01 = "token_01________________________"
+{-# INLINEABLE bsTok01 #-}
+
+bsTok02 :: BuiltinByteString
+bsTok02 = "token_02________________________"
+{-# INLINEABLE bsTok02 #-}
+
+bsTok03 :: BuiltinByteString
+bsTok03 = "token_03________________________"
+{-# INLINEABLE bsTok03 #-}
+
+bsTok04 :: BuiltinByteString
+bsTok04 = "token_04________________________"
+{-# INLINEABLE bsTok04 #-}
+
+bsTok05 :: BuiltinByteString
+bsTok05 = "token_05________________________"
+{-# INLINEABLE bsTok05 #-}
+
+bsTok06 :: BuiltinByteString
+bsTok06 = "token_06________________________"
+{-# INLINEABLE bsTok06 #-}
+
+bsTok07 :: BuiltinByteString
+bsTok07 = "token_07________________________"
+{-# INLINEABLE bsTok07 #-}
+
+bsTok08 :: BuiltinByteString
+bsTok08 = "token_08________________________"
+{-# INLINEABLE bsTok08 #-}
+
+bsTok09 :: BuiltinByteString
+bsTok09 = "token_09________________________"
+{-# INLINEABLE bsTok09 #-}
+
+bsTok10 :: BuiltinByteString
+bsTok10 = "token_10________________________"
+{-# INLINEABLE bsTok10 #-}
+
+-- --------------------------------------------------------------------------
+-- Typed wrappers.
+-- --------------------------------------------------------------------------
+
+cs01, cs02, cs03, cs04, cs05, cs06, cs07, cs08, cs09, cs10 :: DValue.CurrencySymbol
+cs01 = DValue.CurrencySymbol bsPolicy01
+cs02 = DValue.CurrencySymbol bsPolicy02
+cs03 = DValue.CurrencySymbol bsPolicy03
+cs04 = DValue.CurrencySymbol bsPolicy04
+cs05 = DValue.CurrencySymbol bsPolicy05
+cs06 = DValue.CurrencySymbol bsPolicy06
+cs07 = DValue.CurrencySymbol bsPolicy07
+cs08 = DValue.CurrencySymbol bsPolicy08
+cs09 = DValue.CurrencySymbol bsPolicy09
+cs10 = DValue.CurrencySymbol bsPolicy10
+
+tn01, tn02, tn03, tn04, tn05, tn06, tn07, tn08, tn09, tn10 :: DValue.TokenName
+tn01 = DValue.TokenName bsTok01
+tn02 = DValue.TokenName bsTok02
+tn03 = DValue.TokenName bsTok03
+tn04 = DValue.TokenName bsTok04
+tn05 = DValue.TokenName bsTok05
+tn06 = DValue.TokenName bsTok06
+tn07 = DValue.TokenName bsTok07
+tn08 = DValue.TokenName bsTok08
+tn09 = DValue.TokenName bsTok09
+tn10 = DValue.TokenName bsTok10
+
+s100Policies :: [DValue.CurrencySymbol]
+s100Policies = [cs01, cs02, cs03, cs04, cs05, cs06, cs07, cs08, cs09, cs10]
+
+s100Tokens :: [DValue.TokenName]
+s100Tokens = [tn01, tn02, tn03, tn04, tn05, tn06, tn07, tn08, tn09, tn10]
+
+-- --------------------------------------------------------------------------
+-- Sample Values encoded as BuiltinData. Keys are kept sorted by construction:
+-- ada ('') comes first, then policy_01..policy_10 in lexicographic order.
+-- --------------------------------------------------------------------------
+
+valueS1 :: CompiledCode B.BuiltinData
+valueS1 = liftCodeDef . Tx.toBuiltinData $ do
+  listsToValue [(DValue.adaSymbol, [(DValue.adaToken, 1000000)])]
+
+valueS3 :: CompiledCode B.BuiltinData
+valueS3 = liftCodeDef . Tx.toBuiltinData $ do
+  listsToValue
+    [ (DValue.adaSymbol, [(DValue.adaToken, 1000000)])
+    , (cs01, [(tn01, 42)])
+    , (cs02, [(tn02, 7)])
+    ]
+
+valueS8 :: CompiledCode B.BuiltinData
+valueS8 = liftCodeDef . Tx.toBuiltinData $ do
+  listsToValue
+    [ (DValue.adaSymbol, [(DValue.adaToken, 1000000)])
+    , (cs01, [(tn01, 1)])
+    , (cs02, [(tn02, 1)])
+    , (cs03, [(tn03, 1)])
+    , (cs04, [(tn04, 1)])
+    , (cs05, [(tn05, 1)])
+    , (cs06, [(tn06, 1)])
+    , (cs07, [(tn07, 1)])
+    ]
+
+valueS100 :: CompiledCode B.BuiltinData
+valueS100 = liftCodeDef . Tx.toBuiltinData $ do
+  listsToValue
+    $ (DValue.adaSymbol, [(DValue.adaToken, 1000000)])
+    : [(cs, [(tn, 1) | tn <- s100Tokens]) | cs <- s100Policies]
+
+-- --------------------------------------------------------------------------
+-- Builtin column.
+-- --------------------------------------------------------------------------
+
+unionValueBuiltinRaw :: CompiledCode (B.BuiltinData -> B.BuiltinData -> B.BuiltinData)
+unionValueBuiltinRaw =
+  $$( compile
+        [||
+        \bd1 bd2 ->
+          B.mkValue (B.unionValue (B.unsafeDataAsValue bd1) (B.unsafeDataAsValue bd2))
+        ||]
+    )
+
+-- --------------------------------------------------------------------------
+-- Raw sorted-merge column. Plinth translation of Philip's pvalueUnionFast.
+--
+-- Two specialised sorted-merge functions: one for the inner token map (with
+-- integer-summing combine), one for the outer currency map (with recursive
+-- inner-merge combine). Neither is a higher-order function -- a runtime
+-- combinator argument would prevent the plugin from specialising the merge
+-- step.
+-- --------------------------------------------------------------------------
+
+{-| Inner-level sorted-merge over @BuiltinList (BuiltinPair BuiltinData
+BuiltinData)@. Keys are token-name 'ByteString's; values are 'Integer'
+quantities. Assumes inputs are sorted by key and quantities are strictly
+positive (the sum of two positive integers is never zero, so no zero-strip
+pass is needed). -}
+mergeInnerSorted
+  :: BuiltinList (BuiltinPair BuiltinData BuiltinData)
+  -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
+  -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
+mergeInnerSorted = go
+  where
+    go lA lB =
+      B.caseList'
+        lB
+        ( \hdA tlA ->
+            B.caseList'
+              lA
+              ( \hdB tlB ->
+                  let keyA = BI.unsafeDataAsB (BI.fst hdA)
+                      keyB = BI.unsafeDataAsB (BI.fst hdB)
+                   in if B.equalsByteString keyA keyB
+                        then
+                          let qA = BI.unsafeDataAsI (BI.snd hdA)
+                              qB = BI.unsafeDataAsI (BI.snd hdB)
+                           in BI.mkCons
+                                (BI.mkPairData (BI.fst hdA) (BI.mkI (qA + qB)))
+                                (go tlA tlB)
+                        else
+                          if B.lessThanByteString keyA keyB
+                            then BI.mkCons hdA (go tlA lB)
+                            else BI.mkCons hdB (go lA tlB)
+              )
+              lB
+        )
+        lA
+{-# INLINEABLE mergeInnerSorted #-}
+
+{-| Outer-level sorted-merge over @BuiltinList (BuiltinPair BuiltinData
+BuiltinData)@. Keys are currency-symbol 'ByteString's; values are the
+raw inner-map 'BuiltinData'. For a shared currency symbol, the inner
+maps are merged with 'mergeInnerSorted' and the combined inner is
+wrapped back via 'BI.mkMap'. -}
+mergeOuterSorted
+  :: BuiltinList (BuiltinPair BuiltinData BuiltinData)
+  -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
+  -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
+mergeOuterSorted = go
+  where
+    go lA lB =
+      B.caseList'
+        lB
+        ( \hdA tlA ->
+            B.caseList'
+              lA
+              ( \hdB tlB ->
+                  let keyA = BI.unsafeDataAsB (BI.fst hdA)
+                      keyB = BI.unsafeDataAsB (BI.fst hdB)
+                   in if B.equalsByteString keyA keyB
+                        then
+                          let innerA = BI.unsafeDataAsMap (BI.snd hdA)
+                              innerB = BI.unsafeDataAsMap (BI.snd hdB)
+                              merged = mergeInnerSorted innerA innerB
+                           in BI.mkCons
+                                (BI.mkPairData (BI.fst hdA) (BI.mkMap merged))
+                                (go tlA tlB)
+                        else
+                          if B.lessThanByteString keyA keyB
+                            then BI.mkCons hdA (go tlA lB)
+                            else BI.mkCons hdB (go lA tlB)
+              )
+              lB
+        )
+        lA
+{-# INLINEABLE mergeOuterSorted #-}
+
+unionValuePositiveRaw :: CompiledCode (B.BuiltinData -> B.BuiltinData -> B.BuiltinData)
+unionValuePositiveRaw =
+  $$( compile
+        [||
+        \bd1 bd2 ->
+          BI.mkMap
+            ( mergeOuterSorted
+                (BI.unsafeDataAsMap bd1)
+                (BI.unsafeDataAsMap bd2)
+            )
+        ||]
+    )

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_builtin.golden.eval
@@ -1,0 +1,230 @@
+CPU:                83_344_331
+Memory:                 13_242
+AST Size:                   17
+Flat Size:               7_694
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_raw.golden.eval
@@ -1,0 +1,230 @@
+CPU:               372_767_585
+Memory:              1_298_334
+AST Size:                  287
+Flat Size:               7_969
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S100_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_builtin.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_628_911
+Memory:                  2_002
+AST Size:                   17
+Flat Size:                  45
+
+(con data (Map [(B #, Map [(B #, I 2000000)])]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_raw.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 8_467_985
+Memory:                 32_754
+AST Size:                  287
+Flat Size:                 321
+
+(con data (Map [(B #, Map [(B #, I 2000000)])]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S1_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_builtin.golden.eval
@@ -1,0 +1,18 @@
+CPU:                 3_951_025
+Memory:                  2_306
+AST Size:                   17
+Flat Size:                 312
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 84 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 14 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_raw.golden.eval
@@ -1,0 +1,18 @@
+CPU:                22_311_683
+Memory:                 81_606
+AST Size:                  287
+Flat Size:                 587
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 84 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 14 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S3_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_builtin.golden.eval
@@ -1,0 +1,38 @@
+CPU:                 9_757_640
+Memory:                  3_066
+AST Size:                   17
+Flat Size:                 972
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_raw.golden.eval
@@ -1,0 +1,38 @@
+CPU:                56_920_928
+Memory:                203_736
+AST Size:                  287
+Flat Size:               1_247
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.12/union_S8_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_builtin.golden.eval
@@ -1,0 +1,230 @@
+CPU:                83_344_331
+Memory:                 13_242
+AST Size:                   17
+Flat Size:               7_694
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_raw.golden.eval
@@ -1,0 +1,230 @@
+CPU:               372_767_585
+Memory:              1_298_334
+AST Size:                  287
+Flat Size:               7_969
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30385f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f30395f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 )
+         , ( B #746f6b656e5f31305f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S100_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_builtin.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_628_911
+Memory:                  2_002
+AST Size:                   17
+Flat Size:                  45
+
+(con data (Map [(B #, Map [(B #, I 2000000)])]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_raw.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 8_467_985
+Memory:                 32_754
+AST Size:                  287
+Flat Size:                 321
+
+(con data (Map [(B #, Map [(B #, I 2000000)])]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S1_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_builtin.golden.eval
@@ -1,0 +1,18 @@
+CPU:                 3_951_025
+Memory:                  2_306
+AST Size:                   17
+Flat Size:                 312
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 84 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 14 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_raw.golden.eval
@@ -1,0 +1,18 @@
+CPU:                22_311_683
+Memory:                 81_606
+AST Size:                  287
+Flat Size:                 587
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 84 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 14 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S3_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_builtin.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_builtin.golden.eval
@@ -1,0 +1,38 @@
+CPU:                 9_757_640
+Memory:                  3_066
+AST Size:                   17
+Flat Size:                 972
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_builtin.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_builtin.golden.pir
@@ -1,0 +1,2 @@
+\(bd : data) (bd : data) ->
+  valueData (unionValue (unValueData bd) (unValueData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_builtin.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_builtin.golden.uplc
@@ -1,0 +1,3 @@
+(program
+   1.1.0
+   (\bd bd -> valueData (unionValue (unValueData bd) (unValueData bd))))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_raw.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_raw.golden.eval
@@ -1,0 +1,38 @@
+CPU:                56_920_928
+Memory:                203_736
+AST Size:                  287
+Flat Size:               1_247
+
+(con
+  data
+  (Map
+     [ (B #, Map [(B #, I 2000000)])
+     , ( B #706f6c6963795f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30315f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30325f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30335f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30345f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30355f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30365f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] )
+     , ( B #706f6c6963795f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+     , Map
+         [ ( B #746f6b656e5f30375f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f
+         , I 2 ) ] ) ])
+)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_raw.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_raw.golden.pir
@@ -1,0 +1,95 @@
+let
+  !caseList' : all a r. r -> (a -> list a -> r) -> list a -> r
+    = /\a r ->
+        \(z : r) (f : a -> list a -> r) (xs : list a) ->
+          chooseList
+            {a}
+            {all dead. r}
+            xs
+            (/\dead -> z)
+            (/\dead -> f (headList {a} xs) (tailList {a} xs))
+            {r}
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (iData
+                               (addInteger
+                                  (unIData (sndPair {data} {data} hdA))
+                                  (unIData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+letrec
+  !go : list (pair data data) -> list (pair data data) -> list (pair data data)
+    = \(lA : list (pair data data)) (lB : list (pair data data)) ->
+        caseList'
+          {pair data data}
+          {list (pair data data)}
+          lB
+          (\(hdA : pair data data) (tlA : list (pair data data)) ->
+             caseList'
+               {pair data data}
+               {list (pair data data)}
+               lA
+               (\(hdB : pair data data) (tlB : list (pair data data)) ->
+                  let
+                    !keyB : bytestring = unBData (fstPair {data} {data} hdB)
+                    !keyA : bytestring = unBData (fstPair {data} {data} hdA)
+                  in
+                  ifThenElse
+                    {all dead. list (pair data data)}
+                    (equalsByteString keyA keyB)
+                    (/\dead ->
+                       mkCons
+                         {pair data data}
+                         (mkPairData
+                            (fstPair {data} {data} hdA)
+                            (mapData
+                               (go
+                                  (unMapData (sndPair {data} {data} hdA))
+                                  (unMapData (sndPair {data} {data} hdB)))))
+                         (go tlA tlB))
+                    (/\dead ->
+                       ifThenElse
+                         {all dead. list (pair data data)}
+                         (lessThanByteString keyA keyB)
+                         (/\dead -> mkCons {pair data data} hdA (go tlA lB))
+                         (/\dead -> mkCons {pair data data} hdB (go lA tlB))
+                         {all dead. dead})
+                    {all dead. dead})
+               lB)
+          lA
+in
+\(bd : data) (bd : data) -> mapData (go (unMapData bd) (unMapData bd))

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_raw.golden.uplc
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value/UnionBudget/9.6/union_S8_raw.golden.uplc
@@ -1,0 +1,180 @@
+(program
+   1.1.0
+   (case
+      (constr 0
+         [ (force (force fstPair))
+         , (force mkCons)
+         , (force tailList)
+         , (force ifThenElse)
+         , (force (force sndPair))
+         , (force headList)
+         , (force (force chooseList)) ])
+      [ (\forced
+          forced
+          forced
+          forced
+          forced
+          forced
+          forced ->
+           (\caseList' ->
+              (\go ->
+                 (\go bd bd ->
+                    mapData (go (unMapData bd) (unMapData bd)))
+                   ((\s ->
+                       s s)
+                      (\s
+                        lA
+                        lB ->
+                         case
+                           (constr 0
+                              [ lB
+                              , (\hdA
+                                  tlA ->
+                                   case
+                                     (constr 0
+                                        [ lA
+                                        , (\hdB
+                                            tlB ->
+                                             (\keyB ->
+                                                (\cse ->
+                                                   (\keyA ->
+                                                      force
+                                                        (case
+                                                           (constr 0
+                                                              [ (equalsByteString
+                                                                   keyA
+                                                                   keyB)
+                                                              , (delay
+                                                                   (forced
+                                                                      (mkPairData
+                                                                         cse
+                                                                         (mapData
+                                                                            (go
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdA))
+                                                                               (unMapData
+                                                                                  (forced
+                                                                                     hdB)))))
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ s
+                                                                            , tlA
+                                                                            , tlB ])
+                                                                         [s])))
+                                                              , (delay
+                                                                   (force
+                                                                      (case
+                                                                         (constr 0
+                                                                            [ (lessThanByteString
+                                                                                 keyA
+                                                                                 keyB)
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdA
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , tlA
+                                                                                          , lB ])
+                                                                                       [ s ])))
+                                                                            , (delay
+                                                                                 (forced
+                                                                                    hdB
+                                                                                    (case
+                                                                                       (constr 0
+                                                                                          [ s
+                                                                                          , lA
+                                                                                          , tlB ])
+                                                                                       [ s ]))) ])
+                                                                         [ forced ]))) ])
+                                                           [forced]))
+                                                     (unBData cse))
+                                                  (forced hdA))
+                                               (unBData (forced hdB)))
+                                        , lB ])
+                                     [caseList'])
+                              , lA ])
+                           [caseList'])))
+                ((\s ->
+                    s s)
+                   (\s
+                     lA
+                     lB ->
+                      case
+                        (constr 0
+                           [ lB
+                           , (\hdA
+                               tlA ->
+                                case
+                                  (constr 0
+                                     [ lA
+                                     , (\hdB
+                                         tlB ->
+                                          (\keyB ->
+                                             (\cse ->
+                                                (\keyA ->
+                                                   force
+                                                     (case
+                                                        (constr 0
+                                                           [ (equalsByteString
+                                                                keyA
+                                                                keyB)
+                                                           , (delay
+                                                                (forced
+                                                                   (mkPairData
+                                                                      cse
+                                                                      (iData
+                                                                         (addInteger
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdA))
+                                                                            (unIData
+                                                                               (forced
+                                                                                  hdB)))))
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ s
+                                                                         , tlA
+                                                                         , tlB ])
+                                                                      [s])))
+                                                           , (delay
+                                                                (force
+                                                                   (case
+                                                                      (constr 0
+                                                                         [ (lessThanByteString
+                                                                              keyA
+                                                                              keyB)
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdA
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , tlA
+                                                                                       , lB ])
+                                                                                    [ s ])))
+                                                                         , (delay
+                                                                              (forced
+                                                                                 hdB
+                                                                                 (case
+                                                                                    (constr 0
+                                                                                       [ s
+                                                                                       , lA
+                                                                                       , tlB ])
+                                                                                    [ s ]))) ])
+                                                                      [ forced ]))) ])
+                                                        [forced]))
+                                                  (unBData cse))
+                                               (forced hdA))
+                                            (unBData (forced hdB)))
+                                     , lB ])
+                                  [caseList'])
+                           , lA ])
+                        [caseList'])))
+             (\z f xs ->
+                force
+                  (case
+                     (constr 0
+                        [xs, (delay z), (delay (f (forced xs) (forced xs)))])
+                     [forced]))) ]))


### PR DESCRIPTION
## Summary

Not for merge. Compares the on-chain builtin union path (`unsafeDataAsValue` + `unionValue` + `mkValue`) against a hand-rolled sorted-merge over the raw `BuiltinData` representation, so that V3 guidance on union cost can rest on concrete numbers rather than estimates.

The new module `Spec.Data.Value.UnionBudget` adds 8 `goldenBundle` entries: `union_S{1,3,8,100}_{builtin,raw}`. Both bundle paths take two `BuiltinData`-encoded `Value`s (the same value used on both sides, mirroring the conservation-of-value pattern from production validators), produce the merged `BuiltinData`, and report the CEK budget. The bundle no longer chains a `lookupCoin` / `valueOf` on the result so the measured cost is the union itself, not a union-then-lookup composite.

The hand-rolled `unionValuePositiveRaw` is a Plinth translation of Philip's `pvalueUnionFast` (Plutarch, [slack thread `1776810760.659419`](https://input-output-rnd.slack.com/archives/G01EE4NQ9U0/p1776810760659419)). It is a sorted-merge with a three-way branch on key comparison and assumes both inputs are sorted by lexicographic key and that inner-pair values are strictly positive integers. Sorted-merge is O(L + R) per level; lookup-and-merge through `AssocMap.union` would be O(L × R).

`unionValuePositiveRaw` is module-internal and not exported from `plutus-ledger-api`. The positive-quantity precondition is documented at the call site, not encoded in the type system. The `unionValueNonZero` variant from the slack discussion (where inputs may contain zero quantities and the sum-may-cancel branch must drop entries) is left for a follow-up commit if needed; the production case Philip cares about is tx-output values, which are strictly positive.

For [plutus-private#2243](https://github.com/IntersectMBO/plutus-private/issues/2243).

## Union matrix, GHC 9.6, plutus-ledger-api 1.65.0.0

CPU and Memory in absolute units. `builtin` = `unsafeDataAsValue` + `unionValue` + `mkValue`. `raw` = `unionValuePositiveRaw`, the sorted-merge Plinth helper.

Shape legend: **S1** = ada only (1 token); **S3** = ada plus 2 single-token policies (3 tokens); **S8** = ada plus 7 single-token policies (8 tokens); **S100** = ada plus 10 policies of 10 tokens each (101 tokens).

| shape | builtin CPU | builtin Mem | raw CPU | raw Mem | ratio (raw / builtin) CPU | ratio Mem |
|-------|-------------|-------------|---------|---------|----------------------------|-----------|
| S1    |   1 628 911 |       2 002 |       8 467 985 |          32 754 | 5.20× | 16.4× |
| S3    |   3 951 025 |       2 306 |      22 311 683 |          81 606 | 5.65× | 35.4× |
| S8    |   9 757 640 |       3 066 |      56 920 928 |         203 736 | 5.83× | 66.4× |
| S100  |  83 344 331 |      13 242 |     372 767 585 |       1 298 334 | 4.47× | 98.0× |

The raw column is the production-relevant "before BuiltinValue" baseline: validators today do their own sorted-merge over raw `BuiltinData` (see Djed stdlib for an example), and that path is what the builtin replaces. The ratio is roughly 5× on CPU and 16–98× on memory; the CPU ratio stays flat across shapes because both columns scale linearly in total token count with different constants.

## Correctness

Byte-identical output between `builtin` and `raw` columns at every shape:

```
diff <(tail -n +5 .../union_S1_builtin.golden.eval) <(tail -n +5 .../union_S1_raw.golden.eval)
# (no output: identical)
```

Same input on both sides (`valueS* `unsafeApplyCode` valueS*`), so the result is `2 × valueS*` at every token slot. Both columns produce the same outer-key order (preserved from input) and the same per-key sum.

## V3 union guidance

Validators that accumulate `Value`s over many inputs should prefer the `unionValue` builtin when available. The sorted-merge raw path closes most of the gap a typed user-space `unionWith` opens (see [#7799](https://github.com/IntersectMBO/plutus/pull/7799) for the typed delta, sub-1% at S100 against master `unionWith`) but is still 5× the builtin cost. For positive-quantity inputs (tx outputs) `unionValuePositiveRaw` is the right "before BuiltinValue" implementation to compare against.

The 15× headline gap on the original [#7738](https://github.com/IntersectMBO/plutus/pull/7738) at S1 referred to the typed `unionWith` (via `Map.union`, lookup-and-merge). With the raw sorted-merge path the ratio drops to 5.2× at S1 and stays in the 4.5–6× band. The remaining gap is the cost of running UPLC vs native code; the algorithmic improvement is fully realised.

A typed `unionWith` column is not included here. The typed path is on impl PR [#7799](https://github.com/IntersectMBO/plutus/pull/7799), with its own old-vs-new delta measured against master. Including it again here would invite a derail into "why is the typed path even on the matrix" when Philip has already accepted sorted-merge as the canonical baseline.
