### PR TITLE
regen-goldens.sh: only run plutus-tx-plugin tests with GHC 9.12

### DIFF
--- a/scripts/regen-goldens.sh
+++ b/scripts/regen-goldens.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# List of sub‑projects and their tests
-projects=(
-  "plutus-conformance"
-  "plutus-tx-plugin"
-  "plutus-ledger-api"
-  "plutus-benchmark"
-  "cardano-constitution"
-  "plutus-tx"
-  "plutus-core"
-)
+ghc_version=$(ghc --numeric-version)
+
+if [[ "$ghc_version" == 9.12.* ]]; then
+  echo "=== GHC $ghc_version: regenerating plutus-tx-plugin goldens only"
+  projects=(
+    "plutus-tx-plugin"
+  )
+else
+  echo "=== GHC $ghc_version: regenerating all goldens"
+  projects=(
+    "plutus-conformance"
+    "plutus-tx-plugin"
+    "plutus-ledger-api"
+    "plutus-benchmark"
+    "cardano-constitution"
+    "plutus-tx"
+    "plutus-core"
+  )
+fi
 
 tests_plutus_conformance=(
   "cabal run haskell-conformance -- --accept"


### PR DESCRIPTION
Fixes #7889

## What

`scripts/regen-goldens.sh` now detects the GHC version (`ghc --numeric-version`) and, when running with GHC 9.12, regenerates only the `plutus-tx-plugin` goldens. With any other GHC version it regenerates all goldens as before.

## Why

With GHC 9.12 the other test suites are either unnecessary — their golden files do not depend on the GHC version — or currently unbuildable, so running the full sweep either wastes time or fails outright.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible) — n/a, shell script change
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate) — n/a, dev script only
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)