### PR TITLE
Update docs for the new plinth-template installer

### DIFF
--- a/doc/docusaurus/docs/auction-smart-contract/end-to-end/generating-keys.md
+++ b/doc/docusaurus/docs/auction-smart-contract/end-to-end/generating-keys.md
@@ -4,13 +4,16 @@ sidebar_position: 5
 
 # Generating Keys and Addresses
 
-The best way to setup your environment is with the [plinth-template](https://github.com/IntersectMBO/plinth-template) repository. See its [README](https://github.com/IntersectMBO/plinth-template?tab=readme-ov-file#plinth-template) for complete instructions on how to get up and running using Docker, Nix, or a custom approach.
+The best way to set up your environment is with the [plinth-template](https://github.com/IntersectMBO/plinth-template) installer, which creates a ready-to-build Plinth project using your choice of Nix, Docker, Demeter, or plain GHC + Cabal. See its [README](https://github.com/IntersectMBO/plinth-template?tab=readme-ov-file#plinth-template) for details. For this tutorial, create the project in a directory named `on-chain`:
+
+```
+curl -fsSL https://raw.githubusercontent.com/IntersectMBO/plinth-template/main/install.sh | sh -s -- --dir on-chain
+```
 
 Make sure you also have [NodeJS](https://nodejs.org/en) and [yarn](https://yarnpkg.com/) (or [npm](https://github.com/npm/cli), which comes with `NodeJS`) installed.
 Then, create a separate `off-chain` directory, initialize `package.json`, and install the required dependencies:
 
 ```
-git clone git@github.com:IntersectMBO/plinth-template.git on-chain
 mkdir off-chain && cd $_
 yarn init -y
 yarn add @meshsdk/core

--- a/doc/docusaurus/docs/auction-smart-contract/end-to-end/mint.md
+++ b/doc/docusaurus/docs/auction-smart-contract/end-to-end/mint.md
@@ -11,7 +11,7 @@ Therefore, we'll first write the on-chain script, then compute its hash and use 
 
 ## On-chain Minting Policy Script
 
-The full minting policy code can be found at [AuctionMintingPolicy.hs](https://github.com/IntersectMBO/plinth-template/blob/main/src/AuctionMintingPolicy.hs).
+The full minting policy code can be found at [AuctionMintingPolicy.hs](https://github.com/IntersectMBO/plinth-template/blob/main/template/src/AuctionMintingPolicy.hs).
 The main logic is in the following function:
 
 <LiteralInclude file="AuctionMintingPolicy.hs" language="haskell" title="AuctionMintingPolicy.hs" start="-- BLOCK1" end="-- BLOCK2" />
@@ -34,7 +34,7 @@ To do so, we first need to supply a public key hash, which the minting policy wi
 Assuming the seller is the one minting the token, this should be the seller's public key hash.
 Open `GenMintingPolicyBlueprint.hs` in the `on-chain` directory, and replace `error "Replace with seller pkh"` with the content of `off-chain/seller.pkh`.
 
-The minting policy code comes with `plinth-template`, so you can find it in the `on-chain` repository.
+The minting policy code comes with `plinth-template`, so you can find it in the `on-chain` project directory.
 To compile it and generate the blueprint, navigate to the `on-chain` directory and run
 
 ```

--- a/doc/docusaurus/docs/auction-smart-contract/on-chain-code.md
+++ b/doc/docusaurus/docs/auction-smart-contract/on-chain-code.md
@@ -24,7 +24,7 @@ She would like to create and deploy an auction smart contract with the following
 
 Plinth is a subset of Haskell, used to write on-chain code, also known as validators or scripts.
 A Plinth program is compiled into Plutus Core, which is interpreted on-chain.
-The full Plinth code for the auction smart contract can be found at [AuctionValidator.hs](https://github.com/IntersectMBO/plinth-template/blob/main/src/AuctionValidator.hs).
+The full Plinth code for the auction smart contract can be found at [AuctionValidator.hs](https://github.com/IntersectMBO/plinth-template/blob/main/template/src/AuctionValidator.hs).
 
 <!-- will need to update the link and file location for the new docs platform implementation -->
 

--- a/doc/docusaurus/docs/using-plinth/environment-setup.md
+++ b/doc/docusaurus/docs/using-plinth/environment-setup.md
@@ -11,4 +11,10 @@ However, there are a few additional requirements:
 - You’ll need some specific packages, such as `plutus-tx` and `plutus-tx-plugin`, which are hosted on the [Cardano Haskell Package repository](https://github.com/IntersectMBO/cardano-haskell-packages) (CHaP), rather than Hackage, Haskell's default package archive.
 - You'll also need a few C libraries such as `secp256k1` and `blst`, which are required by the `plutus-tx` library.
 
-The best way to setup your environment is with the [plinth-template](https://github.com/IntersectMBO/plinth-template) repository. See its [README](https://github.com/IntersectMBO/plinth-template?tab=readme-ov-file#plinth-template) for complete instructions on how to get up and running using Docker, Nix, or a custom approach.
+The best way to set up your environment is with [plinth-template](https://github.com/IntersectMBO/plinth-template), which creates a ready-to-build Plinth project for you with one command:
+
+```
+curl -fsSL https://raw.githubusercontent.com/IntersectMBO/plinth-template/main/install.sh | sh
+```
+
+The installer asks which development environment you want (Nix, Docker, Demeter, or plain GHC + Cabal), checks that environment's prerequisites, takes care of the required C libraries, and creates a fresh project containing only the files that environment needs. See its [README](https://github.com/IntersectMBO/plinth-template?tab=readme-ov-file#plinth-template) for details.


### PR DESCRIPTION
## Description

IntersectMBO/plinth-template#85 turned plinth-template from a clone-and-adapt GitHub template into an installer script (`curl -fsSL .../install.sh | sh`) and moved the project sources under `template/`. This updates the docusaurus docs accordingly.