### PR TITLE
Fix `lookupCoin` and `valueContains` memory models to match the committed JSON

### DIFF
--- a/plutus-core/cost-model/create-cost-model/BuiltinMemoryModels.hs
+++ b/plutus-core/cost-model/create-cost-model/BuiltinMemoryModels.hs
@@ -366,8 +366,10 @@ builtinMemoryModels =
     , paramListToArray = Id $ ModelOneArgumentLinearInX $ OneVariableLinearFunction 7 1
     , paramIndexArray = Id $ ModelTwoArgumentsConstantCost 32
     , -- Builtin values
-      paramLookupCoin = Id $ ModelThreeArgumentsConstantCost 10
-    , paramValueContains = Id $ ModelTwoArgumentsConstantCost 32
+      -- `lookupCoin` returns a quantity that is already stored in the `Value`, so it
+      -- allocates nothing; `valueContains` returns a `Bool`.
+      paramLookupCoin = Id $ ModelThreeArgumentsConstantCost 1
+    , paramValueContains = Id $ boolMemModel
     , -- See Note [Memory model for Value builtins]
       paramValueData = Id $ ModelOneArgumentLinearInX $ OneVariableLinearFunction 2 22
     , -- See Note [Memory model for Value builtins]


### PR DESCRIPTION
`BuiltinMemoryModels.hs` declared `ModelThreeArgumentsConstantCost 10` for `lookupCoin` and `ModelTwoArgumentsConstantCost 32` for `valueContains`, while every `builtinCostModel*.json` carries 1. `generate-cost-model` copies memory models verbatim into the JSON, so the next full regeneration would have multiplied the memory cost of both builtins by 10x and 32x with nobody intending it.

1 is also the right value. `valueContains` returns a `Bool`, so it now uses the existing `boolMemModel`, and `lookupCoin` returns a quantity already held in the `Value`, so it allocates nothing. The 10 and 32 were copied from the `lengthOfArray` and `indexArray` entries directly above, which construct a fresh `Integer` and are not comparable.

Verified by building `generate-cost-model` with `+with-inline-r` and running it against the committed `benching-conway.csv` and `models.R`. With this change its memory output matches the committed memory model of all 104 builtins in variants C and E, where before it differed on these two. The committed JSON does not change, hence the `No Changelog Required` label.

Found while costing `assetCount`.
