### PR TITLE
Say where each cost model page's data-source values came from

### DIFF
--- a/doc/cost-models/shared/styles.css
+++ b/doc/cost-models/shared/styles.css
@@ -398,6 +398,21 @@ select {
   font-size: 1.2em;
 }
 
+.provenance-note {
+  margin-top: 6px;
+  font-size: 0.85em;
+  color: #744210;
+  background-color: #FFFAF0;
+  border-left: 3px solid #D69E2E;
+  padding: 6px 10px;
+}
+
+.provenance-note button {
+  font-size: 0.9em;
+  padding: 2px 8px;
+  margin-left: 4px;
+}
+
 .error {
   background-color: #FFF5F5;
   border: 2px solid #E53E3E;

--- a/doc/cost-models/shared/styles.css
+++ b/doc/cost-models/shared/styles.css
@@ -398,19 +398,31 @@ select {
   font-size: 1.2em;
 }
 
+/* A footnote rather than a banner: it qualifies the field above it and should not compete
+   with it for attention. */
 .provenance-note {
-  margin-top: 6px;
-  font-size: 0.85em;
-  color: #744210;
-  background-color: #FFFAF0;
-  border-left: 3px solid #D69E2E;
-  padding: 6px 10px;
+  margin: 0;
+  font-size: 0.78em;
+  line-height: 1.5;
+  color: #8A6D3B;
+  border-left: 2px solid #D69E2E;
+  padding: 0 0 0 8px;
 }
 
 .provenance-note button {
-  font-size: 0.9em;
-  padding: 2px 8px;
-  margin-left: 4px;
+  font-size: 1em;
+  font-weight: 400;
+  line-height: inherit;
+  padding: 0 5px;
+  margin-left: 6px;
+  background-color: transparent;
+  color: #8A6D3B;
+  border: 1px solid #D69E2E;
+  border-radius: 3px;
+}
+
+.provenance-note button:hover {
+  background-color: #FFFAF0;
 }
 
 .error {

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -475,7 +475,9 @@ async function loadData(csvUrl, jsonUrl) {
  */
 function getBranchFromUrl() {
   const params = new URLSearchParams(window.location.search);
-  return params.get('branch');
+  // `has`, not a truthiness test: `?branch=` says "the default", not "whatever this browser
+  // happens to remember".
+  return params.has('branch') ? params.get('branch') : null;
 }
 
 // ============================================================================
@@ -548,6 +550,12 @@ const PAGES = [
 ];
 
 // LocalStorage keys
+// Where each data-source field's value came from on this page load: 'link' for a query
+// parameter, 'browser' for `localStorage`, 'branch' for the URL derived from the branch name.
+// A stale stored path 404s where an empty field would have fallen back to the branch and
+// worked, so a failed request needs to be able to say which it was.
+const fieldProvenance = { csv: 'branch', json: 'branch' };
+
 const STORAGE_KEYS = {
   BRANCH: 'plutus-viz-branch',
   CSV_URL: 'plutus-viz-csv-url',
@@ -567,15 +575,71 @@ function getFileUrls(baseUrl) {
   };
 }
 
-// Load settings from localStorage (URL param takes precedence)
+// A link wins over what this browser remembers, and what it remembers wins over the branch
+// default. `csv` and `json` let a review link point at files a branch does not have yet,
+// which needs a local HTTP server because fetch() rejects the file: scheme. See the README.
 function loadSettings() {
+  const params = new URLSearchParams(window.location.search);
   const urlBranch = getBranchFromUrl();
+  const storedBranch = localStorage.getItem(STORAGE_KEYS.BRANCH);
+  const branch = urlBranch !== null ? urlBranch : storedBranch || DEFAULT_BRANCH;
+  // A stored path belongs to the branch it was saved against, so following a link to a
+  // different branch must not drag it along.
+  const storedApplies = urlBranch === null || urlBranch === storedBranch;
+
+  const pick = (param, storageKey) => {
+    if (params.has(param)) return { value: params.get(param), source: 'link' };
+    const stored = storedApplies ? localStorage.getItem(storageKey) : null;
+    if (stored) return { value: stored, source: 'browser' };
+    return { value: '', source: 'branch' };
+  };
+  const csv = pick('csv', STORAGE_KEYS.CSV_URL);
+  const json = pick('json', STORAGE_KEYS.JSON_URL);
+
   return {
-    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
-    csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
-    jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
+    branch,
+    csvUrl: csv.value,
+    csvSource: csv.source,
+    jsonUrl: json.value,
+    jsonSource: json.source,
     collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
   };
+}
+
+/* Mark the fields this browser filled in, and offer to drop the stored value. Without this a
+value nobody chose is indistinguishable from one somebody did. */
+function renderProvenance(settings) {
+  const fields = [
+    ['csv', 'csv-url', settings.csvSource, STORAGE_KEYS.CSV_URL],
+    ['json', 'json-url', settings.jsonSource, STORAGE_KEYS.JSON_URL]
+  ];
+  for (const [key, inputId, source, storageKey] of fields) {
+    fieldProvenance[key] = source;
+    const input = document.getElementById(inputId);
+    if (!input) continue;
+    const previous = document.getElementById(`${inputId}-provenance`);
+    if (previous) previous.remove();
+    if (source !== 'browser') continue;
+
+    const note = document.createElement('div');
+    note.id = `${inputId}-provenance`;
+    note.className = 'provenance-note';
+    note.appendChild(document.createTextNode('Restored from this browser, not from the link. '));
+    const clear = document.createElement('button');
+    clear.type = 'button';
+    clear.textContent = 'Clear';
+    clear.addEventListener('click', () => {
+      localStorage.removeItem(storageKey);
+      fieldProvenance[key] = 'branch';
+      // Only this field: the other one may hold a value somebody chose, and its own note
+      // would be left pointing at something the field no longer contains.
+      const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
+      input.value = getFileUrls (generateUrlFromBranch (branch))[key];
+      note.remove();
+    });
+    note.appendChild(clear);
+    input.insertAdjacentElement('afterend', note);
+  }
 }
 
 function saveSettings(branch, csvUrl, jsonUrl) {
@@ -697,7 +761,13 @@ function setupCostModelPage(page) {
       page.render({ benchmarkData, costModel, overhead, modelPredictions });
     } catch (error) {
       console.error('Error loading data:', error);
-      showError(`Failed to load data. Check console for details. Error: ${error.message}`);
+      const restored = fieldProvenance.csv === 'browser' || fieldProvenance.json === 'browser';
+      const hint = restored
+        ? ' One of these URLs was restored from this browser rather than taken from the link;'
+          + ' use Clear beside the field to fall back to the branch.'
+        : '';
+      showError(
+        `Failed to load data. Check console for details. Error: ${error.message}${hint}`);
     }
   }
 
@@ -739,13 +809,17 @@ function setupCostModelPage(page) {
     const jsonInput = document.getElementById('json-url');
 
     branchInput.value = settings.branch;
-    if (settings.csvUrl && settings.jsonUrl) {
-      csvInput.value = settings.csvUrl;
-      jsonInput.value = settings.jsonUrl;
-    } else {
+    // Derive both from the branch first, then override only what was actually supplied: one
+    // field arriving from a link must not discard the other.
+    updateUrlsFromBranch();
+    if (settings.csvUrl) csvInput.value = settings.csvUrl;
+    if (settings.jsonUrl) jsonInput.value = settings.jsonUrl;
+    renderProvenance(settings);
+
+    branchInput.addEventListener('input', () => {
       updateUrlsFromBranch();
-    }
-    branchInput.addEventListener('input', updateUrlsFromBranch);
+      renderProvenance({ csvSource: 'branch', jsonSource: 'branch' });
+    });
 
     document.getElementById('reload-data').addEventListener('click', async () => {
       const branch = branchInput.value.trim() || DEFAULT_BRANCH;
@@ -758,6 +832,11 @@ function setupCostModelPage(page) {
       const url = new URL(window.location.href);
       url.search = '';
       url.searchParams.set('branch', branch);
+      // Carry any field the branch does not imply, so the link stands on its own instead of
+      // depending on what the recipient's browser remembers.
+      const fromBranch = getFileUrls(generateUrlFromBranch(branch));
+      if (csvInput.value.trim() !== fromBranch.csv) url.searchParams.set('csv', csvInput.value.trim());
+      if (jsonInput.value.trim() !== fromBranch.json) url.searchParams.set('json', jsonInput.value.trim());
       navigator.clipboard.writeText(url.toString());
       const btn = document.getElementById('copy-link');
       const original = btn.textContent;

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -657,7 +657,9 @@ function renderProvenance(settings) {
       note.remove();
     });
     note.appendChild(clear);
-    input.insertAdjacentElement('afterend', note);
+    // Appended to the group rather than placed after the input, because the branch input
+    // shares a flex row with Copy Link and a sibling there lands on the same line.
+    (input.closest('.control-group-vertical') || input.parentElement).appendChild(note);
   }
 }
 

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -551,10 +551,13 @@ const PAGES = [
 
 // LocalStorage keys
 // Where each data-source field's value came from on this page load: 'link' for a query
-// parameter, 'browser' for `localStorage`, 'branch' for the URL derived from the branch name.
-// A stale stored path 404s where an empty field would have fallen back to the branch and
-// worked, so a failed request needs to be able to say which it was.
-const fieldProvenance = { csv: 'branch', json: 'branch' };
+// parameter, 'browser' for `localStorage`, 'typed' for a value entered on the page, and for
+// the rest either 'branch' for a URL derived from the branch name or 'default' for
+// `DEFAULT_BRANCH`.
+// A stale stored value 404s where an empty field would have fallen back and worked, so a
+// failed request needs to be able to say which it was. A remembered branch does it at one
+// remove: both URLs read 'branch' and are built correctly, from a branch nobody chose.
+const fieldProvenance = { branch: 'default', csv: 'branch', json: 'branch' };
 
 const STORAGE_KEYS = {
   BRANCH: 'plutus-viz-branch',
@@ -586,6 +589,7 @@ function loadSettings() {
   // A stored path belongs to the branch it was saved against, so following a link to a
   // different branch must not drag it along.
   const storedApplies = urlBranch === null || urlBranch === storedBranch;
+  const branchSource = urlBranch !== null ? 'link' : storedBranch ? 'browser' : 'default';
 
   const pick = (param, storageKey) => {
     if (params.has(param)) return { value: params.get(param), source: 'link' };
@@ -598,6 +602,7 @@ function loadSettings() {
 
   return {
     branch,
+    branchSource,
     csvUrl: csv.value,
     csvSource: csv.source,
     jsonUrl: json.value,
@@ -609,11 +614,28 @@ function loadSettings() {
 /* Mark the fields this browser filled in, and offer to drop the stored value. Without this a
 value nobody chose is indistinguishable from one somebody did. */
 function renderProvenance(settings) {
+  const deriveFromBranch = key => {
+    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
+    document.getElementById(`${key}-url`).value =
+      getFileUrls (generateUrlFromBranch (branch))[key];
+  };
+  // Each row carries what its own Clear leaves behind, because clearing one field must not
+  // disturb another that holds a value somebody chose. For the branch that means re-deriving
+  // only the URLs still reading 'branch'; a note left beside a field the reset overwrote
+  // would point at something the field no longer contains.
   const fields = [
-    ['csv', 'csv-url', settings.csvSource, STORAGE_KEYS.CSV_URL],
-    ['json', 'json-url', settings.jsonSource, STORAGE_KEYS.JSON_URL]
+    ['branch', 'branch-name', settings.branchSource, STORAGE_KEYS.BRANCH, 'default', () => {
+      document.getElementById('branch-name').value = DEFAULT_BRANCH;
+      for (const key of ['csv', 'json']) {
+        if (fieldProvenance[key] === 'branch') deriveFromBranch(key);
+      }
+    }],
+    ['csv', 'csv-url', settings.csvSource, STORAGE_KEYS.CSV_URL, 'branch',
+     () => deriveFromBranch('csv')],
+    ['json', 'json-url', settings.jsonSource, STORAGE_KEYS.JSON_URL, 'branch',
+     () => deriveFromBranch('json')]
   ];
-  for (const [key, inputId, source, storageKey] of fields) {
+  for (const [key, inputId, source, storageKey, cleared, reset] of fields) {
     fieldProvenance[key] = source;
     const input = document.getElementById(inputId);
     if (!input) continue;
@@ -630,11 +652,8 @@ function renderProvenance(settings) {
     clear.textContent = 'Clear';
     clear.addEventListener('click', () => {
       localStorage.removeItem(storageKey);
-      fieldProvenance[key] = 'branch';
-      // Only this field: the other one may hold a value somebody chose, and its own note
-      // would be left pointing at something the field no longer contains.
-      const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
-      input.value = getFileUrls (generateUrlFromBranch (branch))[key];
+      fieldProvenance[key] = cleared;
+      reset();
       note.remove();
     });
     note.appendChild(clear);
@@ -761,10 +780,11 @@ function setupCostModelPage(page) {
       page.render({ benchmarkData, costModel, overhead, modelPredictions });
     } catch (error) {
       console.error('Error loading data:', error);
-      const restored = fieldProvenance.csv === 'browser' || fieldProvenance.json === 'browser';
-      const hint = restored
-        ? ' One of these URLs was restored from this browser rather than taken from the link;'
-          + ' use Clear beside the field to fall back to the branch.'
+      const restored =
+        ['branch', 'csv', 'json'].filter(field => fieldProvenance[field] === 'browser');
+      const hint = restored.length
+        ? ` Restored from this browser rather than taken from the link: ${restored.join(', ')}.`
+          + ' Use Clear beside the field to fall back to the default.'
         : '';
       showError(
         `Failed to load data. Check console for details. Error: ${error.message}${hint}`);
@@ -818,7 +838,7 @@ function setupCostModelPage(page) {
 
     branchInput.addEventListener('input', () => {
       updateUrlsFromBranch();
-      renderProvenance({ csvSource: 'branch', jsonSource: 'branch' });
+      renderProvenance({ branchSource: 'typed', csvSource: 'branch', jsonSource: 'branch' });
     });
 
     document.getElementById('reload-data').addEventListener('click', async () => {

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -476,8 +476,10 @@ async function loadData(csvUrl, jsonUrl) {
 function getBranchFromUrl() {
   const params = new URLSearchParams(window.location.search);
   // `has`, not a truthiness test: `?branch=` says "the default", not "whatever this browser
-  // happens to remember".
-  return params.has('branch') ? params.get('branch') : null;
+  // happens to remember". Resolving it here keeps that promise in the field as well as in
+  // the URLs derived from it, and lets `storedApplies` compare two branch names.
+  if (!params.has('branch')) return null;
+  return params.get('branch').trim() || DEFAULT_BRANCH;
 }
 
 // ============================================================================
@@ -617,7 +619,7 @@ function renderProvenance(settings) {
   const deriveFromBranch = key => {
     const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
     document.getElementById(`${key}-url`).value =
-      getFileUrls (generateUrlFromBranch (branch))[key];
+      getFileUrls(generateUrlFromBranch(branch))[key];
   };
   // Each row carries what its own Clear leaves behind, because clearing one field must not
   // disturb another that holds a value somebody chose. For the branch that means re-deriving
@@ -663,10 +665,19 @@ function renderProvenance(settings) {
   }
 }
 
+// Only a value the default does not already give is worth remembering: the branch when it
+// is not `DEFAULT_BRANCH`, a URL when the branch does not imply it. Storing one that is
+// implied would report every later visit as restored from the browser, and a note that
+// fires on ordinary use stops carrying information.
 function saveSettings(branch, csvUrl, jsonUrl) {
-  localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
-  localStorage.setItem(STORAGE_KEYS.CSV_URL, csvUrl);
-  localStorage.setItem(STORAGE_KEYS.JSON_URL, jsonUrl);
+  if (branch && branch !== DEFAULT_BRANCH) localStorage.setItem(STORAGE_KEYS.BRANCH, branch);
+  else localStorage.removeItem(STORAGE_KEYS.BRANCH);
+  const fromBranch = getFileUrls(generateUrlFromBranch(branch));
+  const pairs = [['csv', csvUrl, STORAGE_KEYS.CSV_URL], ['json', jsonUrl, STORAGE_KEYS.JSON_URL]];
+  for (const [key, value, storageKey] of pairs) {
+    if (value && value !== fromBranch[key]) localStorage.setItem(storageKey, value);
+    else localStorage.removeItem(storageKey);
+  }
 }
 
 // Update URL fields based on branch name
@@ -842,6 +853,17 @@ function setupCostModelPage(page) {
       updateUrlsFromBranch();
       renderProvenance({ branchSource: 'typed', csvSource: 'branch', jsonSource: 'branch' });
     });
+
+    // Typing into a URL field settles its provenance on the spot. Without this the note
+    // stays beside a value the reader supplied, and its Clear would throw that value away;
+    // a later failure would also blame storage for a URL nobody restored.
+    for (const [key, input] of [['csv', csvInput], ['json', jsonInput]]) {
+      input.addEventListener('input', () => {
+        fieldProvenance[key] = 'typed';
+        const note = document.getElementById(`${input.id}-provenance`);
+        if (note) note.remove();
+      });
+    }
 
     document.getElementById('reload-data').addEventListener('click', async () => {
       const branch = branchInput.value.trim() || DEFAULT_BRANCH;


### PR DESCRIPTION
The pages remember the CSV and JSON URLs you last used and refilled those fields silently. That is fine until a review link loses its query string in transit: the page then loads a path left over from an earlier session, shows it as though somebody had chosen it, and reports a 404 that reads as a broken page.

Each field now says where its value came from:

| Value comes from | When |
|---|---|
| The link | the query parameter is present, even if empty |
| This browser | the link says nothing and does not name a different branch |
| The branch name | neither of the above |

An empty parameter counts as a value, and the value it means is the default: `?json=` takes the URL the branch implies rather than falling through to storage, and `?branch=` takes master. A stored path is dropped when the link names a different branch, because a path saved against one branch is wrong for another.

Only a value the default does not already give is remembered, so an ordinary visit stores nothing and there is nothing to label. The branch counts here too, and it is the case worth watching: both URLs are built from it correctly, which leaves nothing on the page to show that the branch itself was nobody's choice.

A field this browser did fill in is labelled, with a Clear button that drops the stored value for that field alone so anything you did choose stays put. Typing over a field settles it as yours and the label goes. When a request fails, the error names the fields that came from storage.

`?csv=` and `?json=` are new, so a review link can point at files a branch does not have yet. The change is in shared plumbing, so all 14 cost model pages get it.

<img width="818" height="930" alt="image" src="https://github.com/user-attachments/assets/06b9221b-7860-4c32-9cfc-d8b714cc01fa" />

