### PR TITLE
More precise error location for out-of-bounds `constr` tag

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -29,7 +29,17 @@ import Control.Monad.Except (MonadError)
 import Data.Text (Text)
 import Data.Word (Word64)
 
-import Text.Megaparsec (MonadParsec (notFollowedBy), anySingle, choice, many, some, try)
+import Text.Megaparsec
+  ( MonadParsec (notFollowedBy)
+  , anySingle
+  , choice
+  , getOffset
+  , many
+  , region
+  , setErrorOffset
+  , some
+  , try
+  )
 import Text.Megaparsec.Char.Lexer qualified as Lex
 
 -- | A parsable PLC term.
@@ -49,9 +59,9 @@ lamTerm = withSpan $ \sp ->
 
 appTerm :: Parser PTerm
 appTerm = withSpan $ \sp ->
-    inBrackets $
-      setAnn sp <$>
-        (mkIterApp <$> term <*> (fmap (getAnn &&& id) <$> some term))
+  inBrackets $
+    setAnn sp
+      <$> (mkIterApp <$> term <*> (fmap (getAnn &&& id) <$> some term))
 
 conTerm :: Parser PTerm
 conTerm = withSpan $ \sp ->
@@ -63,9 +73,9 @@ builtinTerm = withSpan $ \sp ->
 
 tyInstTerm :: Parser PTerm
 tyInstTerm = withSpan $ \sp ->
-    inBraces $
-      setAnn sp <$>
-        (mkIterInst <$> term <*> (fmap (getAnn &&& id) <$> many pType))
+  inBraces $
+    setAnn sp
+      <$> (mkIterInst <$> term <*> (fmap (getAnn &&& id) <$> many pType))
 
 unwrapTerm :: Parser PTerm
 unwrapTerm = withSpan $ \sp ->
@@ -84,10 +94,14 @@ constrTerm = withSpan $ \sp ->
   inParens $ do
     let maxTag = fromIntegral (maxBound :: Word64)
     ty <- symbol "constr" *> pType
-    tag :: Integer <- lexeme Lex.decimal
+    tag :: Integer <- Lex.decimal
+    when (tag > maxTag) $ do
+      o <- getOffset
+      region (setErrorOffset (o - 1)) $
+        fail "constr tag too large: must be a legal Word64 value"
+    whitespace
     args <- many term
     whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
-    when (tag > maxTag) $ fail "constr tag too large: must be a legal Word64 value"
     pure $ Constr sp ty (fromIntegral tag) args
 
 caseTerm :: Parser PTerm

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -109,10 +109,14 @@ constrTerm tm = withSpan $ \sp ->
   inParens $ do
     let maxTag = fromIntegral (maxBound :: Word64)
     ty <- symbol "constr" *> pType
-    tag :: Integer <- lexeme Lex.decimal
+    tag :: Integer <- Lex.decimal
+    when (tag > maxTag) $ do
+      o <- getOffset
+      region (setErrorOffset (o - 1)) $
+        fail "constr tag too large: must be a legal Word64 value"
+    whitespace
     args <- many tm
     whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
-    when (tag > maxTag) $ fail "constr tag too large: must be a legal Word64 value"
     pure $ PIR.constr sp ty (fromIntegral tag) args
 
 caseTerm :: Parametric
@@ -127,15 +131,15 @@ letTerm = withSpan $ \sp ->
 
 appTerm :: Parametric
 appTerm tm = withSpan $ \sp ->
-    inBrackets $
-      setAnn sp <$>
-        (PIR.mkIterApp <$> tm <*> (fmap (getAnn &&& id) <$> some tm))
+  inBrackets $
+    setAnn sp
+      <$> (PIR.mkIterApp <$> tm <*> (fmap (getAnn &&& id) <$> some tm))
 
 tyInstTerm :: Parametric
 tyInstTerm tm = withSpan $ \sp ->
-    inBraces $
-      setAnn sp <$>
-        (PIR.mkIterInst <$> tm <*> (fmap (getAnn &&& id) <$> some pType))
+  inBraces $
+    setAnn sp
+      <$> (PIR.mkIterInst <$> tm <*> (fmap (getAnn &&& id) <$> some pType))
 
 pTerm :: Parser PTerm
 pTerm = leadingWhitespace go

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -20,7 +20,7 @@ import Control.Monad.Except
 import PlutusCore qualified as PLC
 import PlutusCore.Annotation
 import PlutusCore.Error qualified as PLC
-import PlutusPrelude ((&&&), getAnn, setAnn, through)
+import PlutusPrelude (getAnn, setAnn, through, (&&&))
 import Text.Megaparsec hiding (ParseError, State, parse)
 import Text.Megaparsec.Char (char)
 import Text.Megaparsec.Char.Lexer qualified as Lex
@@ -58,8 +58,8 @@ lamTerm sp =
 
 appTerm :: SrcSpan -> Parser PTerm
 appTerm sp =
-  setAnn sp <$>
-    (mkIterApp <$> term <*> (fmap (getAnn &&& id) <$> some term))
+  setAnn sp
+    <$> (mkIterApp <$> term <*> (fmap (getAnn &&& id) <$> some term))
 
 delayTerm :: SrcSpan -> Parser PTerm
 delayTerm sp =
@@ -76,10 +76,14 @@ errorTerm sp =
 constrTerm :: SrcSpan -> Parser PTerm
 constrTerm sp = do
   let maxTag = fromIntegral (maxBound :: Word64)
-  tag :: Integer <- lexeme Lex.decimal
+  tag :: Integer <- Lex.decimal
+  when (tag > maxTag) $ do
+    o <- getOffset
+    region (setErrorOffset (o - 1)) $
+      fail "constr tag too large: must be a legal Word64 value"
+  whitespace
   args <- many term
   whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
-  when (tag > maxTag) $ fail "constr tag too large: must be a legal Word64 value"
   pure $ UPLC.Constr sp (fromIntegral tag) args
 
 caseTerm :: SrcSpan -> Parser PTerm


### PR DESCRIPTION
The `uplc`  parser's error location for out-of-bounds `constr` tags (they're supposed to fit into a `Word64`) was imprecise: it used to say

```
  |
2 |    (constr 1234567890123254325234234 (con integer 5) (con bool True))
  |                                                                     ^
constr tag too large: must be a legal Word64 value
```
with the error marker a long way from the offending tag.

This PR fixes it so that it says

```
  |
2 |    (constr 1234567890123254325234234 (con integer 5) (con bool True))
  |                                    ^
constr tag too large: must be a legal Word64 value

```
There may be similar things for other constants, but I haven't checked everything yet.


There are some irrelevant changes due to text reformatting.