### PR TITLE
regen-goldens.sh: only run plutus-tx-plugin tests with GHC 9.12

### DIFF
--- a/scripts/regen-goldens.sh
+++ b/scripts/regen-goldens.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# List of sub‑projects and their tests
-projects=(
-  "plutus-conformance"
-  "plutus-tx-plugin"
-  "plutus-ledger-api"
-  "plutus-benchmark"
-  "cardano-constitution"
-  "plutus-tx"
-  "plutus-core"
-)
+ghc_version=$(ghc --numeric-version)
+
+if [[ "$ghc_version" == 9.12.* ]]; then
+  echo "=== GHC $ghc_version: regenerating plutus-tx-plugin goldens only"
+  projects=(
+    "plutus-tx-plugin"
+  )
+else
+  echo "=== GHC $ghc_version: regenerating all goldens"
+  projects=(
+    "plutus-conformance"
+    "plutus-tx-plugin"
+    "plutus-ledger-api"
+    "plutus-benchmark"
+    "cardano-constitution"
+    "plutus-tx"
+    "plutus-core"
+  )
+fi
 
 tests_plutus_conformance=(
   "cabal run haskell-conformance -- --accept"


### PR DESCRIPTION
Fixes #7889

`scripts/regen-goldens.sh` previously regenerated goldens for all seven
sub-projects regardless of the compiler in use. Under GHC 9.12 that
doesn't work: most of the suites are either unbuildable with 9.12 or
have goldens that don't depend on the GHC version, so rerunning them is
pointless.
