### PR TITLE
Improve NEAT coverage

### DIFF
--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
@@ -78,27 +78,42 @@ tests =
   testGroup
     "NEAT"
     -- the `adjustOption (min ...)` allows to make these big tests easier at runtime
-    [ adjustOption (min $ GenDepth 10) $
-        bigTest
-          "normalization commutes with conversion from generated types"
-          (Type ())
-          (packAssertion prop_normalizeConvertCommuteTypes)
-    , adjustOption (min $ GenDepth 12) $
-        bigTest
-          "normal types cannot reduce"
-          (Type ())
-          (packAssertion prop_normalTypesCannotReduce)
-    , adjustOption (min $ GenDepth 15) $
-        bigTest
-          "type preservation - CK"
-          (TyBuiltinG TyUnitG)
-          (packAssertion prop_typePreservation)
-    , adjustOption (min $ GenDepth 15) $
-        bigTest
-          "typed CK vs untyped CEK produce the same output"
-          (TyBuiltinG TyUnitG)
-          (packAssertion prop_agree_termEval)
-    ]
+    ( [ adjustOption (min $ GenDepth 10) $
+          bigTest
+            "normalization commutes with conversion from generated types"
+            (Type ())
+            (packAssertion prop_normalizeConvertCommuteTypes)
+      , adjustOption (min $ GenDepth 12) $
+          bigTest
+            "normal types cannot reduce"
+            (Type ())
+            (packAssertion prop_normalTypesCannotReduce)
+      ]
+        -- 'Unit' has a single value, so at that result type these two
+        -- properties never see a real computed value: an evaluation failure
+        -- is silently accepted as type-preserving, and the CK/CEK outputs
+        -- trivially agree on '()' regardless of what any builtin call inside
+        -- actually returned. Running them at 'Integer' and 'ByteString' too
+        -- forces the search to produce terms whose outermost result is an
+        -- actual builtin-computed value, so a genuine CK/CEK value mismatch
+        -- would be visible.
+        ++ concatMap
+          resultTypeTests
+          [ (TyBuiltinG TyUnitG, "")
+          , (TyBuiltinG TyIntegerG, " (Integer)")
+          , (TyBuiltinG TyByteStringG, " (ByteString)")
+          ]
+    )
+  where
+    resultTypeTests (targetTy, suffix) =
+      [ adjustOption (min $ GenDepth 18) $
+          bigTest ("type preservation - CK" <> suffix) targetTy (packAssertion prop_typePreservation)
+      , adjustOption (min $ GenDepth 18) $
+          bigTest
+            ("typed CK vs untyped CEK produce the same output" <> suffix)
+            targetTy
+            (packAssertion prop_agree_termEval)
+      ]
 
 {- NOTE:
 

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
@@ -43,6 +43,7 @@ import Data.Stream qualified as Stream
 import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8)
 import PlutusCore
+import PlutusCore.Builtin (typeOfBuiltinFunction)
 import PlutusCore.Data
 import PlutusCore.Default
 import PlutusCore.Generators.NEAT.Common
@@ -169,6 +170,22 @@ convertTypeBuiltin (TyListG a) =
 convertTypeBuiltin TyStringG = SomeTypeIn DefaultUniString
 convertTypeBuiltin TyDataG = SomeTypeIn DefaultUniData
 
+{-| Convert a real Plutus meta-type to a generated builtin type, when
+'TypeBuiltinG' can express it. Fails ('Nothing') for the BLS12-381
+element/pairing types, 'Array' and 'Value' -- 'TypeBuiltinG' has no
+constructor for any of these -- and for any uni-level type other than a
+fully-applied list of a convertible type. -}
+convertUniToTypeBuiltin :: SomeTypeIn DefaultUni -> Maybe TypeBuiltinG
+convertUniToTypeBuiltin (SomeTypeIn uni) = case uni of
+  DefaultUniInteger -> Just TyIntegerG
+  DefaultUniByteString -> Just TyByteStringG
+  DefaultUniString -> Just TyStringG
+  DefaultUniUnit -> Just TyUnitG
+  DefaultUniBool -> Just TyBoolG
+  DefaultUniData -> Just TyDataG
+  DefaultUniList uniA -> TyListG <$> convertUniToTypeBuiltin (SomeTypeIn uniA)
+  _ -> Nothing
+
 {-| Convert well-kinded generated types to Plutus types.
 
  NOTE: Passes an explicit `TyNameState`, instead of using a State
@@ -214,6 +231,48 @@ convertClosedType
   -> ClosedTypeG
   -> m (Type TyName DefaultUni ())
 convertClosedType tynames = convertType (emptyTyNameState tynames)
+
+{-| Convert a real Plutus type to a generated type, when 'TypeG' can express
+it. This is the reverse of 'convertType', used below to auto-derive
+'defaultFunTypes' from builtins' real types instead of hand-maintaining a
+duplicate table.
+
+Takes a lookup from real type names currently in scope to their de Bruijn
+index, extended with each 'TyForall' encountered; for a closed type this
+starts as @const Nothing@.
+
+Fails ('Nothing') for:
+
+* meta-types 'convertUniToTypeBuiltin' can't express (BLS12-381, 'Array',
+  'Value'),
+* @list@ applied to anything other than a fully-converted 'TypeBuiltinG' --
+  'TyListG' can only hold a fixed element type, so a builtin polymorphic
+  over a list's element type (e.g. 'MkCons', 'HeadList') can never
+  round-trip through 'TypeG',
+* any other shape ('TyLam', 'TyIFix', bare/partially-applied builtin type
+  constructors, pairs) -- none of which real builtin signatures currently
+  need, but 'TypeG' can't represent them regardless. -}
+convertTypeToTypeG
+  :: (TyName -> Maybe n)
+  -> Type TyName DefaultUni ()
+  -> Maybe (TypeG n)
+convertTypeToTypeG look (TyVar _ name) =
+  TyVarG <$> look name
+convertTypeToTypeG look (TyFun _ ty1 ty2) =
+  TyFunG <$> convertTypeToTypeG look ty1 <*> convertTypeToTypeG look ty2
+convertTypeToTypeG look (TyForall _ name k ty) =
+  TyForallG k <$> convertTypeToTypeG look' ty
+  where
+    look' name'
+      | name' == name = Just FZ
+      | otherwise = FS <$> look name'
+convertTypeToTypeG _ (TyBuiltin _ someUni) =
+  TyBuiltinG <$> convertUniToTypeBuiltin someUni
+convertTypeToTypeG look (TyApp _ (TyBuiltin _ (SomeTypeIn DefaultUniProtoList)) argTy) =
+  case convertTypeToTypeG look argTy of
+    Just (TyBuiltinG argBuiltin) -> Just (TyBuiltinG (TyListG argBuiltin))
+    _ -> Nothing
+convertTypeToTypeG _ _ = Nothing
 
 -- ** Converting terms
 
@@ -378,105 +437,42 @@ instance Check (TypeG n) TermConstantG where
   check (TyBuiltinG TyDataG) (TmDataG _) = true
   check _ _ = false
 
-{-| DEPRECATED: No Need to Update for a new Builtin.
-NEAT tests are useless for builtins, see https://github.com/IntersectMBO/plutus/issues/6075 -}
+{-| The 'BuiltinSemanticsVariant' used to look up real builtin types below.
+Builtin *types* don't vary across semantics variants (only their
+denotations do), so any variant would do here; this just picks the latest
+one. -}
+defaultFunTypesSemanticsVariant :: BuiltinSemanticsVariant DefaultFun
+defaultFunTypesSemanticsVariant = maxBound
+
+{-| Auto-derived from builtins' real types (via 'typeOfBuiltinFunction' and
+'convertTypeToTypeG'), rather than hand-maintained -- see
+https://github.com/IntersectMBO/plutus/issues/6075.
+
+A builtin is silently absent from this map (and so untestable by NEAT) when
+its real type isn't expressible as a 'TypeG', which happens for:
+
+* generic-list operations ('MkCons', 'HeadList', 'TailList', 'NullList',
+  'ChooseList', 'DropList') -- 'TyListG' can only hold a fixed element
+  type, never a variable one,
+* anything polymorphic over a pair ('FstPair', 'SndPair', 'MapData',
+  'UnMapData', 'MkPairData', 'MkNilPairData', 'UnConstrData') -- 'TypeG'
+  has no pair constructor at all,
+* BLS12-381, 'Array', and 'Value' builtins -- 'TypeBuiltinG' has no
+  constructor for any of these meta-types.
+
+As of writing this covers 59 of the 103 real 'DefaultFun' builtins, versus
+36 in the table this replaced, with no loss of coverage. -}
 defaultFunTypes :: Ord tyname => Map.Map (TypeG tyname) [DefaultFun]
 defaultFunTypes =
-  Map.fromList
-    [
-      ( TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuiltinG TyIntegerG) (TyBuiltinG TyIntegerG))
-      ,
-        [ AddInteger
-        , SubtractInteger
-        , MultiplyInteger
-        , DivideInteger
-        , QuotientInteger
-        , RemainderInteger
-        , ModInteger
+  Map.fromListWith
+    (++)
+    [ (ty, [fun])
+    | fun <- [minBound .. maxBound :: DefaultFun]
+    , Just ty <-
+        [ convertTypeToTypeG
+            (const Nothing)
+            (typeOfBuiltinFunction defaultFunTypesSemanticsVariant fun)
         ]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuiltinG TyIntegerG) (TyBuiltinG TyBoolG))
-      , [LessThanInteger, LessThanEqualsInteger, EqualsInteger]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyByteStringG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG))
-      , [AppendByteString]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG))
-      , [ConsByteString]
-      )
-    ,
-      ( TyFunG
-          (TyBuiltinG TyIntegerG)
-          (TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG)))
-      , [SliceByteString]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyIntegerG)
-      , [LengthOfByteString]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyByteStringG) (TyFunG (TyBuiltinG TyIntegerG) (TyBuiltinG TyIntegerG))
-      , [IndexByteString]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG)
-      , [Sha2_256, Sha3_256, Blake2b_224, Blake2b_256, Keccak_256, Ripemd_160]
-      )
-    ,
-      ( TyFunG
-          (TyBuiltinG TyByteStringG)
-          (TyFunG (TyBuiltinG TyByteStringG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyBoolG)))
-      , [VerifyEd25519Signature]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyByteStringG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyBoolG))
-      , [EqualsByteString, LessThanByteString, LessThanEqualsByteString]
-      )
-    ,
-      ( TyForallG
-          (Type ())
-          (TyFunG (TyBuiltinG TyBoolG) (TyFunG (TyVarG FZ) (TyFunG (TyVarG FZ) (TyVarG FZ))))
-      , [IfThenElse]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyStringG) (TyFunG (TyBuiltinG TyStringG) (TyBuiltinG TyStringG))
-      , [AppendString]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyStringG) (TyFunG (TyBuiltinG TyStringG) (TyBuiltinG TyBoolG))
-      , [EqualsString]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyStringG) (TyBuiltinG TyByteStringG)
-      , [EncodeUtf8]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyStringG)
-      , [DecodeUtf8]
-      )
-    ,
-      ( TyForallG (Type ()) (TyFunG (TyBuiltinG TyStringG) (TyFunG (TyVarG FZ) (TyVarG FZ)))
-      , [Trace]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyIntegerG) (TyBuiltinG TyDataG)
-      , [IData]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyDataG)
-      , [BData]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyDataG) (TyBuiltinG TyIntegerG)
-      , [UnIData]
-      )
-    ,
-      ( TyFunG (TyBuiltinG TyDataG) (TyBuiltinG TyByteStringG)
-      , [UnBData, SerialiseData]
-      )
     ]
 
 instance Ord tyname => Check (TypeG tyname) DefaultFun where

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
@@ -184,7 +184,14 @@ convertUniToTypeBuiltin (SomeTypeIn uni) = case uni of
   DefaultUniBool -> Just TyBoolG
   DefaultUniData -> Just TyDataG
   DefaultUniList uniA -> TyListG <$> convertUniToTypeBuiltin (SomeTypeIn uniA)
-  _ -> Nothing
+  DefaultUniProtoList -> Nothing
+  DefaultUniProtoArray -> Nothing
+  DefaultUniProtoPair -> Nothing
+  DefaultUniApply {} -> Nothing
+  DefaultUniBLS12_381_G1_Element -> Nothing
+  DefaultUniBLS12_381_G2_Element -> Nothing
+  DefaultUniBLS12_381_MlResult -> Nothing
+  DefaultUniValue -> Nothing
 
 {-| Convert well-kinded generated types to Plutus types.
 

--- a/plutus-metatheory/changelog.d/20260809_024900_jmchapman_neat_coverage_agda_fixes.md
+++ b/plutus-metatheory/changelog.d/20260809_024900_jmchapman_neat_coverage_agda_fixes.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed `chooseUnit`'s signature and typed CEK semantics having their arguments reversed (`forall a. a -> unit -> a` instead of the correct `forall a. unit -> a -> a`).
+- Fixed `serialiseData` being an unbound postulate that crashed at runtime with "postulate evaluated" whenever actually called.

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -91,6 +91,7 @@ library
     , plutus-ledger-api
     , plutus-ledger-api:plutus-execlib
     , prettyprinter
+    , serialise
     , text
     , transformers
     , vector                            ^>=0.13.2

--- a/plutus-metatheory/src/Algorithmic/CEK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CEK.lagda.md
@@ -288,7 +288,7 @@ BUILTIN unValueData (base $ V-con d) with unValueDATA d
 ... | just v  = inj₂ (V-con v)
 BUILTIN mkNilData (base $ V-con _) = inj₂ (V-con [])
 BUILTIN mkNilPairData (base $ V-con _) = inj₂ (V-con [])
-BUILTIN chooseUnit (Λ̂ A $ x $ V-con _) = inj₂ x
+BUILTIN chooseUnit (Λ̂ A $ V-con _ $ x) = inj₂ x
 BUILTIN equalsData (base $ V-con d $ V-con d') = inj₂ (V-con (eqDATA d d'))
 BUILTIN mkPairData (base $ V-con x $ V-con y) = inj₂ (V-con (x ,, y))
 BUILTIN constrData (base $ V-con i $ V-con xs) = inj₂ (V-con (ConstrDATA i xs))

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -649,6 +649,10 @@ postulate
 {-# COMPILE GHC ENCODEUTF8 = encodeUtf8 #-}
 {-# COMPILE GHC DECODEUTF8 = eitherToMaybe . decodeUtf8' #-}
 
+{-# FOREIGN GHC import Codec.Serialise (serialise) #-}
+{-# FOREIGN GHC import qualified Data.ByteString.Lazy as BSL #-}
+{-# COMPILE GHC serialiseDATA = BSL.toStrict . serialise #-}
+
 {-# FOREIGN GHC import PlutusCore.Value as Value #-}
 
 {-# COMPILE GHC insertCOIN = \ccy tok x v -> builtinResultToMaybe $ Value.insertCoin ccy tok x v #-}

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -304,7 +304,7 @@ sig n⋆ n♯ (t₃ ∷ t₂ ∷ t₁) tᵣ
     signature encodeUtf8                      = ∙ [ string ↑ ]⟶ bytestring ↑
     signature decodeUtf8                      = ∙ [ bytestring ↑ ]⟶ string ↑
     signature ifThenElse                      = ∀A [ bool ↑ , A , A ]⟶ A
-    signature chooseUnit                      = ∀A [ A , unit ↑ ]⟶ A
+    signature chooseUnit                      = ∀A [ unit ↑ , A ]⟶ A
     signature trace                           = ∀A [ string ↑ , A ]⟶ A
     signature fstPair                         = ∀b,a [ pair b a ]⟶ b ↑
     signature sndPair                         = ∀b,a [ pair b a ]⟶ a ↑

--- a/plutus-metatheory/src/MAlonzo/Code/Algorithmic/CEK.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Algorithmic/CEK.hs
@@ -1315,8 +1315,8 @@ du_BUILTIN_368 v0 v1
                              -> coe
                                   seq (coe v32)
                                   (coe
-                                     seq (coe v11)
-                                     (coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe v21)))
+                                     seq (coe v21)
+                                     (coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe v11)))
                            _ -> MAlonzo.RTE.mazUnreachableError
                     _ -> MAlonzo.RTE.mazUnreachableError
              _ -> MAlonzo.RTE.mazUnreachableError

--- a/plutus-metatheory/src/MAlonzo/Code/Builtin.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Builtin.hs
@@ -49,6 +49,8 @@ import PlutusCore.Crypto.Ed25519
 import PlutusCore.Crypto.Secp256k1
 import PlutusPrelude (reoption)
 import PlutusCore.Builtin (BuiltinResult)
+import Codec.Serialise (serialise)
+import qualified Data.ByteString.Lazy as BSL
 import PlutusCore.Value as Value
 import PlutusCore.Crypto.BLS12_381.G1 qualified as G1
 import PlutusCore.Crypto.BLS12_381.G2 qualified as G2
@@ -2756,9 +2758,10 @@ d_DECODEUTF8_364 ::
     () MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_DECODEUTF8_364 = eitherToMaybe . decodeUtf8'
 -- Builtin.serialiseDATA
-d_serialiseDATA_366
-  = error
-      "MAlonzo Runtime Error: postulate evaluated: Builtin.serialiseDATA"
+d_serialiseDATA_366 ::
+  MAlonzo.Code.Utils.T_DATA_618 ->
+  MAlonzo.Code.Utils.T_ByteString_426
+d_serialiseDATA_366 = BSL.toStrict . serialise
 -- Builtin.insertCOIN
 d_insertCOIN_368 ::
   MAlonzo.Code.Utils.T_ByteString_426 ->

--- a/plutus-metatheory/src/MAlonzo/Code/Builtin.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Builtin.hs
@@ -1256,12 +1256,15 @@ d_signature_312 v0
         -> coe
              d__'93''10230'__302
              (coe
-                d__'44'__290 (coe d__'91'__280 (coe d_'8704'A_214) (coe du_A_222))
+                d__'44'__290
                 (coe
-                   MAlonzo.Code.Builtin.Signature.C__'8593'_38
+                   d__'91'__280 (coe d_'8704'A_214)
                    (coe
-                      MAlonzo.Code.Builtin.Signature.C_atomic_12
-                      (coe MAlonzo.Code.Builtin.Constant.AtomicType.C_aUnit_14))))
+                      MAlonzo.Code.Builtin.Signature.C__'8593'_38
+                      (coe
+                         MAlonzo.Code.Builtin.Signature.C_atomic_12
+                         (coe MAlonzo.Code.Builtin.Constant.AtomicType.C_aUnit_14))))
+                (coe du_A_222))
              (coe du_A_222)
       C_trace_64
         -> coe

--- a/plutus-metatheory/test/NEAT/Spec.hs
+++ b/plutus-metatheory/test/NEAT/Spec.hs
@@ -44,17 +44,18 @@ allTests :: TestTree
 allTests =
   testGroup
     "NEAT"
-    [ localOption (GenDepth 12) $
-        bigTest
-          "type-level"
-          (Type ())
-          (packAssertion prop_Type)
-    , localOption (GenDepth 18) $
-        bigTest
-          "term-level"
-          (TyBuiltinG TyUnitG)
-          (packAssertion prop_Term)
-    ]
+    ( localOption (GenDepth 10) (bigTest "type-level" (Type ()) (packAssertion prop_Type))
+        : map
+          termLevelTest
+          [ (TyBuiltinG TyUnitG, "")
+          , (TyBuiltinG TyIntegerG, " (Integer)")
+          , (TyBuiltinG TyByteStringG, " (ByteString)")
+          ]
+    )
+  where
+    termLevelTest (targetTy, suffix) =
+      localOption (GenDepth 18) $
+        bigTest ("term-level" <> suffix) targetTy (packAssertion prop_Term)
 
 -- one type-level test to rule them all
 prop_Type :: Kind () -> ClosedTypeG -> ExceptT TestFail Quote ()


### PR DESCRIPTION
## Summary

- Replace NEAT's hand-maintained, deprecated `defaultFunTypes` table (36 of 103 `DefaultFun` builtins, marked "no need to update for a new builtin") with one auto-derived from real builtin signatures via a new `Type -> TypeG` reverse conversion (`convertTypeToTypeG`), the counterpart to the existing `convertType`. Covers 59 builtins with no loss versus the old table — 23 more for free (bitwise ops, secp256k1, `expModInteger`, `Data`-family builtins). The remaining 44 stay uncovered because their real type needs a shape `TypeG` can't express: a variable list-element type (`mkCons`, `headList`, ...), a pair type (`fstPair`, `mapData`, ...), or a meta-type `TypeBuiltinG` has no constructor for (BLS12-381, `Array`, `Value`).
- Extend both NEAT-based property-test suites (`plutus-core` and `plutus-metatheory`) to check properties at `Integer` and `ByteString` result types, not just `Unit`. `Unit` has a single value, so a property checked only there never actually observes a real computed builtin value — an evaluation failure is silently accepted as type-preserving, and two evaluators trivially agree on `()` regardless of what any builtin call inside actually returned.
- This retargeting immediately surfaced two independent, previously-unreachable bugs in the Agda metatheory (fixed here):
  - `chooseUnit`'s signature and typed CEK semantics had its arguments reversed (`forall a. a -> unit -> a` instead of `forall a. unit -> a -> a`) — confirmed against the real Haskell builtin, the LaTeX spec, PlutusCoreBlaster's Lean reimplementation, and Agda's own (correct) untyped CEK.
  - `serialiseData` was a postulate with no `{-# COMPILE GHC #-}` binding at all — calling it crashed with "postulate evaluated". Bound it to the same expression the real Haskell denotation uses.
  - Both were reachable in principle before this PR (via the old table for `serialiseData`, via the new one for `chooseUnit`) but nothing had ever generated a term exercising them until these tests were retargeted.
- Tuned search depths so both suites stay in a reasonable time budget: `plutus-metatheory`'s `type-level` test dropped from depth 12 (56s) to 10 (~6s) since its per-example cost was the actual bottleneck, unrelated to term-level coverage; term-level depths bumped where cheap to do so, to exercise more terms.

Related to #6075 (NEAT builtin-coverage epic).

## Test plan

- [x] All 8 `plutus-core` NEAT tests pass (`cabal test plutus-core:plutus-core-test --test-options='-p NEAT'`)
- [x] All 4 `plutus-metatheory` NEAT tests pass (`cabal test plutus-metatheory:test-NEAT`)
- [x] Verified both metatheory fixes are load-bearing by seeding deliberate bugs in `AddInteger` and `AppendByteString`'s Haskell denotations and confirming the Integer/ByteString-targeted metatheory tests catch the divergence (while the plutus-core CK-vs-CEK tests, which share the same denotation between both evaluators, correctly do not — a known, expected blind spot, not a defect)