### PR TITLE
Require exact product arity in generated FromData

### DIFF
--- a/plutus-tx/changelog.d/20260912_exact_fromdata_product_arity.md
+++ b/plutus-tx/changelog.d/20260912_exact_fromdata_product_arity.md
@@ -1,0 +1,4 @@
+# Fixed
+
+Generated `FromData` instances for constructor- and list-encoded products now reject trailing
+fields and require nullary products to have an empty field list.

--- a/plutus-tx/src/PlutusTx/IsData/TH.hs
+++ b/plutus-tx/src/PlutusTx/IsData/TH.hs
@@ -62,8 +62,7 @@ mkConstrPartsMatchPattern conIx extractFieldNames =
         [p|(fromBuiltinData -> Just $(TH.varP n))|]
     extractArgsPat = go extractArgPats
       where
-        go [] = [p|_|]
-        go [x] = [p|(Builtins.headMaybe -> Just $x)|]
+        go [] = [p|(Builtins.null -> True)|]
         go (x : xs) = [p|(Builtins.uncons -> Just ($x, $(go xs)))|]
     pat = [p|($ixMatchPat, $extractArgsPat)|]
    in
@@ -76,8 +75,7 @@ mkListPartsMatchPattern extractFieldNames =
     extractArgPats =
       extractFieldNames <&> \n ->
         [p|(fromBuiltinData -> Just $(TH.varP n))|]
-    go [] = [p|_|]
-    go [x] = [p|(Builtins.headMaybe -> Just $x)|]
+    go [] = [p|(Builtins.null -> True)|]
     go (x : xs) = [p|(Builtins.uncons -> Just ($x, $(go xs)))|]
    in
     [p|$(go extractArgPats)|]

--- a/plutus-tx/src/PlutusTx/IsData/TH.hs
+++ b/plutus-tx/src/PlutusTx/IsData/TH.hs
@@ -62,7 +62,7 @@ mkConstrPartsMatchPattern conIx extractFieldNames =
         [p|(fromBuiltinData -> Just $(TH.varP n))|]
     extractArgsPat = go extractArgPats
       where
-        go [] = [p|(Builtins.null -> True)|]
+        go [] = [p|(Builtins.uncons -> Nothing)|]
         go (x : xs) = [p|(Builtins.uncons -> Just ($x, $(go xs)))|]
     pat = [p|($ixMatchPat, $extractArgsPat)|]
    in
@@ -75,7 +75,7 @@ mkListPartsMatchPattern extractFieldNames =
     extractArgPats =
       extractFieldNames <&> \n ->
         [p|(fromBuiltinData -> Just $(TH.varP n))|]
-    go [] = [p|(Builtins.null -> True)|]
+    go [] = [p|(Builtins.uncons -> Nothing)|]
     go (x : xs) = [p|(Builtins.uncons -> Just ($x, $(go xs)))|]
    in
     [p|$(go extractArgPats)|]

--- a/plutus-tx/test/Blueprint/Spec.hs
+++ b/plutus-tx/test/Blueprint/Spec.hs
@@ -49,6 +49,18 @@ import PlutusTx.IsData.Class qualified as PlutusTx
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 
+data ConstructorProduct = ConstructorProduct Integer BuiltinByteString
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (HasBlueprintDefinition)
+
+PlutusTx.makeIsDataSchemaIndexed ''ConstructorProduct [('ConstructorProduct, 0)]
+
+data EmptyConstructorProduct = EmptyConstructorProduct
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (HasBlueprintDefinition)
+
+PlutusTx.makeIsDataSchemaIndexed ''EmptyConstructorProduct [('EmptyConstructorProduct, 0)]
+
 data ListProduct = ListProduct Integer BuiltinByteString
   deriving stock (Eq, Show, Generic)
   deriving anyclass (HasBlueprintDefinition)
@@ -66,18 +78,48 @@ data SumProduct = SumFirst | SumSecond
 tests :: TestTree
 tests =
   testGroup
-    "List product schemas"
-    [ testCase "codec roundtrip" $ do
+    "Product schemas"
+    [ testCase "constructor codec roundtrip" $ do
+        let value = ConstructorProduct 3 "token"
+        PlutusTx.toData value @?= Constr 0 [I 3, B "token"]
+        PlutusTx.fromData (PlutusTx.toData value) @?= Just value
+        PlutusTx.unsafeFromBuiltinData (PlutusTx.toBuiltinData value) @?= value
+    , testCase "reject malformed constructor products" $ do
+        let malformed =
+              [ List [I 3, B "token"]
+              , Constr 0 []
+              , Constr 0 [I 3]
+              , Constr 0 [I 3, I 4]
+              , Constr 0 [I 3, B "token", I 4]
+              , Constr 0 [I 3, B "token", I 4, B "extra"]
+              ]
+        map (PlutusTx.fromData @ConstructorProduct) malformed
+          @?= replicate (length malformed) Nothing
+    , testCase "empty constructor product" $ do
+        PlutusTx.toData EmptyConstructorProduct @?= Constr 0 []
+        PlutusTx.fromData @EmptyConstructorProduct (Constr 0 []) @?= Just EmptyConstructorProduct
+        PlutusTx.fromData @EmptyConstructorProduct (Constr 0 [I 1]) @?= Nothing
+        PlutusTx.fromData @EmptyConstructorProduct (Constr 0 [I 1, I 2]) @?= Nothing
+    , testCase "list codec roundtrip" $ do
         let value = ListProduct 3 "token"
         PlutusTx.toData value @?= List [I 3, B "token"]
         PlutusTx.fromData (PlutusTx.toData value) @?= Just value
         PlutusTx.unsafeFromBuiltinData (PlutusTx.toBuiltinData value) @?= value
-    , testCase "reject malformed products" $ do
-        let malformed = [Constr 0 [I 3, B "token"], List [], List [I 3], List [I 3, I 4]]
+    , testCase "reject malformed list products" $ do
+        let malformed =
+              [ Constr 0 [I 3, B "token"]
+              , List []
+              , List [I 3]
+              , List [I 3, I 4]
+              , List [I 3, B "token", I 4]
+              , List [I 3, B "token", I 4, B "extra"]
+              ]
         map (PlutusTx.fromData @ListProduct) malformed @?= replicate (length malformed) Nothing
-    , testCase "empty product" $ do
+    , testCase "empty list product" $ do
         PlutusTx.toData EmptyProduct @?= List []
         PlutusTx.fromData @EmptyProduct (List []) @?= Just EmptyProduct
+        PlutusTx.fromData @EmptyProduct (List [I 1]) @?= Nothing
+        PlutusTx.fromData @EmptyProduct (List [I 1, I 2]) @?= Nothing
         schema @EmptyProduct @'[] @?= SchemaListTuple emptySchemaInfo []
     , testCase "positional schema" $
         schema @ListProduct @'[Integer, BuiltinByteString]


### PR DESCRIPTION
## Summary

- require generated constructor-encoded product decoders to consume the complete field list
- apply the same exact-arity rule to list-encoded products and nullary products
- use `Builtins.uncons -> Nothing` for the final tail check, preserving exact arity without the separate null/boolean path
- add roundtrip and malformed-input coverage for both encodings

## Testing

- `git diff --check`
- reviewed the existing Hydra evaluation 123082 results: functional IsData cases passed, while the remaining failures were generated-output golden deltas in the plugin, size, Cardano-loans, and Ed25519 checks
- verified the decoder pattern semantics by inspection: each field requires `uncons -> Just`, and the terminal `uncons -> Nothing` rejects both short and trailing field lists
- full local Nix/Cabal execution was not repeated because GHC, Cabal, and Nix are unavailable in this worktree and the cached image is incomplete; Hydra will validate all generated outputs for this revision