### PR TITLE
regen-goldens.sh: only run plutus-tx-plugin tests with GHC 9.12

### DIFF
--- a/scripts/regen-goldens.sh
+++ b/scripts/regen-goldens.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# List of sub‑projects and their tests
-projects=(
-  "plutus-conformance"
-  "plutus-tx-plugin"
-  "plutus-ledger-api"
-  "plutus-benchmark"
-  "cardano-constitution"
-  "plutus-tx"
-  "plutus-core"
-)
+ghc_version=$(ghc --numeric-version)
+
+if [[ "$ghc_version" == 9.12.* ]]; then
+  echo "=== GHC $ghc_version: regenerating plutus-tx-plugin goldens only"
+  projects=(
+    "plutus-tx-plugin"
+  )
+else
+  echo "=== GHC $ghc_version: regenerating all goldens"
+  projects=(
+    "plutus-conformance"
+    "plutus-tx-plugin"
+    "plutus-ledger-api"
+    "plutus-benchmark"
+    "cardano-constitution"
+    "plutus-tx"
+    "plutus-core"
+  )
+fi
 
 tests_plutus_conformance=(
   "cabal run haskell-conformance -- --accept"


### PR DESCRIPTION
Fixes #7889.

`plutus-tx-plugin` golden files are per-GHC-version (`test/*/9.6/` and `test/*/9.12/`), so goldens must also be regenerated from a GHC 9.12 shell. This keeps `scripts/regen-goldens.sh` a single script: it now detects the compiler via `ghc --numeric-version` and, when running with 9.12, only runs the `tests_plutus_tx_plugin` group — the other test suites are either unnecessary (their goldens do not depend on the GHC version) or unbuildable with 9.12. Behavior with the default (9.6) shell is unchanged.

Usage: `nix develop .#ghc912 --command ./scripts/regen-goldens.sh` regenerates the `9.12/` goldens only.

Verified with `bash -n` and a dry-run of both branches using stubbed `ghc`/`cabal` binaries: the 9.12 path runs exactly the three plugin test commands, the non-9.12 path runs the unchanged full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)