### PR TITLE
Test the `multiIndexArray` index-count limit

### DIFF
--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
@@ -39,6 +39,7 @@ import Evaluation.Builtins.SignatureVerification
 
 import PlutusCore hiding (Constr)
 import PlutusCore qualified as PLC
+import PlutusCore.Arrays qualified as Arrays (maximumIndexCount)
 import PlutusCore.Builtin
 import PlutusCore.Compiler.Erase (eraseTerm)
 import PlutusCore.Data
@@ -480,6 +481,33 @@ test_BuiltinArray =
             term = mkIterAppNoAnn (tyInst () (builtin () MultiIndexArray) integer) [arrayOfInts, indices]
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting term
           @?= Right EvaluationFailure
+    , testCase "multiIndexArray-at-index-limit" do
+        -- Exactly 'maximumIndexCount' indices are accepted: the limit is an inclusive
+        -- maximum.  The array is a singleton so that this varies the number of indices
+        -- and nothing else.
+        let atLimit = Arrays.maximumIndexCount
+            indices = mkConstant @[Integer] @DefaultUni () (replicate atLimit 0)
+            arrayOfInts = mkConstant @(Vector Integer) @DefaultUni () (Vector.fromList [42])
+            expected = mkConstant @[Integer] @DefaultUni () (replicate atLimit 42)
+            term = mkIterAppNoAnn (tyInst () (builtin () MultiIndexArray) integer) [arrayOfInts, indices]
+        typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting term
+          @?= Right (EvaluationSuccess expected)
+    , testCase "multiIndexArray-over-index-limit-fails" do
+        -- One index past the limit fails even though every index is in bounds, so the
+        -- count is the only thing under test.
+        -- See Note [Index count limitation for multiIndexArray].
+        let overLimit = Arrays.maximumIndexCount + 1
+            indices = mkConstant @[Integer] @DefaultUni () (replicate overLimit 0)
+            arrayOfInts = mkConstant @(Vector Integer) @DefaultUni () (Vector.fromList [42])
+            term = mkIterAppNoAnn (tyInst () (builtin () MultiIndexArray) integer) [arrayOfInts, indices]
+        typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting term
+          @?= Right EvaluationFailure
+    , testCase "multiIndexArray-index-limit-value" $
+        -- The two cases above are written against 'maximumIndexCount', so they keep
+        -- testing the boundary wherever it sits.  This one pins the value itself:
+        -- CIP-0156 specifies it and the cost model is fitted over exactly this range,
+        -- so moving it changes on-chain behaviour.
+        Arrays.maximumIndexCount @?= 1024
     ]
 
 test_BuiltinPair :: TestTree

--- a/plutus-tx/test/Array/Spec.hs
+++ b/plutus-tx/test/Array/Spec.hs
@@ -4,6 +4,7 @@ module Array.Spec (arrayTests) where
 
 import Control.Exception (ErrorCall)
 import Data.Either (isLeft)
+import PlutusCore.Arrays (maximumIndexCount)
 import PlutusCore.Test (pureTry)
 import PlutusTx.Builtins.Internal qualified as BI
 
@@ -13,7 +14,8 @@ import Prelude
 
 -- The Haskell implementation of the builtin must fail exactly where the on-chain
 -- builtin fails: any index outside @[0..length)@, including one exceeding
--- @maxBound :: Int@, is an error rather than a wrap-around lookup.
+-- @maxBound :: Int@, is an error rather than a wrap-around lookup, and so is an index
+-- list longer than 'maximumIndexCount'.
 arrayTests :: TestTree
 arrayTests =
   testGroup
@@ -30,6 +32,9 @@ arrayTests =
                   x : _ -> x
                   [] -> 0
               )
+        , testCase "more indices than maximumIndexCount fails" $
+            throwsErrorCall
+              (BI.multiIndexArray arr (BI.BuiltinList (replicate (maximumIndexCount + 1) 0)))
         ]
     ]
   where


### PR DESCRIPTION
`multiIndexArray` accepts at most 1024 indices and nothing tested that: every existing test used at most four, and `maximumIndexCount` was referenced outside `PlutusCore.Arrays` only by the benchmarks. These cases pin the boundary as inclusive (`maximumIndexCount` accepted, one more rejected) and pin the literal 1024, which the in-flight CIP-0156 amendment makes normative.

Found while preparing that amendment. No changelog fragment: the unreleased costing entry already says the builtin fails above 1024 indices.
