### PR TITLE
Support ghc 9.14 in nix

### DIFF
--- a/.github/workflows/cabal-build-all.yml
+++ b/.github/workflows/cabal-build-all.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: [self-hosted, plutus-runner]
     strategy:
       matrix:
-        ghc: [ghc912, ghc96]
+        ghc: [ghc914, ghc96]
       fail-fast: false
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -107,6 +107,11 @@ if impl (ghc >= 9.14)
     location: https://github.com/snowleopard/alga
     tag: d4e43fb42db05413459fb2df493361d5a666588a
 
+  -- microstache (dependency of criterion) does not allow aeson 2.3 yet,
+  -- and without this constraint the solver hits the backjump limit.
+  constraints:
+    , aeson <2.3
+
   allow-newer:
     , canonical-json:containers
     , cborg:base
@@ -120,5 +125,6 @@ if impl (ghc >= 9.14)
     , serialise:base
     , serialise:containers
     , serialise:time
+    , turtle:containers
     , turtle:time
     , with-utf8:base

--- a/doc/notes/fomega/lazy-machine/ckmachine.tex
+++ b/doc/notes/fomega/lazy-machine/ckmachine.tex
@@ -11,8 +11,6 @@
                        &        &     & s \return V                 & \textrm{returning a term value}\\
                        &        &     & \ckerror{}                        & \textrm{throwing an error}\\
                        &        &     & \square V                        & \textrm{halt and return a value}
-
-
     \end{array}\]
 }
 \end{subfigure}

--- a/doc/papers/unraveling-recursion/RecursiveTerms.lagda
+++ b/doc/papers/unraveling-recursion/RecursiveTerms.lagda
@@ -35,11 +35,11 @@ following types:
   selfApply s = unself s s
 \end{code}
 
-\noindent The first thing we defined was $\Fix0 : (\Type \kindArrow \Type)
+\noindent The first thing we defined was $\FixZero : (\Type \kindArrow \Type)
 \kindArrow \Type$, which is a fixpoint operator that only works at kind $\Type$.
 We won't need the full power of $\ifix$ for this section, so the techniques
 here should be applicable for other recursive variants of \FOM{}, provided
-they are able to define $\Fix0$.
+they are able to define $\FixZero$.
 
 Now we can define the Y combinator and its $\eta$-expanded version, the Z combinator.
 
@@ -75,7 +75,7 @@ a non-strict and strict setting. We will present the steps
 using recursive definitions for clarity, but all of these can be implemented
 with the Z combinator.
 
-Let us start with the function $\fix2$ which takes the fixpoint of a function
+Let us start with the function $\fixTwo$ which takes the fixpoint of a function
 of 2-tuples.
 \begin{code}
   fix₂ : ∀ {A B} → (A × B → A × B) → A × B

--- a/doc/papers/unraveling-recursion/RecursiveTermsFormal.tex
+++ b/doc/papers/unraveling-recursion/RecursiveTermsFormal.tex
@@ -22,13 +22,10 @@ functions.
   \Lambda Q . 
   \lambda (k : F\ Q) . 
   r\ f\ \{ Q \}\ (f\ \{ Q \}\ k)))\\
-
   \selk{k}(\seq{T}) &=& \lambda (\seq{x:T}) . x_k\\
-
   \by(\seq{T}) &=& \lambda (r : \forall Q . (\seqFunArr{T}{Q}) \rightarrow Q) . \Lambda Q. 
   \lambda (k : \seqFunArr{T}{Q}).
   k\ \seq{\fixed{r}\ \{ \fixed{Q} \}\ (\selk{j} \fixed{(\seq{T})})}^j\\
-
   \fixml(\seq{T}) &=& \fixBy\ \{ \lambda Q . \seqFunArr{T}{Q} \}\ \by(\seq{T})\\
   \\
   \multicolumn{3}{l}{\textsc{Compilation function}}\\

--- a/doc/papers/unraveling-recursion/unraveling-recursion.tex
+++ b/doc/papers/unraveling-recursion/unraveling-recursion.tex
@@ -91,8 +91,8 @@ Michael Peyton Jones\inst{1}\orcidID{0000-0003-0602-1657}
 \DeclareMathOperator{\fixo}{\texttt{fix}}
 % metalanguage version for functions
 \DeclareMathOperator{\fixml}{\mathsf{fix}}
-\DeclareMathOperator{\Fix0}{\mathsf{Fix}_0}
-\DeclareMathOperator{\fix2}{\mathsf{fix}_2}
+\DeclareMathOperator{\FixZero}{\mathsf{Fix}_0}
+\DeclareMathOperator{\fixTwo}{\mathsf{fix}_2}
 \DeclareMathOperator{\fixBy}{\mathsf{fixBy}}
 
 % fir syntax bits

--- a/doc/plutus-core-spec-old/figures/Builtins.tex
+++ b/doc/plutus-core-spec-old/figures/Builtins.tex
@@ -87,7 +87,6 @@
     \hspace{\builtinoffset}\(\begin{array}{llclll}
     \textrm{Builtin Name} & \textrm{Signature}& \textrm{Type Args} & \textrm{Term Args} & \textrm{Semantics} & \textrm{Success Conditions}\\
 \hline\\
-
 \texttt{ifThenElse}  &  \sig{\alpha}{\boolean, \alpha, \alpha}{\alpha} & \alpha & b, t_1, t_2 &
 \hspace{-2mm} \begin{array}{ll}
   t_1 & \mbox{if $b=\true$}\\
@@ -113,7 +112,6 @@
         \texttt{greaterThanByteString}  &   \sig{}{\str,\str}{\boolean}   & - & s_1 , s_2 & s_1 > s_2\\
         \texttt{takeByteString}         &   \sig{}{\integer,\str}{\str}   & - &   i, s    & \texttt{take} \ i \  s\\
         \texttt{dropByteString}         &   \sig{}{\integer,\str}{\str}   & - &   i, s    & \texttt{drop} \ i \  s\\
-
         \texttt{sha2$\_256$}         &  \sig{}{\str}{\str}  & - &   s           & sha2\_256 \  s\\
         \texttt{sha3$\_256$}         &  \sig{}{\str}{\str}  & - &   s           & sha3\_256\  s\\
 \\
@@ -124,7 +122,6 @@
   \\[-3mm]
   \mathtt{False} & \mbox{otherwise}
   \end{array} &\\
-
     \end{array}\)
 
     \vspace{1em}

--- a/doc/plutus-core-spec-old/figures/LexicalGrammar.tex
+++ b/doc/plutus-core-spec-old/figures/LexicalGrammar.tex
@@ -5,26 +5,18 @@
 \begin{minipage}{\linewidth}
     \centering
     \[\begin{array}{lrclr}
-
         \textrm{Name}        & n      & ::= & [\texttt{a}\!\hyphen{}\!\texttt{z}\texttt{A}\!\hyphen{}\!\texttt{Z}][\texttt{a}\!\hyphen{}\!\texttt{zA}\!\hyphen{}\!\texttt{Z0}\!\hyphen{}\!\texttt{9\_'}]^*   & \textrm{name}\\
-
         \textrm{Var}           & x      & ::= & n & \textrm{term variable}\\
         \textrm{TyVar}         & \alpha & ::= & n & \textrm{type variable}\\
         \textrm{BuiltinName}   & bn     & ::= & n & \textrm{builtin term name}\\
         \textrm{Integer} & i  & ::= & [\texttt{+-}]^?[\texttt{0}\!\hyphen{}\!\texttt{9}]^+ & \textrm{integer}\\
-
         \textrm{ByteString}   & s  & ::= & \texttt{\#}([\texttt{a}\!\hyphen{}\!\texttt{fA}\!\hyphen{}\!\texttt{F0}\!\hyphen{}\!\texttt{9}][\texttt{a}\!\hyphen{}\!\texttt{fA}\!\hyphen{}\!\texttt{F0}\!\hyphen{}\!\texttt{9}])^+ & \textrm{hex string}\\
-
         \textrm{Version} & v & ::= & [\texttt{0}\!\hyphen{}\!\texttt{9}]^+(.[\texttt{0}\!\hyphen{}\!\texttt{9}]^+)^* & \textrm{version}\\
-
         \textrm{Constant} & cn & ::= & \texttt{()} & \textrm{unit constant}\\
                           &    &     & \true \texttt{\,|\,} \false & \textrm{boolean constant}\\
                           &    &     & i & \textrm{integer constant}\\
                           &    &     & s & \textrm{bytestring constant}\\
-
         \textrm{TypeConstant} & tn    & ::= & n & \textrm{type constant}\\
-
-
     \end{array}\]
     \captionof{figure}{Lexical grammar of Plutus Core}
     \label{fig:lexical-grammar}

--- a/doc/plutus-core-spec-old/figures/TermReduction.tex
+++ b/doc/plutus-core-spec-old/figures/TermReduction.tex
@@ -18,7 +18,6 @@
                        &   &     & \inAppLeftFrame{M}                 & \textrm{left application}\\
                        &   &     & \inAppRightFrame{V}                & \textrm{right application}\\
                        &   &     & \inBuiltin{bn}{A^*}{V^*}{\_}{M^*}   & \textrm{builtin application}\\
-
     \end{array}\]
     \caption{Grammar of reduction frames}
     \label{fig:reduction-frames}

--- a/doc/plutus-core-spec-old/figures/TypedGrammar.tex
+++ b/doc/plutus-core-spec-old/figures/TypedGrammar.tex
@@ -29,7 +29,6 @@
         \textrm{Signature}        & G      & ::= & \sig{(\alpha :: K)^*}{B^*}{C}     & \textrm{signature}\\
         \textrm{Constant Signature}   & Q      & ::= & tn                     & \textrm{constant signature}\\
         \textrm{Program}          & P      & ::= & \version{v}{M}             & \textrm{versioned program}
-
     \end{array}\]
     \captionof{figure}{Grammar of Plutus Core}
     \label{fig:grammar}

--- a/doc/plutus-core-spec-old/figures/UntypedGrammar.tex
+++ b/doc/plutus-core-spec-old/figures/UntypedGrammar.tex
@@ -14,7 +14,6 @@
                         &        &     & \builtinU{bn}{M^*}     & \textrm{builtin}\\
                         &        &     & \errorU                & \textrm{error}\\
         \textrm{Program}& P      & ::= & \version{v}{M}         & \textrm{versioned program}
-
     \end{array}\]
     \captionof{figure}{Grammar of untyped Plutus Core}
     \label{fig:untyped-grammar}

--- a/doc/plutus-core-spec/builtins.tex
+++ b/doc/plutus-core-spec/builtins.tex
@@ -568,7 +568,6 @@ must have been an argument of the builtin.
 
 %% \begin{minipage}{\linewidth}
 %%     \centering \[\begin{array}{llll}
-
 %%     t & ::= & b   &\text{for } b \in \Uni  \\
 %%     & & \typearg                 \\
 %%     & & \star               \\

--- a/doc/plutus-core-spec/untyped-cek-machine.tex
+++ b/doc/plutus-core-spec/untyped-cek-machine.tex
@@ -60,7 +60,6 @@ to apply a variable to some other term).
                        &    &       & \inAppRightFrame{V}                                                 & \textrm{right application of value}\\
                        &    &       & \inConstrFrame{i}{\repetition{V}}{(\repetition{M}, \rho)}           & \textrm{constructor argument}\\
                        &    &       & \inCaseFrame{(\repetition{M}, \rho)}                                & \textrm{case scrutinee}
-
     \end{array}\]
     \caption{Grammar of CEK stack frames}
     \label{fig:untyped-cek-reduction-frames}

--- a/doc/plutus-core-spec/untyped-grammar.tex
+++ b/doc/plutus-core-spec/untyped-grammar.tex
@@ -15,15 +15,12 @@ binary format described in Appendix~\ref{appendix:flat-serialisation}.
 \begin{minipage}{\linewidth}
     \centering
     \[\begin{array}{lrclr}
-
         \textrm{Name}          & n      & ::= & \texttt{[a-zA-Z][a-zA-Z0-9\_\textquotesingle]*(-[0-9]+)?}   & \textrm{name}\\
-
         \textrm{Var}           & x      & ::= & n & \textrm{term variable}\\
         \textrm{BuiltinName}   & bn     & ::= & n & \textrm{built-in function name}\\
         \textrm{Version} & v & ::= & \texttt{[0-9]+.[0-9]+.[0-9]+}& \textrm{version}\\
         \textrm{Natural}  & k      & ::= & \texttt{[0-9]+} & \textrm{a natural number}\\
         \textrm{Constant} & c & ::= & \langle{\textrm{literal constant}}\rangle& \\
-
     \end{array}\]
     \captionof{figure}{Lexical grammar of Plutus Core}
     \label{fig:lexical-grammar-untyped}
@@ -76,7 +73,6 @@ binary format described in Appendix~\ref{appendix:flat-serialisation}.
                         &        &     & \kase{M}{N_1 \ldots N_n}        & \textrm{case analysis with $n$ alternatives ($n \geq 0$)}\\
                         &        &     & \errorU                         & \textrm{error}\\
         \textrm{Program}& P      & ::= & \version{v}{M}                  & \textrm{versioned program}
-
     \end{array}\]
     \captionof{figure}{Grammar of untyped Plutus Core}
     \label{fig:untyped-grammar}

--- a/flake.lock
+++ b/flake.lock
@@ -50,23 +50,6 @@
         "type": "github"
       }
     },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -208,11 +191,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1756772734,
-        "narHash": "sha256-kot2lTSCBuWIuJAm28n9PSbrIqrOn92u83kVWFBtZtI=",
+        "lastModified": 1786581049,
+        "narHash": "sha256-mjhsrGtCWCCAogFABIDH4zF3f05017lps8NUbKum0QA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "0dabf399347c164d6309843a0fe84460cbc008ec",
+        "rev": "a9a9b63cb1c7e09496857720b78bae3c625a5247",
         "type": "github"
       },
       "original": {
@@ -238,10 +221,25 @@
         "type": "github"
       }
     },
+    "hackage-overlay-repo-tool": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1671663228,
+        "narHash": "sha256-GKeke8FT9w2u6J9aI4eN3mOV0BURHiytQAEir4/4M1Q=",
+        "owner": "bgamari",
+        "repo": "hackage-overlay-repo-tool",
+        "rev": "f60aa0d497961745a503ddea2adb0facb58376e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bgamari",
+        "repo": "hackage-overlay-repo-tool",
+        "type": "github"
+      }
+    },
     "haskell-nix": {
       "inputs": {
         "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
@@ -251,11 +249,14 @@
         ],
         "hackage-for-stackage": "hackage-for-stackage",
         "hackage-internal": "hackage-internal",
+        "hackage-overlay-repo-tool": "hackage-overlay-repo-tool",
+        "head-hackage": "head-hackage",
         "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -275,22 +276,41 @@
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1756774299,
-        "narHash": "sha256-sHqFfSIi0ghs7xsS/033rUYzNU6DYSsMze+oxIS2hc4=",
+        "lastModified": 1786582325,
+        "narHash": "sha256-mTU9Mti1/oL3zMeFvW/LQ55NNjaRURflfoJpK3q+QQg=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ac987ef18ca39c612dc08a80ee4550c99b66fd9a",
+        "rev": "abd2d75a7b75994f9d2ca4933fccc901b6da6afa",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
         "type": "github"
+      }
+    },
+    "head-hackage": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.haskell.org",
+        "lastModified": 1780387533,
+        "narHash": "sha256-oifEa/JYg8ZLUtkbM8HVzKmqCcT9QxaDmG0ex2qT0Ng=",
+        "owner": "ghc",
+        "repo": "head.hackage",
+        "rev": "a50bec6c7722f774415bc0f0a0e64f6e2b8989b7",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.haskell.org",
+        "owner": "ghc",
+        "repo": "head.hackage",
+        "type": "gitlab"
       }
     },
     "hls": {
@@ -373,6 +393,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -555,11 +592,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1778457436,
+        "narHash": "sha256-bzZAHGzwcQGzBTipJuUs9tvMGO28kp0373zqnpn0g5A=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "8cdc446f8e2d91b120ecc075063e9475d387df52",
         "type": "github"
       },
       "original": {
@@ -635,11 +672,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -651,11 +688,11 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1754477006,
-        "narHash": "sha256-suIgZZHXdb4ca9nN4MIcmdjeN+ZWsTwCtYAG4HExqAo=",
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4896699973299bffae27d0d9828226983544d9e9",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
         "type": "github"
       },
       "original": {
@@ -665,13 +702,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1754393734,
-        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -773,11 +826,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1756771957,
-        "narHash": "sha256-4gpnaFvpLwD+jk1BGkGcNPWPy0pKHCLd0suGPrP9tJk=",
+        "lastModified": 1786580371,
+        "narHash": "sha256-Iij40uujjMWTRIO2DYxLdboGw2PJG0Y589xuVJG5P8s=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "ad1a53a776a6e1a9e106898d88df9920a6e80d4a",
+        "rev": "b64465aaacaf1d0eb72e0794ee68ef5aefcddaf8",
         "type": "github"
       },
       "original": {

--- a/nix/agda-tools.nix
+++ b/nix/agda-tools.nix
@@ -2,31 +2,9 @@
 
 let
 
-  # Agda standard library pinned to v2.3.
+  # Agda standard library, v2.3 in the current nixpkgs.
   # Used in: `nix/metatheory.nix` (as a build input) and `nix/shell.nix` (via agda-with-stdlib).
-  agda-stdlib = agda-packages.standard-library.overrideAttrs (oldAtts: rec {
-
-    version = "2.3";
-
-    src = pkgs.fetchFromGitHub {
-      repo = "agda-stdlib";
-      owner = "agda";
-      rev = "v${version}";
-      sha256 = "sha256-JOeoek6OfyIk9vwTj5QUJU6LnRzwfiG0e0ysW6zbhZ8=";
-    };
-
-    # This is preConfigure is copied from more recent nixpkgs that also
-    # uses version 2.3 of standard-library. Old nixpkgs (that used 1.4)
-    # had a preConfigure step that worked with 1.7. Less old nixpkgs
-    # (that used 1.6) had a preConfigure step that attempts to `rm`
-    # files that are now in the .gitignore list for 1.
-    preConfigure = ''
-      runhaskell GenerateEverything.hs --include-deprecated
-      # We will only build/consider Everything.agda, in particular we don't want Everything*.agda
-      # do be copied to the store.
-      rm EverythingSafe.agda
-    '';
-  });
+  agda-stdlib = agda-packages.standard-library;
 
   # Compose a tailored Agda toolchain and expose it via agdaPackages.
   # Used in: `nix/metatheory.nix` (to build agda-with-stdlib-and-metatheory) and `nix/shell.nix`.

--- a/nix/fourmolu.nix
+++ b/nix/fourmolu.nix
@@ -21,6 +21,11 @@ let
       inherit (attrs) rev sha256;
     };
     compiler-nix-name = ghc;
+    # The fork pins an old index-state whose ghc-lib-parser snapshot no longer
+    # compiles with GHC 9.12.4; solve against a newer index instead.
+    cabalProjectLocal = ''
+      index-state: 2026-06-22T23:30:49Z
+    '';
   };
 
 in

--- a/nix/metatheory.nix
+++ b/nix/metatheory.nix
@@ -83,7 +83,7 @@ let
     {
       buildInputs = [
         pkgs.jekyll
-        inputs.nixpkgs-2405.legacyPackages.${pkgs.system}.linkchecker
+        inputs.nixpkgs-2405.legacyPackages.${pkgs.stdenv.hostPlatform.system}.linkchecker
       ];
     } ''
     mkdir "$out"

--- a/nix/metatheory.nix
+++ b/nix/metatheory.nix
@@ -8,9 +8,14 @@ let
     pname = "plutus-metatheory";
     src = lib.cleanSource (self + /plutus-metatheory);
     buildInputs = [ agda-tools.agda-stdlib ];
-    # The everythingFile is the compilation target for Agda, and is assumed
-    # to transitively reference all other .agda files in the project.
-    everythingFile = "./src/index.lagda.md";
+    # The default buildPhase runs `agda --build-library`, which checks every
+    # file in the library. We only want to check index.lagda.md and the files
+    # it transitively references.
+    buildPhase = ''
+      runHook preBuild
+      agda src/index.lagda.md
+      runHook postBuild
+    '';
     meta = { };
   };
 

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -121,15 +121,9 @@ let
     ghc914 = mkShell "ghc914";
     ghc96-profiled = mkShell "ghc96-profiled";
     ghc912-profiled = mkShell "ghc912-profiled";
-    ghc914-profiled = mkShell "ghc914-profiled";
     metatheory-jailbreak = metatheory-jailbreak-shell;
   };
 
-  # The dev shells built by CI. All the entries must live in a single attrset:
-  # `//` merges shallowly, so consecutive `{ devShells.* = ...; }` operands
-  # would override one another and only the last one would become a CI job.
-  # The profiled shells are deliberately excluded: they force profiled builds
-  # of the entire dependency closure, which CI does not otherwise build.
   ci-devShells = {
     devShells.ghc96 = devShells.ghc96;
     devShells.ghc912 = devShells.ghc912;
@@ -142,7 +136,6 @@ let
       (windows-hydra-jobs) //
       (packages) //
       { ghc96 = project-variants-hydra-jobs.ghc96; } //
-      { ghc912 = project-variants-hydra-jobs.ghc912; } //
       { ghc914 = project-variants-hydra-jobs.ghc914; } //
       (ci-devShells) //
       { required = hydra-required-job; };

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -78,8 +78,10 @@ let
   project-variants-hydra-jobs = {
     ghc96 = (project.flake { }).hydraJobs.ghc96;
     ghc912 = (project.flake { }).hydraJobs.ghc912;
+    ghc914 = (project.flake { }).hydraJobs.ghc914;
     ghc96-profiled = (project.flake { }).hydraJobs.ghc96-profiled;
     ghc912-profiled = (project.flake { }).hydraJobs.ghc912-profiled;
+    ghc914-profiled = (project.flake { }).hydraJobs.ghc914-profiled;
   };
 
   project-variants-roots-and-plan-nix = {
@@ -87,10 +89,14 @@ let
     ghc96.plan-nix = project-variants-hydra-jobs.ghc96.plan-nix;
     ghc912.roots = project-variants-hydra-jobs.ghc912.roots;
     ghc912.plan-nix = project-variants-hydra-jobs.ghc912.plan-nix;
+    ghc914.roots = project-variants-hydra-jobs.ghc914.roots;
+    ghc914.plan-nix = project-variants-hydra-jobs.ghc914.plan-nix;
     ghc96-profiled.roots = project-variants-hydra-jobs.ghc96-profiled.roots;
     ghc96-profiled.plan-nix = project-variants-hydra-jobs.ghc96-profiled.plan-nix;
     ghc912-profiled.roots = project-variants-hydra-jobs.ghc912-profiled.roots;
     ghc912-profiled.plan-nix = project-variants-hydra-jobs.ghc912-profiled.plan-nix;
+    ghc914-profiled.roots = project-variants-hydra-jobs.ghc914-profiled.roots;
+    ghc914-profiled.plan-nix = project-variants-hydra-jobs.ghc914-profiled.plan-nix;
   };
 
   packages =
@@ -112,8 +118,10 @@ let
     default = ghc96;
     ghc96 = mkShell "ghc96";
     ghc912 = mkShell "ghc912";
+    ghc914 = mkShell "ghc914";
     ghc96-profiled = mkShell "ghc96-profiled";
     ghc912-profiled = mkShell "ghc912-profiled";
+    ghc914-profiled = mkShell "ghc914-profiled";
     metatheory-jailbreak = metatheory-jailbreak-shell;
   };
 
@@ -123,10 +131,13 @@ let
       (packages) //
       { ghc96 = project-variants-hydra-jobs.ghc96; } //
       { ghc912 = project-variants-hydra-jobs.ghc912; } //
+      { ghc914 = project-variants-hydra-jobs.ghc914; } //
       { devShells.ghc96 = devShells.ghc96; } //
       { devShells.ghc912 = devShells.ghc912; } //
+      { devShells.ghc914 = devShells.ghc914; } //
       { devShells.ghc96-profiled = devShells.ghc96-profiled; } //
       { devShells.ghc912-profiled = devShells.ghc912-profiled; } //
+      { devShells.ghc914-profiled = devShells.ghc914-profiled; } //
       { devShells.metatheory-jailbreak = metatheory-jailbreak-shell; } //
       { required = hydra-required-job; };
     "x86_64-darwin" =
@@ -137,8 +148,10 @@ let
       (project-variants-roots-and-plan-nix) //
       { devShells.ghc96 = devShells.ghc96; } //
       { devShells.ghc912 = devShells.ghc912; } //
+      { devShells.ghc914 = devShells.ghc914; } //
       { devShells.ghc96-profiled = devShells.ghc96-profiled; } //
       { devShells.ghc912-profiled = devShells.ghc912-profiled; } //
+      { devShells.ghc914-profiled = devShells.ghc914-profiled; } //
       { devShells.metatheory-jailbreak = metatheory-jailbreak-shell; } //
       { required = hydra-required-job; };
   };

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -125,6 +125,18 @@ let
     metatheory-jailbreak = metatheory-jailbreak-shell;
   };
 
+  # The dev shells built by CI. All the entries must live in a single attrset:
+  # `//` merges shallowly, so consecutive `{ devShells.* = ...; }` operands
+  # would override one another and only the last one would become a CI job.
+  # The profiled shells are deliberately excluded: they force profiled builds
+  # of the entire dependency closure, which CI does not otherwise build.
+  ci-devShells = {
+    devShells.ghc96 = devShells.ghc96;
+    devShells.ghc912 = devShells.ghc912;
+    devShells.ghc914 = devShells.ghc914;
+    devShells.metatheory-jailbreak = metatheory-jailbreak-shell;
+  };
+
   nested-ci-jobs = {
     "x86_64-linux" =
       (windows-hydra-jobs) //
@@ -132,13 +144,7 @@ let
       { ghc96 = project-variants-hydra-jobs.ghc96; } //
       { ghc912 = project-variants-hydra-jobs.ghc912; } //
       { ghc914 = project-variants-hydra-jobs.ghc914; } //
-      { devShells.ghc96 = devShells.ghc96; } //
-      { devShells.ghc912 = devShells.ghc912; } //
-      { devShells.ghc914 = devShells.ghc914; } //
-      { devShells.ghc96-profiled = devShells.ghc96-profiled; } //
-      { devShells.ghc912-profiled = devShells.ghc912-profiled; } //
-      { devShells.ghc914-profiled = devShells.ghc914-profiled; } //
-      { devShells.metatheory-jailbreak = metatheory-jailbreak-shell; } //
+      (ci-devShells) //
       { required = hydra-required-job; };
     "x86_64-darwin" =
       { };
@@ -146,13 +152,7 @@ let
       { };
     "aarch64-darwin" =
       (project-variants-roots-and-plan-nix) //
-      { devShells.ghc96 = devShells.ghc96; } //
-      { devShells.ghc912 = devShells.ghc912; } //
-      { devShells.ghc914 = devShells.ghc914; } //
-      { devShells.ghc96-profiled = devShells.ghc96-profiled; } //
-      { devShells.ghc912-profiled = devShells.ghc912-profiled; } //
-      { devShells.ghc914-profiled = devShells.ghc914-profiled; } //
-      { devShells.metatheory-jailbreak = metatheory-jailbreak-shell; } //
+      (ci-devShells) //
       { required = hydra-required-job; };
   };
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -27,6 +27,14 @@ let
           }];
         };
         ghc912.compiler-nix-name = "ghc912";
+        ghc914-profiled = {
+          compiler-nix-name = "ghc914";
+          modules = [{
+            enableProfiling = true;
+            enableLibraryProfiling = true;
+          }];
+        };
+        ghc914.compiler-nix-name = "ghc914";
         ghc96-coverage.modules = [{
           packages.plutus-metatheory.doCoverage = true;
           packages.plutus-core.doCoverage = true;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -29,7 +29,6 @@ let
 
     "ghc96-profiled" = ghc96;
     "ghc912-profiled" = ghc912;
-    "ghc914-profiled" = ghc914;
   };
 
   tools = all-tools.${ghc};
@@ -183,7 +182,6 @@ let
     ghc914 = full-shell;
     ghc96-profiled = full-shell;
     ghc912-profiled = full-shell;
-    ghc914-profiled = full-shell;
   }.${ghc};
 
 in

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -20,14 +20,22 @@ let
     "ghc912".fourmolu = mkFourmolu "ghc912";
     "ghc912".hlint = project.projectVariants.ghc912.tool "hlint" "latest";
 
+    "ghc914".cabal = project.projectVariants.ghc914.tool "cabal" "latest";
+    "ghc914".cabal-fmt = project.projectVariants.ghc96.tool "cabal-fmt" "latest"; # cabal-fmt not buildable with ghc914
+    "ghc914".haskell-language-server = project.projectVariants.ghc96.tool "haskell-language-server" "latest"; # HLS does not support ghc914 yet (hie-compat requires base <4.22)
+    "ghc914".stylish-haskell = project.projectVariants.ghc912.tool "stylish-haskell" "latest"; # stylish-haskell not buildable with ghc914 (requires ghc-lib-parser <9.13)
+    "ghc914".fourmolu = mkFourmolu "ghc912"; # Our fourmolu fork has no ghc914-compatible revision yet
+    "ghc914".hlint = project.projectVariants.ghc912.tool "hlint" "latest"; # hlint not buildable with ghc914 (requires ghc-lib-parser 9.12.*)
+
     "ghc96-profiled" = ghc96;
     "ghc912-profiled" = ghc912;
+    "ghc914-profiled" = ghc914;
   };
 
   tools = all-tools.${ghc};
 
   # Pre-commit hooks for the repo. Injects into shell via shellHook.
-  pre-commit-check = inputs.pre-commit-hooks.lib.${pkgs.system}.run {
+  pre-commit-check = inputs.pre-commit-hooks.lib.${pkgs.stdenv.hostPlatform.system}.run {
     src = ../.;
     hooks = {
       nixpkgs-fmt = {
@@ -80,7 +88,7 @@ let
   };
 
   # Add extra Linux-only packages to the dev shell here.
-  linux-pkgs = lib.optionals pkgs.hostPlatform.isLinux [
+  linux-pkgs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
     pkgs.papi
     pkgs.util-linux
   ];
@@ -95,7 +103,7 @@ let
     metatheory.agda-with-stdlib-and-metatheory
 
     r-with-packages
-    inputs.nixpkgs-2405.legacyPackages.${pkgs.system}.linkchecker
+    inputs.nixpkgs-2405.legacyPackages.${pkgs.stdenv.hostPlatform.system}.linkchecker
 
     tools.haskell-language-server
     tools.stylish-haskell
@@ -172,8 +180,10 @@ let
   shell = {
     ghc96 = full-shell;
     ghc912 = full-shell;
+    ghc914 = full-shell;
     ghc96-profiled = full-shell;
     ghc912-profiled = full-shell;
+    ghc914-profiled = full-shell;
   }.${ghc};
 
 in

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,11 +21,11 @@ let
     "ghc912".hlint = project.projectVariants.ghc912.tool "hlint" "latest";
 
     "ghc914".cabal = project.projectVariants.ghc914.tool "cabal" "latest";
-    "ghc914".cabal-fmt = project.projectVariants.ghc96.tool "cabal-fmt" "latest"; # cabal-fmt not buildable with ghc914
-    "ghc914".haskell-language-server = project.projectVariants.ghc96.tool "haskell-language-server" "latest"; # HLS does not support ghc914 yet (hie-compat requires base <4.22)
-    "ghc914".stylish-haskell = project.projectVariants.ghc912.tool "stylish-haskell" "latest"; # stylish-haskell not buildable with ghc914 (requires ghc-lib-parser <9.13)
-    "ghc914".fourmolu = mkFourmolu "ghc912"; # Our fourmolu fork has no ghc914-compatible revision yet
-    "ghc914".hlint = project.projectVariants.ghc912.tool "hlint" "latest"; # hlint not buildable with ghc914 (requires ghc-lib-parser 9.12.*)
+    "ghc914".cabal-fmt = project.projectVariants.ghc96.tool "cabal-fmt" "latest";
+    "ghc914".haskell-language-server = project.projectVariants.ghc96.tool "haskell-language-server" "latest";
+    "ghc914".stylish-haskell = project.projectVariants.ghc912.tool "stylish-haskell" "latest";
+    "ghc914".fourmolu = mkFourmolu "ghc912";
+    "ghc914".hlint = project.projectVariants.ghc912.tool "hlint" "latest";
 
     "ghc96-profiled" = ghc96;
     "ghc912-profiled" = ghc912;

--- a/nix/utils.nix
+++ b/nix/utils.nix
@@ -25,7 +25,7 @@ rec {
     let
       clean-jobs =
         lib.filterAttrsRecursive (name: _: name != "recurseForDerivations")
-          (removeAttrs self.hydraJobs.${pkgs.system} [ "required" ]);
+          (removeAttrs self.hydraJobs.${pkgs.stdenv.hostPlatform.system} [ "required" ]);
     in
     pkgs.releaseTools.aggregate {
       name = "required";

--- a/plutus-core/flat/test/Spec.hs
+++ b/plutus-core/flat/test/Spec.hs
@@ -35,6 +35,7 @@ import PlutusCore.Flat.Encoder.Prim qualified as E
 import PlutusCore.Flat.Encoder.Strict qualified as E
 import PlutusCore.Flat.Endian
 import System.Exit
+import System.Info (os)
 import Test.Data
 import Test.Data.Arbitrary ()
 import Test.Data.Flat
@@ -122,7 +123,12 @@ testFlat = testGroup
   , testContainers
   , flatUnflatRT
   , flatTests
-  , testEncodingStability
+  -- The golden test fails under Wine on CI with "openBinaryFile: invalid
+  -- argument". The encodings are platform-independent and the test runs on
+  -- Linux and macOS, so we lose no coverage by skipping it on Windows.
+  , if os == "mingw32"
+      then testGroup "stable byte encodings" []
+      else testEncodingStability
   ]
 
 -- Flat.Endian tests (to run, need to modify imports and cabal file)

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
@@ -56,10 +56,7 @@ deriving stock instance
   => Eq (Type TyDeBruijn uni ann)
 
 deriving stock instance
-  ( GEq uni
-  , Closed uni
-  , uni `Everywhere` Eq
-  , Eq fun
+  ( uni `Everywhere` Eq
   , Eq ann
   , Eq (Term tyname name uni fun ann)
   )

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -66,6 +66,10 @@ import PlutusCore.Value (Value)
 import Control.Monad.Except (throwError)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
+#if MIN_VERSION_some(1,1,0)
+import Data.EqP (EqP (..))
+import Data.GADT.Compare (defaultEq)
+#endif
 import Data.Int
   ( Int16
   , Int32
@@ -203,6 +207,16 @@ instance AllBuiltinArgs DefaultUni (GEqL DefaultUni) a => GEqL DefaultUni a wher
     DefaultUniValue <- pure a2
     pure Refl
   {-# INLINE geqL #-}
+
+#if MIN_VERSION_some(1,1,0)
+-- Since some-1.1, 'EqP' is a superclass of 'GEq', and 'EqP' itself has a
+-- @forall a. Eq (f a)@ superclass.
+instance Eq (DefaultUni a) where
+  (==) = defaultEq
+
+instance EqP DefaultUni where
+  eqp = defaultEq
+#endif
 
 instance GEq DefaultUni where
   -- We define 'geq' manually instead of using 'deriveGEq', because the latter creates a single

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -68,7 +68,6 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
 #if MIN_VERSION_some(1,1,0)
 import Data.EqP (EqP (..))
-import Data.GADT.Compare (defaultEq)
 #endif
 import Data.Int
   ( Int16

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -83,10 +83,7 @@ deriving stock instance
 deriving stock instance
   ( Eq (Term tyname name uni fun ann)
   , Eq (Type tyname uni ann)
-  , GEq uni
-  , Closed uni
   , uni `Everywhere` Eq
-  , Eq fun
   , Eq ann
   )
   => Eq (NormCheckError tyname name uni fun ann)
@@ -156,15 +153,15 @@ data Error uni fun ann
   deriving stock (Generic, Functor)
 
 deriving stock instance
-  (Eq fun, Eq ann, Closed uni, Everywhere uni Eq, GEq uni, Eq ParserError)
+  (Eq fun, Eq ann, Closed uni, Everywhere uni Eq, GEq uni)
   => Eq (Error uni fun ann)
 
 deriving anyclass instance
-  (NFData fun, NFData ann, Closed uni, Everywhere uni NFData, NFData ParserError)
+  (NFData fun, NFData ann, Closed uni, Everywhere uni NFData)
   => NFData (Error uni fun ann)
 
 deriving stock instance
-  (Show fun, Show ann, Closed uni, Everywhere uni Show, GShow uni, Show ParserError)
+  (Show fun, Show ann, Closed uni, Everywhere uni Show, GShow uni)
   => Show (Error uni fun ann)
 
 instance Pretty SourcePos where

--- a/plutus-core/plutus-core/src/Universe/Core.hs
+++ b/plutus-core/plutus-core/src/Universe/Core.hs
@@ -1,5 +1,6 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -57,6 +58,10 @@ import Control.DeepSeq
 import Control.Monad
 import Control.Monad.Trans.State.Strict
 import Data.Dependent.Sum
+#if MIN_VERSION_some(1,1,0)
+import Data.EqP
+import Data.OrdP
+#endif
 import Data.GADT.Compare
 import Data.GADT.DeepSeq
 import Data.GADT.Show
@@ -752,6 +757,12 @@ instance (GShow uni, Closed uni, uni `Everywhere` Show) => Show (ValueOf uni a) 
 
 -------------------- 'Eq' / 'GEq'
 
+#if MIN_VERSION_some(1,1,0)
+-- Since some-1.1, 'EqP' is a superclass of 'GEq'.
+instance (GEq uni, Closed uni, uni `Everywhere` Eq) => EqP (ValueOf uni) where
+  eqp = defaultEq
+#endif
+
 instance (GEq uni, Closed uni, uni `Everywhere` Eq) => GEq (ValueOf uni) where
   ValueOf uni1 x1 `geq` ValueOf uni2 x2 = do
     Refl <- uni1 `geq` uni2
@@ -765,6 +776,15 @@ instance (GEq uni, Closed uni, uni `Everywhere` Eq) => Eq (ValueOf uni a) where
   (==) = defaultEq
 
 -------------------- 'Compare' / 'GCompare'
+
+#if MIN_VERSION_some(1,1,0)
+-- Since some-1.1, 'OrdP' is a superclass of 'GCompare'.
+instance
+  (GCompare uni, Closed uni, uni `Everywhere` Ord, uni `Everywhere` Eq)
+  => OrdP (ValueOf uni)
+  where
+  comparep = defaultCompare
+#endif
 
 instance
   (GCompare uni, Closed uni, uni `Everywhere` Ord, uni `Everywhere` Eq)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
@@ -67,10 +67,7 @@ deriving stock instance
 instance HashableTermConstraints uni fun ann => Hashable (Term DeBruijn uni fun ann)
 
 deriving stock instance
-  ( GEq uni
-  , Closed uni
-  , uni `Everywhere` Eq
-  , Eq fun
+  ( uni `Everywhere` Eq
   , Eq ann
   , Eq (Term name uni fun ann)
   )

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.Address.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.Address.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Address.Address where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Address.Address l1l_0 l2l_0)
+    (PlutusLedgerApi.V1.Address.Address r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.Credential.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.Credential.golden.th
@@ -1,0 +1,9 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Credential.Credential where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Credential.PubKeyCredential l1l_0)
+    (PlutusLedgerApi.V1.Credential.PubKeyCredential r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Credential.ScriptCredential l1l_0)
+    (PlutusLedgerApi.V1.Credential.ScriptCredential r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.DCert.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.DCert.golden.th
@@ -1,0 +1,26 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.DCert.DCert where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.DCert.DCertDelegRegKey l1l_0)
+    (PlutusLedgerApi.V1.DCert.DCertDelegRegKey r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.DCert.DCertDelegDeRegKey l1l_0)
+    (PlutusLedgerApi.V1.DCert.DCertDelegDeRegKey r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.DCert.DCertDelegDelegate l1l_0 l2l_0)
+    (PlutusLedgerApi.V1.DCert.DCertDelegDelegate r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.DCert.DCertPoolRegister l1l_0 l2l_0)
+    (PlutusLedgerApi.V1.DCert.DCertPoolRegister r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.DCert.DCertPoolRetire l1l_0 l2l_0)
+    (PlutusLedgerApi.V1.DCert.DCertPoolRetire r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.DCert.DCertGenesis)
+    (PlutusLedgerApi.V1.DCert.DCertGenesis) = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==) (PlutusLedgerApi.V1.DCert.DCertMir) (PlutusLedgerApi.V1.DCert.DCertMir)
+    = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.Extended.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.Extended.golden.th
@@ -1,0 +1,11 @@
+instance PlutusTx.Eq.Class.Eq a_0 => PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Interval.Extended
+    a_0 where
+  (PlutusTx.Eq.Class.==) (PlutusLedgerApi.V1.Interval.NegInf) (PlutusLedgerApi.V1.Interval.NegInf)
+    = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Interval.Finite l1l_0)
+    (PlutusLedgerApi.V1.Interval.Finite r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) (PlutusLedgerApi.V1.Interval.PosInf) (PlutusLedgerApi.V1.Interval.PosInf)
+    = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.ScriptContext.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.ScriptContext.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Contexts.ScriptContext where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Contexts.ScriptContext l1l_0 l2l_0)
+    (PlutusLedgerApi.V1.Contexts.ScriptContext r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.ScriptPurpose.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.ScriptPurpose.golden.th
@@ -1,0 +1,15 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Contexts.ScriptPurpose where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Contexts.Minting l1l_0)
+    (PlutusLedgerApi.V1.Contexts.Minting r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Contexts.Spending l1l_0)
+    (PlutusLedgerApi.V1.Contexts.Spending r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Contexts.Rewarding l1l_0)
+    (PlutusLedgerApi.V1.Contexts.Rewarding r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Contexts.Certifying l1l_0)
+    (PlutusLedgerApi.V1.Contexts.Certifying r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.StakingCredential.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.StakingCredential.golden.th
@@ -1,0 +1,11 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Credential.StakingCredential where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Credential.StakingHash l1l_0)
+    (PlutusLedgerApi.V1.Credential.StakingHash r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Credential.StakingPtr l1l_0 l2l_0 l3l_0)
+    (PlutusLedgerApi.V1.Credential.StakingPtr r1r_0 r2r_0 r3r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& ((l2l_0 PlutusTx.Eq.Class.== r2r_0)
+        PlutusTx.Bool.&& (l3l_0 PlutusTx.Eq.Class.== r3r_0))
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxInInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxInInfo.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Contexts.TxInInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Contexts.TxInInfo l1l_0 l2l_0)
+    (PlutusLedgerApi.V1.Contexts.TxInInfo r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxInfo.golden.th
@@ -1,0 +1,30 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Contexts.TxInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Contexts.TxInfo l1l_0
+      l2l_0
+      l3l_0
+      l4l_0
+      l5l_0
+      l6l_0
+      l7l_0
+      l8l_0
+      l9l_0
+      l10l_0)
+    (PlutusLedgerApi.V1.Contexts.TxInfo r1r_0
+      r2r_0
+      r3r_0
+      r4r_0
+      r5r_0
+      r6r_0
+      r7r_0
+      r8r_0
+      r9r_0
+      r10r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& ((l2l_0
+          PlutusTx.Eq.Class.== r2r_0) PlutusTx.Bool.&& ((l3l_0 PlutusTx.Eq.Class.== r3r_0)
+          PlutusTx.Bool.&& ((l4l_0 PlutusTx.Eq.Class.== r4r_0) PlutusTx.Bool.&& ((l5l_0
+                PlutusTx.Eq.Class.== r5r_0) PlutusTx.Bool.&& ((l6l_0 PlutusTx.Eq.Class.== r6r_0)
+                PlutusTx.Bool.&& ((l7l_0 PlutusTx.Eq.Class.== r7r_0) PlutusTx.Bool.&& ((l8l_0
+                      PlutusTx.Eq.Class.== r8r_0) PlutusTx.Bool.&& ((l9l_0
+                        PlutusTx.Eq.Class.== r9r_0) PlutusTx.Bool.&& (l10l_0
+                        PlutusTx.Eq.Class.== r10r_0)))))))))
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxOut.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxOut.golden.th
@@ -1,0 +1,7 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Tx.TxOut where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Tx.TxOut l1l_0 l2l_0 l3l_0)
+    (PlutusLedgerApi.V1.Tx.TxOut r1r_0 r2r_0 r3r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& ((l2l_0 PlutusTx.Eq.Class.== r2r_0) PlutusTx.Bool.&& (l3l_0
+          PlutusTx.Eq.Class.== r3r_0))
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxOutRef.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1.TxOutRef.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Tx.TxOutRef where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Tx.TxOutRef l1l_0 l2l_0)
+    (PlutusLedgerApi.V1.Tx.TxOutRef r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.Address.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.Address.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Address.Address where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Address.Address l1l_0)
+    (PlutusLedgerApi.V1.Data.Address.Address r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.Credential.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.Credential.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Credential.Credential where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Credential.Credential l1l_0)
+    (PlutusLedgerApi.V1.Data.Credential.Credential r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.DCert.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.DCert.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.DCert.DCert where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.DCert.DCert l1l_0)
+    (PlutusLedgerApi.V1.Data.DCert.DCert r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.ScriptContext.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.ScriptContext.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Contexts.ScriptContext where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Contexts.ScriptContext l1l_0)
+    (PlutusLedgerApi.V1.Data.Contexts.ScriptContext r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.ScriptPurpose.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.ScriptPurpose.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Contexts.ScriptPurpose where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Contexts.ScriptPurpose l1l_0)
+    (PlutusLedgerApi.V1.Data.Contexts.ScriptPurpose r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.StakingCredential.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.StakingCredential.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Credential.StakingCredential where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Credential.StakingCredential l1l_0)
+    (PlutusLedgerApi.V1.Data.Credential.StakingCredential r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxInInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxInInfo.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Contexts.TxInInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Contexts.TxInInfo l1l_0)
+    (PlutusLedgerApi.V1.Data.Contexts.TxInInfo r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxInfo.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Contexts.TxInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Contexts.TxInfo l1l_0)
+    (PlutusLedgerApi.V1.Data.Contexts.TxInfo r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxOut.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxOut.golden.th
@@ -1,0 +1,5 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Tx.TxOut where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Tx.TxOut l1l_0)
+    (PlutusLedgerApi.V1.Data.Tx.TxOut r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxOutRef.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V1D.TxOutRef.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V1.Data.Tx.TxOutRef where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V1.Data.Tx.TxOutRef l1l_0)
+    (PlutusLedgerApi.V1.Data.Tx.TxOutRef r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2.OutputDatum.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2.OutputDatum.golden.th
@@ -1,0 +1,11 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V2.Tx.OutputDatum where
+  (PlutusTx.Eq.Class.==) (PlutusLedgerApi.V2.Tx.NoOutputDatum) (PlutusLedgerApi.V2.Tx.NoOutputDatum)
+    = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V2.Tx.OutputDatumHash l1l_0)
+    (PlutusLedgerApi.V2.Tx.OutputDatumHash r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V2.Tx.OutputDatum l1l_0)
+    (PlutusLedgerApi.V2.Tx.OutputDatum r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2.TxInInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2.TxInInfo.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V2.Contexts.TxInInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V2.Contexts.TxInInfo l1l_0 l2l_0)
+    (PlutusLedgerApi.V2.Contexts.TxInInfo r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2.TxOut.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2.TxOut.golden.th
@@ -1,0 +1,7 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V2.Tx.TxOut where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V2.Tx.TxOut l1l_0 l2l_0 l3l_0 l4l_0)
+    (PlutusLedgerApi.V2.Tx.TxOut r1r_0 r2r_0 r3r_0 r4r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& ((l2l_0 PlutusTx.Eq.Class.== r2r_0) PlutusTx.Bool.&& ((l3l_0
+            PlutusTx.Eq.Class.== r3r_0) PlutusTx.Bool.&& (l4l_0 PlutusTx.Eq.Class.== r4r_0)))
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2D.OutputDatum.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2D.OutputDatum.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V2.Data.Tx.OutputDatum where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V2.Data.Tx.OutputDatum l1l_0)
+    (PlutusLedgerApi.V2.Data.Tx.OutputDatum r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2D.TxInInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2D.TxInInfo.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V2.Data.Contexts.TxInInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V2.Data.Contexts.TxInInfo l1l_0)
+    (PlutusLedgerApi.V2.Data.Contexts.TxInInfo r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2D.TxOut.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V2D.TxOut.golden.th
@@ -1,0 +1,5 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V2.Data.Tx.TxOut where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V2.Data.Tx.TxOut l1l_0)
+    (PlutusLedgerApi.V2.Data.Tx.TxOut r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Constitution.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Constitution.golden.th
@@ -1,0 +1,5 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.Constitution where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.Constitution l1l_0)
+    (PlutusLedgerApi.V3.Contexts.Constitution r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.DRep.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.DRep.golden.th
@@ -1,0 +1,12 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.DRep where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.DRep l1l_0)
+    (PlutusLedgerApi.V3.Contexts.DRep r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.DRepAlwaysAbstain)
+    (PlutusLedgerApi.V3.Contexts.DRepAlwaysAbstain) = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.DRepAlwaysNoConfidence)
+    (PlutusLedgerApi.V3.Contexts.DRepAlwaysNoConfidence) = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Delegatee.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Delegatee.golden.th
@@ -1,0 +1,13 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.Delegatee where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.DelegStake l1l_0)
+    (PlutusLedgerApi.V3.Contexts.DelegStake r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.DelegVote l1l_0)
+    (PlutusLedgerApi.V3.Contexts.DelegVote r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.DelegStakeVote l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.DelegStakeVote r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.GovernanceActionId.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.GovernanceActionId.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.GovernanceActionId where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.GovernanceActionId l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.GovernanceActionId r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.ProtocolVersion.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.ProtocolVersion.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.ProtocolVersion where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.ProtocolVersion l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.ProtocolVersion r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.TxCert.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.TxCert.golden.th
@@ -1,0 +1,46 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.TxCert where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertRegStaking l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertRegStaking r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertUnRegStaking l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertUnRegStaking r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertDelegStaking l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertDelegStaking r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertRegDeleg l1l_0 l2l_0 l3l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertRegDeleg r1r_0 r2r_0 r3r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& ((l2l_0 PlutusTx.Eq.Class.== r2r_0)
+        PlutusTx.Bool.&& (l3l_0 PlutusTx.Eq.Class.== r3r_0))
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertRegDRep l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertRegDRep r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertUpdateDRep l1l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertUpdateDRep r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertUnRegDRep l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertUnRegDRep r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertPoolRegister l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertPoolRegister r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertPoolRetire l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertPoolRetire r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertAuthHotCommittee l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertAuthHotCommittee r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxCertResignColdCommittee l1l_0)
+    (PlutusLedgerApi.V3.Contexts.TxCertResignColdCommittee r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.TxInInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.TxInInfo.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.TxInInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.TxInInfo l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.TxInInfo r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.TxOutRef.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.TxOutRef.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Tx.TxOutRef where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Tx.TxOutRef l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Tx.TxOutRef r1r_0 r2r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Vote.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Vote.golden.th
@@ -1,0 +1,9 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.Vote where
+  (PlutusTx.Eq.Class.==) (PlutusLedgerApi.V3.Contexts.VoteNo) (PlutusLedgerApi.V3.Contexts.VoteNo)
+    = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==) (PlutusLedgerApi.V3.Contexts.VoteYes) (PlutusLedgerApi.V3.Contexts.VoteYes)
+    = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==) (PlutusLedgerApi.V3.Contexts.Abstain) (PlutusLedgerApi.V3.Contexts.Abstain)
+    = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Voter.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3.Voter.golden.th
@@ -1,0 +1,12 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Contexts.Voter where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.CommitteeVoter l1l_0)
+    (PlutusLedgerApi.V3.Contexts.CommitteeVoter r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.DRepVoter l1l_0)
+    (PlutusLedgerApi.V3.Contexts.DRepVoter r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Contexts.StakePoolVoter l1l_0)
+    (PlutusLedgerApi.V3.Contexts.StakePoolVoter r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Constitution.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Constitution.golden.th
@@ -1,0 +1,5 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.Constitution where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.Constitution l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.Constitution r1r_0) = l1l_0 PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.DRep.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.DRep.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.DRep where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.DRep l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.DRep r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Delegatee.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Delegatee.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.Delegatee where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.Delegatee l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.Delegatee r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.GovernanceActionId.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.GovernanceActionId.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.GovernanceActionId where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.GovernanceActionId l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.GovernanceActionId r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.ProtocolVersion.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.ProtocolVersion.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.ProtocolVersion where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.ProtocolVersion l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.ProtocolVersion r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.TxCert.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.TxCert.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.TxCert where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.TxCert l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.TxCert r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.TxInInfo.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.TxInInfo.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.TxInInfo where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.TxInInfo l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.TxInInfo r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.TxOutRef.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.TxOutRef.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Tx.TxOutRef where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Tx.TxOutRef l1l_0)
+    (PlutusLedgerApi.V3.Data.Tx.TxOutRef r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Vote.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Vote.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.Vote where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.Vote l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.Vote r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Voter.golden.th
+++ b/plutus-ledger-api/test/Spec/Eq/Golden/9.14/V3D.Voter.golden.th
@@ -1,0 +1,6 @@
+instance PlutusTx.Eq.Class.Eq PlutusLedgerApi.V3.Data.Contexts.Voter where
+  (PlutusTx.Eq.Class.==)
+    (PlutusLedgerApi.V3.Data.Contexts.Voter l1l_0)
+    (PlutusLedgerApi.V3.Data.Contexts.Voter r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-ledger-api/test/Spec/Ord/Golden/9.14/V1.Extended.golden.th
+++ b/plutus-ledger-api/test/Spec/Ord/Golden/9.14/V1.Extended.golden.th
@@ -1,0 +1,16 @@
+instance PlutusTx.Ord.Class.Ord a_0 => PlutusTx.Ord.Class.Ord PlutusLedgerApi.V1.Interval.Extended
+    a_0 where
+  PlutusTx.Ord.Class.compare
+    (PlutusLedgerApi.V1.Interval.NegInf)
+    (PlutusLedgerApi.V1.Interval.NegInf) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare
+    (PlutusLedgerApi.V1.Interval.Finite l1l_0)
+    (PlutusLedgerApi.V1.Interval.Finite r1r_0) = l1l_0 PlutusTx.Ord.Class.compare r1r_0
+  PlutusTx.Ord.Class.compare
+    (PlutusLedgerApi.V1.Interval.PosInf)
+    (PlutusLedgerApi.V1.Interval.PosInf) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (PlutusLedgerApi.V1.Interval.NegInf {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (PlutusLedgerApi.V1.Interval.NegInf {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (PlutusLedgerApi.V1.Interval.Finite {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (PlutusLedgerApi.V1.Interval.Finite {}) = GHC.Internal.Types.GT
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-ledger-api/test/Spec/Ord/Golden/9.14/V3.ProtocolVersion.golden.th
+++ b/plutus-ledger-api/test/Spec/Ord/Golden/9.14/V3.ProtocolVersion.golden.th
@@ -1,0 +1,7 @@
+instance PlutusTx.Ord.Class.Ord PlutusLedgerApi.V3.Contexts.ProtocolVersion where
+  PlutusTx.Ord.Class.compare
+    (PlutusLedgerApi.V3.Contexts.ProtocolVersion l1l_0 l2l_0)
+    (PlutusLedgerApi.V3.Contexts.ProtocolVersion r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Ord.Class.compare r1r_0) GHC.Internal.Base.<> (l2l_0
+        PlutusTx.Ord.Class.compare r2r_0)
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-tx/test/Enum/Golden/9.14/Bool.golden.th
+++ b/plutus-tx/test/Enum/Golden/9.14/Bool.golden.th
@@ -1,0 +1,17 @@
+instance PlutusTx.Enum.Class.Enum GHC.Internal.Types.Bool where
+  PlutusTx.Enum.Class.succ (GHC.Internal.Types.False) = GHC.Internal.Types.True
+  PlutusTx.Enum.Class.succ (GHC.Internal.Types.True) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.succBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.succ #-}
+  PlutusTx.Enum.Class.pred (GHC.Internal.Types.False) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.predBadArgumentError
+  PlutusTx.Enum.Class.pred (GHC.Internal.Types.True) = GHC.Internal.Types.False
+  {-# INLINABLE PlutusTx.Enum.Class.pred #-}
+  PlutusTx.Enum.Class.toEnum 0 = GHC.Internal.Types.False
+  PlutusTx.Enum.Class.toEnum 1 = GHC.Internal.Types.True
+  PlutusTx.Enum.Class.toEnum _ = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.toEnumBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.toEnum #-}
+  PlutusTx.Enum.Class.fromEnum (GHC.Internal.Types.False) = 0
+  PlutusTx.Enum.Class.fromEnum (GHC.Internal.Types.True) = 1
+  {-# INLINABLE PlutusTx.Enum.Class.fromEnum #-}

--- a/plutus-tx/test/Enum/Golden/9.14/SomeVeryLargeEnum.golden.th
+++ b/plutus-tx/test/Enum/Golden/9.14/SomeVeryLargeEnum.golden.th
@@ -1,0 +1,49 @@
+instance PlutusTx.Enum.Class.Enum Enum.Spec.SomeVeryLargeEnum where
+  PlutusTx.Enum.Class.succ (Enum.Spec.E1) = Enum.Spec.E2
+  PlutusTx.Enum.Class.succ (Enum.Spec.E2) = Enum.Spec.E3
+  PlutusTx.Enum.Class.succ (Enum.Spec.E3) = Enum.Spec.E4
+  PlutusTx.Enum.Class.succ (Enum.Spec.E4) = Enum.Spec.E5
+  PlutusTx.Enum.Class.succ (Enum.Spec.E5) = Enum.Spec.E6
+  PlutusTx.Enum.Class.succ (Enum.Spec.E6) = Enum.Spec.E7
+  PlutusTx.Enum.Class.succ (Enum.Spec.E7) = Enum.Spec.E8
+  PlutusTx.Enum.Class.succ (Enum.Spec.E8) = Enum.Spec.E9
+  PlutusTx.Enum.Class.succ (Enum.Spec.E9) = Enum.Spec.E10
+  PlutusTx.Enum.Class.succ (Enum.Spec.E10) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.succBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.succ #-}
+  PlutusTx.Enum.Class.pred (Enum.Spec.E1) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.predBadArgumentError
+  PlutusTx.Enum.Class.pred (Enum.Spec.E2) = Enum.Spec.E1
+  PlutusTx.Enum.Class.pred (Enum.Spec.E3) = Enum.Spec.E2
+  PlutusTx.Enum.Class.pred (Enum.Spec.E4) = Enum.Spec.E3
+  PlutusTx.Enum.Class.pred (Enum.Spec.E5) = Enum.Spec.E4
+  PlutusTx.Enum.Class.pred (Enum.Spec.E6) = Enum.Spec.E5
+  PlutusTx.Enum.Class.pred (Enum.Spec.E7) = Enum.Spec.E6
+  PlutusTx.Enum.Class.pred (Enum.Spec.E8) = Enum.Spec.E7
+  PlutusTx.Enum.Class.pred (Enum.Spec.E9) = Enum.Spec.E8
+  PlutusTx.Enum.Class.pred (Enum.Spec.E10) = Enum.Spec.E9
+  {-# INLINABLE PlutusTx.Enum.Class.pred #-}
+  PlutusTx.Enum.Class.toEnum 0 = Enum.Spec.E1
+  PlutusTx.Enum.Class.toEnum 1 = Enum.Spec.E2
+  PlutusTx.Enum.Class.toEnum 2 = Enum.Spec.E3
+  PlutusTx.Enum.Class.toEnum 3 = Enum.Spec.E4
+  PlutusTx.Enum.Class.toEnum 4 = Enum.Spec.E5
+  PlutusTx.Enum.Class.toEnum 5 = Enum.Spec.E6
+  PlutusTx.Enum.Class.toEnum 6 = Enum.Spec.E7
+  PlutusTx.Enum.Class.toEnum 7 = Enum.Spec.E8
+  PlutusTx.Enum.Class.toEnum 8 = Enum.Spec.E9
+  PlutusTx.Enum.Class.toEnum 9 = Enum.Spec.E10
+  PlutusTx.Enum.Class.toEnum _ = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.toEnumBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.toEnum #-}
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E1) = 0
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E2) = 1
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E3) = 2
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E4) = 3
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E5) = 4
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E6) = 5
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E7) = 6
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E8) = 7
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E9) = 8
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.E10) = 9
+  {-# INLINABLE PlutusTx.Enum.Class.fromEnum #-}

--- a/plutus-tx/test/Enum/Golden/9.14/SomeVeryLargePhantom.golden.th
+++ b/plutus-tx/test/Enum/Golden/9.14/SomeVeryLargePhantom.golden.th
@@ -1,0 +1,56 @@
+instance PlutusTx.Enum.Class.Enum (Enum.Spec.SomeVeryLargePhantom a_0
+    b_0
+    c_0
+    d_0
+    e_0
+    f_0
+    g_0
+    h_0) where
+  PlutusTx.Enum.Class.succ (Enum.Spec.P1) = Enum.Spec.P2
+  PlutusTx.Enum.Class.succ (Enum.Spec.P2) = Enum.Spec.P3
+  PlutusTx.Enum.Class.succ (Enum.Spec.P3) = Enum.Spec.P4
+  PlutusTx.Enum.Class.succ (Enum.Spec.P4) = Enum.Spec.P5
+  PlutusTx.Enum.Class.succ (Enum.Spec.P5) = Enum.Spec.P6
+  PlutusTx.Enum.Class.succ (Enum.Spec.P6) = Enum.Spec.P7
+  PlutusTx.Enum.Class.succ (Enum.Spec.P7) = Enum.Spec.P8
+  PlutusTx.Enum.Class.succ (Enum.Spec.P8) = Enum.Spec.P9
+  PlutusTx.Enum.Class.succ (Enum.Spec.P9) = Enum.Spec.P10
+  PlutusTx.Enum.Class.succ (Enum.Spec.P10) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.succBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.succ #-}
+  PlutusTx.Enum.Class.pred (Enum.Spec.P1) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.predBadArgumentError
+  PlutusTx.Enum.Class.pred (Enum.Spec.P2) = Enum.Spec.P1
+  PlutusTx.Enum.Class.pred (Enum.Spec.P3) = Enum.Spec.P2
+  PlutusTx.Enum.Class.pred (Enum.Spec.P4) = Enum.Spec.P3
+  PlutusTx.Enum.Class.pred (Enum.Spec.P5) = Enum.Spec.P4
+  PlutusTx.Enum.Class.pred (Enum.Spec.P6) = Enum.Spec.P5
+  PlutusTx.Enum.Class.pred (Enum.Spec.P7) = Enum.Spec.P6
+  PlutusTx.Enum.Class.pred (Enum.Spec.P8) = Enum.Spec.P7
+  PlutusTx.Enum.Class.pred (Enum.Spec.P9) = Enum.Spec.P8
+  PlutusTx.Enum.Class.pred (Enum.Spec.P10) = Enum.Spec.P9
+  {-# INLINABLE PlutusTx.Enum.Class.pred #-}
+  PlutusTx.Enum.Class.toEnum 0 = Enum.Spec.P1
+  PlutusTx.Enum.Class.toEnum 1 = Enum.Spec.P2
+  PlutusTx.Enum.Class.toEnum 2 = Enum.Spec.P3
+  PlutusTx.Enum.Class.toEnum 3 = Enum.Spec.P4
+  PlutusTx.Enum.Class.toEnum 4 = Enum.Spec.P5
+  PlutusTx.Enum.Class.toEnum 5 = Enum.Spec.P6
+  PlutusTx.Enum.Class.toEnum 6 = Enum.Spec.P7
+  PlutusTx.Enum.Class.toEnum 7 = Enum.Spec.P8
+  PlutusTx.Enum.Class.toEnum 8 = Enum.Spec.P9
+  PlutusTx.Enum.Class.toEnum 9 = Enum.Spec.P10
+  PlutusTx.Enum.Class.toEnum _ = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.toEnumBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.toEnum #-}
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P1) = 0
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P2) = 1
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P3) = 2
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P4) = 3
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P5) = 4
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P6) = 5
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P7) = 6
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P8) = 7
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P9) = 8
+  PlutusTx.Enum.Class.fromEnum (Enum.Spec.P10) = 9
+  {-# INLINABLE PlutusTx.Enum.Class.fromEnum #-}

--- a/plutus-tx/test/Enum/Golden/9.14/Unit.golden.th
+++ b/plutus-tx/test/Enum/Golden/9.14/Unit.golden.th
@@ -1,0 +1,13 @@
+instance PlutusTx.Enum.Class.Enum GHC.Internal.Tuple.Unit where
+  PlutusTx.Enum.Class.succ ((GHC.Internal.Tuple.())) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.succBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.succ #-}
+  PlutusTx.Enum.Class.pred ((GHC.Internal.Tuple.())) = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.predBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.pred #-}
+  PlutusTx.Enum.Class.toEnum 0 = GHC.Internal.Tuple.()
+  PlutusTx.Enum.Class.toEnum _ = PlutusTx.Trace.traceError
+      PlutusTx.ErrorCodes.toEnumBadArgumentError
+  {-# INLINABLE PlutusTx.Enum.Class.toEnum #-}
+  PlutusTx.Enum.Class.fromEnum ((GHC.Internal.Tuple.())) = 0
+  {-# INLINABLE PlutusTx.Enum.Class.fromEnum #-}

--- a/plutus-tx/test/Eq/Golden/9.14/MyNewtype.golden.th
+++ b/plutus-tx/test/Eq/Golden/9.14/MyNewtype.golden.th
@@ -1,0 +1,4 @@
+instance PlutusTx.Eq.Class.Eq Eq.Spec.MyNewtype where
+  (PlutusTx.Eq.Class.==) (Eq.Spec.MyNewtype l1l_0) (Eq.Spec.MyNewtype r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-tx/test/Eq/Golden/9.14/PhantomADT.golden.th
+++ b/plutus-tx/test/Eq/Golden/9.14/PhantomADT.golden.th
@@ -1,0 +1,4 @@
+instance PlutusTx.Eq.Class.Eq Eq.Spec.PhantomADT e_0 where
+  (PlutusTx.Eq.Class.==) (Eq.Spec.PhantomADT l1l_0) (Eq.Spec.PhantomADT r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-tx/test/Eq/Golden/9.14/Rational.golden.th
+++ b/plutus-tx/test/Eq/Golden/9.14/Rational.golden.th
@@ -1,0 +1,4 @@
+instance PlutusTx.Eq.Class.Eq PlutusTx.Ratio.Rational where
+  (PlutusTx.Eq.Class.==) (PlutusTx.Ratio.Rational l1l_0 l2l_0) (PlutusTx.Ratio.Rational r1r_0 r2r_0)
+    = (l1l_0 PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-tx/test/Eq/Golden/9.14/SomeLargeADT.golden.th
+++ b/plutus-tx/test/Eq/Golden/9.14/SomeLargeADT.golden.th
@@ -1,0 +1,21 @@
+instance (PlutusTx.Eq.Class.Eq a_0
+, PlutusTx.Eq.Class.Eq b_0
+, PlutusTx.Eq.Class.Eq c_0
+, PlutusTx.Eq.Class.Eq d_0
+, PlutusTx.Eq.Class.Eq e_0) => PlutusTx.Eq.Class.Eq (Eq.Spec.SomeLargeADT a_0 b_0 c_0 d_0 e_0) where
+  (PlutusTx.Eq.Class.==)
+    (Eq.Spec.SomeLargeADT1 l1l_0 l2l_0 l3l_0 l4l_0 l5l_0 l6l_0)
+    (Eq.Spec.SomeLargeADT1 r1r_0 r2r_0 r3r_0 r4r_0 r5r_0 r6r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& ((l2l_0 PlutusTx.Eq.Class.== r2r_0) PlutusTx.Bool.&& ((l3l_0
+            PlutusTx.Eq.Class.== r3r_0) PlutusTx.Bool.&& ((l4l_0 PlutusTx.Eq.Class.== r4r_0)
+            PlutusTx.Bool.&& ((l5l_0 PlutusTx.Eq.Class.== r5r_0) PlutusTx.Bool.&& (l6l_0
+                PlutusTx.Eq.Class.== r6r_0)))))
+  (PlutusTx.Eq.Class.==) (Eq.Spec.SomeLargeADT2) (Eq.Spec.SomeLargeADT2) = GHC.Internal.Types.True
+  (PlutusTx.Eq.Class.==)
+    (Eq.Spec.SomeLargeADT3 l1l_0 l2l_0 l3l_0 l4l_0 l5l_0)
+    (Eq.Spec.SomeLargeADT3 r1r_0 r2r_0 r3r_0 r4r_0 r5r_0) = (l1l_0 PlutusTx.Eq.Class.== r1r_0)
+      PlutusTx.Bool.&& ((l2l_0 PlutusTx.Eq.Class.== r2r_0) PlutusTx.Bool.&& ((l3l_0
+            PlutusTx.Eq.Class.== r3r_0) PlutusTx.Bool.&& ((l4l_0 PlutusTx.Eq.Class.== r4r_0)
+            PlutusTx.Bool.&& (l5l_0 PlutusTx.Eq.Class.== r5r_0))))
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-tx/test/Eq/Golden/9.14/These.golden.th
+++ b/plutus-tx/test/Eq/Golden/9.14/These.golden.th
@@ -1,0 +1,10 @@
+instance (PlutusTx.Eq.Class.Eq a_0, PlutusTx.Eq.Class.Eq b_0) => PlutusTx.Eq.Class.Eq
+  (PlutusTx.These.These a_0 b_0) where
+  (PlutusTx.Eq.Class.==) (PlutusTx.These.This l1l_0) (PlutusTx.These.This r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) (PlutusTx.These.That l1l_0) (PlutusTx.These.That r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) (PlutusTx.These.These l1l_0 l2l_0) (PlutusTx.These.These r1r_0 r2r_0)
+    = (l1l_0 PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-tx/test/Eq/Golden/9.14/Tree.golden.th
+++ b/plutus-tx/test/Eq/Golden/9.14/Tree.golden.th
@@ -1,0 +1,7 @@
+instance PlutusTx.Eq.Class.Eq a_0 => PlutusTx.Eq.Class.Eq Eq.Spec.Tree a_0 where
+  (PlutusTx.Eq.Class.==) (Eq.Spec.Leaf l1l_0) (Eq.Spec.Leaf r1r_0) = l1l_0
+      PlutusTx.Eq.Class.== r1r_0
+  (PlutusTx.Eq.Class.==) (Eq.Spec.Node l1l_0 l2l_0) (Eq.Spec.Node r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Eq.Class.== r1r_0) PlutusTx.Bool.&& (l2l_0 PlutusTx.Eq.Class.== r2r_0)
+  (PlutusTx.Eq.Class.==) _ _ = GHC.Internal.Types.False
+  {-# INLINABLE (PlutusTx.Eq.Class.==) #-}

--- a/plutus-tx/test/Ord/Golden/9.14/MyNewtype.golden.th
+++ b/plutus-tx/test/Ord/Golden/9.14/MyNewtype.golden.th
@@ -1,0 +1,4 @@
+instance PlutusTx.Ord.Class.Ord Ord.Spec.MyNewtype where
+  PlutusTx.Ord.Class.compare (Ord.Spec.MyNewtype l1l_0) (Ord.Spec.MyNewtype r1r_0) = l1l_0
+      PlutusTx.Ord.Class.compare r1r_0
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-tx/test/Ord/Golden/9.14/PhantomADT.golden.th
+++ b/plutus-tx/test/Ord/Golden/9.14/PhantomADT.golden.th
@@ -1,0 +1,4 @@
+instance PlutusTx.Ord.Class.Ord Ord.Spec.PhantomADT e_0 where
+  PlutusTx.Ord.Class.compare (Ord.Spec.PhantomADT l1l_0) (Ord.Spec.PhantomADT r1r_0) = l1l_0
+      PlutusTx.Ord.Class.compare r1r_0
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-tx/test/Ord/Golden/9.14/SomeLargeADT.golden.th
+++ b/plutus-tx/test/Ord/Golden/9.14/SomeLargeADT.golden.th
@@ -1,0 +1,33 @@
+instance (PlutusTx.Ord.Class.Ord a_0
+, PlutusTx.Ord.Class.Ord b_0
+, PlutusTx.Ord.Class.Ord c_0
+, PlutusTx.Ord.Class.Ord d_0
+, PlutusTx.Ord.Class.Ord e_0) => PlutusTx.Ord.Class.Ord (Ord.Spec.SomeLargeADT a_0
+    b_0
+    c_0
+    d_0
+    e_0) where
+  PlutusTx.Ord.Class.compare
+    (Ord.Spec.SomeLargeADT1 l1l_0 l2l_0 l3l_0 l4l_0 l5l_0 l6l_0)
+    (Ord.Spec.SomeLargeADT1 r1r_0 r2r_0 r3r_0 r4r_0 r5r_0 r6r_0) = (l1l_0
+        PlutusTx.Ord.Class.compare r1r_0) GHC.Internal.Base.<> ((l2l_0
+          PlutusTx.Ord.Class.compare r2r_0) GHC.Internal.Base.<> ((l3l_0
+            PlutusTx.Ord.Class.compare r3r_0) GHC.Internal.Base.<> ((l4l_0
+              PlutusTx.Ord.Class.compare r4r_0) GHC.Internal.Base.<> ((l5l_0
+                PlutusTx.Ord.Class.compare r5r_0) GHC.Internal.Base.<> (l6l_0
+                PlutusTx.Ord.Class.compare r6r_0)))))
+  PlutusTx.Ord.Class.compare (Ord.Spec.SomeLargeADT2) (Ord.Spec.SomeLargeADT2)
+    = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare
+    (Ord.Spec.SomeLargeADT3 l1l_0 l2l_0 l3l_0 l4l_0 l5l_0)
+    (Ord.Spec.SomeLargeADT3 r1r_0 r2r_0 r3r_0 r4r_0 r5r_0) = (l1l_0
+        PlutusTx.Ord.Class.compare r1r_0) GHC.Internal.Base.<> ((l2l_0
+          PlutusTx.Ord.Class.compare r2r_0) GHC.Internal.Base.<> ((l3l_0
+            PlutusTx.Ord.Class.compare r3r_0) GHC.Internal.Base.<> ((l4l_0
+              PlutusTx.Ord.Class.compare r4r_0) GHC.Internal.Base.<> (l5l_0
+              PlutusTx.Ord.Class.compare r5r_0))))
+  PlutusTx.Ord.Class.compare (Ord.Spec.SomeLargeADT1 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.SomeLargeADT1 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.SomeLargeADT2 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.SomeLargeADT2 {}) = GHC.Internal.Types.GT
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-tx/test/Ord/Golden/9.14/SomeProduct.golden.th
+++ b/plutus-tx/test/Ord/Golden/9.14/SomeProduct.golden.th
@@ -1,0 +1,8 @@
+instance PlutusTx.Ord.Class.Ord Ord.Spec.SomeProduct where
+  PlutusTx.Ord.Class.compare
+    (Ord.Spec.SomeProduct l1l_0 l2l_0 l3l_0 l4l_0)
+    (Ord.Spec.SomeProduct r1r_0 r2r_0 r3r_0 r4r_0) = (l1l_0 PlutusTx.Ord.Class.compare r1r_0)
+      GHC.Internal.Base.<> ((l2l_0 PlutusTx.Ord.Class.compare r2r_0) GHC.Internal.Base.<> ((l3l_0
+            PlutusTx.Ord.Class.compare r3r_0) GHC.Internal.Base.<> (l4l_0
+            PlutusTx.Ord.Class.compare r4r_0)))
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-tx/test/Ord/Golden/9.14/SomeVeryLargeEnum.golden.th
+++ b/plutus-tx/test/Ord/Golden/9.14/SomeVeryLargeEnum.golden.th
@@ -1,0 +1,30 @@
+instance PlutusTx.Ord.Class.Ord Ord.Spec.SomeVeryLargeEnum where
+  PlutusTx.Ord.Class.compare (Ord.Spec.E1) (Ord.Spec.E1) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E2) (Ord.Spec.E2) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E3) (Ord.Spec.E3) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E4) (Ord.Spec.E4) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E5) (Ord.Spec.E5) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E6) (Ord.Spec.E6) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E7) (Ord.Spec.E7) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E8) (Ord.Spec.E8) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E9) (Ord.Spec.E9) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E10) (Ord.Spec.E10) = GHC.Internal.Types.EQ
+  PlutusTx.Ord.Class.compare (Ord.Spec.E1 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E1 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E2 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E2 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E3 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E3 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E4 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E4 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E5 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E5 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E6 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E6 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E7 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E7 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E8 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E8 {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (Ord.Spec.E9 {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.E9 {}) = GHC.Internal.Types.GT
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-tx/test/Ord/Golden/9.14/These.golden.th
+++ b/plutus-tx/test/Ord/Golden/9.14/These.golden.th
@@ -1,0 +1,14 @@
+instance (PlutusTx.Ord.Class.Ord a_0, PlutusTx.Ord.Class.Ord b_0) => PlutusTx.Ord.Class.Ord
+  (PlutusTx.These.These a_0 b_0) where
+  PlutusTx.Ord.Class.compare (PlutusTx.These.This l1l_0) (PlutusTx.These.This r1r_0) = l1l_0
+      PlutusTx.Ord.Class.compare r1r_0
+  PlutusTx.Ord.Class.compare (PlutusTx.These.That l1l_0) (PlutusTx.These.That r1r_0) = l1l_0
+      PlutusTx.Ord.Class.compare r1r_0
+  PlutusTx.Ord.Class.compare (PlutusTx.These.These l1l_0 l2l_0) (PlutusTx.These.These r1r_0 r2r_0)
+    = (l1l_0 PlutusTx.Ord.Class.compare r1r_0) GHC.Internal.Base.<> (l2l_0
+        PlutusTx.Ord.Class.compare r2r_0)
+  PlutusTx.Ord.Class.compare (PlutusTx.These.This {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (PlutusTx.These.This {}) = GHC.Internal.Types.GT
+  PlutusTx.Ord.Class.compare (PlutusTx.These.That {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (PlutusTx.These.That {}) = GHC.Internal.Types.GT
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}

--- a/plutus-tx/test/Ord/Golden/9.14/Tree.golden.th
+++ b/plutus-tx/test/Ord/Golden/9.14/Tree.golden.th
@@ -1,0 +1,9 @@
+instance PlutusTx.Ord.Class.Ord a_0 => PlutusTx.Ord.Class.Ord Ord.Spec.Tree a_0 where
+  PlutusTx.Ord.Class.compare (Ord.Spec.Leaf l1l_0) (Ord.Spec.Leaf r1r_0) = l1l_0
+      PlutusTx.Ord.Class.compare r1r_0
+  PlutusTx.Ord.Class.compare (Ord.Spec.Node l1l_0 l2l_0) (Ord.Spec.Node r1r_0 r2r_0) = (l1l_0
+        PlutusTx.Ord.Class.compare r1r_0) GHC.Internal.Base.<> (l2l_0
+        PlutusTx.Ord.Class.compare r2r_0)
+  PlutusTx.Ord.Class.compare (Ord.Spec.Leaf {}) _ = GHC.Internal.Types.LT
+  PlutusTx.Ord.Class.compare _ (Ord.Spec.Leaf {}) = GHC.Internal.Types.GT
+  {-# INLINABLE PlutusTx.Ord.Class.compare #-}


### PR DESCRIPTION
Adds `ghc914` project variants, dev shell, and CI jobs to the nix setup, mirroring ghc912. Compilation support for GHC 9.14 landed in #7335; this makes it buildable and testable via nix/CI.
