### PR TITLE
Restore order of error checks when parsing `constr`

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -94,6 +94,7 @@ constrTerm = withSpan $ \sp ->
   inParens $ do
     let maxTag = fromIntegral (maxBound :: Word64)
     ty <- symbol "constr" *> pType
+    whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
     tag :: Integer <- Lex.decimal
     when (tag > maxTag) $ do
       o <- getOffset
@@ -101,7 +102,6 @@ constrTerm = withSpan $ \sp ->
         fail "constr tag too large: must be a legal Word64 value"
     whitespace
     args <- many term
-    whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
     pure $ Constr sp ty (fromIntegral tag) args
 
 caseTerm :: Parser PTerm

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -109,6 +109,7 @@ constrTerm tm = withSpan $ \sp ->
   inParens $ do
     let maxTag = fromIntegral (maxBound :: Word64)
     ty <- symbol "constr" *> pType
+    whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
     tag :: Integer <- Lex.decimal
     when (tag > maxTag) $ do
       o <- getOffset
@@ -116,7 +117,6 @@ constrTerm tm = withSpan $ \sp ->
         fail "constr tag too large: must be a legal Word64 value"
     whitespace
     args <- many tm
-    whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
     pure $ PIR.constr sp ty (fromIntegral tag) args
 
 caseTerm :: Parametric

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -76,6 +76,7 @@ errorTerm sp =
 constrTerm :: SrcSpan -> Parser PTerm
 constrTerm sp = do
   let maxTag = fromIntegral (maxBound :: Word64)
+  whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
   tag :: Integer <- Lex.decimal
   when (tag > maxTag) $ do
     o <- getOffset
@@ -83,7 +84,6 @@ constrTerm sp = do
       fail "constr tag too large: must be a legal Word64 value"
   whitespace
   args <- many term
-  whenVersion (\v -> v < plcVersion110) $ fail "'constr' is not allowed before version 1.1.0"
   pure $ UPLC.Constr sp (fromIntegral tag) args
 
 caseTerm :: SrcSpan -> Parser PTerm


### PR DESCRIPTION
At least two things can got wrong when parsing `constr`:

 1. The Plutus version is 1.0.0
 2. The tag is 2^64 or greater.

in #7901 I improved the error location for 2 but carelessly swapped the order of the checks for 1 and 2, as pointed out by @Unisay in the PR comments.  This PR changes the checks back to the previous order, which is more consistent with what the flat decoder does (although the issue is quite subtle: see this [comment](https://github.com/IntersectMBO/plutus/pull/7901#issuecomment-5326053857)).  The version check does seem more fundamental, so doing it first is probably better.