### PR TITLE
Evaluate Scott caseInteger scrutinee once

### DIFF
--- a/plutus-tx-plugin/changelog.d/20260912_caseinteger_shared_scrutinee.md
+++ b/plutus-tx-plugin/changelog.d/20260912_caseinteger_shared_scrutinee.md
@@ -1,0 +1,4 @@
+# Fixed
+
+Scott-encoded `caseInteger` now evaluates its scrutinee once and shares the result across branch
+comparisons.

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -142,6 +142,7 @@ test-suite plutus-tx-plugin-tests
     Budget.Spec
     Budget.WithGHCOptimisations
     Budget.WithoutGHCOptimisations
+    BuiltinCasing.Scott.Spec
     BuiltinCasing.Spec
     BuiltinList.Budget.Spec
     BuiltinList.NoCasing.Spec

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -995,7 +995,10 @@ compileExpr mloc e = do
           pure $ PIR.kase annAlwaysInline resultTy scrutinee branches
         PIR.ScottEncoding -> do
           dead <- safeFreshTyName "dead"
-          let thunkTy = PLC.TyForall annMayInline dead (PLC.Type annMayInline) resultTy
+          scrutineeName <- safeFreshName "caseIntegerScrutinee"
+          let integerTy = PLC.mkTyBuiltin @_ @Integer annMayInline
+              scrutineeVar = PIR.var annMayInline scrutineeName
+              thunkTy = PLC.TyForall annMayInline dead (PLC.Type annMayInline) resultTy
               thunk = PIR.TyAbs annMayInline dead (PLC.Type annMayInline)
               unthunk term = PIR.TyInst annMayInline term resultTy
               -- Uses the (all dead. resultTy) / (/\dead -> branch) encoding to avoid
@@ -1010,13 +1013,25 @@ compileExpr mloc e = do
                       , PIR.mkIterApp
                           (PIR.builtin annMayInline PLC.EqualsInteger)
                           [ (annMayInline, PIR.mkConstant @Integer annMayInline idx)
-                          , (annMayInline, scrutinee)
+                          , (annMayInline, scrutineeVar)
                           ]
                       )
                     , (annMayInline, thunk branch)
                     , (annMayInline, thunk (mkChain (idx + 1) laterBranches))
                     ]
-          pure $ mkChain (0 :: Integer) branches
+          -- A strict binding preserves source evaluation even when there are no branches,
+          -- while sharing the result across every equality test in the chain.
+          pure $
+            PIR.mkLet
+              annMayInline
+              PIR.NonRec
+              [ PIR.TermBind
+                  annMayInline
+                  PIR.Strict
+                  (PIR.VarDecl annMayInline scrutineeName integerTy)
+                  scrutinee
+              ]
+              (mkChain (0 :: Integer) branches)
 
     compileDataCase resultTy scrutinee branches =
       case coDatatypeStyle opts of

--- a/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCase.golden.pir
+++ b/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCase.golden.pir
@@ -1,0 +1,26 @@
+\(i : integer) ->
+  let
+    !caseIntegerScrutinee : integer
+      = trace
+          {integer}
+          "scrutinee"
+          (divideInteger (addInteger (multiplyInteger i i) i) 3)
+  in
+  ifThenElse
+    {all dead. string}
+    (equalsInteger 0 caseIntegerScrutinee)
+    (/\dead -> trace {string} "branch 0" "a")
+    (/\dead ->
+       ifThenElse
+         {all dead. string}
+         (equalsInteger 1 caseIntegerScrutinee)
+         (/\dead -> trace {string} "branch 1" "b")
+         (/\dead ->
+            ifThenElse
+              {all dead. string}
+              (equalsInteger 2 caseIntegerScrutinee)
+              (/\dead -> trace {string} "branch 2" "c")
+              (/\dead -> error {string})
+              {string})
+         {string})
+    {string}

--- a/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCaseFirst.golden.eval
+++ b/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCaseFirst.golden.eval
@@ -1,0 +1,1 @@
+[scrutinee, branch 0]

--- a/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCaseThird.golden.eval
+++ b/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCaseThird.golden.eval
@@ -1,0 +1,1 @@
+[scrutinee, branch 2]

--- a/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCaseThirdBudget.golden.eval
+++ b/plutus-tx-plugin/test/BuiltinCasing/Scott/9.6/integerCaseThirdBudget.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_964_744
+Memory:                  7_275
+AST Size:                   82
+Flat Size:                 134
+
+(con string "c")

--- a/plutus-tx-plugin/test/BuiltinCasing/Scott/Spec.hs
+++ b/plutus-tx-plugin/test/BuiltinCasing/Scott/Spec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fplugin-opt Plinth.Plugin:target-version=1.0.0 #-}
+
+module BuiltinCasing.Scott.Spec (tests) where
+
+import Test.Tasty.Extras
+
+import PlutusTx (CompiledCode, compile, unsafeApplyCode)
+import PlutusTx.Builtins qualified as Builtins
+import PlutusTx.Prelude
+import PlutusTx.Test
+
+integerCase :: CompiledCode (Integer -> BuiltinString)
+integerCase = $$(compile [||integerCaseWithTrace||])
+
+integerZero :: CompiledCode Integer
+integerZero = $$(compile [||0||])
+
+integerTwo :: CompiledCode Integer
+integerTwo = $$(compile [||2||])
+
+integerCaseWithTrace :: Integer -> BuiltinString
+integerCaseWithTrace i =
+  Builtins.caseInteger
+    ( Builtins.trace
+        "scrutinee"
+        ( Builtins.divideInteger
+            (Builtins.addInteger (Builtins.multiplyInteger i i) i)
+            3
+        )
+    )
+    [ Builtins.trace "branch 0" "a"
+    , Builtins.trace "branch 1" "b"
+    , Builtins.trace "branch 2" "c"
+    ]
+
+tests :: TestNested
+tests =
+  testNested "BuiltinCasing/Scott"
+    . pure
+    $ testNestedGhc
+      [ goldenPirReadable "integerCase" integerCase
+      , goldenEvalCekLog
+          "integerCaseFirst"
+          (integerCase `unsafeApplyCode` integerZero)
+      , goldenEvalCekLog
+          "integerCaseThird"
+          (integerCase `unsafeApplyCode` integerTwo)
+      , goldenEvalCekCatchBudget
+          "integerCaseThirdBudget"
+          (integerCase `unsafeApplyCode` integerTwo)
+      ]

--- a/plutus-tx-plugin/test/Spec.hs
+++ b/plutus-tx-plugin/test/Spec.hs
@@ -5,6 +5,7 @@ import AsData.Budget.Spec qualified as AsData.Budget
 import AssocMap.Spec qualified as AssocMap
 import Blueprint.Tests qualified
 import Budget.Spec qualified as Budget
+import BuiltinCasing.Scott.Spec qualified as BuiltinCasing.Scott
 import BuiltinCasing.Spec qualified as BuiltinCasing
 import BuiltinList.Budget.Spec qualified as BuiltinList.Budget
 import BuiltinList.NoCasing.Spec qualified as BuiltinList.NoCasing
@@ -73,5 +74,6 @@ tests =
     , StageViolation.tests
     , CallTrace.tests
     , BuiltinCasing.tests
+    , BuiltinCasing.Scott.tests
     , Unsupported.tests
     ]


### PR DESCRIPTION
## Summary

- bind the Scott-encoded `caseInteger` scrutinee once in a strict non-recursive PIR let
- share that value across equality tests while preserving lazy branch selection
- add PIR, trace, and budget goldens for the first and third branches

The sums-of-products lowering is unchanged.

## Testing

- pinned GHC 9.6/Nix: `cabal test plutus-tx-plugin:plutus-tx-plugin-tests --builddir=/tmp/caseinteger-dist -j2 --test-options='--accept --pattern BuiltinCasing'` — all 10 focused tests passed
- `git diff --cached --check`
- a clean GHC 9.12 build was started but not completed locally because it required rebuilding the full dependency graph; CI will provide that compiler-version check