### PR TITLE
Make Data AssocMap FromData shape-safe

### DIFF
--- a/plutus-tx-plugin/test/AssocMap/Spec.hs
+++ b/plutus-tx-plugin/test/AssocMap/Spec.hs
@@ -19,9 +19,14 @@
 
 module AssocMap.Spec where
 
+import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
+import PlutusTx.Data.AssocMap qualified as Data.AssocMap
 import PlutusTx.IsData ()
+import PlutusTx.IsData qualified as IsData
 import PlutusTx.Lift (liftCodeDef)
+import PlutusTx.Prelude qualified as PlutusTx
+import PlutusTx.TH (compile)
 import PlutusTx.Test
 
 import AssocMap.Golden
@@ -33,6 +38,7 @@ import AssocMap.Semantics
 import Test.Tasty (TestTree, localOption, testGroup)
 import Test.Tasty.Extras
 import Test.Tasty.Hedgehog (HedgehogTestLimit (..), testProperty)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 goldenTests :: TestNested
 goldenTests =
@@ -66,4 +72,51 @@ propertyTests =
       , testProperty "mapMaybe" mapMaybeSpec
       , testProperty "mapMaybeWithKey" mapMaybeWithKeySpec
       , testProperty "builtinDataEncoding" builtinDataEncodingSpec
+      , fromBuiltinDataTests
       ]
+
+fromBuiltinDataProgram ::
+  CompiledCode
+    ( PlutusTx.BuiltinData
+      -> PlutusTx.Maybe [(PlutusTx.Integer, PlutusTx.Integer)]
+    )
+fromBuiltinDataProgram =
+  $$( compile
+        [||
+        \d -> PlutusTx.fmap Data.AssocMap.toSOPList (IsData.fromBuiltinData d)
+        ||]
+    )
+
+fromBuiltinDataTests :: TestTree
+fromBuiltinDataTests =
+  testGroup
+    "Data.AssocMap FromData"
+    [ testCase "rejects Constr data" $
+        assertDecodesTo (Builtins.mkConstr 0 []) PlutusTx.Nothing
+    , testCase "rejects List data" $
+        assertDecodesTo (Builtins.mkList []) PlutusTx.Nothing
+    , testCase "rejects I data" $
+        assertDecodesTo (Builtins.mkI 1) PlutusTx.Nothing
+    , testCase "rejects B data" $
+        assertDecodesTo (Builtins.mkB "bytes") PlutusTx.Nothing
+    , testCase "decodes an empty map" $
+        assertDecodesTo (Builtins.mkMap []) (PlutusTx.Just [])
+    , testCase "decodes a populated map" $
+        assertDecodesTo
+          ( Builtins.mkMap
+              [ (Builtins.mkI 1, Builtins.mkI 2)
+              , (Builtins.mkI 3, Builtins.mkI 4)
+              ]
+          )
+          (PlutusTx.Just [(1, 2), (3, 4)])
+    ]
+
+assertDecodesTo ::
+  PlutusTx.BuiltinData
+  -> PlutusTx.Maybe [(PlutusTx.Integer, PlutusTx.Integer)]
+  -> Assertion
+assertDecodesTo d expected =
+  evaluationResultMatchesHaskell
+    (fromBuiltinDataProgram `unsafeApplyCode` liftCodeDef d)
+    (@?=)
+    expected

--- a/plutus-tx/changelog.d/20260912_assocmap_fromdata.md
+++ b/plutus-tx/changelog.d/20260912_assocmap_fromdata.md
@@ -1,0 +1,4 @@
+# Fixed
+
+`PlutusTx.Data.AssocMap.Map`'s `FromData` instance now returns `Nothing` when given a non-map
+`Data` value.

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -222,6 +222,7 @@ test-suite plutus-tx-test
     Blueprint.Spec
     Bool.Spec
     Builtins.Spec
+    Data.AssocMap.Spec
     Enum.Spec
     Eq.Spec
     List.Spec

--- a/plutus-tx/src/PlutusTx/Data/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/Data/AssocMap.hs
@@ -78,7 +78,14 @@ instance P.ToData (Map k a) where
   toBuiltinData (Map d) = BI.mkMap d
 instance P.FromData (Map k a) where
   {-# INLINEABLE fromBuiltinData #-}
-  fromBuiltinData = Just . Map . BI.unsafeDataAsMap
+  fromBuiltinData d =
+    P.matchData'
+      d
+      (\_ _ -> Nothing)
+      (Just . Map)
+      (\_ -> Nothing)
+      (\_ -> Nothing)
+      (\_ -> Nothing)
 
 instance P.UnsafeFromData (Map k a) where
   {-# INLINEABLE unsafeFromBuiltinData #-}

--- a/plutus-tx/test/Data/AssocMap/Spec.hs
+++ b/plutus-tx/test/Data/AssocMap/Spec.hs
@@ -7,7 +7,7 @@ import PlutusTx.Data.AssocMap qualified as AssocMap
 import PlutusTx.IsData qualified as IsData
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
-import Prelude (Integer, Maybe (..), fmap)
+import Prelude (Integer, Maybe (..), fmap, ($))
 
 assocMapTests :: TestTree
 assocMapTests =

--- a/plutus-tx/test/Data/AssocMap/Spec.hs
+++ b/plutus-tx/test/Data/AssocMap/Spec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Data.AssocMap.Spec (assocMapTests) where
+
+import PlutusCore.Data (Data (B, Constr, I, List, Map))
+import PlutusTx.Data.AssocMap qualified as AssocMap
+import PlutusTx.IsData qualified as IsData
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+import Prelude (Integer, Maybe (..), fmap)
+
+assocMapTests :: TestTree
+assocMapTests =
+  testGroup
+    "PlutusTx.Data.AssocMap FromData tests"
+    [ testCase "rejects Constr data" $ assertDecodesTo (Constr 0 []) Nothing
+    , testCase "rejects List data" $ assertDecodesTo (List []) Nothing
+    , testCase "rejects I data" $ assertDecodesTo (I 1) Nothing
+    , testCase "rejects B data" $ assertDecodesTo (B "bytes") Nothing
+    , testCase "decodes an empty map" $ assertDecodesTo (Map []) (Just [])
+    , testCase "decodes a populated map" $
+        assertDecodesTo (Map [(I 1, I 2), (I 3, I 4)]) (Just [(1, 2), (3, 4)])
+    ]
+
+assertDecodesTo :: Data -> Maybe [(Integer, Integer)] -> Assertion
+assertDecodesTo d expected =
+  fmap AssocMap.toSOPList
+    (IsData.fromData d :: Maybe (AssocMap.Map Integer Integer))
+    @?= expected

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -14,6 +14,7 @@ import Codec.CBOR.FlatTerm qualified as FlatTerm
 import Codec.Serialise (deserialiseOrFail, serialise)
 import Codec.Serialise qualified as Serialise
 import Control.Exception (ErrorCall, catch)
+import Data.AssocMap.Spec (assocMapTests)
 import Data.ByteString qualified as BS
 import Data.Either (isLeft)
 import Data.Word (Word64)
@@ -44,6 +45,7 @@ tests =
   testGroup
     "plutus-tx"
     [ arrayTests
+    , assocMapTests
     , serdeTests
     , sqrtTests
     , ratioTests


### PR DESCRIPTION
## Summary

- make `PlutusTx.Data.AssocMap.Map` safe decoding dispatch on the `Data` shape
- return `Nothing` for every non-map shape while preserving map decoding
- cover empty and populated maps plus all four non-map shapes in host and compiled evaluation tests

## Testing

- `git diff --cached --check`
- local formatter and focused test commands could not run because `pre-commit`, `cabal`, and `nix` are unavailable in this environment