### PR TITLE
Reject non-positive CEK machine costs

### DIFF
--- a/plutus-core/changelog.d/validate-cek-machine-costs.md
+++ b/plutus-core/changelog.d/validate-cek-machine-costs.md
@@ -1,0 +1,3 @@
+# Changed
+
+`applyCostModelParams` now rejects non-positive CEK machine-step CPU and memory costs.

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -18,22 +18,28 @@ where
 import PlutusCore.Evaluation.Machine.MachineParameters (CostModel (..))
 import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
   ( CekMachineCosts
+  , CekMachineCostsBase (..)
   , cekMachineCostsPrefix
   )
 
 import Control.DeepSeq (NFData)
 import Control.Exception
+import Control.Monad (unless)
 import Control.Monad.Except
 import Data.Aeson
 import Data.Aeson.Flatten
 import Data.Data (Data)
+import Data.Functor.Identity (Identity (..))
 import Data.HashMap.Strict qualified as HM
 import Data.Int (Int64)
 import Data.Map qualified as Map
 import Data.Map.Merge.Lazy qualified as Map
+import Data.SatInt (unSatInt)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import NoThunks.Class
+import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
+import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import Prettyprinter
 
 {- Note [Cost model parameters]
@@ -244,6 +250,8 @@ extractParams cm = case toJSON cm of
 data CostModelApplyError
   = -- | a costmodel parameter with the give name does not exist in the costmodel to be applied upon
     CMUnknownParamError !Text.Text
+  | -- | a CEK machine cost must be strictly positive
+    CMNonPositiveMachineCost !Text.Text !Int64
   | -- | internal error when we are transforming the applyParams' input to json (should not happen)
     CMInternalReadError
   | -- | internal error when we are transforming the applied params from json with given jsonstring error (should not happen)
@@ -262,6 +270,11 @@ instance Pretty CostModelApplyError where
   pretty =
     (preamble <+>) . \case
       CMUnknownParamError k -> "No such parameter in target cost model:" <+> pretty k
+      CMNonPositiveMachineCost k value ->
+        "CEK machine cost must be strictly positive:"
+          <+> pretty k
+          <+> "is"
+          <+> pretty value
       CMInternalReadError -> "Internal problem occurred upon reading the given cost model parameters"
       CMInternalWriteError str ->
         "Internal problem occurred upon generating the applied cost model parameters with JSON error:"
@@ -370,13 +383,53 @@ applySplitCostModelParams prefix model params =
 Note that this is costly. See [here](https://github.com/IntersectMBO/plutus/issues/4962).
 Callers are recommended to call this once and cache the results. -}
 applyCostModelParams
-  :: ( FromJSON evaluatorcosts
-     , FromJSON builtincosts
-     , ToJSON evaluatorcosts
+  :: ( FromJSON builtincosts
      , ToJSON builtincosts
      , MonadError CostModelApplyError m
      )
-  => CostModel evaluatorcosts builtincosts
+  => CostModel CekMachineCosts builtincosts
   -> CostModelParams
-  -> m (CostModel evaluatorcosts builtincosts)
-applyCostModelParams = applySplitCostModelParams cekMachineCostsPrefix
+  -> m (CostModel CekMachineCosts builtincosts)
+applyCostModelParams model params = do
+  updatedModel <- applySplitCostModelParams cekMachineCostsPrefix model params
+  validateCekMachineCosts $ _machineCostModel updatedModel
+  pure updatedModel
+
+-- | Ensure that every realized CEK machine-step cost is strictly positive.
+validateCekMachineCosts :: MonadError CostModelApplyError m => CekMachineCosts -> m ()
+validateCekMachineCosts
+  ( CekMachineCostsBase
+      startupCost
+      varCost
+      constCost
+      lamCost
+      delayCost
+      forceCost
+      applyCost
+      builtinCost
+      constrCost
+      caseCost
+    ) =
+    mapM_
+      (uncurry validateCekMachineBudget)
+      [ ("cekStartupCost", startupCost)
+      , ("cekVarCost", varCost)
+      , ("cekConstCost", constCost)
+      , ("cekLamCost", lamCost)
+      , ("cekDelayCost", delayCost)
+      , ("cekForceCost", forceCost)
+      , ("cekApplyCost", applyCost)
+      , ("cekBuiltinCost", builtinCost)
+      , ("cekConstrCost", constrCost)
+      , ("cekCaseCost", caseCost)
+      ]
+
+validateCekMachineBudget
+  :: MonadError CostModelApplyError m => Text.Text -> Identity ExBudget -> m ()
+validateCekMachineBudget name (Identity (ExBudget (ExCPU cpu) (ExMemory memory))) = do
+  validateCost (name <> "-exBudgetCPU") $ unSatInt cpu
+  validateCost (name <> "-exBudgetMemory") $ unSatInt memory
+  where
+    validateCost :: MonadError CostModelApplyError m => Text.Text -> Int64 -> m ()
+    validateCost parameterName value =
+      unless (value > 0) $ throwError $ CMNonPositiveMachineCost parameterName value

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -17,6 +17,7 @@ import Data.Aeson
 import Data.ByteString.Lazy qualified as BSL
 import Data.Either
 import Data.Either.Extras
+import Data.Int (Int64)
 import Data.Map qualified as Map
 import Data.Maybe
 import Data.Text qualified as Text
@@ -57,9 +58,9 @@ randomCekCosts =
     { cekStartupCost = pure $ ExBudget 2342 234321
     , cekVarCost = pure $ ExBudget 12312 56545
     , cekConstCost = pure $ ExBudget 23490290838 2323423
-    , cekLamCost = pure $ ExBudget 0 712127381
+    , cekLamCost = pure $ ExBudget 1 712127381
     , cekDelayCost = pure $ ExBudget 999 7777
-    , cekForceCost = pure $ ExBudget 1028234 0
+    , cekForceCost = pure $ ExBudget 1028234 1
     , cekApplyCost = pure $ ExBudget 324628348 8273
     , cekBuiltinCost = pure $ ExBudget 4 4
     , cekConstrCost = pure $ ExBudget 8 100000
@@ -190,6 +191,13 @@ testMispelled = do
     cekVarCostCpuKeyMispelled = "cekVarCost--exBudgetCPU"
     deleteLookup = Map.updateLookupWithKey (const $ const Nothing)
 
+testNonPositiveMachineCost :: Text.Text -> Int64 -> Assertion
+testNonPositiveMachineCost parameterName value =
+  Left (CMNonPositiveMachineCost parameterName value)
+    @=? applyCostModelParams
+      defaultCekCostModelForTesting
+      (Map.singleton parameterName value)
+
 test_costModelInterface :: TestTree
 test_costModelInterface =
   testGroup
@@ -251,5 +259,12 @@ test_costModelInterface =
         , -- TODO: do something here for each version of the cost model?
           testCase "default ledger params can be applied to default cost model" testApply
         , testCase "mispelled param in ledger params " testMispelled
+        ]
+    , testGroup
+        "CEK machine costs are strictly positive"
+        [ testCase "zero CPU cost is rejected" $
+            testNonPositiveMachineCost "cekVarCost-exBudgetCPU" 0
+        , testCase "negative memory cost is rejected" $
+            testNonPositiveMachineCost "cekStartupCost-exBudgetMemory" (-1)
         ]
     ]

--- a/plutus-ledger-api/test/Spec/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/CostModelParams.hs
@@ -5,7 +5,8 @@
 module Spec.CostModelParams where
 
 import PlutusLedgerApi.Common
-  ( CostModelApplyWarn (CMTooManyParamsWarn, cmActual, cmExpected)
+  ( CostModelApplyError (CMNonPositiveMachineCost)
+  , CostModelApplyWarn (CMTooManyParamsWarn, cmActual, cmExpected)
   , IsParamName (readParamName, showParamName)
   )
 import PlutusLedgerApi.Test.V3.EvaluationContext qualified as V3
@@ -19,6 +20,7 @@ import Control.Monad.Except (runExcept)
 import Control.Monad.Writer.Strict (WriterT (runWriterT))
 import Data.Either (isRight)
 import Data.Foldable (for_)
+import Data.Int (Int64)
 import Data.List.Extra (enumerate)
 import Data.Set (isSubsetOf)
 import Data.Set qualified as Set
@@ -30,10 +32,23 @@ import Test.Tasty.Extras
   , testNestedNamed
   )
 import Test.Tasty.HUnit
-  ( assertBool
+  ( Assertion
+  , assertBool
+  , assertFailure
   , testCase
   , (@=?)
   )
+
+assertNonPositiveMachineCost :: V3.ParamName -> Int64 -> Assertion
+assertNonPositiveMachineCost parameterName value =
+  case runExcept $ runWriterT $ V3.mkEvaluationContext costValues of
+    Left err -> CMNonPositiveMachineCost (showParamName parameterName) value @=? err
+    Right _ -> assertFailure "non-positive CEK machine cost was accepted"
+  where
+    costValues =
+      fmap
+        (\(name, originalValue) -> if name == parameterName then value else originalValue)
+        V3.costModelParamsForTesting
 
 tests :: TestNested
 tests =
@@ -101,6 +116,10 @@ tests =
           $ runWriterT
           $ V4.mkEvaluationContext
           $ costValuesForTesting ++ [1] -- dummy param value appended
+    , embed $ testCase "zero CEK CPU cost is rejected" $
+        assertNonPositiveMachineCost V3.CekVarCost'exBudgetCPU 0
+    , embed $ testCase "negative CEK memory cost is rejected" $
+        assertNonPositiveMachineCost V3.CekStartupCost'exBudgetMemory (-1)
     , embed $ testCase "cost model parameters" do
         -- From PV11, the v1 and v2 parameter names are identical; before PV11
         -- the v1 parameter names were a subset of the v2 ones.

--- a/plutus-ledger-api/test/Spec/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Eval.hs
@@ -8,7 +8,6 @@ module Spec.Eval (tests) where
 
 import PlutusCore.Default
 import PlutusCore.Evaluation.Machine.ExBudget
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
 import PlutusCore.StdLib.Data.Unit
@@ -16,6 +15,9 @@ import PlutusCore.Version as PLC
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.Common.Versions
 import PlutusLedgerApi.Test.V1.EvaluationContext qualified as V1
+import PlutusLedgerApi.Test.V2.EvaluationContext qualified as V2
+import PlutusLedgerApi.Test.V3.EvaluationContext qualified as V3
+import PlutusLedgerApi.Test.V4.EvaluationContext qualified as V4
 import PlutusLedgerApi.V1 qualified as V1
 import PlutusLedgerApi.V2 qualified as V2
 import PlutusLedgerApi.V3 qualified as V3
@@ -28,9 +30,6 @@ import UntypedPlutusCore.Test.DeBruijn.Good
 import Control.Exception (evaluate)
 import Control.Monad.Extra (whenJust)
 import Control.Monad.Writer
-import Data.Int (Int64)
-import Data.Map qualified as Map
-import Data.Maybe (fromJust)
 import NoThunks.Class
 import PlutusCore.Data qualified as Data
 import Test.Tasty
@@ -115,23 +114,14 @@ testUnlifting = testCase "check unlifting behaviour changes in Vasil" $ do
     evalAPI alonzoPV illPartialBuiltin @?= True
     evalAPI vasilPV illPartialBuiltin @?= True -}
 
-costParams :: [Int64]
-costParams = Map.elems (fromJust defaultCostModelParamsForTesting)
-
-lengthParamNamesV :: PlutusLedgerLanguage -> Int
-lengthParamNamesV PlutusV1 = length $ enumerate @V1.ParamName
-lengthParamNamesV PlutusV2 = length $ enumerate @V2.ParamName
-lengthParamNamesV PlutusV3 = length $ enumerate @V3.ParamName
-lengthParamNamesV PlutusV4 = length $ enumerate @V4.ParamName
-
 mkEvaluationContextV :: PlutusLedgerLanguage -> IO EvaluationContext
 mkEvaluationContextV ll =
-  either (assertFailure . display) (pure . fst) . runWriterT $
-    take (lengthParamNamesV ll) costParams & case ll of
-      PlutusV1 -> V1.mkEvaluationContext
-      PlutusV2 -> V2.mkEvaluationContext
-      PlutusV3 -> V3.mkEvaluationContext
-      PlutusV4 -> V4.mkEvaluationContext
+  -- Cost parameters are positional, so each ledger version needs its own ledger-ordered values.
+  either (assertFailure . display) (pure . fst) . runWriterT $ case ll of
+    PlutusV1 -> V1.mkEvaluationContext $ fmap snd V1.costModelParamsForTesting
+    PlutusV2 -> V2.mkEvaluationContext $ fmap snd V2.costModelParamsForTesting
+    PlutusV3 -> V3.mkEvaluationContext $ fmap snd V3.costModelParamsForTesting
+    PlutusV4 -> V4.mkEvaluationContext $ fmap snd V4.costModelParamsForTesting
 
 -- | Ensure that 'toMachineParameters' never throws for all language and protocol versions.
 evaluationContextCacheIsComplete :: TestTree


### PR DESCRIPTION
## Summary

- validate every realized CEK machine-step CPU and memory charge after applying cost-model parameters
- reject zero or negative charges with a parameter-specific error
- cover the core application API and the V3 evaluation-context construction path
- construct each ledger-version test context from that version parameter list in ledger order

The validation is deliberately limited to realized CEK base charges; it does not reject individual builtin polynomial coefficients that may be negative while the resulting cost function remains positive. The ledger API context tests now use their existing version-specific fixtures instead of reusing alphabetically ordered values from the newest model.

## Testing

- `git diff --check`
- the pinned Nix `plutus-core-test` derivation compiled the changed library and core test suite successfully
- Hydra runs the complete `plutus-ledger-api-test` suite on GHC 9.6 and GHC 9.12