### PR TITLE
Cost model visualization: multiIndexArray page, shared page plumbing

### DIFF
--- a/doc/cost-models/README.md
+++ b/doc/cost-models/README.md
@@ -59,7 +59,7 @@ doc/cost-models/
 ## Data Sources
 
 - **Benchmark Data**: `plutus-core/cost-model/data/benching-conway.csv`
-- **Cost Models**: `plutus-core/cost-model/data/builtinCostModelC.json`
+- **Cost Models**: `plutus-core/cost-model/data/builtinCostModelE.json`
 
 Data is loaded dynamically from the Plutus repository using the browser's `fetch()` API.
 
@@ -164,7 +164,7 @@ No build process required - the workflow copies static files directly to `gh-pag
 
 **Model not found:**
 
-- Verify function name matches key in `builtinCostModelC.json`
+- Verify function name matches key in `builtinCostModelE.json`
 - Check console for detailed error messages
 
 **Plot not rendering:**

--- a/doc/cost-models/README.md
+++ b/doc/cost-models/README.md
@@ -20,11 +20,8 @@ Then open your browser to:
 
 ### Available Visualizations
 
-- **ValueData** - Converts Value to Data representation (2D plot)
-- **UnValueData** - Converts Data back to Value (2D plot)
-- **ValueContains** - Checks if one Value contains another (3D plot)
-- **LookupCoin** - Looks up a coin in a Value (2D plot)
-- **IndexByteString** - Retrieves a byte at a given index from a ByteString (2D plot)
+One page per builtin, one directory each. The list of pages lives in `PAGES`
+in `shared/utils.js`, which also drives the navigation bar on every page.
 
 ## Project Structure
 
@@ -33,19 +30,14 @@ doc/cost-models/
 ├── index.html              # Landing page with overview
 ├── shared/
 │   ├── styles.css         # Shared CSS styling
-│   └── utils.js           # Shared utilities (CSV parser, cost model evaluator)
+│   └── utils.js           # Everything shared: page list (PAGES), navigation,
+│                          # data-source panel and URL handling, CSV parser,
+│                          # cost model evaluators, page bootstrap
+│                          # (setupCostModelPage)
 ├── valuedata/
-│   ├── index.html         # ValueData visualization page
-│   └── plot.js            # ValueData-specific plot configuration
-├── unvaluedata/
-│   ├── index.html
-│   └── plot.js
-├── valuecontains/
-│   ├── index.html
-│   └── plot.js
-└── lookupcoin/
-    ├── index.html
-    └── plot.js
+│   ├── index.html         # Page markup: heading, controls, info panel
+│   └── plot.js            # Page identity and rendering only
+├── unvaluedata/           # ... and so on, one directory per builtin
 ```
 
 ## Features
@@ -67,55 +59,57 @@ Data is loaded dynamically from the Plutus repository using the browser's `fetch
 
 ### Quick Steps
 
-1. Copy an existing function directory:
+1. Copy the directory of an existing function whose plot has the same shape:
 
    ```bash
    cp -r valuedata/ myfunction/
    ```
 
-2. Edit `myfunction/index.html`:
-   - Update page title and heading
-   - Update navigation links
-   - Update plot information panel labels
+2. Add the page to `PAGES` in `shared/utils.js` (slug and display name).
+   The navigation bar on every page and the landing page pick it up from
+   there; no other page needs editing.
 
-3. Edit `myfunction/plot.js`:
-   - Update `FUNCTION_NAME` constant (must match CSV entry)
-   - Update `ARITY` constant (number of arguments)
-   - Adjust plot type if needed (2D vs 3D)
-   - Update axis labels
+3. Edit `myfunction/plot.js`: the constants at the top (`FUNCTION_NAME` as it
+   appears in the CSV, `COST_MODEL_NAME` as the key in the JSON, `ARITY`), the
+   `slug` in the `setupCostModelPage` call, and the rendering functions.
+   Loading, URL handling and navigation come from `setupCostModelPage`.
 
-4. Test locally:
+4. Edit `myfunction/index.html`: page title, heading, description, and the
+   info panel labels.
+
+5. If the function's cost model type has no entry in `CostModelEvaluators` in
+   `shared/utils.js`, add one there and a matching case in
+   `formatModelFormula`. Take the coefficient names from the JSON file, not
+   from other evaluators; a name mismatch silently evaluates the model as
+   zero.
+
+6. Test locally:
 
    ```bash
    python -m http.server 8000
    # Visit http://localhost:8000/myfunction/
    ```
 
-5. Add to navigation:
-   - Update `index.html` to include your function
-   - Add navigation link to all other function pages
-
-### Configuration Examples
-
-**2D plot with one argument:**
+### Page Skeleton
 
 ```javascript
-const FUNCTION_NAME = 'MyFunction';
-const ARITY = 1;
-
-const benchmarkX = benchmarkData.map(d => d.args[0]);
-const benchmarkY = benchmarkData.map(d => d.time);
-```
-
-**3D plot with two arguments:**
-
-```javascript
-const FUNCTION_NAME = 'MyFunction';
+const FUNCTION_NAME = 'MyFunction';    // CSV uses PascalCase
+const COST_MODEL_NAME = 'myFunction';  // JSON uses camelCase
 const ARITY = 2;
 
-const benchmarkX = benchmarkData.map(d => d.args[0]);
-const benchmarkY = benchmarkData.map(d => d.args[1]);
-const benchmarkZ = benchmarkData.map(d => d.time);
+setupCostModelPage({
+  slug: 'myfunction',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    // Draw the plots from data.benchmarkData, data.costModel,
+    // data.overhead, data.modelPredictions.
+  },
+  setupControls() {
+    // Wire page-specific controls (checkboxes, selectors).
+  }
+});
 ```
 
 ## Technical Details
@@ -129,15 +123,9 @@ const benchmarkZ = benchmarkData.map(d => d.time);
 
 ### Cost Model Evaluation
 
-JavaScript implementations of cost model evaluators:
-
-- `constant_cost`
-- `linear_in_x`, `linear_in_y`, `linear_in_z`
-- `quadratic_in_x`, `quadratic_in_y`, `quadratic_in_z`
-- `linear_in_xy`, `linear_in_xz`, `linear_in_yz`
-- `addedSizes`, `multipliedSizes`
-- `minSize`, `maxSize`
-- `linear_in_max_yz`
+`CostModelEvaluators` in `shared/utils.js` implements one evaluator per cost
+model type, keyed by the `type` string from the JSON file. The coefficient
+names inside each evaluator must match the JSON's `arguments` keys exactly.
 
 ### Overhead Calculation
 

--- a/doc/cost-models/README.md
+++ b/doc/cost-models/README.md
@@ -67,7 +67,7 @@ Data is loaded dynamically from the Plutus repository using the browser's `fetch
 
 2. Add the page to `PAGES` in `shared/utils.js` (slug and display name).
    The navigation bar on every page and the landing page pick it up from
-   there; no other page needs editing.
+   there, so the pages that already exist stay untouched.
 
 3. Edit `myfunction/plot.js`: the constants at the top (`FUNCTION_NAME` as it
    appears in the CSV, `COST_MODEL_NAME` as the key in the JSON, `ARITY`), the

--- a/doc/cost-models/index.html
+++ b/doc/cost-models/index.html
@@ -20,6 +20,7 @@
       <li><a href="listtoarray/index.html">ListToArray</a></li>
       <li><a href="lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="indexarray/index.html">IndexArray</a></li>
+      <li><a href="multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -136,6 +137,16 @@
         </li>
 
         <li>
+          <a href="multiindexarray/index.html">MultiIndexArray</a>
+          <p class="description">
+            Looks up a list of indices in a Plutus array; linear in the number of indices,
+            independent of the array size.
+            (3D visualization: Haystack Size &times; Needles Size vs Time, plus per-index time
+            distribution histogram)
+          </p>
+        </li>
+
+        <li>
           <a href="indexbytestring/index.html">IndexByteString</a>
           <p class="description">
             Retrieves a byte at a given index from a ByteString in O(1) time. Performs a bounds check and returns the byte value (Word8).
@@ -157,7 +168,7 @@
         </li>
         <li>
           <strong>Cost Models:</strong>
-          <a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a>
+          <a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a>
         </li>
       </ul>
       <p>
@@ -239,7 +250,7 @@
         </li>
         <li>
           <strong>Model not found:</strong> Verify function name matches the key in
-          <code>builtinCostModelC.json</code>
+          <code>builtinCostModelE.json</code>
         </li>
         <li>
           <strong>Plot not rendering:</strong> Check Plotly errors in console;

--- a/doc/cost-models/index.html
+++ b/doc/cost-models/index.html
@@ -7,23 +7,7 @@
   <link rel="stylesheet" href="shared/styles.css">
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="index.html" class="active">Home</a></li>
-      <li><a href="valuedata/index.html">ValueData</a></li>
-      <li><a href="unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="valuecontains/index.html">ValueContains</a></li>
-      <li><a href="lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="insertcoin/index.html">InsertCoin</a></li>
-      <li><a href="unionvalue/index.html">UnionValue</a></li>
-      <li><a href="scalevalue/index.html">ScaleValue</a></li>
-      <li><a href="listtoarray/index.html">ListToArray</a></li>
-      <li><a href="lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="indexarray/index.html">IndexArray</a></li>
-      <li><a href="multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>Plutus Cost Model Visualization</h1>
@@ -323,5 +307,7 @@ python3 -m http.server 8000</code></pre>
       <a href="https://plutus.cardano.intersectmbo.org/docs/" target="_blank">Plutus Documentation</a>
     </p>
   </footer>
+  <script src="shared/utils.js"></script>
+  <script>document.addEventListener('DOMContentLoaded', () => renderNav(null, '.'));</script>
 </body>
 </html>

--- a/doc/cost-models/indexarray/index.html
+++ b/doc/cost-models/indexarray/index.html
@@ -8,20 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html" class="active">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>IndexArray Cost Model Visualization</h1>
@@ -117,17 +104,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/indexarray/index.html
+++ b/doc/cost-models/indexarray/index.html
@@ -18,6 +18,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html" class="active">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -118,7 +119,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/indexarray/plot.js
+++ b/doc/cost-models/indexarray/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/indexarray/plot.js
+++ b/doc/cost-models/indexarray/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'IndexArray';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'indexArray';  // JSON uses camelCase
 const ARITY = 2;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'indexarray',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -349,16 +169,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/indexbytestring/index.html
+++ b/doc/cost-models/indexbytestring/index.html
@@ -8,23 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../insertcoin/index.html">InsertCoin</a></li>
-      <li><a href="../unionvalue/index.html">UnionValue</a></li>
-      <li><a href="../scalevalue/index.html">ScaleValue</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html" class="active">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>IndexByteString Cost Model Visualization</h1>
@@ -120,17 +104,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/indexbytestring/index.html
+++ b/doc/cost-models/indexbytestring/index.html
@@ -21,6 +21,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html" class="active">IndexByteString</a></li>
     </ul>
   </nav>
@@ -121,7 +122,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/indexbytestring/plot.js
+++ b/doc/cost-models/indexbytestring/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/indexbytestring/plot.js
+++ b/doc/cost-models/indexbytestring/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'IndexByteString';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'indexByteString';  // JSON uses camelCase
 const ARITY = 2;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'indexbytestring',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -349,16 +169,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/insertcoin/index.html
+++ b/doc/cost-models/insertcoin/index.html
@@ -8,23 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../insertcoin/index.html" class="active">InsertCoin</a></li>
-      <li><a href="../unionvalue/index.html">UnionValue</a></li>
-      <li><a href="../scalevalue/index.html">ScaleValue</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>InsertCoin Cost Model Visualization</h1>
@@ -110,17 +94,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/insertcoin/index.html
+++ b/doc/cost-models/insertcoin/index.html
@@ -21,6 +21,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -111,7 +112,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/insertcoin/plot.js
+++ b/doc/cost-models/insertcoin/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/insertcoin/plot.js
+++ b/doc/cost-models/insertcoin/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'InsertCoin';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'insertCoin';  // JSON uses camelCase
 const ARITY = 4;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,184 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'insertcoin',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-  } catch (error) {
-    console.error('Error loading data:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats for the 4th argument (Value size metric)
@@ -344,16 +165,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/lengthofarray/index.html
+++ b/doc/cost-models/lengthofarray/index.html
@@ -18,6 +18,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html" class="active">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -118,7 +119,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/lengthofarray/index.html
+++ b/doc/cost-models/lengthofarray/index.html
@@ -8,20 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html" class="active">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>LengthOfArray Cost Model Visualization</h1>
@@ -117,17 +104,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/lengthofarray/plot.js
+++ b/doc/cost-models/lengthofarray/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/lengthofarray/plot.js
+++ b/doc/cost-models/lengthofarray/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'LengthOfArray';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'lengthOfArray';  // JSON uses camelCase
 const ARITY = 1;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'lengthofarray',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -349,16 +169,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/listtoarray/index.html
+++ b/doc/cost-models/listtoarray/index.html
@@ -8,20 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../listtoarray/index.html" class="active">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>ListToArray Cost Model Visualization</h1>
@@ -117,17 +104,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/listtoarray/index.html
+++ b/doc/cost-models/listtoarray/index.html
@@ -18,6 +18,7 @@
       <li><a href="../listtoarray/index.html" class="active">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -118,7 +119,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/listtoarray/plot.js
+++ b/doc/cost-models/listtoarray/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/listtoarray/plot.js
+++ b/doc/cost-models/listtoarray/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'ListToArray';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'listToArray';  // JSON uses camelCase
 const ARITY = 1;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'listtoarray',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -349,16 +169,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/lookupcoin/index.html
+++ b/doc/cost-models/lookupcoin/index.html
@@ -18,6 +18,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -118,7 +119,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/lookupcoin/index.html
+++ b/doc/cost-models/lookupcoin/index.html
@@ -8,20 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html" class="active">LookupCoin</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>LookupCoin Cost Model Visualization</h1>
@@ -117,17 +104,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/lookupcoin/plot.js
+++ b/doc/cost-models/lookupcoin/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/lookupcoin/plot.js
+++ b/doc/cost-models/lookupcoin/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'LookupCoin';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'lookupCoin';  // JSON uses camelCase
 const ARITY = 3;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,184 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'lookupcoin',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-  } catch (error) {
-    console.error('Error loading data:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats for the 3rd argument (Value size, index 2)
@@ -350,16 +171,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/multiindexarray/index.html
+++ b/doc/cost-models/multiindexarray/index.html
@@ -8,23 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../insertcoin/index.html">InsertCoin</a></li>
-      <li><a href="../unionvalue/index.html">UnionValue</a></li>
-      <li><a href="../scalevalue/index.html">ScaleValue</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html" class="active">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>MultiIndexArray Cost Model Visualization</h1>
@@ -138,10 +122,7 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a>
-            (PlutusV3 from PV&nbsp;11 / vanRossem)</dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
@@ -157,9 +138,7 @@
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/multiindexarray/index.html
+++ b/doc/cost-models/multiindexarray/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ValueData - Plutus Cost Model Visualization</title>
+  <title>MultiIndexArray - Plutus Cost Model Visualization</title>
   <link rel="stylesheet" href="../shared/styles.css">
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
@@ -11,23 +11,29 @@
   <nav>
     <ul>
       <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html" class="active">ValueData</a></li>
+      <li><a href="../valuedata/index.html">ValueData</a></li>
       <li><a href="../unvaluedata/index.html">UnValueData</a></li>
       <li><a href="../valuecontains/index.html">ValueContains</a></li>
       <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
+      <li><a href="../insertcoin/index.html">InsertCoin</a></li>
+      <li><a href="../unionvalue/index.html">UnionValue</a></li>
+      <li><a href="../scalevalue/index.html">ScaleValue</a></li>
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
+      <li><a href="../multiindexarray/index.html" class="active">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
 
   <div class="container">
-    <h1>ValueData Cost Model Visualization</h1>
+    <h1>MultiIndexArray Cost Model Visualization</h1>
     <p>
-      Interactive visualization of benchmark data and fitted cost model for the <code>ValueData</code> builtin function.
-      This function converts a Plutus <code>Value</code> to <code>Data</code> representation.
+      Interactive visualization of benchmark data and fitted cost model for the <code>MultiIndexArray</code> builtin function.
+      This function looks up a list of indices (needles) in a Plutus array (haystack); the cost depends on the
+      number of indices and not on the array size, so the model surface in the 3D view is flat along the
+      haystack axis. The number of indices is limited, because beyond that limit the execution time is not
+      predictable from the index count alone; the histogram below shows the per-index time distribution.
     </p>
 
     <div class="controls" id="data-source-controls">
@@ -62,10 +68,18 @@
           <label for="show-model">Show model predictions</label>
         </div>
         <div class="control-group">
-          <label for="y-axis-mode">Y-axis range:</label>
-          <select id="y-axis-mode">
+          <label for="z-axis-mode">Z-axis range:</label>
+          <select id="z-axis-mode">
             <option value="zero">Start from 0</option>
             <option value="auto">Auto-scale from min</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label for="hist-threshold">Histogram: min index count:</label>
+          <select id="hist-threshold">
+            <option value="1000">1000</option>
+            <option value="2000" selected>2000</option>
+            <option value="3000">3000</option>
           </select>
         </div>
       </div>
@@ -82,13 +96,17 @@
         <div class="info-section">
           <dl>
             <dt>X-axis:</dt>
-            <dd id="info-x-axis">Value Size</dd>
+            <dd id="info-x-axis">Haystack size (array length, log scale)</dd>
 
             <dt>Y-axis:</dt>
-            <dd id="info-y-axis">Time (nanoseconds)</dd>
+            <dd id="info-y-axis">Needles size (length of the index list)</dd>
+
+            <dt>Z-axis:</dt>
+            <dd id="info-z-axis">Time (nanoseconds)</dd>
 
             <dt>Description:</dt>
-            <dd id="info-description">Each point represents one benchmark run</dd>
+            <dd id="info-description">Each point is one benchmark. The model surface is flat along the
+              haystack axis and rises along the needles axis.</dd>
           </dl>
         </div>
 
@@ -108,8 +126,11 @@
             <dt>Data points:</dt>
             <dd id="info-data-points">-</dd>
 
-            <dt>Value Size range:</dt>
+            <dt>Index count range:</dt>
             <dd id="info-x-range">-</dd>
+
+            <dt>Array size range:</dt>
+            <dd id="info-array-range">-</dd>
 
             <dt>Time range:</dt>
             <dd id="info-time-range">-</dd>
@@ -119,9 +140,20 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a>
+            (PlutusV3 from PV&nbsp;11 / vanRossem)</dd>
         </div>
       </div>
+    </div>
+
+    <h2>Per-index time distribution</h2>
+    <p>
+      Net time per index, <code>(t &minus; overhead) / indexCount</code>, for benchmarks with at least the
+      selected number of indices. The dashed line marks the fitted model's net time per index at that
+      number of indices.
+    </p>
+    <div id="hist-container">
+      <div class="loading">Loading...</div>
     </div>
   </div>
 

--- a/doc/cost-models/multiindexarray/index.html
+++ b/doc/cost-models/multiindexarray/index.html
@@ -30,9 +30,9 @@
     <h1>MultiIndexArray Cost Model Visualization</h1>
     <p>
       Interactive visualization of benchmark data and fitted cost model for the <code>MultiIndexArray</code> builtin function.
-      This function looks up a list of indices (needles) in a Plutus array (haystack); the cost depends on the
+      This function looks up a list of indices in a Plutus array; the cost depends on the
       number of indices and not on the array size, so the model surface in the 3D view is flat along the
-      haystack axis. The number of indices is limited, because beyond that limit the execution time is not
+      array-size axis. The number of indices is limited, because beyond that limit the execution time is not
       predictable from the index count alone; the histogram below shows the per-index time distribution.
     </p>
 
@@ -77,9 +77,9 @@
         <div class="control-group">
           <label for="hist-threshold">Histogram: min index count:</label>
           <select id="hist-threshold">
-            <option value="1000">1000</option>
-            <option value="2000" selected>2000</option>
-            <option value="3000">3000</option>
+            <option value="250">250</option>
+            <option value="500" selected>500</option>
+            <option value="750">750</option>
           </select>
         </div>
       </div>
@@ -96,17 +96,17 @@
         <div class="info-section">
           <dl>
             <dt>X-axis:</dt>
-            <dd id="info-x-axis">Haystack size (array length, log scale)</dd>
+            <dd id="info-x-axis">Array size (log scale)</dd>
 
             <dt>Y-axis:</dt>
-            <dd id="info-y-axis">Needles size (length of the index list)</dd>
+            <dd id="info-y-axis">Index count (length of the index list)</dd>
 
             <dt>Z-axis:</dt>
             <dd id="info-z-axis">Time (nanoseconds)</dd>
 
             <dt>Description:</dt>
             <dd id="info-description">Each point is one benchmark. The model surface is flat along the
-              haystack axis and rises along the needles axis.</dd>
+              array-size axis and rises along the index-count axis.</dd>
           </dl>
         </div>
 

--- a/doc/cost-models/multiindexarray/index.html
+++ b/doc/cost-models/multiindexarray/index.html
@@ -15,9 +15,10 @@
     <p>
       Interactive visualization of benchmark data and fitted cost model for the <code>MultiIndexArray</code> builtin function.
       This function looks up a list of indices in a Plutus array; the cost depends on the
-      number of indices and not on the array size, so the model surface in the 3D view is flat along the
-      array-size axis. The number of indices is limited, because beyond that limit the execution time is not
-      predictable from the index count alone; the histogram below shows the per-index time distribution.
+      number of indices and not on the array size. Points are coloured by array size, so that independence
+      is visible directly: every colour lies on the same curve. The number of indices is limited, because
+      beyond that limit the execution time is not predictable from the index count alone; the panels below
+      show the per-index cost across the range and its distribution.
     </p>
 
     <div class="controls" id="data-source-controls">
@@ -52,8 +53,8 @@
           <label for="show-model">Show model predictions</label>
         </div>
         <div class="control-group">
-          <label for="z-axis-mode">Z-axis range:</label>
-          <select id="z-axis-mode">
+          <label for="y-axis-mode">Y-axis range:</label>
+          <select id="y-axis-mode">
             <option value="zero">Start from 0</option>
             <option value="auto">Auto-scale from min</option>
           </select>
@@ -80,17 +81,14 @@
         <div class="info-section">
           <dl>
             <dt>X-axis:</dt>
-            <dd id="info-x-axis">Array size (log scale)</dd>
+            <dd id="info-x-axis">Index count (length of the index list)</dd>
 
             <dt>Y-axis:</dt>
-            <dd id="info-y-axis">Index count (length of the index list)</dd>
-
-            <dt>Z-axis:</dt>
-            <dd id="info-z-axis">Time (nanoseconds)</dd>
+            <dd id="info-y-axis">Time (nanoseconds)</dd>
 
             <dt>Description:</dt>
-            <dd id="info-description">Each point is one benchmark. The model surface is flat along the
-              array-size axis and rises along the index-count axis.</dd>
+            <dd id="info-description">Each point is one benchmark, coloured by array size. The model
+              depends on the index count alone, so points of every colour follow the same line.</dd>
           </dl>
         </div>
 
@@ -127,11 +125,23 @@
       </div>
     </div>
 
+    <h2>Per-index cost across the range</h2>
+    <p>
+      Net time per index with the model's per-call constant subtracted,
+      <code>(t &minus; overhead &minus; c0) / indexCount</code>. In the total time the constant swamps the
+      per-index cost, so its rise across the range is only visible here; the model's charge per index is
+      <code>c1 + c2 &middot; indexCount</code>, a straight line. Small index counts are omitted: there the
+      constant dominates the total, and dividing the small remainder by the count amplifies noise.
+    </p>
+    <div id="perindex-container">
+      <div class="loading">Loading...</div>
+    </div>
+
     <h2>Per-index time distribution</h2>
     <p>
-      Net time per index, <code>(t &minus; overhead) / indexCount</code>, for benchmarks with at least the
-      selected number of indices. The dashed line marks the fitted model's net time per index at that
-      number of indices.
+      The same per-index times, <code>(t &minus; overhead &minus; c0) / indexCount</code>, as a histogram
+      for benchmarks with at least the selected number of indices. The dashed line marks the fitted
+      model's net time per index at that number of indices.
     </p>
     <div id="hist-container">
       <div class="loading">Loading...</div>

--- a/doc/cost-models/multiindexarray/plot.js
+++ b/doc/cost-models/multiindexarray/plot.js
@@ -5,16 +5,35 @@
 // cost model is quadratic_in_y: it depends on the number of indices and not on
 // the array size.
 //
-// The main view is a 3D scatter (array size, index count, time) with the
-// fitted model drawn as a surface: flat along the array-size axis, rising
-// along the index-count axis.  A histogram of net per-index times at large index counts
-// makes the distribution of the benchmark results (and any multi-modality)
-// directly visible.
+// The main view is a 2D scatter of time against index count, with one colour
+// per array size and the fitted model drawn as a line.  The array-size
+// independence the model assumes shows up directly: points of every colour lie
+// on the same curve.  A second panel plots the per-index cost with the model's
+// per-call constant subtracted, which is the view where its rise across the
+// range is visible.  A histogram of the same per-index costs at large index
+// counts makes their distribution (and any multi-modality) directly visible.
 
 // Configuration
 const FUNCTION_NAME = 'MultiIndexArray';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'multiIndexArray';  // JSON uses camelCase
 const ARITY = 2;
+
+// The benchmark's random points use array sizes at every power of two, so
+// colouring by exact size would need a colour per size.  Bucket the sizes
+// instead, one ordered dark-to-warm colour per bucket (upper bounds,
+// inclusive).
+const ARRAY_SIZE_BUCKETS = [
+  { limit: 8, color: '#0D0887' },
+  { limit: 64, color: '#6A00A8' },
+  { limit: 512, color: '#B12A90' },
+  { limit: 4096, color: '#D6556D' },
+  { limit: 32768, color: '#EF7E50' },
+  { limit: Infinity, color: '#FCA636' }
+];
+
+// Below this index count the per-call constant dominates the total, and
+// dividing the small remainder by the count amplifies noise.
+const PER_INDEX_MIN_COUNT = 50;
 
 // Global state
 let benchmarkData = [];
@@ -22,7 +41,7 @@ let modelPredictions = [];
 let costModel = null;
 let overhead = 0;
 let showModel = true;
-let zAxisMode = 'zero';
+let yAxisMode = 'zero';
 let histThreshold = 500;
 
 setupCostModelPage({
@@ -34,6 +53,7 @@ setupCostModelPage({
     ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
     renderPlot();
+    renderPerIndex();
     renderHistogram();
   },
   setupControls
@@ -78,92 +98,104 @@ function updateInfoPanel() {
   }
 }
 
-// The model surface: the fitted cost at each index count (+ overhead), flat
-// along the array-size axis.
-function modelPlaneTrace() {
-  const arraySizes = [...new Set(benchmarkData.map(d => d.args[0]))].sort((a, b) => a - b);
-  const maxIndexCount = Math.max(...benchmarkData.map(d => d.args[1]));
-  const steps = 30;
-  const indexCounts = Array.from({ length: steps + 1 }, (_, i) => Math.max(1, Math.round(i * maxIndexCount / steps)));
-
+// The model evaluated at index count n, in nanoseconds, overhead included.
+function modelAt(n) {
   const evaluate = CostModelEvaluators[costModel.modelType];
+  return evaluate(costModel.coefficients, [0, n]) / 1000 + overhead;
+}
 
-  // z[i][j] corresponds to (y = indexCounts[i], x = arraySizes[j])
-  const z = indexCounts.map(n =>
-    arraySizes.map(h => evaluate(costModel.coefficients, [h, n]) / 1000 + overhead));
+// The model's per-call constant, in nanoseconds, without overhead.
+function modelConstant() {
+  const evaluate = CostModelEvaluators[costModel.modelType];
+  return evaluate(costModel.coefficients, [0, 0]) / 1000;
+}
 
-  return {
-    x: arraySizes,
-    y: indexCounts,
-    z: z,
-    type: 'surface',
-    name: 'Model Prediction',
-    showscale: false,
-    opacity: 0.35,
-    colorscale: [[0, '#E53E3E'], [1, '#E53E3E']],
-    hovertemplate: 'indices: %{y}<br>model: %{z:.0f} ns<extra></extra>'
-  };
+// One scatter trace per array-size bucket, so the legend doubles as a size key
+// and single buckets can be toggled to check that no colour sits apart from
+// the rest.  The hover still reports the exact array size of each point.
+function perSizeTraces(pointsToXY) {
+  let lower = 1;
+  return ARRAY_SIZE_BUCKETS.flatMap(bucket => {
+    const from = lower;
+    lower = bucket.limit + 1;
+    const inBucket = benchmarkData.filter(d => from <= d.args[0] && d.args[0] <= bucket.limit);
+    const points = inBucket.map(d => {
+      const xy = pointsToXY(d);
+      return xy && { ...xy, size: d.args[0] };
+    }).filter(Boolean);
+    if (points.length === 0) return [];
+    const name = bucket.limit === Infinity
+      ? `array size > ${from - 1}`
+      : from === bucket.limit ? `array size ${from}` : `array size ${from}-${bucket.limit}`;
+    return [{
+      x: points.map(p => p.x),
+      y: points.map(p => p.y),
+      customdata: points.map(p => p.size),
+      mode: 'markers',
+      type: 'scatter',
+      name,
+      hovertemplate: 'array: %{customdata}<br>indices: %{x}<br>%{y:.1f} ns<extra></extra>',
+      marker: {
+        size: 6,
+        color: bucket.color,
+        opacity: 0.75
+      }
+    }];
+  });
+}
+
+// Index counts at which to draw the model line.
+function modelLineCounts() {
+  const maxIndexCount = Math.max(...benchmarkData.map(d => d.args[1]));
+  const steps = 64;
+  return Array.from({ length: steps + 1 }, (_, i) =>
+    Math.max(1, Math.round(i * maxIndexCount / steps)));
 }
 
 function renderPlot() {
-  const benchmarkTrace = {
-    x: benchmarkData.map(d => d.args[0]),
-    y: benchmarkData.map(d => d.args[1]),
-    z: benchmarkData.map(d => d.time),
-    mode: 'markers',
-    type: 'scatter3d',
-    name: 'Benchmark Data',
-    hovertemplate: 'array: %{x}<br>indices: %{y}<br>time: %{z:.0f} ns<extra></extra>',
-    marker: {
-      size: 3.5,
-      color: '#0033AD',
-      opacity: 0.75
-    }
-  };
+  const traces = perSizeTraces(d => ({ x: d.args[1], y: d.time }));
 
-  const traces = [benchmarkTrace];
-
-  if (showModel && costModel && CostModelEvaluators[costModel.modelType]) {
-    traces.push(modelPlaneTrace());
+  const haveEvaluator = costModel && CostModelEvaluators[costModel.modelType];
+  if (showModel && haveEvaluator) {
+    const counts = modelLineCounts();
+    traces.push({
+      x: counts,
+      y: counts.map(modelAt),
+      mode: 'lines',
+      type: 'scatter',
+      name: 'Model',
+      line: { color: '#E53E3E', width: 2 },
+      hovertemplate: 'indices: %{x}<br>model: %{y:.0f} ns<extra></extra>'
+    });
   } else if (showModel && modelPredictions.length > 0) {
     // Fallback for other model shapes: prediction markers at the data points
     traces.push({
-      x: modelPredictions.map(d => d.args[0]),
-      y: modelPredictions.map(d => d.args[1]),
-      z: modelPredictions.map(d => d.predictedTime),
+      x: modelPredictions.map(d => d.args[1]),
+      y: modelPredictions.map(d => d.predictedTime),
       mode: 'markers',
-      type: 'scatter3d',
+      type: 'scatter',
       name: 'Model Predictions',
-      marker: { size: 3.5, color: '#E53E3E', opacity: 0.4, symbol: 'x' }
+      marker: { size: 6, color: '#E53E3E', opacity: 0.4, symbol: 'x' }
     });
   }
 
-  const benchmarkZ = benchmarkTrace.z;
+  const benchmarkTimes = benchmarkData.map(d => d.time);
 
   // Layout configuration
   const layout = {
     title: {
-      text: `${FUNCTION_NAME} - Benchmark vs Model (3D)`,
+      text: `${FUNCTION_NAME} - Benchmark vs Model`,
       font: { size: 20 }
     },
-    scene: {
-      xaxis: {
-        title: 'Array size (log)',
-        type: 'log',
-        gridcolor: '#E0E0E0'
-      },
-      yaxis: {
-        title: 'Index count',
-        gridcolor: '#E0E0E0'
-      },
-      zaxis: {
-        title: 'Time (nanoseconds)',
-        gridcolor: '#E0E0E0'
-      },
-      camera: {
-        eye: { x: 1.7, y: -1.7, z: 0.6 }
-      }
+    xaxis: {
+      title: 'Index count',
+      gridcolor: '#E0E0E0'
     },
+    yaxis: {
+      title: 'Time (nanoseconds)',
+      gridcolor: '#E0E0E0'
+    },
+    hovermode: 'closest',
     showlegend: true,
     legend: {
       x: 0.02,
@@ -172,17 +204,18 @@ function renderPlot() {
       bordercolor: '#BDC3C7',
       borderwidth: 1
     },
+    plot_bgcolor: '#FAFAFA',
     paper_bgcolor: 'rgba(0,0,0,0)'
   };
 
-  // Set Z-axis range based on mode
-  if (zAxisMode === 'zero') {
-    layout.scene.zaxis.range = [0, Math.max(...benchmarkZ) * 1.1];
+  // Set Y-axis range based on mode
+  if (yAxisMode === 'zero') {
+    layout.yaxis.range = [0, Math.max(...benchmarkTimes) * 1.1];
   } else {
-    const minZ = Math.min(...benchmarkZ);
-    const maxZ = Math.max(...benchmarkZ);
-    const padding = (maxZ - minZ) * 0.1;
-    layout.scene.zaxis.range = [minZ - padding, maxZ + padding];
+    const minY = Math.min(...benchmarkTimes);
+    const maxY = Math.max(...benchmarkTimes);
+    const padding = (maxY - minY) * 0.1;
+    layout.yaxis.range = [minY - padding, maxY + padding];
   }
 
   // Config
@@ -198,17 +231,100 @@ function renderPlot() {
   Plotly.newPlot('plot-container', traces, layout, config);
 }
 
+// Per-index cost with the per-call constant subtracted:
+// (t - overhead - c0) / indexCount against the index count.  The model's
+// charge per index is then c1 + c2*y, a straight line, and the rise of the
+// measured per-index cost across the range is visible instead of being
+// swamped by the constant.
+function renderPerIndex() {
+  const container = document.getElementById('perindex-container');
+
+  if (!(costModel && CostModelEvaluators[costModel.modelType])) {
+    container.innerHTML =
+      '<div class="error"><p>Per-index view needs an evaluable cost model</p></div>';
+    return;
+  }
+
+  const c0 = modelConstant();
+  const traces = perSizeTraces(d =>
+    d.args[1] >= PER_INDEX_MIN_COUNT
+      ? { x: d.args[1], y: (d.time - overhead - c0) / d.args[1] }
+      : null);
+
+  if (showModel) {
+    const counts = modelLineCounts().filter(n => n >= PER_INDEX_MIN_COUNT);
+    traces.push({
+      x: counts,
+      y: counts.map(n => (modelAt(n) - overhead - c0) / n),
+      mode: 'lines',
+      type: 'scatter',
+      name: 'Model',
+      line: { color: '#E53E3E', width: 2 },
+      hovertemplate: 'indices: %{x}<br>model: %{y:.2f} ns/index<extra></extra>'
+    });
+  }
+
+  const layout = {
+    title: {
+      text: `Per-index cost across the range (index count ≥ ${PER_INDEX_MIN_COUNT})`,
+      font: { size: 18 }
+    },
+    xaxis: {
+      title: 'Index count',
+      gridcolor: '#E0E0E0'
+    },
+    // Auto-scaled on purpose: the rise across the range is the point of this
+    // panel, and from zero it flattens into invisibility.
+    yaxis: {
+      title: 'Net time per index (nanoseconds)',
+      gridcolor: '#E0E0E0'
+    },
+    hovermode: 'closest',
+    showlegend: true,
+    // Below the axis: anywhere inside the plot area it covers data, because
+    // the auto-scaled panel has points in every corner.
+    legend: {
+      orientation: 'h',
+      x: 0,
+      y: -0.25,
+      yanchor: 'top',
+      bgcolor: 'rgba(255, 255, 255, 0.8)',
+      bordercolor: '#BDC3C7',
+      borderwidth: 1
+    },
+    plot_bgcolor: '#FAFAFA',
+    paper_bgcolor: 'rgba(0,0,0,0)'
+  };
+
+  const config = {
+    responsive: true,
+    displayModeBar: true,
+    displaylogo: false
+  };
+
+  container.innerHTML = '';
+  Plotly.newPlot('perindex-container', traces, layout, config);
+}
+
 function renderHistogram() {
   const container = document.getElementById('hist-container');
 
-  // Net per-index time for large index counts
+  if (!(costModel && CostModelEvaluators[costModel.modelType])) {
+    container.innerHTML =
+      '<div class="error"><p>Histogram needs an evaluable cost model</p></div>';
+    return;
+  }
+
+  // Net per-index time for large index counts, per-call constant subtracted
+  // (the same quantity as the per-index panel above).
   const points = benchmarkData.filter(d => d.args[1] >= histThreshold);
   if (points.length === 0) {
     container.innerHTML = `<div class="error"><p>No benchmarks with index count ≥ ${histThreshold}</p></div>`;
     return;
   }
 
-  const perIndex = points.map(d => (d.time - overhead) / d.args[1]);
+  const c0 = modelConstant();
+  const perIndex = points.map(d => (d.time - overhead - c0) / d.args[1]);
 
   const histTrace = {
     x: perIndex,
@@ -241,14 +357,11 @@ function renderHistogram() {
     annotations: []
   };
 
-  // Mark the model's net time per index (ps -> ns) at the histogram threshold on
-  // the distribution.  The model is not linear in the index count, so this is the
+  // Mark the model's net time per index at the histogram threshold on the
+  // distribution.  The model is not linear in the index count, so this is the
   // average over the indices of one call rather than a single slope.
-  const evaluate = costModel && CostModelEvaluators[costModel.modelType];
-  if (evaluate && histThreshold > 0) {
-    const coeffs = costModel.coefficients;
-    const perIndexNs =
-      (evaluate(coeffs, [0, histThreshold]) - evaluate(coeffs, [0, 0])) / histThreshold / 1000;
+  if (histThreshold > 0) {
+    const perIndexNs = (modelAt(histThreshold) - overhead - c0) / histThreshold;
     layout.shapes.push({
       type: 'line',
       x0: perIndexNs, x1: perIndexNs,
@@ -283,12 +396,13 @@ function setupControls() {
   showModelCheckbox.addEventListener('change', (e) => {
     showModel = e.target.checked;
     renderPlot();
+    renderPerIndex();
   });
 
-  // Z-axis mode selector
-  const zAxisModeSelect = document.getElementById('z-axis-mode');
-  zAxisModeSelect.addEventListener('change', (e) => {
-    zAxisMode = e.target.value;
+  // Y-axis mode selector
+  const yAxisModeSelect = document.getElementById('y-axis-mode');
+  yAxisModeSelect.addEventListener('change', (e) => {
+    yAxisMode = e.target.value;
     renderPlot();
   });
 

--- a/doc/cost-models/multiindexarray/plot.js
+++ b/doc/cost-models/multiindexarray/plot.js
@@ -1,13 +1,13 @@
 // MultiIndexArray plot configuration and rendering
 //
 // Benchmark names are MultiIndexArray/<arraySize>/<indexCount>, so
-// args[0] = array size (haystack) and args[1] = index count (needles).  The
+// args[0] = array size and args[1] = index count.  The
 // cost model is quadratic_in_y: it depends on the number of indices and not on
 // the array size.
 //
-// The main view is a 3D scatter (haystack size, needles size, time) with the
-// fitted model drawn as a surface: flat along the haystack axis, rising along
-// the needles axis.  A histogram of net per-index times at large index counts
+// The main view is a 3D scatter (array size, index count, time) with the
+// fitted model drawn as a surface: flat along the array-size axis, rising
+// along the index-count axis.  A histogram of net per-index times at large index counts
 // makes the distribution of the benchmark results (and any multi-modality)
 // directly visible.
 
@@ -36,7 +36,7 @@ let costModel = null;
 let overhead = 0;
 let showModel = true;
 let zAxisMode = 'zero';
-let histThreshold = 2000;
+let histThreshold = 500;
 
 // Generate URL from template and branch
 function generateUrlFromBranch(branch) {
@@ -259,29 +259,29 @@ function updateInfoPanel() {
 }
 
 // The model surface: the fitted cost at each index count (+ overhead), flat
-// along the haystack axis.
+// along the array-size axis.
 function modelPlaneTrace() {
-  const haystacks = [...new Set(benchmarkData.map(d => d.args[0]))].sort((a, b) => a - b);
-  const maxNeedles = Math.max(...benchmarkData.map(d => d.args[1]));
+  const arraySizes = [...new Set(benchmarkData.map(d => d.args[0]))].sort((a, b) => a - b);
+  const maxIndexCount = Math.max(...benchmarkData.map(d => d.args[1]));
   const steps = 30;
-  const needles = Array.from({ length: steps + 1 }, (_, i) => Math.max(1, Math.round(i * maxNeedles / steps)));
+  const indexCounts = Array.from({ length: steps + 1 }, (_, i) => Math.max(1, Math.round(i * maxIndexCount / steps)));
 
   const evaluate = CostModelEvaluators[costModel.modelType];
 
-  // z[i][j] corresponds to (y = needles[i], x = haystacks[j])
-  const z = needles.map(n =>
-    haystacks.map(h => evaluate(costModel.coefficients, [h, n]) / 1000 + overhead));
+  // z[i][j] corresponds to (y = indexCounts[i], x = arraySizes[j])
+  const z = indexCounts.map(n =>
+    arraySizes.map(h => evaluate(costModel.coefficients, [h, n]) / 1000 + overhead));
 
   return {
-    x: haystacks,
-    y: needles,
+    x: arraySizes,
+    y: indexCounts,
     z: z,
     type: 'surface',
     name: 'Model Prediction',
     showscale: false,
     opacity: 0.35,
     colorscale: [[0, '#E53E3E'], [1, '#E53E3E']],
-    hovertemplate: 'needles: %{y}<br>model: %{z:.0f} ns<extra></extra>'
+    hovertemplate: 'indices: %{y}<br>model: %{z:.0f} ns<extra></extra>'
   };
 }
 
@@ -293,7 +293,7 @@ function renderPlot() {
     mode: 'markers',
     type: 'scatter3d',
     name: 'Benchmark Data',
-    hovertemplate: 'haystack: %{x}<br>needles: %{y}<br>time: %{z:.0f} ns<extra></extra>',
+    hovertemplate: 'array: %{x}<br>indices: %{y}<br>time: %{z:.0f} ns<extra></extra>',
     marker: {
       size: 3.5,
       color: '#0033AD',
@@ -328,12 +328,12 @@ function renderPlot() {
     },
     scene: {
       xaxis: {
-        title: 'Haystack Size (array, log)',
+        title: 'Array size (log)',
         type: 'log',
         gridcolor: '#E0E0E0'
       },
       yaxis: {
-        title: 'Needles Size (index count)',
+        title: 'Index count',
         gridcolor: '#E0E0E0'
       },
       zaxis: {

--- a/doc/cost-models/multiindexarray/plot.js
+++ b/doc/cost-models/multiindexarray/plot.js
@@ -1,8 +1,19 @@
-// UnionValue plot configuration and rendering (3D)
+// MultiIndexArray plot configuration and rendering
+//
+// Benchmark names are MultiIndexArray/<arraySize>/<indexCount>, so
+// args[0] = array size (haystack) and args[1] = index count (needles).  The
+// cost model is quadratic_in_y: it depends on the number of indices and not on
+// the array size.
+//
+// The main view is a 3D scatter (haystack size, needles size, time) with the
+// fitted model drawn as a surface: flat along the haystack axis, rising along
+// the needles axis.  A histogram of net per-index times at large index counts
+// makes the distribution of the benchmark results (and any multi-modality)
+// directly visible.
 
 // Configuration
-const FUNCTION_NAME = 'UnionValue';  // CSV uses PascalCase
-const COST_MODEL_NAME = 'unionValue';  // JSON uses camelCase
+const FUNCTION_NAME = 'MultiIndexArray';  // CSV uses PascalCase
+const COST_MODEL_NAME = 'multiIndexArray';  // JSON uses camelCase
 const ARITY = 2;
 
 // Default configuration
@@ -25,13 +36,15 @@ let costModel = null;
 let overhead = 0;
 let showModel = true;
 let zAxisMode = 'zero';
+let histThreshold = 2000;
 
 // Generate URL from template and branch
 function generateUrlFromBranch(branch) {
   return URL_TEMPLATE.replace('{BRANCH}', branch);
 }
 
-// Get file URLs
+// Get file URLs.  Variant E is the PlutusV3 cost model from the vanRossem
+// hard fork (PV 11) onwards (C is the previous V3 era).
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
@@ -196,9 +209,9 @@ async function loadAndRenderData() {
     // Update info panel
     updateInfoPanel();
 
-    // Render plot
+    // Render plots
     renderPlot();
-
+    renderHistogram();
 
   } catch (error) {
     console.error('Initialization error:', error);
@@ -207,25 +220,20 @@ async function loadAndRenderData() {
 }
 
 function updateInfoPanel() {
-  // Calculate stats
-  const stats = calculateStats(benchmarkData);
+  // Calculate stats over the index count (second argument)
+  const stats = calculateStats(benchmarkData, 1);
 
   // Update data points
   document.getElementById('info-data-points').textContent = stats.dataPoints;
 
-  // Update ranges for X and Y axes (Value sizes)
-  if (benchmarkData.length > 0) {
-    const xValues = benchmarkData.map(d => d.args[0]);
-    const yValues = benchmarkData.map(d => d.args[1]);
-
-    const minX = Math.min(...xValues);
-    const maxX = Math.max(...xValues);
-    const minY = Math.min(...yValues);
-    const maxY = Math.max(...yValues);
-
-    document.getElementById('info-x-range').textContent = `${minX} - ${maxX}`;
-    document.getElementById('info-y-range').textContent = `${minY} - ${maxY}`;
+  // Update ranges
+  if (stats.minArg !== undefined) {
+    document.getElementById('info-x-range').textContent = `${stats.minArg} - ${stats.maxArg}`;
   }
+
+  const arraySizes = benchmarkData.map(d => d.args[0]);
+  document.getElementById('info-array-range').textContent =
+    `${Math.min(...arraySizes)} - ${Math.max(...arraySizes)}`;
 
   document.getElementById('info-time-range').textContent = stats.timeRange;
 
@@ -250,51 +258,67 @@ function updateInfoPanel() {
   }
 }
 
-function renderPlot() {
-  // Prepare benchmark trace (3D scatter)
-  const benchmarkX = benchmarkData.map(d => d.args[0]);
-  const benchmarkY = benchmarkData.map(d => d.args[1]);
-  const benchmarkZ = benchmarkData.map(d => d.time);
+// The model surface: the fitted cost at each index count (+ overhead), flat
+// along the haystack axis.
+function modelPlaneTrace() {
+  const haystacks = [...new Set(benchmarkData.map(d => d.args[0]))].sort((a, b) => a - b);
+  const maxNeedles = Math.max(...benchmarkData.map(d => d.args[1]));
+  const steps = 30;
+  const needles = Array.from({ length: steps + 1 }, (_, i) => Math.max(1, Math.round(i * maxNeedles / steps)));
 
+  const evaluate = CostModelEvaluators[costModel.modelType];
+
+  // z[i][j] corresponds to (y = needles[i], x = haystacks[j])
+  const z = needles.map(n =>
+    haystacks.map(h => evaluate(costModel.coefficients, [h, n]) / 1000 + overhead));
+
+  return {
+    x: haystacks,
+    y: needles,
+    z: z,
+    type: 'surface',
+    name: 'Model Prediction',
+    showscale: false,
+    opacity: 0.35,
+    colorscale: [[0, '#E53E3E'], [1, '#E53E3E']],
+    hovertemplate: 'needles: %{y}<br>model: %{z:.0f} ns<extra></extra>'
+  };
+}
+
+function renderPlot() {
   const benchmarkTrace = {
-    x: benchmarkX,
-    y: benchmarkY,
-    z: benchmarkZ,
+    x: benchmarkData.map(d => d.args[0]),
+    y: benchmarkData.map(d => d.args[1]),
+    z: benchmarkData.map(d => d.time),
     mode: 'markers',
     type: 'scatter3d',
     name: 'Benchmark Data',
+    hovertemplate: 'haystack: %{x}<br>needles: %{y}<br>time: %{z:.0f} ns<extra></extra>',
     marker: {
-      size: 4,
+      size: 3.5,
       color: '#0033AD',
-      opacity: 0.7
+      opacity: 0.75
     }
   };
 
   const traces = [benchmarkTrace];
 
-  // Prepare model trace if available
-  if (showModel && modelPredictions.length > 0) {
-    const modelX = modelPredictions.map(d => d.args[0]);
-    const modelY = modelPredictions.map(d => d.args[1]);
-    const modelZ = modelPredictions.map(d => d.predictedTime);
-
-    const modelTrace = {
-      x: modelX,
-      y: modelY,
-      z: modelZ,
+  if (showModel && costModel && CostModelEvaluators[costModel.modelType]) {
+    traces.push(modelPlaneTrace());
+  } else if (showModel && modelPredictions.length > 0) {
+    // Fallback for other model shapes: prediction markers at the data points
+    traces.push({
+      x: modelPredictions.map(d => d.args[0]),
+      y: modelPredictions.map(d => d.args[1]),
+      z: modelPredictions.map(d => d.predictedTime),
       mode: 'markers',
       type: 'scatter3d',
       name: 'Model Predictions',
-      marker: {
-        size: 4,
-        color: '#E53E3E',
-        opacity: 0.4,
-        symbol: 'x'
-      }
-    };
-
-    traces.push(modelTrace);
+      marker: { size: 3.5, color: '#E53E3E', opacity: 0.4, symbol: 'x' }
+    });
   }
+
+  const benchmarkZ = benchmarkTrace.z;
 
   // Layout configuration
   const layout = {
@@ -304,16 +328,20 @@ function renderPlot() {
     },
     scene: {
       xaxis: {
-        title: 'Value 1 total size',
+        title: 'Haystack Size (array, log)',
+        type: 'log',
         gridcolor: '#E0E0E0'
       },
       yaxis: {
-        title: 'Value 2 total size',
+        title: 'Needles Size (index count)',
         gridcolor: '#E0E0E0'
       },
       zaxis: {
         title: 'Time (nanoseconds)',
         gridcolor: '#E0E0E0'
+      },
+      camera: {
+        eye: { x: 1.7, y: -1.7, z: 0.6 }
       }
     },
     showlegend: true,
@@ -345,10 +373,88 @@ function renderPlot() {
   };
 
   // Render
-  // Clear loading message
   const container = document.getElementById('plot-container');
   container.innerHTML = '';
   Plotly.newPlot('plot-container', traces, layout, config);
+}
+
+function renderHistogram() {
+  const container = document.getElementById('hist-container');
+
+  // Net per-index time for large index counts
+  const points = benchmarkData.filter(d => d.args[1] >= histThreshold);
+  if (points.length === 0) {
+    container.innerHTML = `<div class="error"><p>No benchmarks with index count ≥ ${histThreshold}</p></div>`;
+    return;
+  }
+
+  const perIndex = points.map(d => (d.time - overhead) / d.args[1]);
+
+  const histTrace = {
+    x: perIndex,
+    type: 'histogram',
+    name: `per-index time (y ≥ ${histThreshold})`,
+    xbins: { size: 1 },
+    marker: {
+      color: '#0033AD',
+      opacity: 0.8
+    }
+  };
+
+  const layout = {
+    title: {
+      text: `Distribution of net per-index time (index count ≥ ${histThreshold}, n = ${points.length})`,
+      font: { size: 18 }
+    },
+    xaxis: {
+      title: 'Net time per index (nanoseconds)',
+      gridcolor: '#E0E0E0'
+    },
+    yaxis: {
+      title: 'Benchmark count',
+      gridcolor: '#E0E0E0'
+    },
+    bargap: 0.05,
+    plot_bgcolor: '#FAFAFA',
+    paper_bgcolor: 'rgba(0,0,0,0)',
+    shapes: [],
+    annotations: []
+  };
+
+  // Mark the model's net time per index (ps -> ns) at the histogram threshold on
+  // the distribution.  The model is not linear in the index count, so this is the
+  // average over the indices of one call rather than a single slope.
+  const evaluate = costModel && CostModelEvaluators[costModel.modelType];
+  if (evaluate && histThreshold > 0) {
+    const coeffs = costModel.coefficients;
+    const perIndexNs =
+      (evaluate(coeffs, [0, histThreshold]) - evaluate(coeffs, [0, 0])) / histThreshold / 1000;
+    layout.shapes.push({
+      type: 'line',
+      x0: perIndexNs, x1: perIndexNs,
+      y0: 0, y1: 1,
+      yref: 'paper',
+      line: { color: '#E53E3E', width: 2, dash: 'dash' }
+    });
+    layout.annotations.push({
+      x: perIndexNs,
+      y: 1,
+      yref: 'paper',
+      yanchor: 'bottom',
+      text: `model: ${perIndexNs.toFixed(1)} ns/index at ${histThreshold}`,
+      showarrow: false,
+      font: { color: '#E53E3E' }
+    });
+  }
+
+  const config = {
+    responsive: true,
+    displayModeBar: true,
+    displaylogo: false
+  };
+
+  container.innerHTML = '';
+  Plotly.newPlot('hist-container', [histTrace], layout, config);
 }
 
 function setupControls() {
@@ -364,6 +470,13 @@ function setupControls() {
   zAxisModeSelect.addEventListener('change', (e) => {
     zAxisMode = e.target.value;
     renderPlot();
+  });
+
+  // Histogram threshold selector
+  const histThresholdSelect = document.getElementById('hist-threshold');
+  histThresholdSelect.addEventListener('change', (e) => {
+    histThreshold = parseInt(e.target.value, 10);
+    renderHistogram();
   });
 }
 

--- a/doc/cost-models/multiindexarray/plot.js
+++ b/doc/cost-models/multiindexarray/plot.js
@@ -16,19 +16,6 @@ const FUNCTION_NAME = 'MultiIndexArray';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'multiIndexArray';  // JSON uses camelCase
 const ARITY = 2;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -38,186 +25,19 @@ let showModel = true;
 let zAxisMode = 'zero';
 let histThreshold = 500;
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs.  Variant E is the PlutusV3 cost model from the vanRossem
-// hard fork (PV 11) onwards (C is the previous V3 era).
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'multiindexarray',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plots
     renderPlot();
     renderHistogram();
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats over the index count (second argument)
@@ -479,16 +299,3 @@ function setupControls() {
     renderHistogram();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/scalevalue/index.html
+++ b/doc/cost-models/scalevalue/index.html
@@ -8,23 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../insertcoin/index.html">InsertCoin</a></li>
-      <li><a href="../unionvalue/index.html">UnionValue</a></li>
-      <li><a href="../scalevalue/index.html" class="active">ScaleValue</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>ScaleValue Cost Model Visualization</h1>
@@ -110,17 +94,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/scalevalue/index.html
+++ b/doc/cost-models/scalevalue/index.html
@@ -21,6 +21,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -111,7 +112,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/scalevalue/plot.js
+++ b/doc/cost-models/scalevalue/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/scalevalue/plot.js
+++ b/doc/cost-models/scalevalue/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'ScaleValue';
 const COST_MODEL_NAME = 'scaleValue';
 const ARITY = 2;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,184 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'scalevalue',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -348,16 +169,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -473,3 +473,249 @@ function getBranchFromUrl() {
   const params = new URLSearchParams(window.location.search);
   return params.get('branch');
 }
+
+// ============================================================================
+// Shared page plumbing
+// ============================================================================
+// Every builtin page has the same navigation, data-source controls, URL
+// scheme and loading flow; a page supplies only its identity and rendering.
+// Adding a builtin page or switching to a new cost model file is done here,
+// in one place.
+
+const DEFAULT_BRANCH = 'master';
+const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
+const GITHUB_DATA_URL = 'https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data';
+
+const BENCH_CSV_FILE = 'benching-conway.csv';
+// Variant E is the PlutusV3 cost model from the vanRossem hard fork (PV 11)
+// onwards (C is the previous V3 era).
+const COST_MODEL_FILE = 'builtinCostModelE.json';
+const COST_MODEL_NOTE = '(PlutusV3 from PV 11 / vanRossem)';
+
+// One entry per builtin page, in navigation order.
+const PAGES = [
+  ['valuedata', 'ValueData'],
+  ['unvaluedata', 'UnValueData'],
+  ['valuecontains', 'ValueContains'],
+  ['lookupcoin', 'LookupCoin'],
+  ['insertcoin', 'InsertCoin'],
+  ['unionvalue', 'UnionValue'],
+  ['scalevalue', 'ScaleValue'],
+  ['listtoarray', 'ListToArray'],
+  ['lengthofarray', 'LengthOfArray'],
+  ['indexarray', 'IndexArray'],
+  ['multiindexarray', 'MultiIndexArray'],
+  ['indexbytestring', 'IndexByteString']
+];
+
+// LocalStorage keys
+const STORAGE_KEYS = {
+  BRANCH: 'plutus-viz-branch',
+  CSV_URL: 'plutus-viz-csv-url',
+  JSON_URL: 'plutus-viz-json-url',
+  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
+  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
+};
+
+function generateUrlFromBranch(branch) {
+  return URL_TEMPLATE.replace('{BRANCH}', branch);
+}
+
+function getFileUrls(baseUrl) {
+  return {
+    csv: `${baseUrl}/${BENCH_CSV_FILE}`,
+    json: `${baseUrl}/${COST_MODEL_FILE}`
+  };
+}
+
+// Load settings from localStorage (URL param takes precedence)
+function loadSettings() {
+  const urlBranch = getBranchFromUrl();
+  return {
+    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
+    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
+    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
+    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
+  };
+}
+
+function saveSettings(branch, csvUrl, jsonUrl) {
+  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
+  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
+  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
+}
+
+// Update URL fields based on branch name
+function updateUrlsFromBranch() {
+  const branchInput = document.getElementById('branch-name');
+  const csvInput = document.getElementById('csv-url');
+  const jsonInput = document.getElementById('json-url');
+
+  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
+  const urls = getFileUrls(generateUrlFromBranch(branch));
+
+  csvInput.value = urls.csv;
+  jsonInput.value = urls.json;
+}
+
+function showError(message) {
+  const container = document.getElementById('plot-container');
+  container.innerHTML = `
+    <div class="error">
+      <h3>Error Loading Data</h3>
+      <p>${message}</p>
+    </div>
+  `;
+}
+
+// Fill <nav> with the standard page list; `active` is the page's slug and
+// `prefix` the relative path to the site root ('..' from a page, '.' from
+// the home page).
+function renderNav(active, prefix = '..') {
+  const nav = document.querySelector('nav');
+  if (!nav) return;
+  const items = [[`${prefix}/index.html`, 'Home', active === null]].concat(
+    PAGES.map(([slug, name]) => [`${prefix}/${slug}/index.html`, name, slug === active]));
+  nav.innerHTML = '<ul>' + items.map(([href, name, isActive]) =>
+    `<li><a href="${href}"${isActive ? ' class="active"' : ''}>${name}</a></li>`).join('') + '</ul>';
+}
+
+function renderFooter() {
+  const footer = document.querySelector('footer');
+  if (!footer) return;
+  footer.innerHTML = '<p>Plutus Cost Model Visualization | ' +
+    '<a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>';
+}
+
+// Fill the info-panel "Data sources" list from the shared file names.
+function renderDataSources() {
+  const el = document.getElementById('info-data-sources');
+  if (!el) return;
+  el.innerHTML = `
+    <dt>Data sources:</dt>
+    <dd><a href="${GITHUB_DATA_URL}/${BENCH_CSV_FILE}" target="_blank">${BENCH_CSV_FILE}</a></dd>
+    <dd><a href="${GITHUB_DATA_URL}/${COST_MODEL_FILE}" target="_blank">${COST_MODEL_FILE}</a>
+      ${COST_MODEL_NOTE}</dd>
+  `;
+}
+
+
+/**
+ * Wire up a builtin page.  The page supplies its identity and two callbacks;
+ * everything else -- navigation, data-source controls, URL handling,
+ * loading -- is shared.
+ *
+ * @param {Object} page
+ * @param {string} page.slug            Directory name, used to highlight the nav
+ * @param {string} page.functionName    Benchmark name (PascalCase, as in the CSV)
+ * @param {string} page.costModelName   Cost model key (camelCase, as in the JSON)
+ * @param {number} page.arity           Number of arguments, for the Nop overhead
+ * @param {Function} page.render        Called with {benchmarkData, costModel,
+ *                                      overhead, modelPredictions} after each load
+ * @param {Function} page.setupControls Called once to wire plot-specific controls
+ */
+function setupCostModelPage(page) {
+  async function loadAndRenderData() {
+    const container = document.getElementById('plot-container');
+    container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
+
+    try {
+      const csvUrl = document.getElementById('csv-url').value.trim();
+      const jsonUrl = document.getElementById('json-url').value.trim();
+
+      if (!csvUrl || !jsonUrl) {
+        showError('Please provide both CSV and JSON file URLs');
+        return;
+      }
+
+      const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
+
+      const benchmarkData = filterByFunction(parsedData, page.functionName);
+      if (benchmarkData.length === 0) {
+        showError(`No benchmark data found for ${page.functionName}`);
+        return;
+      }
+
+      const costModel = extractCostModel(costModelJson, page.costModelName);
+      const overhead = overheadMap[page.arity] || 0;
+      const modelPredictions =
+        costModel ? generateModelPredictions(benchmarkData, costModel, overhead) : [];
+
+      page.render({ benchmarkData, costModel, overhead, modelPredictions });
+    } catch (error) {
+      console.error('Error loading data:', error);
+      showError(`Failed to load data. Check console for details. Error: ${error.message}`);
+    }
+  }
+
+  async function init() {
+    renderNav(page.slug);
+    renderFooter();
+    renderDataSources();
+
+    const settings = loadSettings();
+
+    // Collapsible sections
+    const dataSourceControls = document.getElementById('data-source-controls');
+    const dataSourceToggle = document.getElementById('data-source-toggle');
+    if (dataSourceControls && dataSourceToggle) {
+      if (settings.collapsed) {
+        dataSourceControls.classList.add('collapsed');
+      }
+      dataSourceToggle.addEventListener('click', () => {
+        const isCollapsed = dataSourceControls.classList.toggle('collapsed');
+        localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
+      });
+    }
+
+    const plotControls = document.getElementById('plot-controls');
+    const plotControlsToggle = document.getElementById('plot-controls-toggle');
+    if (plotControls && plotControlsToggle) {
+      if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
+        plotControls.classList.add('collapsed');
+      }
+      plotControlsToggle.addEventListener('click', () => {
+        const isCollapsed = plotControls.classList.toggle('collapsed');
+        localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
+      });
+    }
+
+    // Data-source inputs
+    const branchInput = document.getElementById('branch-name');
+    const csvInput = document.getElementById('csv-url');
+    const jsonInput = document.getElementById('json-url');
+
+    branchInput.value = settings.branch;
+    if (settings.csvUrl && settings.jsonUrl) {
+      csvInput.value = settings.csvUrl;
+      jsonInput.value = settings.jsonUrl;
+    } else {
+      updateUrlsFromBranch();
+    }
+    branchInput.addEventListener('input', updateUrlsFromBranch);
+
+    document.getElementById('reload-data').addEventListener('click', async () => {
+      const branch = branchInput.value.trim() || DEFAULT_BRANCH;
+      saveSettings(branch, csvInput.value.trim(), jsonInput.value.trim());
+      await loadAndRenderData();
+    });
+
+    document.getElementById('copy-link').addEventListener('click', () => {
+      const branch = branchInput.value.trim() || DEFAULT_BRANCH;
+      const url = new URL(window.location.href);
+      url.search = '';
+      url.searchParams.set('branch', branch);
+      navigator.clipboard.writeText(url.toString());
+      const btn = document.getElementById('copy-link');
+      const original = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(() => btn.textContent = original, 1500);
+    });
+
+    page.setupControls();
+
+    await loadAndRenderData();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+}

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -201,12 +201,13 @@ const CostModelEvaluators = {
     return 0;
   },
 
+  // c00 + c10*x + c01*y + c11*x*y, the coefficient names the JSON uses
+  // (TwoVariableWithInteractionFunction in CostingFun.Core).
   with_interaction_in_x_and_y: (coeffs, args) => {
-    const c0 = coeffs.intercept ?? coeffs.c0 ?? 0;
-    const cx = coeffs.slopex ?? coeffs.c1 ?? 0;
-    const cy = coeffs.slopey ?? coeffs.c2 ?? 0;
-    const cxy = coeffs.slopexy ?? coeffs.c3 ?? 0;
-    return c0 + cx * args[0] + cy * args[1] + cxy * args[0] * args[1];
+    return (coeffs.c00 ?? 0)
+      + (coeffs.c10 ?? 0) * args[0]
+      + (coeffs.c01 ?? 0) * args[1]
+      + (coeffs.c11 ?? 0) * args[0] * args[1];
   },
 
   linear_in_u: (coeffs, args) => {
@@ -391,10 +392,11 @@ function formatModelFormula(modelType, coefficients) {
     }
 
     case 'with_interaction_in_x_and_y': {
-      const cx = coefficients.slopex ?? coefficients.c1 ?? 0;
-      const cy = coefficients.slopey ?? coefficients.c2 ?? 0;
-      const cxy = coefficients.slopexy ?? coefficients.c3 ?? 0;
-      return `${formatCoeff(c0)} + ${formatCoeff(cx)} × (arg1) + ${formatCoeff(cy)} × (arg2) + ${formatCoeff(cxy)} × (arg1×arg2) picoseconds`;
+      const c00 = coefficients.c00 ?? 0;
+      const c10 = coefficients.c10 ?? 0;
+      const c01 = coefficients.c01 ?? 0;
+      const c11 = coefficients.c11 ?? 0;
+      return `${formatCoeff(c00)} + ${formatCoeff(c10)} × (arg1) + ${formatCoeff(c01)} × (arg2) + ${formatCoeff(c11)} × (arg1×arg2) picoseconds`;
     }
 
     case 'linear_in_u':

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -443,12 +443,14 @@ async function loadData(csvUrl, jsonUrl) {
       fetch(jsonUrl)
     ]);
 
+    // Include status and URL: a stale saved branch (deleted after its PR
+    // merges) is the routine failure here, and the URL is what reveals it.
     if (!csvResponse.ok) {
-      throw new Error(`Failed to load CSV: ${csvResponse.statusText}`);
+      throw new Error(`CSV request returned HTTP ${csvResponse.status} for ${csvUrl}`);
     }
 
     if (!jsonResponse.ok) {
-      throw new Error(`Failed to load JSON: ${jsonResponse.statusText}`);
+      throw new Error(`JSON request returned HTTP ${jsonResponse.status} for ${jsonUrl}`);
     }
 
     const csvText = await csvResponse.text();

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -239,7 +239,7 @@ function evaluateCostModel(modelType, coefficients, args) {
 }
 
 /**
- * Extract cost model from builtinCostModelC.json for a specific function
+ * Extract cost model from builtinCostModelE.json for a specific function
  * Returns { modelType, coefficients } or null if not found
  */
 function extractCostModel(costModelJson, functionName) {

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -564,12 +564,15 @@ function updateUrlsFromBranch() {
 
 function showError(message) {
   const container = document.getElementById('plot-container');
+  // The message can contain request URLs built from the user-editable
+  // data-source fields, so it goes in as text, never as HTML.
   container.innerHTML = `
     <div class="error">
       <h3>Error Loading Data</h3>
-      <p>${message}</p>
+      <p></p>
     </div>
   `;
+  container.querySelector('.error p').textContent = message;
 }
 
 // Fill <nav> with the standard page list; `active` is the page's slug and

--- a/doc/cost-models/unionvalue/index.html
+++ b/doc/cost-models/unionvalue/index.html
@@ -8,23 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../insertcoin/index.html">InsertCoin</a></li>
-      <li><a href="../unionvalue/index.html" class="active">UnionValue</a></li>
-      <li><a href="../scalevalue/index.html">ScaleValue</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>UnionValue Cost Model Visualization</h1>
@@ -112,17 +96,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/unionvalue/index.html
+++ b/doc/cost-models/unionvalue/index.html
@@ -21,6 +21,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -113,7 +114,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/unionvalue/plot.js
+++ b/doc/cost-models/unionvalue/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'UnionValue';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'unionValue';  // JSON uses camelCase
 const ARITY = 2;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let zAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'unionvalue',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -366,16 +186,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/unvaluedata/index.html
+++ b/doc/cost-models/unvaluedata/index.html
@@ -18,6 +18,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -118,7 +119,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/unvaluedata/index.html
+++ b/doc/cost-models/unvaluedata/index.html
@@ -8,20 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html" class="active">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>UnValueData Cost Model Visualization</h1>
@@ -117,17 +104,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/unvaluedata/plot.js
+++ b/doc/cost-models/unvaluedata/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/unvaluedata/plot.js
+++ b/doc/cost-models/unvaluedata/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'UnValueData';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'unValueData';  // JSON uses camelCase
 const ARITY = 1;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'unvaluedata',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -349,16 +169,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/valuecontains/index.html
+++ b/doc/cost-models/valuecontains/index.html
@@ -8,20 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html" class="active">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>ValueContains Cost Model Visualization</h1>
@@ -123,17 +110,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/valuecontains/index.html
+++ b/doc/cost-models/valuecontains/index.html
@@ -18,6 +18,7 @@
       <li><a href="../listtoarray/index.html">ListToArray</a></li>
       <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
       <li><a href="../indexarray/index.html">IndexArray</a></li>
+      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
       <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
     </ul>
   </nav>
@@ -124,7 +125,7 @@
         <div class="info-section">
           <dt>Data sources:</dt>
           <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelC.json" target="_blank">builtinCostModelC.json</a></dd>
+          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
         </div>
       </div>
     </div>

--- a/doc/cost-models/valuecontains/plot.js
+++ b/doc/cost-models/valuecontains/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/valuecontains/plot.js
+++ b/doc/cost-models/valuecontains/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'ValueContains';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'valueContains';  // JSON uses camelCase
 const ARITY = 2;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let zAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'valuecontains',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -366,16 +186,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);

--- a/doc/cost-models/valuedata/index.html
+++ b/doc/cost-models/valuedata/index.html
@@ -8,20 +8,7 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
 <body>
-  <nav>
-    <ul>
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../valuedata/index.html" class="active">ValueData</a></li>
-      <li><a href="../unvaluedata/index.html">UnValueData</a></li>
-      <li><a href="../valuecontains/index.html">ValueContains</a></li>
-      <li><a href="../lookupcoin/index.html">LookupCoin</a></li>
-      <li><a href="../listtoarray/index.html">ListToArray</a></li>
-      <li><a href="../lengthofarray/index.html">LengthOfArray</a></li>
-      <li><a href="../indexarray/index.html">IndexArray</a></li>
-      <li><a href="../multiindexarray/index.html">MultiIndexArray</a></li>
-      <li><a href="../indexbytestring/index.html">IndexByteString</a></li>
-    </ul>
-  </nav>
+  <nav></nav>
 
   <div class="container">
     <h1>ValueData Cost Model Visualization</h1>
@@ -117,17 +104,13 @@
         </div>
 
         <div class="info-section">
-          <dt>Data sources:</dt>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv" target="_blank">benching-conway.csv</a></dd>
-          <dd><a href="https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/builtinCostModelE.json" target="_blank">builtinCostModelE.json</a></dd>
+          <dl id="info-data-sources"></dl>
         </div>
       </div>
     </div>
   </div>
 
-  <footer>
-    <p>Plutus Cost Model Visualization | <a href="https://github.com/IntersectMBO/plutus" target="_blank">Plutus Repository</a></p>
-  </footer>
+  <footer></footer>
 
   <script src="../shared/utils.js"></script>
   <script src="plot.js"></script>

--- a/doc/cost-models/valuedata/plot.js
+++ b/doc/cost-models/valuedata/plot.js
@@ -35,7 +35,7 @@ function generateUrlFromBranch(branch) {
 function getFileUrls(baseUrl) {
   return {
     csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelC.json`
+    json: `${baseUrl}/builtinCostModelE.json`
   };
 }
 

--- a/doc/cost-models/valuedata/plot.js
+++ b/doc/cost-models/valuedata/plot.js
@@ -5,19 +5,6 @@ const FUNCTION_NAME = 'ValueData';  // CSV uses PascalCase
 const COST_MODEL_NAME = 'valueData';  // JSON uses camelCase
 const ARITY = 1;
 
-// Default configuration
-const DEFAULT_BRANCH = 'master';
-const URL_TEMPLATE = 'https://raw.githubusercontent.com/IntersectMBO/plutus/{BRANCH}/plutus-core/cost-model/data';
-
-// LocalStorage keys
-const STORAGE_KEYS = {
-  BRANCH: 'plutus-viz-branch',
-  CSV_URL: 'plutus-viz-csv-url',
-  JSON_URL: 'plutus-viz-json-url',
-  DATA_SOURCE_COLLAPSED: 'plutus-viz-data-source-collapsed',
-  PLOT_CONTROLS_COLLAPSED: 'plutus-viz-plot-controls-collapsed'
-};
-
 // Global state
 let benchmarkData = [];
 let modelPredictions = [];
@@ -26,185 +13,18 @@ let overhead = 0;
 let showModel = true;
 let yAxisMode = 'zero';
 
-// Generate URL from template and branch
-function generateUrlFromBranch(branch) {
-  return URL_TEMPLATE.replace('{BRANCH}', branch);
-}
-
-// Get file URLs
-function getFileUrls(baseUrl) {
-  return {
-    csv: `${baseUrl}/benching-conway.csv`,
-    json: `${baseUrl}/builtinCostModelE.json`
-  };
-}
-
-// Load settings from localStorage (URL param takes precedence)
-function loadSettings() {
-  const urlBranch = getBranchFromUrl();
-  return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
-    collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
-  };
-}
-
-// Save settings to localStorage
-function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
-}
-
-// Update URL fields based on branch name
-function updateUrlsFromBranch() {
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-  const baseUrl = generateUrlFromBranch(branch);
-  const urls = getFileUrls(baseUrl);
-
-  csvInput.value = urls.csv;
-  jsonInput.value = urls.json;
-}
-
-// Initialize
-async function init() {
-  // Load saved settings
-  const settings = loadSettings();
-
-  // Set up collapsible data source section
-  const dataSourceControls = document.getElementById('data-source-controls');
-  const dataSourceToggle = document.getElementById('data-source-toggle');
-
-  if (settings.collapsed) {
-    dataSourceControls.classList.add('collapsed');
-  }
-
-  dataSourceToggle.addEventListener('click', () => {
-    const isCollapsed = dataSourceControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED, isCollapsed);
-  });
-
-  // Set up collapsible plot controls section
-  const plotControls = document.getElementById('plot-controls');
-  const plotControlsToggle = document.getElementById('plot-controls-toggle');
-
-  if (localStorage.getItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED) === 'true') {
-    plotControls.classList.add('collapsed');
-  }
-
-  plotControlsToggle.addEventListener('click', () => {
-    const isCollapsed = plotControls.classList.toggle('collapsed');
-    localStorage.setItem(STORAGE_KEYS.PLOT_CONTROLS_COLLAPSED, isCollapsed);
-  });
-
-  // Set up form inputs
-  const branchInput = document.getElementById('branch-name');
-  const csvInput = document.getElementById('csv-url');
-  const jsonInput = document.getElementById('json-url');
-
-  // Initialize with saved or default values
-  branchInput.value = settings.branch;
-
-  if (settings.csvUrl && settings.jsonUrl) {
-    csvInput.value = settings.csvUrl;
-    jsonInput.value = settings.jsonUrl;
-  } else {
-    updateUrlsFromBranch();
-  }
-
-  // Update URLs when branch name changes
-  branchInput.addEventListener('input', updateUrlsFromBranch);
-
-  // Load data button
-  const reloadButton = document.getElementById('reload-data');
-  reloadButton.addEventListener('click', async () => {
-    const branch = branchInput.value.trim() || DEFAULT_BRANCH;
-    const csvUrl = csvInput.value.trim();
-    const jsonUrl = jsonInput.value.trim();
-
-    // Save settings
-    saveSettings(branch, csvUrl, jsonUrl);
-
-    // Load data
-    await loadAndRenderData();
-  });
-
-  // Set up plot control event listeners (only once)
-  setupControls();
-
-  // Set up copy link button
-  document.getElementById('copy-link').addEventListener('click', () => {
-    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-    const url = new URL(window.location.href);
-    url.search = '';
-    url.searchParams.set('branch', branch);
-    navigator.clipboard.writeText(url.toString());
-    // Brief visual feedback
-    const btn = document.getElementById('copy-link');
-    const original = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = original, 1500);
-  });
-
-  // Initial load
-  await loadAndRenderData();
-}
-
-// Load and render data
-async function loadAndRenderData() {
-  // Show loading state
-  const container = document.getElementById('plot-container');
-  container.innerHTML = '<div class="loading">Loading data and generating plot...</div>';
-
-  try {
-    // Get URLs from form inputs
-    const csvUrl = document.getElementById('csv-url').value.trim();
-    const jsonUrl = document.getElementById('json-url').value.trim();
-
-    if (!csvUrl || !jsonUrl) {
-      showError('Please provide both CSV and JSON file URLs');
-      return;
-    }
-
-    // Load data
-    const { parsedData, costModelJson, overheadMap } = await loadData(csvUrl, jsonUrl);
-
-    // Filter for this function
-    benchmarkData = filterByFunction(parsedData, FUNCTION_NAME);
-
-    if (benchmarkData.length === 0) {
-      showError(`No benchmark data found for ${FUNCTION_NAME}`);
-      return;
-    }
-
-    // Extract cost model
-    costModel = extractCostModel(costModelJson, COST_MODEL_NAME);
-
-    // Get overhead
-    overhead = overheadMap[ARITY] || 0;
-
-    // Generate model predictions
-    if (costModel) {
-      modelPredictions = generateModelPredictions(benchmarkData, costModel, overhead);
-    }
-
-    // Update info panel
+setupCostModelPage({
+  slug: 'valuedata',
+  functionName: FUNCTION_NAME,
+  costModelName: COST_MODEL_NAME,
+  arity: ARITY,
+  render(data) {
+    ({ benchmarkData, costModel, overhead, modelPredictions } = data);
     updateInfoPanel();
-
-    // Render plot
     renderPlot();
-
-
-  } catch (error) {
-    console.error('Initialization error:', error);
-    showError(`Failed to load data. Check console for details. Error: ${error.message}`);
-  }
-}
+  },
+  setupControls
+});
 
 function updateInfoPanel() {
   // Calculate stats
@@ -349,16 +169,3 @@ function setupControls() {
     renderPlot();
   });
 }
-
-function showError(message) {
-  const container = document.getElementById('plot-container');
-  container.innerHTML = `
-    <div class="error">
-      <h3>Error Loading Data</h3>
-      <p>${message}</p>
-    </div>
-  `;
-}
-
-// Start initialization when page loads
-document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
Split out of #7869 so the costing changes and the visualization site can be reviewed separately; this PR is stacked on that branch and merges after it. It adds the multiIndexArray page and switches the pages to builtinCostModelE.json.

It also addresses the duplication kwxm pointed out in #7869: navigation, footer, data-source links, URL handling and the loading flow now live in shared/utils.js, and each page supplies only its identity and rendering (-2706/+405 lines). Introducing a new cost model file is now one edit in one place.
