### PR TITLE
Fix Constr cost using wrong accessor in Agda metatheory

### DIFF
--- a/plutus-metatheory/changelog.d/20260808_215732_jmchapman_fix_constr_cost.md
+++ b/plutus-metatheory/changelog.d/20260808_215732_jmchapman_fix_constr_cost.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed the Agda metatheory's `cekMachineCostFunction` calling `getCekConstCost` instead of `getCekConstrCost` for the `Constr` case, a copy-paste bug that would silently mis-cost `Constr`-containing terms once a cost-model update sets the two parameters apart.

--- a/plutus-metatheory/src/Cost.lagda.md
+++ b/plutus-metatheory/src/Cost.lagda.md
@@ -139,7 +139,7 @@ cekMachineCostFunction mc BApply = fromHExBudget (getCekApplyCost mc)
 cekMachineCostFunction mc BDelay = fromHExBudget (getCekDelayCost mc)
 cekMachineCostFunction mc BForce = fromHExBudget (getCekForceCost mc)
 cekMachineCostFunction mc BBuiltin = fromHExBudget (getCekBuiltinCost mc)
-cekMachineCostFunction mc BConstr = fromHExBudget (getCekConstCost mc)
+cekMachineCostFunction mc BConstr = fromHExBudget (getCekConstrCost mc)
 cekMachineCostFunction mc BCase = fromHExBudget (getCekCaseCost mc)
 
 exBudgetCategoryCost : CostModel → ExBudgetCategory → ExBudget

--- a/plutus-metatheory/src/MAlonzo/Code/Cost.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Cost.hs
@@ -487,7 +487,7 @@ d_cekMachineCostFunction_116 v0 v1
       MAlonzo.Code.Cost.Base.C_BConstr_22
         -> coe
              d_fromHExBudget_64
-             (coe MAlonzo.Code.Cost.Raw.d_getCekConstCost_12 v0)
+             (coe MAlonzo.Code.Cost.Raw.d_getCekConstrCost_24 v0)
       MAlonzo.Code.Cost.Base.C_BCase_24
         -> coe
              d_fromHExBudget_64


### PR DESCRIPTION
Fixes #7879.

`cekMachineCostFunction`'s `BConstr` case called `getCekConstCost` instead of `getCekConstrCost` -- a copy-paste bug from the `BConst` case above it. `getCekConstrCost` already exists as its own correctly-bound postulate, wired to Haskell's real, distinct `cekConstrCost` field.

Currently silent: all five published cost-model parameter files (`cekMachineCosts{A..E}.json`) happen to set `cekConstCost` and `cekConstrCost` to identical values. Would silently mis-cost every `Constr`-containing term the moment a future cost-model update sets the two fields apart.

**Verified:** the full `plutus-metatheory` library (`agda-with-stdlib-and-metatheory`) typechecks cleanly with this change.

**Testing:** no current test distinguishes these two costs, since no published parameter file does. Happy to add a regression test (a synthetic cost-model instance with the two fields set apart) if wanted -- flagging for discussion rather than assuming either way.